### PR TITLE
[RDY] Fix localization

### DIFF
--- a/src/nvim/po/Makefile
+++ b/src/nvim/po/Makefile
@@ -138,6 +138,7 @@ VIM = ../../../build/bin/nvim
 MSGFMT = OLD_PO_FILE_INPUT=yes msgfmt -v
 XGETTEXT = OLD_PO_FILE_INPUT=yes OLD_PO_FILE_OUTPUT=yes xgettext
 MSGMERGE = OLD_PO_FILE_INPUT=yes OLD_PO_FILE_OUTPUT=yes msgmerge
+SAFE_SED = LANG=C LC_CTYPE=C LC_ALL=C sed
 
 .SUFFIXES:
 .SUFFIXES: .po .mo .pot .ck
@@ -205,44 +206,44 @@ sjiscorr: sjiscorr.c
 
 ja.euc-jp.po: ja.po
 	iconv -f utf-8 -t euc-jp ja.po | \
-		sed -e 's/charset=utf-8/charset=euc-jp/' -e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' > ja.euc-jp.po
+		$(SAFE_SED) -e 's/charset=utf-8/charset=euc-jp/' -e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' > ja.euc-jp.po
 
 # Convert cs.po to create cs.cp1250.po.
 cs.cp1250.po: cs.po
 	rm -f cs.cp1250.po
 	iconv -f iso-8859-2 -t cp1250 cs.po | \
-		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from cs.po, DO NOT EDIT/' > cs.cp1250.po
+		$(SAFE_SED) -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from cs.po, DO NOT EDIT/' > cs.cp1250.po
 
 # Convert pl.po to create pl.cp1250.po.
 pl.cp1250.po: pl.po
 	rm -f pl.cp1250.po
 	iconv -f iso-8859-2 -t cp1250 pl.po | \
-		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.cp1250.po
+		$(SAFE_SED) -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.cp1250.po
 
 # Convert pl.po to create pl.UTF-8.po.
 pl.UTF-8.po: pl.po
 	rm -f pl.UTF-8.po
 	iconv -f iso-8859-2 -t utf-8 pl.po | \
-		sed -e 's/charset=ISO-8859-2/charset=utf-8/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.UTF-8.po
+		$(SAFE_SED) -e 's/charset=ISO-8859-2/charset=utf-8/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.UTF-8.po
 
 # Convert sk.po to create sk.cp1250.po.
 sk.cp1250.po: sk.po
 	rm -f sk.cp1250.po
 	iconv -f iso-8859-2 -t cp1250 sk.po | \
-		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from sk.po, DO NOT EDIT/' > sk.cp1250.po
+		$(SAFE_SED) -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from sk.po, DO NOT EDIT/' > sk.cp1250.po
 
 # Convert zh_CN.po to create zh_CN.cp936.po.
 # set 'charset' to gbk to avoid that msfmt generates a warning
 zh_CN.cp936.po: zh_CN.po
 	rm -f zh_CN.cp936.po
 	iconv -f gb2312 -t cp936 zh_CN.po | \
-		sed -e 's/charset=gb2312/charset=gbk/' -e 's/# Original translations/# Generated from zh_CN.po, DO NOT EDIT/' > zh_CN.cp936.po
+		$(SAFE_SED) -e 's/charset=gb2312/charset=gbk/' -e 's/# Original translations/# Generated from zh_CN.po, DO NOT EDIT/' > zh_CN.cp936.po
 
 # Convert ko.UTF-8.po to create ko.po.
 ko.po: ko.UTF-8.po
 	rm -f ko.po
 	iconv -f UTF-8 -t euc-kr ko.UTF-8.po | \
-		sed -e 's/charset=UTF-8/charset=euc-kr/' \
+		$(SAFE_SED) -e 's/charset=UTF-8/charset=euc-kr/' \
 		    -e 's/# Korean translation for Vim/# Generated from ko.UTF-8.po, DO NOT EDIT/' \
 		    > ko.po
 
@@ -250,13 +251,13 @@ ko.po: ko.UTF-8.po
 ru.cp1251.po: ru.po
 	rm -f ru.cp1251.po
 	iconv -f utf-8 -t cp1251 ru.po | \
-		sed -e 's/charset=utf-8/charset=cp1251/' -e 's/# Original translations/# Generated from ru.po, DO NOT EDIT/' > ru.cp1251.po
+		$(SAFE_SED) -e 's/charset=utf-8/charset=cp1251/' -e 's/# Original translations/# Generated from ru.po, DO NOT EDIT/' > ru.cp1251.po
 
 # Convert uk.po to create uk.cp1251.po.
 uk.cp1251.po: uk.po
 	rm -f uk.cp1251.po
 	iconv -f utf-8 -t cp1251 uk.po | \
-		sed -e 's/charset=utf-8/charset=cp1251/' -e 's/# Original translations/# Generated from uk.po, DO NOT EDIT/' > uk.cp1251.po
+		$(SAFE_SED) -e 's/charset=utf-8/charset=cp1251/' -e 's/# Original translations/# Generated from uk.po, DO NOT EDIT/' > uk.cp1251.po
 
 prefixcheck:
 	@if test "x" = "x$(prefix)"; then \

--- a/src/nvim/po/Makefile
+++ b/src/nvim/po/Makefile
@@ -272,10 +272,10 @@ distclean: clean
 checkclean:
 	rm -f *.ck
 
-$(PACKAGE).pot: ../*.c ../if_perl.xs ../GvimExt/gvimext.cpp ../globals.h ../if_py_both.h
+$(PACKAGE).pot: ../*.c ../globals.h 
 	cd ..; $(XGETTEXT) --default-domain=$(PACKAGE) \
 		--add-comments --keyword=_ --keyword=N_ \
-		*.c if_perl.xs GvimExt/gvimext.cpp globals.h if_py_both.h
+		*.c globals.h
 	mv -f ../$(PACKAGE).po $(PACKAGE).pot
 
 update-po: $(LANGUAGES)

--- a/src/nvim/po/Makefile
+++ b/src/nvim/po/Makefile
@@ -125,6 +125,8 @@ CHECKFILES = \
 		uk.cp1251.ck \
 		zh_CN.cp936.ck
 
+SOURCE_FILES = $(shell find .. -type f -name '*.[ch]')
+
 PACKAGE = nvim
 SHELL = /bin/sh
 VIM = ../../../build/bin/nvim
@@ -272,11 +274,11 @@ distclean: clean
 checkclean:
 	rm -f *.ck
 
-$(PACKAGE).pot: ../*.c ../globals.h 
-	cd ..; $(XGETTEXT) --default-domain=$(PACKAGE) \
+$(PACKAGE).pot: $(SOURCE_FILES)
+	$(XGETTEXT) --default-domain=$(PACKAGE) \
 		--add-comments --keyword=_ --keyword=N_ \
-		*.c globals.h
-	mv -f ../$(PACKAGE).po $(PACKAGE).pot
+		$(SOURCE_FILES)
+	mv $(PACKAGE).po $(PACKAGE).pot
 
 update-po: $(LANGUAGES)
 

--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -26,144 +26,217 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 6.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-04-17 23:24+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: Wed Oct 31 13:41 SAST 2001\n"
 "Last-Translator: Danie Roux <droux@tuks.co.za>\n"
 "Language-Team: Danie Roux <droux@tuks.co.za>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO_8859-1\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "E258: Kan nie na kliënt stuur nie"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Kan nie buffer toeken nie, program sluit..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Kan nie buffer toeken nie, gaan ander een gebruik..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Geen buffers is uitgelaai nie"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Geen buffers is geskrap nie"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Geen buffers is geskrap nie"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer uitgelaai"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffers uitgelaai"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer geskrap"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffers geskrap"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer geskrap"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffers geskrap"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Kan nie laaste buffer uitlaai nie"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Geen veranderde buffer gevind nie"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Daar is geen gelyste buffer nie"
 
+#: ../buffer.c:913
+#, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Buffer %<PRId64> bestaan nie"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan nie verby laaste buffer gaan nie"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan nie vóór eerste buffer gaan nie"
 
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
-msgstr "E89: Buffer %<PRId64> nog ongestoor sedert vorige wysiging (gebruik ! om te dwing)"
+#: ../buffer.c:945
+#, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr ""
+"E89: Buffer %<PRId64> nog ongestoor sedert vorige wysiging (gebruik ! om te "
+"dwing)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Kan nie laaste buffer uitlaai nie"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Waarskuwing: Lêerlys loop oor"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: buffer %<PRId64> kon nie gevind word nie"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Meer as een treffer vir %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Geen buffer wat by %s pas nie"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "reël %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer met hierdie naam bestaan alreeds"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Gewysig]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Ongewysig]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nuwe lêer]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Leesfoute]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[lees alleen]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 reël --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> reëls --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "reël %<PRId64> van %<PRId64> --%d%%-- kolom "
 
-msgid "[No file]"
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+#, fuzzy
+msgid "[No Name]"
 msgstr "[Geen lêer]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "help"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[help]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Voorskou]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Alles"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Ond"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Bo"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -171,12 +244,11 @@ msgstr ""
 "\n"
 "# Buffer lys:\n"
 
-msgid "[Error List]"
-msgstr "[Foutlys]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[No File]"
-msgstr "[Geen lêer]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -184,118 +256,208 @@ msgstr ""
 "\n"
 "--- Tekens ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Tekens vir %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    reël=%<PRId64>  id=%d  naam=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Ontbrekende dubbelpunt"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Ongeldige modus"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: syfer verwag"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Ongeldige persentasie"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Kan nie meer as %<PRId64> buffers 'diff' nie"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Kan nie 'termcap'-lêer oopmaak nie"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan nie 'diffs' skep nie "
 
-msgid "Patch file"
-msgstr "Laslap lêer"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Kan nie 'diff' afvoer lees nie"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Kan nie 'diff' afvoer lees nie"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Huidige buffer is nie in 'diff' modus nie"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: Geen ander buffer in 'diff' modus nie"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Geen ander buffer in 'diff' modus nie"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Meer as twee buffers in 'diff' modus, weet nie watter een om te "
 "gebruik nie"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Kan buffer %s nie vind nie"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffer \"%s\" is nie in 'diff' modus nie"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 'Escape' nie toegelaat in digraaf nie"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Sleutelbindinglêer nie gevind nie"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap word buite 'n uitvoerlêer gebruik"
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Sleutelwoord voltooiing (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^E^Y^L^]^F^I^K^D^V^N^P)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X modus (^E^Y^L^]^F^I^K^D^V^N^P)"
 
-#. Scroll has it's own msgs, in it's place there is the msg for local
-#. * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-msgid " Keyword Local completion (^N^P)"
-msgstr " Sleutelwoord Lokale voltooiing (^N^P)"
-
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Hele-reël voltooiing (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Lêernaam voltooiing (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Etiketvoltooiing (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Gidspatroon voltooiing (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Definisievoltooiing (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Woordeboekvoltooiing (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Tesourusvoltooiing (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Bevelreëlvoltooiing (^V^N^P)"
 
+#: ../edit.c:94
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " Hele-reël voltooiing (^L^N^P)"
+
+#: ../edit.c:95
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " Etiketvoltooiing (^]^N^P)"
+
+#: ../edit.c:96
+#, fuzzy
+msgid " Spelling suggestion (s^N^P)"
+msgstr " Hele-reël voltooiing (^L^N^P)"
+
+#: ../edit.c:97
+msgid " Keyword Local completion (^N^P)"
+msgstr " Sleutelwoord Lokale voltooiing (^N^P)"
+
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Het einde van paragraaf getref"
 
-msgid "'thesaurus' option is empty"
-msgstr "'thesaurus' opsie is leeg"
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
 
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary' opsie is leeg"
 
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr "'thesaurus' opsie is leeg"
+
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Deursoek woordeboek: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (invoeg) Rol (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (vervang) Rol (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Soek vir: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Deursoek etikette."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Word bygevoeg"
 
@@ -303,198 +465,597 @@ msgstr " Word bygevoeg"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Soekend..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Terug by oorspronklike"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Woord van ander reël"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Die enigste treffer"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "treffer %d van %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "treffer %d"
 
-#. Skip further arguments but do continue to
-#. * search for a trailing command.
-#, c-format
-msgid "E106: Unknown variable: \"%s\""
-msgstr "E106: Onbekende veranderlike: \"%s\""
+#: ../eval.c:137
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: Onverwagte karakters voor '='"
 
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: Ontbrekende hakies: %s"
+#: ../eval.c:138
+#, fuzzy, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E322: reëlnommer buite perke: %<PRId64> verby die einde"
 
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: Geen veranderlike: \"%s\""
-
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: Ontbrekende ':' na '?'"
-
-msgid "E110: Missing ')'"
-msgstr "E110: Ontbrekende ')'"
-
-msgid "E111: Missing ']'"
-msgstr "E111: Ontbrekende ']'"
-
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: Opsienaam ontbreek: %s"
-
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: Onbekende opsie: %s"
-
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: Ontbrekende aanhalingsteken: %s"
-
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: Ontbrekende aanhalingsteken: %s"
-
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: Ongeldige parameters vir funksie %s"
-
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: Onbekende funksie: %s"
-
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: Te veel parameters vir funksie: %s"
-
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Te min parameters vir funksie: %s"
-
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: <SID> word buite skripkonteks gebruik: %s"
-
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
-msgid "&Ok"
-msgstr "&Ok"
-
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld reëls: "
-
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Kanselleer"
-
-msgid "called inputrestore() more often than inputsave()"
-msgstr "inputrestore() is meer gereeld as inputsave() geroep"
-
-msgid "E655: Too many symbolic links (cycle?)"
-msgstr "E655: Te veel simboliese skakels (siklus?)"
-
-msgid "E240: No connection to Vim server"
-msgstr "E240: Geen verbinding met Vim bediener"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Kon bediener-terugvoer nie lees nie"
-
-msgid "E258: Unable to send to client"
-msgstr "E258: Kan nie na kliënt stuur nie"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Kan nie na %s stuur nie"
-
-msgid "(Invalid)"
-msgstr "(Ongeldig)"
-
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Ongedefinieerde veranderlike: %s"
 
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: Ongeldige veranderlikenaam: %s"
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr "E111: Ontbrekende ']'"
 
+#: ../eval.c:141
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "E487: Parameter moet positief wees"
+
+#: ../eval.c:143
+#, fuzzy, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E487: Parameter moet positief wees"
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: Kan nie tydelike lêer vind vir skryf nie"
+
+#: ../eval.c:145
+#, fuzzy
+msgid "E714: List required"
+msgstr "E471: Parameter benodig"
+
+#: ../eval.c:146
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: Funksienaam vereis"
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Te veel parameters vir funksie: %s"
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
+#, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funksie %s bestaan alreeds, gebruik ! om te vervang"
 
+#: ../eval.c:151
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: Buffer met hierdie naam bestaan alreeds"
+
+#: ../eval.c:152
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: Funksienaam vereis"
+
+#: ../eval.c:153
+#, fuzzy
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E360: Kan nie dop met -f opsie uitvoer nie"
+
+#: ../eval.c:154
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr ""
+
+#: ../eval.c:155
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: Onbekende funksie: %s"
+
+#: ../eval.c:156
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: Ongeldige veranderlikenaam: %s"
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E138: Kan nie viminfo lêer %s stoor nie!"
+
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E69: Ontbrekende ] na %s%%["
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: Ontbrekende hakies: %s"
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: Geen veranderlike: \"%s\""
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: Ontbrekende ':' na '?'"
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+#, fuzzy
+msgid "E692: Invalid operation for Lists"
+msgstr "E449: Ongeldige uitdrukking ontvang"
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: Ongeldige parameters vir funksie %s"
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: Ongeldige parameters vir funksie %s"
+
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: Kan nie dop met -f opsie uitvoer nie"
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr "E110: Ontbrekende ')'"
+
+#: ../eval.c:4609
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: Kan nie laaste buffer uitlaai nie"
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: Opsienaam ontbreek: %s"
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: Onbekende opsie: %s"
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: Ontbrekende aanhalingsteken: %s"
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: Ontbrekende aanhalingsteken: %s"
+
+#: ../eval.c:5084
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: Ontbrekende gelykaanteken: %s"
+
+#: ../eval.c:5091
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: Ontbrekende '=': %s"
+
+#: ../eval.c:6475
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E242: Ontbrekende kleur: %s"
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E242: Ontbrekende kleur: %s"
+
+#: ../eval.c:6524
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: Ontbrekende ':endfunction'"
+
+#: ../eval.c:6555
+#, fuzzy
+msgid "E724: variable nested too deep for displaying"
+msgstr "E22: Skripte te diep ge-nes"
+
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Te veel parameters vir funksie: %s"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: Ongeldige parameters vir funksie %s"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Onbekende funksie: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Te min parameters vir funksie: %s"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> word buite skripkonteks gebruik: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Nommer vereis na ="
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "Ongeldige parameter vir"
+
+#: ../eval.c:7907
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "Te veel redigeer-parameters"
+
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: Kieslys bestaan slegs in 'n ander modus"
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr "&Ok"
+
+#: ../eval.c:8676
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: binding bestaan alreeds vir %s"
+
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr " vim [parameters] "
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld reëls: "
+
+#: ../eval.c:9291
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: Onbekende funksie: %s"
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr "inputrestore() is meer gereeld as inputsave() geroep"
+
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "Te veel redigeer-parameters"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E481: Geen omvang toegelaat nie"
+
+#: ../eval.c:11140
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E596: Ongeldige font(e)"
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
+
+#: ../eval.c:12466
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: Te veel simboliese skakels (siklus?)"
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "Ongeldige parameter vir"
+
+#: ../eval.c:13776
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: Drukker-seleksie het gefaal"
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr "(Ongeldig)"
+
+#: ../eval.c:14590
+#, fuzzy
+msgid "E677: Error writing temp file"
+msgstr "E208: Kan nie skryf na \"%s\""
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+#, fuzzy
+msgid "E730: using List as a String"
+msgstr "E374: Ontbrekende ] in formaatstring"
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, fuzzy, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E93: Meer as een treffer vir %s"
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E46: Kan nie lees-alleen veranderlike stel nie \"%s\""
+
+#: ../eval.c:16724
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: Funksienaam moet met 'n hoofletter begin: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E284: Kan nie IC waardes stel nie"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Ongedefinieerde funksie: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Ontbrekende '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Kan nie IC waardes stel nie"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Ongeldige parameter: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Ongeldige parameter: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Ontbrekende ':endfunction'"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: Funksienaam moet met 'n hoofletter begin: %s"
+
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Kan funksie %s nie herdefinieer nie: Dit is in gebruik"
 
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E128: Funksienaam moet met 'n hoofletter begin: %s"
+
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Funksienaam vereis"
 
-#, c-format
-msgid "E128: Function name must start with a capital: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: Funksienaam moet met 'n hoofletter begin: %s"
 
-#, c-format
-msgid "E130: Undefined function: %s"
-msgstr "E130: Ongedefinieerde funksie: %s"
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Funksienaam moet met 'n hoofletter begin: %s"
 
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Kan funksie %s nie verwyder nie: Dit is in gebruik"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Funksieroepdiepte is groter as 'maxfuncdepth'"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "roep %s"
 
+#: ../eval.c:18651
+#, c-format
 msgid "%s aborted"
 msgstr "%s gekanselleer"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s lewer #%<PRId64> op"
 
-#, c-format
-msgid "%s returning \"%s\""
+#: ../eval.c:18670
+#, fuzzy, c-format
+msgid "%s returning %s"
 msgstr "%s lewer \"%s\" op"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "vervolg in %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: ':return' buite funksie"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -502,253 +1063,114 @@ msgstr ""
 "\n"
 "# globale veranderlikes:\n"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Ontfoutmodus begin nou.  Tik \"cont\" om te verlaat."
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+"\n"
+"\tLaas gestel vanaf "
 
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "reël %<PRId64>: %s"
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "Geen ingeslote lêers nie"
 
-#, c-format
-msgid "cmd: %s"
-msgstr "cmd: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Inspeksiepunt in \"%s%s\" reël %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Inspeksiepunt kon nie gevind word nie: %s"
-
-msgid "No breakpoints defined"
-msgstr "Geen inspeksiepunte gedefinieer nie"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  reël %<PRId64>"
-
-msgid "Save As"
-msgstr "Stoor As"
-
-#, c-format
-msgid "Save changes to \"%.*s\"?"
-msgstr "Stoor veranderinge na \"%.*s\"?"
-
-msgid "Untitled"
-msgstr "Ongetiteld"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Buffer \"%s\" is nie geskryf sedert vorige wysiging nie"
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Waarskuwing: Ander buffer onverwags betree (kyk na outobevele)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Daar is net een lêer om te bewerk"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Kan nie vóór die eerste lêer gaan nie"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Kan nie verby die laaste lêer gaan nie"
-
-msgid "E666: compiler not supported: %s"
-msgstr "E666: vertaler word nie ondersteun nie: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Besig om te soek vir \"%s\" in \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Besig om te soek vir \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "kon nie in 'runtimepath' gevind word nie: \"%s\""
-
-msgid "Source Vim script"
-msgstr "Voer Vim skrip uit"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Kan nie gids uitvoer nie: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "kon nie \"%s\" uitvoer nie"
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "reël %<PRId64>: kon nie \"%s\" uitvoer nie"
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "besig om \"%s\" uit te voer"
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "reël %<PRId64>: voer nou \"%s\" uit"
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "%s klaar uitgevoer"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Waarskuwing: Verkeerde reëlskeiding, ^M ontbreek dalk"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: ':scriptencoding' buite 'n uitvoerlêer gebruik"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: ':finish' buite 'n uitvoerlêer gebruik"
-
-#, c-format
-msgid "Page %d"
-msgstr "Bladsy %d"
-
-msgid "No text to be printed"
-msgstr "Geen teks om te druk nie"
-
-#, c-format
-msgid "Printing page %d (%d%%)"
-msgstr "Druk nou bladsy %d (%d%%)"
-
-#, c-format
-msgid " Copy %d of %d"
-msgstr " Kopie %d van %d"
-
-#, c-format
-msgid "Printed: %s"
-msgstr "Gedruk: %s"
-
-#, c-format
-msgid "Printing aborted"
-msgstr "Drukkery gestaak"
-
-msgid "E455: Error writing to PostScript output file"
-msgstr "E455: Kan nie na 'PostScript' afvoerlêer skryf nie"
-
-msgid "E624: Can't open file \"%s\""
-msgstr "E624: Kan nie lêer \"%s\" oopmaak nie"
-
-#, c-format
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: Kan nie 'PostScript' hulpbron-lêer \"%s\" lees nie"
-
-msgid "E618: file \"%s\" is not a PostScript resource file"
-msgstr "E618: Lêer \"%s\" is nie 'n 'PostScript' hulpbron-lêer nie"
-
-msgid "E619: file \"%s\" is not a supported PostScript resource file"
-msgstr "E619: Lêer \"%s\" is nie 'n ondersteunde 'PostScript' hulpbron-lêer nie"
-
-#, c-format
-msgid "E621: \"%s\" resource file has wrong version"
-msgstr "E621: \"%s\" die hulpbron lêer het die verkeerde weergawe"
-
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: Kan nie 'PostScript' afvoerlêer oopmaak nie"
-
-#, c-format
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: Kan nie lêer %s oopmaak nie"
-
-msgid "E456: Can't find PostScript resource file \"prolog.ps\""
-msgstr "E456: Kan nie 'PostScript' hulpbron-lêer \"prolog.ps\" lees nie"
-
-msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: Kan nie 'PostScript' hulpbron-lêer \"%s\" vind nie"
-
-#, c-format
-msgid "E620: Unable to convert from multi-byte to \"%s\" encoding"
-msgstr "E620: Kon nie van wye-greep na \"%s\" enkodering verander nie"
-
-msgid "Sending to printer..."
-msgstr "Besig om te stuur na drukker..."
-
-msgid "E365: Failed to print PostScript file"
-msgstr "E365: Kon nie 'PostScript' lêer druk nie"
-
-msgid "Print job sent."
-msgstr "Druktaak gestuur."
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Huidige %staal: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Kan nie taal na \"%s\" verander nie"
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktaal %03o"
 
+#: ../ex_cmds.c:145
+#, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Oktaal %o"
 
+#: ../ex_cmds.c:146
+#, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktaal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Skuif reëls in hulself in"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 reël geskuif"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> reëls geskuif"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> reëls filtreer"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Outobevele mag nie die huidige buffer verander nie"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Ongestoor sedert vorige verandering]\n"
 
+#: ../ex_cmds.c:1424
+#, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s in reël: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Te veel foute, slaan die res van die lêer oor"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Besig om viminfo lêer \"%s\"%s%s%s te lees"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " inligting"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " merkers"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "Geen ingeslote lêers nie"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " GEFAAL"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo lêer is nie skryfbaar nie: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Kan nie viminfo lêer %s stoor nie!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Besig om viminfo lêer \"%s\" te stoor"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Hierdie viminfo lêer is gegenereer deur Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -756,91 +1178,141 @@ msgstr ""
 "# Jy mag dit wysig as jy versigtig is!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Waarde van 'encoding' toe hierdie lêer gestoor is\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Ongeldige beginkarakter"
 
-#. Overwriting a file that is loaded in another buffer is not a
-#. * good idea.
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Lêer is gelaai in ander buffer"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Skryf gedeeltelike lêer?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Gebruik ! om gedeeltelike buffer te skryf"
 
-#, c-format
-msgid "Overwrite existing file \"%.*s\"?"
+#: ../ex_cmds.c:2281
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
 msgstr "Oorskryf bestaande lêer \"%.*s\"?"
 
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: Lêer bestaan (gebruik ! om te dwing)"
+
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Geen lêernaam vir buffer %<PRId64> nie"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Lêer nie gestoor nie: Stoor is afgeskakel deur die 'write' opsie"
 
-#, c-format
+#: ../ex_cmds.c:2434
+#, fuzzy, c-format
 msgid ""
-"'readonly' option is set for \"%.*s\".\n"
+"'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "'readonly' opsie is aan vir \"%.*s\".\n"
 "Wil jy dit forseer?"
 
-msgid "Edit File"
-msgstr "Verander lêer"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "is lees-alleen (gebruik ! om te dwing)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Outobevele het nuwe buffer %s onverwags geskrap"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nie-numeriese parameter vir :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Dop bevele nie toegelaat in rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Patrone kan nie deur letters afgebaken word nie"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "vervang met %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Onderbreek) "
 
+#: ../ex_cmds.c:4384
+#, fuzzy
+msgid "1 match"
+msgstr "; treffer "
+
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 vervanging"
 
+#: ../ex_cmds.c:4387
+#, fuzzy, c-format
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> veranderinge"
+
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> vervangings"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " op 1 reël"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " op %<PRId64> reëls"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan nie :global rekursief doen nie "
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Patroon ontbreek uit globaal"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Patroon gevind in elke reël: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Patroon nie gevind nie"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -850,134 +1322,339 @@ msgstr ""
 "# Vorige Vervangstring:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Bly kalm!"
 
+#: ../ex_cmds.c:4717
+#, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Jammer, geen '%s' hulp vir %s nie"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Jammer, geen hulp vir %s nie"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Jammer, hulplêer \"%s\" kan nie gevind word nie"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Nie 'n gids nie: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Kan nie %s oopmaak om te skryf nie"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Kan nie %s oop maak om te lees nie"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 'n Mengsel van hulplêer enkoderings in 'n taal: %s"
 
+#: ../ex_cmds.c:5565
+#, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplikaat etiket \"%s\" in lêer %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Onbekende funksie: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Ontbrekende tekennaam"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Te veel tekens gedefinieer"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Ongeldige tekenteks: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Onbekende opsie: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Ontbrekende tekennommer"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ongeldige buffernaam: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Ongeldige teken ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NIE GEVIND NIE)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (word nie ondersteun nie)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Geskrap]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Ontfoutmodus begin nou.  Tik \"cont\" om te verlaat."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "reël %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "cmd: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Inspeksiepunt in \"%s%s\" reël %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Inspeksiepunt kon nie gevind word nie: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Geen inspeksiepunte gedefinieer nie"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  reël %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Stoor veranderinge na \"%.*s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Ongetiteld"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Buffer \"%s\" is nie geskryf sedert vorige wysiging nie"
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "Waarskuwing: Ander buffer onverwags betree (kyk na outobevele)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Daar is net een lêer om te bewerk"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Kan nie vóór die eerste lêer gaan nie"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Kan nie verby die laaste lêer gaan nie"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: vertaler word nie ondersteun nie: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Besig om te soek vir \"%s\" in \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Besig om te soek vir \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "kon nie in 'runtimepath' gevind word nie: \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Kan nie gids uitvoer nie: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "kon nie \"%s\" uitvoer nie"
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "reël %<PRId64>: kon nie \"%s\" uitvoer nie"
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "besig om \"%s\" uit te voer"
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "reël %<PRId64>: voer nou \"%s\" uit"
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "%s klaar uitgevoer"
+
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "1 reël meer"
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr " vim [parameters] "
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr " vim [parameters] "
+
+#: ../ex_cmds2.c:2771
+#, fuzzy
+msgid "environment variable"
+msgstr "Stel die 'LANG' omgewingsveranderlike na jou lokaal toe"
+
+#: ../ex_cmds2.c:2773
+#, fuzzy
+msgid "error handler"
+msgstr "Fout en onderbreking"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Waarskuwing: Verkeerde reëlskeiding, ^M ontbreek dalk"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: ':scriptencoding' buite 'n uitvoerlêer gebruik"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: ':finish' buite 'n uitvoerlêer gebruik"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Huidige %staal: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Kan nie taal na \"%s\" verander nie"
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Betree Ex modus.  Tik \"visual\" om na Normale modus terug te keer."
 
-#. must be at EOF
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: By lêereinde"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Bevel te rekursief"
 
+#: ../ex_docmd.c:1006
+#, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Uitsondering nie gevang nie: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Einde van uitvoerlêer"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Einde van funksie "
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Dubbelsinnige gebruik van gebruiker-gedefinieerde bevel"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Nie 'n verwerkerbevel nie"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Terugwaardse omvang gegee"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Terugwaardse omvang gegee, OK om te ruil"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Gebruik w of w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Jammer, die bevel is nie geïmplementeer nie"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Slegs een lêernaam toegelaat"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Nog 1 lêer om te bewerk.  Stop in elk geval?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Nog %d lêers om te bewerk.  Stop in elk geval?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Nog 1 lêer om te bewerk"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Nog %<PRId64> lêers om te bewerk"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Bevel bestaan alreeds: gebruik ! om te herdefinieer"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -985,246 +1662,351 @@ msgstr ""
 "\n"
 "    Naam        Args Reeks Klaar     Definisie"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Geen gebruiker-gedefinieerde bevele gevind nie"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Geen eienskappe gespesifiseer nie"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Ongeldige aantal parameters"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Telling kan nie twee keer gespesifiseer word nie"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Ongeldige verstekwaarde vir telling"
 
-msgid "E179: argument required for complete"
+#: ../ex_docmd.c:4625
+#, fuzzy
+msgid "E179: argument required for -complete"
 msgstr "E179: parameter nodig vir voltooiing"
 
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: Ongeldige voltooiingswaarde: %s"
-
-msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: Voltooiingsargument words slegs toegelaat vir eie voltooiing"
-
-msgid "E467: Custom completion requires a function argument"
-msgstr "E467: Eie voltooiing benodig 'n funksie parameter"
-
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Ongeldige eienskap: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Ongeldige bevelnaam"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Gebruiker-gedefinieerde bevele moet met 'n hoofletter begin"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Dubbelsinnige gebruik van gebruiker-gedefinieerde bevel"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Geen gebruiker-gedefinieerde bevel nie: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: Ongeldige voltooiingswaarde: %s"
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr "E468: Voltooiingsargument words slegs toegelaat vir eie voltooiing"
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr "E467: Eie voltooiing benodig 'n funksie parameter"
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Kan nie kleurskema %s vind nie"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Goeiedag, Vim gebruiker!"
 
-msgid "Edit File in new window"
-msgstr "Bewerk lêer in nuwe venster"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Kan nie laaste venster toemaak nie"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "Daar is alreeds slegs een venster"
+
+#: ../ex_docmd.c:6004
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "Bladsy %d"
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Geen ruillêer"
 
-msgid "Append File"
-msgstr "Las aan by lêer"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr "E509: Kan rugsteunlêer nie skep nie (gebruik ! om te dwing)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Geen vorige gids nie"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Onbekend"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: ':winsize' benodig twee nommer parameters"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Vensterposisie: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Verkryging van vensterposisie is nie vir hierdie platform "
 "geïmplementeer nie"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos benodig twee parameters"
 
-msgid "Save Redirection"
-msgstr "Stoor Herversturing"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
+msgstr "Kan nie gids uitvoer nie: \"%s\""
 
-msgid "Save View"
-msgstr "Stoor Oorsig"
-
-msgid "Save Session"
-msgstr "Stoor Sessie"
-
-msgid "Save Setup"
-msgstr "Stoor konfigurasie"
-
+#: ../ex_docmd.c:7268
+#, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" bestaan (gebruik ! om te dwing)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Kan \"%s\" nie oopmaak vir skryf nie"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr ""
 "E191: Parameter moet 'n letter of 'n terug/vorentoe aanhalingsteken wees"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursiewe gebruik van ':normal' te diep"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Geen alternatiewe lêernaam vir '#' nie"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: geen outobevel-lêernaam om \"<afile>\" mee te vervang nie"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: geen outobevel buffernommer om \"<abuf>\" mee te vervang nie"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: geen outobevel treffernaam om \"<amatch>\" mee te vervang nie"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: geen ':source' lêernaam om \"<sfile>\" mee te vervang nie"
 
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: geen ':source' lêernaam om \"<sfile>\" mee te vervang nie"
+
+#: ../ex_docmd.c:7903
+#, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Leë lêernaam vir '%' of '#', werk slegs met \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Evalueer na 'n leë string"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Kan 'viminfo' lêer nie oopmaak om te lees nie"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Geen digrawe in hierdie weergawe nie"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Kan nie uitsonderings ':throw' met 'Vim' voorvoegsel nie"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Uitsondering gegooi: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Uitsondering het klaar gemaak: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Uitsondering weg gegooi: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
+#, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, reël %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
+#, c-format
 msgid "Exception caught: %s"
 msgstr "Uitsondering gevang: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s is afwagtend gemaak"
 
+#: ../ex_eval.c:679
+#, c-format
 msgid "%s resumed"
 msgstr "%s teruggekeer"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s weg gegooi"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Uitsondering"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Fout en onderbreking"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Fout"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Onderbreek"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: geneste ':if' te diep"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: ':endif' sonder ':if'"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: ':else' sonder ':if'"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: ':elseif' sonder ':if'"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: meer as een ':else'"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: ':elseif' na ':else'"
 
-msgid "E585: :while nesting too deep"
+#: ../ex_eval.c:941
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
 msgstr "E585: ':while' te diep genes"
 
-msgid "E586: :continue without :while"
+#: ../ex_eval.c:1028
+#, fuzzy
+msgid "E586: :continue without :while or :for"
 msgstr "E586: ':continue' sonder ':while'"
 
-msgid "E587: :break without :while"
+#: ../ex_eval.c:1061
+#, fuzzy
+msgid "E587: :break without :while or :for"
 msgstr "E587: ':break' sonder ':while'"
 
+#: ../ex_eval.c:1102
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: Ontbrekende ':endwhile'"
+
+#: ../ex_eval.c:1104
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: Ontbrekende ':endwhile'"
+
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: geneste ':try' te diep"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: ':catch' sonder ':try'"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: ':catch' na ':finally'"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: ':finally' sonder ':try'"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: meer as een ':finally'"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: ':endtry' sonder ':try'"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: ':endfunction' nie in 'n funksie nie"
 
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: Nie toegelaat in sandput nie"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: Geen buffer wat by %s pas nie"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "etiketnaam"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " tipe lêer\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history' opsie is nul"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1233,194 +2015,304 @@ msgstr ""
 "\n"
 "# %s Geskiedenis (van nuutste na oudste):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Bevelreël"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Soekstring"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Uitdrukking"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Invoer Lyn"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: 'cmd_pchar' verby die einde van opdraglengte"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktiewe venster of buffer geskrap"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Ongeldige pad: '**[nommer]' moet aan die einde van 'n pad wees of "
+"gevolg wees deur %s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Kan nie gids \"%s\" in 'cdpath' vind nie"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Kan lêer \"%s\" nie vind in pad nie"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Geen gids \"%s\" meer gevind in 'cdpath' nie"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Geen lêer \"%s\" meer gevind in pad nie"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* Outobevele mag nie die huidige buffer verander nie"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Ongeldige lêernaam"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "is 'n gids"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "is nie 'n lêer nie"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nuwe lêer]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Toestemming Geweier]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: '*ReadPre' outobevele het die lêer onleesbaar gemaak"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: '*ReadPre' outobevele mag nie die huidige buffer verander nie"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Lees nou vanaf 'stdin'...\n"
 
-msgid "Reading from stdin..."
-msgstr "Lees nou vanaf stdin... "
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Omsetting het lêer onleesbaar gemaak!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[RO]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 karakter"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR ontbreek]"
 
-msgid "[NL found]"
-msgstr "[NL gevind]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[lang reëls verdeel]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NIE omgesit nie]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[omgesit]"
 
-msgid "[crypted]"
-msgstr "[gekodeer]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ONWETTIGE GREEP in reël %<PRId64>]"
 
-msgid "[CONVERSION ERROR]"
-msgstr "[OMSETTINGSFOUT]"
-
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[ONWETTIGE GREEP in reël %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LEESFOUTE]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Kan nie tydelike lêer vir omsetting vind nie"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Omsetting met 'charconvert' het gefaal"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "kan afvoer van 'charconvert' nie lees nie"
 
+#: ../fileio.c:2437
+#, fuzzy
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr "Geen passende outobevele nie"
+
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Outobevele het die skryfbuffer geskrap of uitgelaai"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Outobevel het etlike reëls op onverwagse wyse verander "
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans laat nie skryf toe van onveranderde buffers nie"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Gedeeltelike skryf word nie toegelaat vir NetBeans buffers nie"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "is nie 'n lêer of 'n skryfbare toestel nie"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "is lees-alleen (gebruik ! om te dwing)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Kan nie na rugsteunlêer skryf nie (gebruik ! om te dwing)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Sluitfout vir rugsteunlêer (gebruik ! om te dwing)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Kan rugsteunlêer nie lees nie (gebruik ! om te dwing)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Kan rugsteunlêer nie skep nie (gebruik ! om te dwing)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Kan rugsteunlêer nie skep nie (gebruik ! om te dwing)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Die hulpbronvurk sal verlore gaan (gebruik ! om te dwing)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Kan nie tydelike lêer vind vir skryf nie"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Kan nie omsit nie (gebruik ! om te skryf sonder omsetting)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Kan lêer nie oopmaak vir skryf nie"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Kan lêer nie oopmaak vir skryf nie"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: 'Fsync' het gefaal"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Sluiting gefaal"
 
-msgid "E513: write error, conversion failed"
+#: ../fileio.c:3436
+#, fuzzy
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: skryffout, omsetting gefaal"
 
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: skryffout (lêerstelsel vol?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " OMSETTINGSFOUT"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "reël %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Toestel]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nuut]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " bygevoeg"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " geskryf"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: kan oorspronklike lêer nie stoor nie"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: kan leë oorspronglêer nie 'touch' nie"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Kan rugsteunlêer nie verwyder nie"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1428,75 +2320,96 @@ msgstr ""
 "\n"
 "WAARSKUWING: Oorspronklike lêer mag verlore of beskadig wees\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "moenie die verwerker verlaat voor die lêer suksesvol geskryf is nie!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos formaat]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac formaat]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix formaat]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 reël, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> reëls, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 karakter"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> karakters"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Onvoltooide laaste reël]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "WAARSKUWING: Die lêer het verander sedert dit gelees is!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Wil jy regtig soontoe skryf?"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Kan nie skryf na \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Kan \"%s\" nie sluit nie"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Kan \"%s\" nie lees nie"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: 'FileChangedShell' outobevel het buffer verwyder"
 
-#, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
+#: ../fileio.c:4894
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Waarskuwing: Lêer \"%s\" is nie meer beskikbaar nie"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1505,26 +2418,42 @@ msgstr ""
 "W12: Waarskuwing: Lêer \"%s\" het verander sedert bewerking begin het en die "
 "buffer in Vim het ook verander"
 
+#: ../fileio.c:4907
+#, fuzzy
+msgid "See \":help W12\" for more info."
+msgstr "Sien \":help W11\" vir meer inligting."
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Waarskuwing: Lêer \"%s\" het verander sedert bewerking begin het"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr "Sien \":help W11\" vir meer inligting."
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Waarskuwing: Modus van lêer \"%s\" het verander sedert bewerking begin "
 "het"
 
+#: ../fileio.c:4915
+#, fuzzy
+msgid "See \":help W16\" for more info."
+msgstr "Sien \":help W11\" vir meer inligting."
+
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Waarskuwing: Lêer \"%s\" is geskep sedert bewerking begin het"
 
-msgid "See \":help W11\" for more info."
-msgstr "Sien \":help W11\" vir meer inligting."
-
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Waarskuwing"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1532,33 +2461,48 @@ msgstr ""
 "&OK\n"
 "&Laai Lêer"
 
+#: ../fileio.c:5065
+#, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Kon nie voorberei vir herlaai nie \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Kon nie \"%s\" herlaai nie"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Geskrap--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Geen sodanige groep nie: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Ongeldige karakter na *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Geen sodanige gebeurtenis nie: %s"
 
+#: ../fileio.c:5907
+#, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Geen sodanige groep of gebeurtenis nie: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1566,383 +2510,805 @@ msgstr ""
 "\n"
 "--- Outobevele ---"
 
+#: ../fileio.c:6293
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr "ongeldige buffernommer"
+
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Kan nie outobevele uitvoer vir 'ALL' gebeurtenisse nie"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Geen passende outobevele nie"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: outobevele te diep genes"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s outobevele vir \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Voer %s uit"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "outobevel %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Ontbrekende {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Ontbrekende }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Geen vou gevind nie"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Kan nie vou skep met huidige 'foldmethod' nie"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Kan nie vou skrap met huidige 'foldmethod' nie"
 
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr "+--%3ld reëls gevou "
+
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Voeg by leesbuffer"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursiewe binding"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: globale afkorting bestaan alreeds vir %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: globale binding bestaan alreeds vir %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: afkorting bestaan already vir %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: binding bestaan alreeds vir %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Geen afkorting gevind nie"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Geen binding gevind nie"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Ongeldige modus"
 
-msgid "<cannot open> "
-msgstr "<kan nie oopmaak nie> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Geen reëls in buffer--"
 
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: 'vim_SelFile': kan font %s nie kry nie"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Bevel gekanselleer"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: 'vim_SelFile': Kan nie terugkeer na huidige gids nie"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Parameter benodig"
 
-msgid "Pathname:"
-msgstr "Gidsnaam:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ moet gevolg word deur /, ? of &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: Kan nie huidige gids verkry nie"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Ongeldig in bevelreël venster: <CR> voer uit, CTRL-C stop"
 
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Kanselleer"
-
-msgid "Vim dialog"
-msgstr "Vim dialooghokkie"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Rolstaafelement: Kon nie pikselmatriks-duimnael se geometrie kry nie"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Kan nie BalloonEval skep met beide boodskap en terugroep nie"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Kan nie die GUI begin nie"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Kan nie lees uit \"%s\" nie"
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Kan nie GUI begin nie, geen geldige font gevind nie"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' ongeldig"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Waarde van 'imactivatekey' is ongeldig"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Kan nie kleur %s toeken nie"
-
-msgid "Vim dialog..."
-msgstr "Vim dialooghokkie..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Ja\n"
-"&Nee\n"
-"&Kanselleer"
+"E12: Bevel uit exrc/vimrc nie toegelaat in huidige gids- of etiketsoektog nie"
 
-msgid "Input _Methods"
-msgstr "Invoer _Metodes"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Ontbrekende ':endif'"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Soek en Vervang..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Ontbrekende ':endtry'"
 
-msgid "VIM - Search..."
-msgstr "VIM - Soek..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Ontbrekende ':endwhile'"
 
-msgid "Find what:"
-msgstr "Soek na:"
+#: ../globals.h:1006
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: Ontbrekende ':endif'"
 
-msgid "Replace with:"
-msgstr "Vervang met:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: ':endwhile' sonder ':while'"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Tref slegs presiese woord"
+#: ../globals.h:1008
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr "E580: ':endif' sonder ':if'"
 
-#. match case button
-msgid "Match case"
-msgstr "Tref kas"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Lêer bestaan (gebruik ! om te dwing)"
 
-msgid "Direction"
-msgstr "Rigting"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Bevel het gefaal"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Op"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Interne fout"
 
-msgid "Down"
-msgstr "Af"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Onderbreek"
 
-msgid "Find Next"
-msgstr "Vind volgende"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Ongeldige adres"
 
-msgid "Replace"
-msgstr "Vervang"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Ongeldige parameter"
 
-msgid "Replace All"
-msgstr "Vervang alles"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Het die \"die\" opdrag ontvang van sessiebestuurder\n"
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Hoofvenster onverwags verwoes\n"
-
-msgid "Font Selection"
-msgstr "Fontkeuse"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "'CUT_BUFFER0' is gebruik in plaas van leë seleksie"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "Directories"
-msgstr "Gidse"
-
-msgid "Help"
-msgstr "Hulp"
-
-msgid "Files"
-msgstr "Lêers"
-
-msgid "Selection"
-msgstr "Seleksie"
-
-msgid "Undo"
-msgstr "Herroep"
-
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Kan nie venster titel vind nie \"%s\""
-
+#: ../globals.h:1015
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Parameter nie bekend: \"-%s\"; Gebruik die OLE weergawe."
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Ongeldige parameter: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Kon nie venster oopmaak binne 'n MDI toepassing nie"
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Ongeldige uitdrukking: %s"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Vind string (gebruik '\\\\' om 'n '\\' te vind"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Ongeldige omvang"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Vind & vervang string (gebruik '\\\\' om 'n '\\' te vind"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Ongeldige bevel"
 
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" is 'n gids"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Ongeldige rolgrootte"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Kan nie kleurkaart-inskrywing toeken nie, sommige kleure mag "
-"verkeerd wees"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"E250: Fonte vir die volgende karakterstelle ontbreek in fontversameling %s:"
 
+#: ../globals.h:1024
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Fontstel naam: %s"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Biblioteekroep het gefaal vir \"%s\"()"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Merker het ongeldige reëlnommer"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Merker nie gestel nie"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Kan nie wysig nie, 'modifiable' is af"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skripte te diep ge-nes"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Geen alternatiewe lêer nie"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Afkorting bestaan nie"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Geen ! toegelaat nie"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI kan nie gebruik word nie: Nie tydens kompilering gekies nie"
+
+#: ../globals.h:1036
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Font '%s' is nie 'n vaste-wydte font nie"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Geen sodanige uitliggroepnaam nie: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Nog geen ingevoegde teks nie"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Geen vorige bevelreël nie"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Geen so 'n binding nie"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Geen treffer nie"
+
+#: ../globals.h:1041
 #, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Fonstel naam: %s\n"
+msgid "E480: No match: %s"
+msgstr "E480: Geen treffer: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Geen lêernaam"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Geen vorige vervangingspatroon nie"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Geen vorige bevel nie"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Geen vorige patroon nie"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Geen omvang toegelaat nie"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Te min plek"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
+msgid "E482: Can't create file %s"
+msgstr "E482: Kan nie lêer %s skep nie"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Kan nie tydelike lêernaam kry nie"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
+msgid "E484: Can't open file %s"
+msgstr "E484: Kan nie lêer %s oopmaak nie"
 
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Font%<PRId64> wydte is nie twee keer díe van font0 nie\n"
-
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Font0 wydte: %<PRId64>\n"
+msgid "E485: Can't read file %s"
+msgstr "E485: Kan nie lêer %s lees nie"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Ongeskryf sedert vorige verandering (gebruik ! om te dwing)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Ongestoor sedert vorige verandering]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nul parameter"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nommer verwag"
+
+#: ../globals.h:1058
 #, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Kan nie foutlêer %s oopmaak nie"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Geheue op!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Patroon nie gevind nie"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Patroon nie gevind nie: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Parameter moet positief wees"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Kan nie terug gaan na die vorige gids nie"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Geen Foute"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
 msgstr ""
-"Font1 wydte: %<PRId64>\n"
-"\n"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul outomatiserings FOUT"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Beskadige trefferstring"
 
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Korrupte patroonprogram"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' opsie is aan (gebruik ! om te dwing)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Kan nie lees-alleen veranderlike stel nie \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Kan nie lees-alleen veranderlike stel nie \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Fout tydens lees van 'errorfile'"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Nie toegelaat in sandput nie"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Nie hier toegelaat nie"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Skermmodus instelling nie ondersteun nie"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Ongeldige rolgrootte"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' (dop) opsie is leeg"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Fout -- kon nie tekendata lees nie!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Sluitfout met ruillêer"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: etiketstapel leeg"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Bevel te kompleks"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Naam te lank"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Te veel ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Te veel lêername"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Oorbodige karakters"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Onbekende merker"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Kan nie plekhouers uitbrei nie"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' kan nie kleiner as 'winminheight' wees nie"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' kan nie kleiner as 'winminwidth' wees nie"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Fout tydens skryfoperasie"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nul telling"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Gebruik van '<SID>' buite skripkonteks"
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "E473: Interne fout"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr ""
+
+#: ../globals.h:1105
+#, fuzzy
+msgid "E749: empty buffer"
+msgstr "E279: Nie 'n SNiFF+ buffer nie"
+
+#: ../globals.h:1108
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: Ongeldige soekstring: %s"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Lêer is gelaai in ander buffer"
+
+#: ../globals.h:1110
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: Font \"%s\" is nie 'n vaste-wydte font nie"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Ongeldige registernaam: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "soektog het BO getref, gaan voort van ONDER af"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "soektog het ONDER getref, gaan voort van BO af"
+
+#: ../hardcopy.c:240
+msgid "E550: Missing colon"
+msgstr "E550: Ontbrekende dubbelpunt"
+
+#: ../hardcopy.c:252
+msgid "E551: Illegal component"
+msgstr "E551: Ongeldige komponent"
+
+#: ../hardcopy.c:259
+msgid "E552: digit expected"
+msgstr "E552: syfer verwag"
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr "Bladsy %d"
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr "Geen teks om te druk nie"
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "Druk nou bladsy %d (%d%%)"
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr " Kopie %d van %d"
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr "Gedruk: %s"
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr "Drukkery gestaak"
+
+#: ../hardcopy.c:1365
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: Kan nie na 'PostScript' afvoerlêer skryf nie"
+
+#: ../hardcopy.c:1747
+#, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E624: Kan nie lêer \"%s\" oopmaak nie"
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: Kan nie 'PostScript' hulpbron-lêer \"%s\" lees nie"
+
+#: ../hardcopy.c:1772
+#, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E618: Lêer \"%s\" is nie 'n 'PostScript' hulpbron-lêer nie"
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr ""
+"E619: Lêer \"%s\" is nie 'n ondersteunde 'PostScript' hulpbron-lêer nie"
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr "E621: \"%s\" die hulpbron lêer het die verkeerde weergawe"
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: Kan nie 'PostScript' afvoerlêer oopmaak nie"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: Kan nie lêer %s oopmaak nie"
+
+#: ../hardcopy.c:2583
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E456: Kan nie 'PostScript' hulpbron-lêer \"prolog.ps\" lees nie"
+
+#: ../hardcopy.c:2593
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E456: Kan nie 'PostScript' hulpbron-lêer \"%s\" vind nie"
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E456: Kan nie 'PostScript' hulpbron-lêer \"%s\" vind nie"
+
+#: ../hardcopy.c:2654
+#, fuzzy, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr "E620: Kon nie van wye-greep na \"%s\" enkodering verander nie"
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr "Besig om te stuur na drukker..."
+
+#: ../hardcopy.c:2881
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: Kon nie 'PostScript' lêer druk nie"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr "Druktaak gestuur."
+
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Voeg 'n nuwe databasis by"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Soek vir 'n patroon"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Wys hierdie boodskap"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Sluit 'n verbinding"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Herstel alle verbindings"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Wys verbindings"
 
+#: ../if_cscope.c:101
+#, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Gebruik: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr ""
 "Hierdie 'cscope' bevel ondersteun nie die splitsing van die venster nie.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Gebruik: 'cstag <ident>'"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: 'cstag': etiket nie gevind nie"
 
+#: ../if_cscope.c:461
+#, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: 'stat(%s)' fout: %d"
 
-msgid "E563: stat error"
-msgstr "E563: 'stat' fout"
-
+#: ../if_cscope.c:551
+#, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s is nie 'n gids of 'n geldige 'cscope' databasis nie"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "'cscope' databasis %s bygevoeg"
 
+#: ../if_cscope.c:616
+#, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: 'cscope' verbinding %<PRId64> kon nie gelees word nie"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: onbekende 'cscope' soektipe"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Kon nie 'cscope' pype skep nie"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Kon nie vurk vir 'cscope' nie"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "'cs_create_connection' uitvoering het misluk"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "'cs_create_connection' uitvoering het misluk"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Kon nie 'cscope' proses skep nie"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "'cs_create_connection': 'fdopen' vir 'to_fp' het misluk"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "'cs_create_connection': 'fdopen' vir 'fr_fp' het misluk"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Kon nie 'cscope' proses skep nie"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: geen 'cscope' verbindings nie"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: geen treffers gevind vir 'cscope' versoek %s van %s nie"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: ongeldige 'cscopequickfix' vlag %c vir %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: geen treffers gevind vir 'cscope' versoek %s van %s nie"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "'cscope' bevele:\n"
 
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s: (Gebruik: %s)"
 
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Kon nie 'cscope' databasis oopmaak nie: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: kan nie 'cscope' databasisinligting kry nie"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: duplikaat 'cscope' databasis nie bygevoeg nie"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: maksimum aantal 'cscope' verbindings bereik"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: 'cscope' verbinding %s nie gevind nie"
 
+#: ../if_cscope.c:1364
+#, c-format
 msgid "cscope connection %s closed"
 msgstr "'cscope' verbinding %s gesluit"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: fatale fout in 'cs_manage_matches'"
 
+#: ../if_cscope.c:1693
+#, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope etiket: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -1950,337 +3316,89 @@ msgstr ""
 "\n"
 "   #   reël"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "lêernaam / konteks / reël\n"
 
+#: ../if_cscope.c:1809
+#, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope fout: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Alle 'cscope' databasisse herstel"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "geen 'cscope' verbindings nie\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    databasis naam                      gidsvoorvoegsel\n"
 
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Jammer, hierdie bevel is afgeskakel, die Python biblioteek lêer kon "
-"nie gelaai word nie."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Kan nie Python rekursief roep nie"
-
-msgid "can't delete OutputObject attributes"
-msgstr "kan nie 'OutputObject' eienskappe skrap nie"
-
-msgid "softspace must be an integer"
-msgstr "'softspace' moet 'n heelgetal wees"
-
-msgid "invalid attribute"
-msgstr "ongeldige eienskap"
-
-msgid "writelines() requires list of strings"
-msgstr "'writelines()' benodig 'n lys van stringe"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Kon nie I/O objekte inwy nie"
-
-# njj: net 'n voorstel ..
-msgid "invalid expression"
-msgstr "ongeldige uitdrukking"
-
-msgid "expressions disabled at compile time"
-msgstr "uitdrukkings afgeskakel tydens kompilering"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "poging om na 'n geskrapte buffer te verwys"
-
-msgid "line number out of range"
-msgstr "reëlnommer buite omvang"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<buffervoorwerp (geskrap) by %8lX>"
-
-msgid "invalid mark name"
-msgstr "onbekende merknaam"
-
-msgid "no such buffer"
-msgstr "buffer bestaan nie"
-
-msgid "attempt to refer to deleted window"
-msgstr "poging om na geskrapte venster te verwys"
-
-msgid "readonly attribute"
-msgstr "leesalleen eienskap"
-
-msgid "cursor position outside buffer"
-msgstr "loperposisie buite buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<venster voorwerp (geskrap) by %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<verwyder voorwerp (onbekend) by %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<venster %d>"
-
-msgid "no such window"
-msgstr "geen sodanige venster nie"
-
-msgid "cannot save undo information"
-msgstr "kan nie herwin-inligting stoor nie"
-
-msgid "cannot delete line"
-msgstr "kan reël nie verwyder nie"
-
-msgid "cannot replace line"
-msgstr "kan reël nie vervang nie"
-
-msgid "cannot insert line"
-msgstr "kan reël nie byvoeg nie"
-
-msgid "string cannot contain newlines"
-msgstr "string kan nie 'newlines' bevat nie"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Jammer, hierdie bevel is afgeskakel, die Ruby biblioteeklêer kon nie "
-"gelaai word nie."
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Onbekende 'longjmp' status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Stel en herstel implimentasie/definisie"
-
-msgid "Show base class of"
-msgstr "Wys basisklas van"
-
-msgid "Show overridden member function"
-msgstr "Wys vervangde lidfunksie"
-
-msgid "Retrieve from file"
-msgstr "Gaan haal uit lêer"
-
-msgid "Retrieve from project"
-msgstr "Gaan haal uit projek"
-
-msgid "Retrieve from all projects"
-msgstr "Gaan haal uit alle projekte"
-
-msgid "Retrieve"
-msgstr "Gaan haal"
-
-msgid "Show source of"
-msgstr "Wys kode van"
-
-msgid "Find symbol"
-msgstr "Vind simbool"
-
-msgid "Browse class"
-msgstr "Kyk klas deur"
-
-msgid "Show class in hierarchy"
-msgstr "Wys klas in hiërargie"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Wys klas in beperkte hiërargie"
-
-msgid "Xref refers to"
-msgstr "Xref verwys na"
-
-msgid "Xref referred by"
-msgstr "Xref verwys deur"
-
-msgid "Xref has a"
-msgstr "Xref het 'n"
-
-msgid "Xref used by"
-msgstr "Xref gebruik deur"
-
-msgid "Show docu of"
-msgstr "Wys 'docu' van"
-
-msgid "Generate docu for"
-msgstr "Genereer 'docu' vir"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Kan nie 'n verbinding met 'SNiFF+' maak nie. Kyk of die omgewing reg is "
-"('sniffemacs' moet in '$PATH' gevind word).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Fout gedurende lees. Verbinding gebreek"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ is tans"
-
-msgid "not "
-msgstr "nie "
-
-msgid "connected"
-msgstr "gekonnekteer"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Onbekende SNiFF+ versoek: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Fout in konnekteer met SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ is nie gekonnekteer nie"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Nie 'n SNiFF+ buffer nie"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Fout gedurende stoor. Verbinding gebreek"
-
-msgid "invalid buffer number"
-msgstr "ongeldige buffernommer"
-
-msgid "not implemented yet"
-msgstr "nog nie geïmplementeer nie"
-
-msgid "unknown option"
-msgstr "onbekende opsie"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "kan nie reël(s) stel nie"
-
-msgid "mark not set"
-msgstr "merker nie gestel nie"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "ry %d kolom %d"
-
-msgid "cannot insert/append line"
-msgstr "kan nie reël invoeg/aanlas nie"
-
-msgid "unknown flag: "
-msgstr "onbekende vlag: "
-
-msgid "unknown vimOption"
-msgstr "onbekende 'vimOption'"
-
-msgid "keyboard interrupt"
-msgstr "sleutelbordonderbreking"
-
-msgid "vim error"
-msgstr "vim fout"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "kan nie buffer/venster bevel skep nie: voorwerp word geskrap"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"kan nie terugroepbevel registreer nie: buffer/venster word alreeds geskrap"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATALE FOUT: verwlys korrup!? Rapporteer dit asb. aan <vim-dev@vim."
-"org>"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"kan terugroepbevel nie registreer nie: buffer/vensterverwysing nie gevind nie"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Jammer, hierdie bevel is afgeskakel, die Tcl biblioteek kon nie gelaai "
-"word nie."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL FOUT: verlaatkode is nie 'n 'int'!? Rapporteer dit asb. aan <vim-"
-"dev@vim.org>"
-
-msgid "cannot get line"
-msgstr "kan nie reël kry nie"
-
-msgid "Unable to register a command server name"
-msgstr "Kon nie bevelbediener naam registreer nie"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Het gefaal om bevel na doel program te stuur"
-
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Ongeldige bediener-id gebruik: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM instansie register-kenmerk is swak gevorm. Geskrap!"
-
-msgid "Unknown option"
+#: ../main.c:144
+#, fuzzy
+msgid "Unknown option argument"
 msgstr "Onbekende opsie"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Te veel redigeer-parameters"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Parameter ontbreek na"
 
-msgid "Garbage after option"
+#: ../main.c:150
+#, fuzzy
+msgid "Garbage after option argument"
 msgstr "Gemors na opsie"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Te veel \"+command\", \"-c command\" of \"--cmd command\" parameters"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Ongeldige parameter vir"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Hierdie Vim is nie gekompileer met 'diff' funksionaliteit nie."
-
-msgid "Attempt to open script file again: \""
-msgstr "Probeer weer om skriplêer oop te maak: \""
-
-msgid "Cannot open for reading: \""
-msgstr "Kan nie oopmaak om te lees nie: \""
-
-msgid "Cannot open for script output: \""
-msgstr "Kan nie oopmaak vir skrip-afvoer nie: \""
-
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d lêers om te bewerk\n"
 
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr "Probeer weer om skriplêer oop te maak: \""
+
+#: ../main.c:1350
+msgid "Cannot open for reading: \""
+msgstr "Kan nie oopmaak om te lees nie: \""
+
+#: ../main.c:1393
+msgid "Cannot open for script output: \""
+msgstr "Kan nie oopmaak vir skrip-afvoer nie: \""
+
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Waarskuwing: Afvoer gaan nie na 'n terminaal nie\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Waarskuwing: Invoer kom nie vanaf 'n terminaal nie\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "vóór-'vimrc' bevelreël"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kan nie lees uit \"%s\" nie"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2288,18 +3406,23 @@ msgstr ""
 "\n"
 "Meer inligting met: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[lêer ..]       bewerk lêer(s)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               lees teks uit 'stdin'"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          bewerk lêer waar etiket gedefinieer is"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [foutlêer]   bewerk lêer met eerste fout"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2309,9 +3432,11 @@ msgstr ""
 "\n"
 "gebruik:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [parameters] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2319,6 +3444,7 @@ msgstr ""
 "\n"
 "   of:"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2328,319 +3454,191 @@ msgstr ""
 "\n"
 "Parameters:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tSlegs lêername hierna"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tMoet nie plekhouers uitbrei nie"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistreer hierdie gvim vir OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tOnregistreer gvim vir OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tVoer uit met die GUI (soos \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  of  --nofork\tVoorgrond: Moenie vurk wanneer GUI begin nie"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi modus (soos \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx modus (soos \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tStil (bondel) modus (slegs vir \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff modus (soos \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tEasy modus (soos \"evim\", modusloos)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tLeesalleen modus (soos \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tBeperkte modus (soos \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tVeranderings (skryf van lêers) nie toegelaat nie"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tVeranderings aan teks nie toegelaat nie"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinêre modus"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp modus"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVersoenbaar met Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNie ten volle Vi-versoenbaar nie: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tOmslagtigheidsgraad"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tOntfoutmodus"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tGeen ruillêer, gebruik slegs geheue"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tLys ruillêers en verlaat vim"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (met lêer naam)\tHerwin ineengestorte sessie"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tSelfde as -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tMoet nie 'newcli' gebruik om venster oop te maak nie"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <toestel>\t\tGebruik <toestel> vir I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tbegin in Arabiese modus"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tBegin in Hebreeuse modus"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tBegin in Farsi modus"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminaal>\tStel terminaaltipe na <terminaal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tGebruik <vimrc> in plaas van enige ander .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tGebruik <gvimrc> in plaas van enige .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tMoet nie inpropskripte laai nie"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tMaak N vensters oop (verstek: een vir elke lêer)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tMaak N vensters oop (verstek: een vir elke lêer)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tSoos -o maar verdeel vertikaal"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tBegin by einde van lêer"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tBegin by reël <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <bevel>\tVoer <bevel> uit voor enige .vimrc-lêer gelaai word"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <bevel>\t\tVoer <bevel> uit na eerste lêer gelaai is"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sessie>\t\tVoer bevele in lêer <sessie> uit na eerste lêer gelaai is"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skripin>\t\tLees Normale-modus bevele van lêer <skripin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <skripuit>\tLas alle getikte bevele aan by lêer <skripuit>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <skripuit>\tSkryf alle getikte bevele na lêer <skripuit>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tBewerk geënkripteerde lêers"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tKoppel vim aan hierdie X-bediener"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tMoet nie verbinding met X-bediener maak nie"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <lêers>\tWysig die <lêers> in a Vim bediener indien moontlik"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <lêers>  Dieselfde, moet nie kla as daar nie so 'n bediener is nie"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <lêers> Soos '--remote', maar wag vir lêers om gewysig te word"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <lêers>  Dieselfde, moet nie kla as daar nie so 'n bediener is nie"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr ""
-"--remote-send <sleutels>\tStuur <sleutels> na 'n Vim-bediener en verlaat"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <expr>\tEvalueer <expr> in 'n Vim-bediener en druk resultaat"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tLys beskikbare Vim-bediener name en verlaat"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <naam>\tStuur na/word die Vim-bediener <naam>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tGebruik <viminfo> in plaas van .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  of  --help\tSkryf Hulp (hierdie boodskap) en sluit"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tSkryf weergawe-inligting en sluit"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Parameters deur gvim herken (Motif weergawe):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Parameters deur gvim herken (neXtaw weergawe):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Parameters deur gvim herken (Athena weergawe):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tVoer vim op <display> uit"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tBegin vim as ikoon"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\tGebruik hulpbron asof vim <name> was"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Nog nie geïmplementeer nie)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <kleur>\tGebruik <kleur> vir die agtergrond (ook: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-voorgrond <kleur>\tGebruik <kleur> vir normale teks (ook: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tGebruik <font> vir normale teks (ook -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "­boldfont <font>\t Gebruik <font> vir vetletter teks"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\tGebruik <font> vir kursiewe teks"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\tGebruik <geom> vir aanvanklike geometrie"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <wydte>\tGebruik 'n grenswydte van <wydte> (ook: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <wydte>\tGebruik 'n rolstaafwydte van <wydte> (ook: -sw>"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <hoogte>\tGebruik a kieslysstaafhoogte van <hoogte> (ook: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tGebruik tru-video (ook: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tMoet nie tru-video gebruik nie (ook: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <hulpbron>\tStel die gespesifiseerde hulpbron"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Parameters wat gvim verstaan (RISC OS weergawe):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <aantal>\tAanvanklike wydte van venster in kolomme"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <aantal>\tAanvanklike hoogte van venster in rye"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Parameters wat gvim verstaan (GTK+ weergawe):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <skerm>\tVoer vim op <skerm> uit: (ook --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <rol>\tStel 'n unieke rol om die hoofvenster te identifiseer"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tMaak Vim in 'n ander GTK element oop"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <ouer title>\tMaak Vim oop binne 'n ouer toepassing"
-
-msgid "No display"
-msgstr "Geen vertoonskerm"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Stuur het gefaal.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Stuur het gefaal. Probeer om lokaal uit te voer\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d van %d lêers bewerk"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Geen vertoonskerm: Stuur van uitdrukking het gefaal.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Stuur van uitdrukking het gefaal.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Geen merkers gestel nie"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Geen merkers pas op \"%s\" nie"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2649,6 +3647,7 @@ msgstr ""
 "merk reël   kol lêer/teks"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2657,6 +3656,7 @@ msgstr ""
 " spring reël kol lêer/teks"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -2664,7 +3664,7 @@ msgstr ""
 "\n"
 "verander reël  kol teks"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2673,7 +3673,7 @@ msgstr ""
 "# Lêermerkers:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -2681,7 +3681,7 @@ msgstr ""
 "\n"
 "# Springlys (nuutste eerste):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -2689,94 +3689,85 @@ msgstr ""
 "\n"
 "# Geskiedenis van merkers in lêers (nuutste tot oudste):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Ontbrekende '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Nie 'n geldige kodeblad nie"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Kan nie IC waardes stel nie"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Gefaal met die skep van invoerkonteks"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Gefaal om invoermetode oop te maak"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Waarskuwing: Kon nie uitwis-terugroep na IM stel nie"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: invoermetode ondersteun geen styl nie"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: invoermetode ondersteun nie my voor-bewerking tipe nie"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: oor-die-plek styl vereis fontstel"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Jou GTK+ is ouer as 1.2.3. Statusarea afgeskakel"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Invoermetodebediener voer nie uit nie"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok was nie gesluit nie"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Soekfout in lees van ruillêer"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Leesfout in ruillêer"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Soekfout in skryf van ruillêer"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Skryffout in ruillêer"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Ruillêer bestaan alreeds! ('symlink' probleem?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Het nie blok no 0 gekry nie?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Het nie blok no 1 gekry nie?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Het nie blok no 2 gekry nie?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Hiert, die ruillêer is weg!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Kon nie ruillêer vernoem nie"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Kon nie ruillêer oopmaak vir \"%s\" nie, herwinning onmoontlik"
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: 'ml_timestamp': Het nie blok 0 gekry nie??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Geen ruillêer gevind vir %s nie"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Tik die nommer van die ruillêer om te gebruik (0 om te stop)"
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Kan %s nie oopmaak nie"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Kan nie blok 0 lees vanaf "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -2784,22 +3775,28 @@ msgstr ""
 "\n"
 "Vim het die ruillêer nie opgedateer nie. Dalk was niks verander nie."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " kan nie gebruik word met hierdie weergawe van Vim nie.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Gebruik Vim weergawe 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s lyk nie soos 'n Vim ruillêer nie"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " kan nie gebruik word op hierdie rekenaar nie.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Die lêer is geskep op "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -2807,63 +3804,85 @@ msgstr ""
 ",\n"
 "of die lêer is beskadig."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Gebruik ruillêer \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Oorspronklike lêer \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Waarskuwing: Oorspronklike lêer is dalk gewysig"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Kan nie block 1 lees van %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???BAIE REËLS WEG"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???REËLTELLING FOUTIEF"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???LEË BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???REËLS WEG"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Blok 1 se ID is foutief (%s nie 'n .swp lêer nie?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOK WEG"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? van hier tot ???END mag reëls deurmekaar wees"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? van hier tot ???END mag daar reëls ingevoeg/geskrap wees"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Herwinning onderbreek"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Foute raakgesien gedurende herwinning; soek vir reëls wat begin met ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Sien \":help E312\" vir meer inligting."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Herwinning is klaar. Kyk of alles reg is."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -2871,50 +3890,71 @@ msgstr ""
 "\n"
 "(Jy wil dalk die lêer stoor onder 'n ander naam\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "en dit \"diff\" teen die oorspronklike lêer om wysigings te soek)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Verwyder die .swp-lêer na die tyd.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Ruillêers gevind:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   In huidige gids:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Wat gespesifiseerde naam gebruik:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   In gids "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- geen --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          eienaar: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   gedateer: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             gedateer: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [van Vim weergawe 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [lyk nie soos 'n Vim ruillêer nie]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         lêernaam: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -2922,12 +3962,15 @@ msgstr ""
 "\n"
 "          gewysig: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nee"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -2935,9 +3978,11 @@ msgstr ""
 "\n"
 "         gebruikersnaam: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   gasheernaam: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -2945,6 +3990,7 @@ msgstr ""
 "\n"
 "         gasheernaam: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -2952,16 +3998,11 @@ msgstr ""
 "\n"
 "         proses ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (nog steeds aan die uitvoer)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nie bruikbaar met hierdie weergawe van Vim nie]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -2969,71 +4010,97 @@ msgstr ""
 "\n"
 "         [nie bruikbaar op hierdie rekenaar nie]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [kan nie gelees word nie]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [kan nie oopgemaak word nie]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Kan nie bewaar nie, daar is geen ruillêer nie"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Lêer bewaar"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Kon nie bewaar nie"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: 'ml_get': ongeldige 'lnum': %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: 'ml_get': kan reël %<PRId64> nie vind nie"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: wyser blok id verkeerd 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "'stack_idx' moet 0 wees"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Te veel blokke opgedateer?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: wyser blok id verkeerd 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "verwyder blok 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Kan nie reël %<PRId64> vind nie"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: wyser blok id verkeerd"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "'pe_line_count' is nul"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: reëlnommer buite perke: %<PRId64> verby die einde"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: reëltelling mag verkeerd wees in blok %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Stapel grootte verhoog"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: wyser blok id verkeerd 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: LET OP"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3041,38 +4108,44 @@ msgstr ""
 "\n"
 "Het 'n ruillêer gevind met die naam \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Tydens oopmaak van lêer \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NUWER as die ruillêer!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 'n Ander program mag besig wees met hierdie lêer.\n"
 "    Indien wel, pas op om nie met twee verskillende weergawes\n"
 "    van dieselfde lêer te sit wanneer veranderinge gemaak word nie.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Stop, of gaan versigtig voort.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 'n Bewerkingsessie van hierdie lêer het ineengestort.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Indien wel, gebruik \":recover\" of \"vim -r"
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3080,9 +4153,11 @@ msgstr ""
 "\"\n"
 "    om die veranderinge te herwin (sien \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Indien jy dit alreeds gedoen het, verwyder die ruillêer \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3090,18 +4165,23 @@ msgstr ""
 "\"\n"
 "    om hierdie boodskap te vermy.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Ruillêer \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" bestaan alreeds!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - LET OP"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Ruillêer bestaan alreeds!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3115,44 +4195,72 @@ msgstr ""
 "&Verlaat\n"
 "&Stop"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Abort\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "&Maak as lees-alleen oop\n"
 "&Bewerk in elk geval\n"
 "&Herwin\n"
 "&Verlaat\n"
-"&Stop\n"
-"S&krap dit"
+"&Stop"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Te veel ruillêers gevind"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Geheue is op! (ken %<PRIu64> grepe toe)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Deel van kieslys-item pad is nie 'n sub-kieslys nie"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Kieslys bestaan slegs in 'n ander modus"
 
-msgid "E329: No menu of that name"
+#: ../menu.c:64
+#, fuzzy, c-format
+msgid "E329: No menu \"%s\""
 msgstr "E329: Geen kieslys met daardie naam nie"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Kieslyspad moenie lei na 'n sub-kieslys nie"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Moenie kieslysitems direk by kieslysstaaf voeg nie"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Verdeler kan nie deel wees van kieslyspad nie"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3160,61 +4268,74 @@ msgstr ""
 "\n"
 "--- Kieslyste ---"
 
-msgid "Tear off this menu"
-msgstr "Skeur die kieslys af"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Kieslyspad moet lei na 'n kieslysitem"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Kieslys nie gevind nie: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Kieslys nie gedefinieer vir %s modus nie"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Kieslyspad moet lei na 'n sub-kieslys"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Kieslys nie gevind nie - maak seker oor die kieslys name"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Fout ontdek tydens verwerking van %s: "
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "reël %4ld:"
 
-msgid "[string too long]"
-msgstr "[string te lank]"
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: Ongeldige registernaam: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Boodskappe onderhouers: Danie Roux en Jean Jordaan <droux@tuks.co.za>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Onderbreek: "
 
-msgid "Hit ENTER to continue"
-msgstr "Druk ENTER om voort te gaan"
-
-msgid "Hit ENTER or type command to continue"
+#: ../message.c:988
+#, fuzzy
+msgid "Press ENTER or type command to continue"
 msgstr "Druk ENTER of tik 'n bevel om voort te gaan"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, reël %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Meer --"
 
-msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-msgstr " (RET/BS: reël, SPACE/b: bladsy, d/u: halwe bladsy, q: los dit"
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
-msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-msgstr " (RET: reël, SPACE: bladsy, d: halwe bladsy, q: los dit"
-
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Vraag"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3222,6 +4343,17 @@ msgstr ""
 "&Ja\n"
 "&Nee"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ja\n"
+"&Nee\n"
+"&Kanselleer"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3235,230 +4367,180 @@ msgstr ""
 "&Gooi alles weg\n"
 "&Kanselleer"
 
-msgid "Save File dialog"
-msgstr "Stoor Lêer dialooghokkie"
+#: ../message.c:3058
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: Ongeldige parameters vir funksie %s"
 
-msgid "Open File dialog"
-msgstr "Maak lêer oop dialooghokkie"
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
 
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Jammer, lêerblaaier nie beskikbaar in konsole-modus nie"
+#: ../message.c:3873
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: Te veel parameters vir funksie: %s"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Waarskuwing: Jy wysig aan 'n leesalleen lêer"
 
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 reël meer"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 reël minder"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> meer reëls"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> minder reëls"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Onderbreek)"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: bewaar lêers...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Klaar.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "FOUT: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
+#: ../misc1.c:2635
+msgid "Beep!"
 msgstr ""
-"\n"
-"[grepe] totaal 'alloc'-vrygelaat %<PRIu64>-%<PRIu64>, in gebruik %<PRIu64>, piekgebruik %<PRIu64>\n"
 
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[roepe] totaal re/malloc()'s %<PRIu64>, totale free()'s %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Rëel word te lank"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Interne fout: 'lalloc(%<PRId64>, )'"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Geheue is op! (ken %<PRIu64> grepe toe)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Roep dop om uit te voer: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Ontbrekende dubbelpunt"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Ongeldige modus"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Ongeldige muisvorm"
-
-msgid "E548: digit expected"
-msgstr "E548: syfer verwag"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Ongeldige persentasie"
-
-msgid "Enter encryption key: "
-msgstr "Voer enkripsie-sleutel in: "
-
-msgid "Enter same key again: "
-msgstr "Voer die sleutel weer in: "
-
-msgid "Keys don't match!"
-msgstr "Sleutels verskil!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Ongeldige pad: '**[nommer]' moet aan die einde van 'n pad wees of "
-"gevolg wees deur %s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Kan nie gids \"%s\" in 'cdpath' vind nie"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Kan lêer \"%s\" nie vind in pad nie"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Geen gids \"%s\" meer gevind in 'cdpath' nie"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Geen lêer \"%s\" meer gevind in pad nie"
-
-msgid "E550: Missing colon"
-msgstr "E550: Ontbrekende dubbelpunt"
-
-msgid "E551: Illegal component"
-msgstr "E551: Ongeldige komponent"
-
-msgid "E552: digit expected"
-msgstr "E552: syfer verwag"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Kan nie aan Netbeans #2 koppel nie"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Kan nie aan Netbeans koppel nie"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Verkeerde toegangsmodue vir NetBeans konneksie inligtingslêer: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "lees vanaf Netbeans 'socket'"
-
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: NetBeans konneksie vir buffer %<PRId64> verloor"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Waarskuwing: terminaal kan nie teks uitlig nie"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Geen string onder loper nie"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Geen identifiseerder onder loper nie"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E221: 'commentstring' opsie is leeg"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Waarskuwing: terminaal kan nie teks uitlig nie"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Geen string onder loper nie"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Kan nie voue verwyder met huidige 'foldmethod' nie"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 'changelist' is leeg"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: By die begin van die veranderingslys"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: By die einde van die veranderingslys"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Tik   :quit<Enter>  om Vim te verlaat"
 
 # Het te doen met < en >
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 reël 1 keer ge-%s"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 reël ge-%s %d keer"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> reëls 1 keer ge-%s"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> reëls ge-%s %d keer"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> reëls om in te keep..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 reël ingekeep "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> reëls ingekeep "
 
+#: ../ops.c:938
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: Geen vorige gids nie"
+
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "kan nie pluk nie: verwyder in elk geval"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 reël verander"
 
+#: ../ops.c:1931
+#, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> reëls verander"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "laat %<PRId64> reëls gaan"
+#: ../ops.c:2521
+#, fuzzy
+msgid "block of 1 line yanked"
+msgstr "1 reël gepluk"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 reël gepluk"
 
+#: ../ops.c:2525
+#, fuzzy, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> reëls gepluk"
+
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> reëls gepluk"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Niks in register %s nie"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3466,10 +4548,11 @@ msgstr ""
 "\n"
 "--- Registers ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Ongeldige registernaam"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3477,146 +4560,196 @@ msgstr ""
 "\n"
 "# Registers:\n"
 
+#: ../ops.c:4575
+#, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Onbekende registertipe %d"
 
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: Ongeldige registernaam: '%s'"
-
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kolomme; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "%s%<PRId64> van %<PRId64> reëls gekies; %<PRId64> van %<PRId64> Woorde; %<PRId64> van %<PRId64> Grepe"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"%s%<PRId64> van %<PRId64> reëls gekies; %<PRId64> van %<PRId64> Woorde; "
+"%<PRId64> van %<PRId64> Grepe"
+
+#: ../ops.c:5105
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"%s%<PRId64> van %<PRId64> reëls gekies; %<PRId64> van %<PRId64> Woorde; "
+"%<PRId64> van %<PRId64> Grepe"
 
 # njj: Karakters kan meerdere grepe wees, sien ':h multibyte'
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s van %s; Reël %<PRId64> van %<PRId64>; Woord %<PRId64> van %<PRId64>; Greep %<PRId64> van %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s van %s; Reël %<PRId64> van %<PRId64>; Woord %<PRId64> van %<PRId64>; "
+"Greep %<PRId64> van %<PRId64>"
 
+# njj: Karakters kan meerdere grepe wees, sien ':h multibyte'
+#: ../ops.c:5133
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s van %s; Reël %<PRId64> van %<PRId64>; Woord %<PRId64> van %<PRId64>; "
+"Greep %<PRId64> van %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> vir 'BOM')"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Bladsy %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dankie dat jy vlieg met Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Onbekende opsie"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opsie is nie ondersteun nie"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Nie toegelaat in 'n moduslyn nie"
 
-msgid ""
-"\n"
-"\tLast set from "
+#: ../option.c:2815
+msgid "E846: Key code not set"
 msgstr ""
-"\n"
-"\tLaas gestel vanaf "
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Nommer vereis na ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nie gevind in 'termcap' nie"
 
+#: ../option.c:3335
+#, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Ongeldige karakter <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Kan nie 'term' stel na leë string nie"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Kan nie 'term' verander in GUI nie"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Gebruik \":gui\" om die GUI te begin"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' en 'patchmode' is dieselfde"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Kan nie 'term' verander in die GTK+ 2 GUI nie"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Ontbrekende dubbelpunt"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Nul-lengte string"
 
+#: ../option.c:4220
+#, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Ontbrekende nommer na <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Ontbrekende komma"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Moet 'n ' waarde spesifiseer"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: bevat 'n ondrukbare of wye karakter"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Ongeldige font(e)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: kan nie fontstel kies nie"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Ongeldige fontstel"
-
-msgid "E533: can't select wide font"
-msgstr "E533: kan nie wye font kies nie"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Ongeldige wye font"
-
+#: ../option.c:4469
+#, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ongeldige karakter na <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: komma benodig"
 
+#: ../option.c:4543
+#, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' moet leeg wees of %s bevat"
 
-msgid "E538: No mouse support"
-msgstr "E538: Geen muisondersteuning nie"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Onvoltooide uitdrukkingreeks"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: te veel items"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: ongebalanseerde groepe"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Daar bestaan reeds 'n voorskouvenster"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabies benodig UTF-8, doen ':set encoding=utf-8'"
 
+#: ../option.c:5623
+#, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Benodig ten minste %d reëls"
 
+#: ../option.c:5631
+#, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Benodig ten minste %d kolomme"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Onbekende opsie: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Nommer vereis na ="
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3624,6 +4757,7 @@ msgstr ""
 "\n"
 "--- Terminaal kodes ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3631,6 +4765,7 @@ msgstr ""
 "\n"
 "--- Globale opsie waardes ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3638,6 +4773,7 @@ msgstr ""
 "\n"
 "--- Lokale opsie waardes ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3645,128 +4781,21 @@ msgstr ""
 "\n"
 "--- Opsies ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: 'get_varp' FOUT"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Passende karakter ontbreek vir %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap: Ekstra karakters na kommapunt: %s"
 
-msgid "cannot open "
-msgstr "kan nie oopmaak nie "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Kan nie venster oopmaak nie!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Benodig Amigados weergawe 2.04 of later\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Benodig %s weergawe %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Kan nie NIL: oopmaak nie\n"
-
-msgid "Cannot create "
-msgstr "Kan nie skep nie: "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim stop met %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "kan konsole-modus nie verander nie ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "'mch_get_shellsize': nie 'n konsole nie??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Kan nie dop met -f opsie uitvoer nie"
-
-msgid "Cannot execute "
-msgstr "Kan nie uitvoer nie "
-
-msgid "shell "
-msgstr "dop "
-
-msgid " returned\n"
-msgstr " teruggekeer\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "'ANCHOR_BUF_SIZE' is te klein"
-
-msgid "I/O ERROR"
-msgstr "I/O FOUT"
-
-msgid "...(truncated)"
-msgstr "...(afgekap)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' is nie 80 nie, kan nie eksterne bevele uitvoer nie"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Drukker-seleksie het gefaal"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "na %s op %s"
-
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Onbekende drukker font: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Drukfout: %s"
-
-msgid "Unknown"
-msgstr "Onbekend"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Druk nou '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Ongeldige karakterstelnaam \"%s\" in fontnaam \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Ongeldige karakter '%c' in fontnaam \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Dubbel sein, staak\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Het dodelike sein %s gevang\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Het dodelike sein gevang\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Om die X-vertoonskerm oop te maak het %<PRId64> msek gevat"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Het X fout ontvang\n"
-
-msgid "Testing the X display failed"
-msgstr "Toetsing van die X-vertoonskerm het gefaal"
-
-msgid "Opening the X display timed out"
-msgstr "Oopmaak van die X-vertoonskerm het uitgetel"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -3774,13 +4803,7 @@ msgstr ""
 "\n"
 "Kan nie dop uitvoer nie "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Kan nie dop 'sh' uitvoer nie\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -3788,372 +4811,959 @@ msgstr ""
 "\n"
 "dop lewer "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Kan nie pype skep nie\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Kan nie vurk nie\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Bevel beëindig\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP het ICE konneksie verloor"
-
-msgid "Opening the X display failed"
-msgstr "Oopmaak van die X vertoonskerm het gefaal"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP hanteer 'save-yourself' versoek"
-
-msgid "XSMP opening connection"
-msgstr "XSMP maak nou konneksie oop"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE konneksie beloer het gefaal"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP 'SmcOpenConnection' het gefaal: %s"
-
-msgid "At line"
-msgstr "By reël"
-
-msgid "Could not allocate memory for command line."
-msgstr "Kan nie geheue toeken vir bevelreël nie"
-
-msgid "VIM Error"
-msgstr "VIM Fout"
-
-msgid "Could not load vim32.dll!"
-msgstr "Kon nie 'vim32.dll' laai nie!"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Kon nie funksiewysers na die DLL opstel nie!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "dop het %d gelewer"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Het %s gebeurtenis gevang\n"
-
-msgid "close"
-msgstr "maak toe"
-
-msgid "logoff"
-msgstr "teken uit"
-
-msgid "shutdown"
-msgstr "sit af"
-
-msgid "E371: Command not found"
-msgstr "E371: Bevel nie gevind nie"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
+msgid "dlerror = \"%s\""
 msgstr ""
-"'VIMRUN.EXE' nie gevind in '$PATH' nie.\n"
-"Eksterne opdragte sal nie wag na voltooiing nie\n"
-"Sien ':help win32-vimrun' vir meer inligting."
 
-msgid "Vim Warning"
-msgstr "Vim Waarskuwing"
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Kan lêer \"%s\" nie vind in pad nie"
 
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Te veel %%%c in formaatstring"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Onverwagte %%%c in formaatstring"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Ontbrekende ] in formaatstring"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Ongesteunde %%%c in formaatstring"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Ongeldige %%%c in formaatstringvoorvoegsel"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Ongeldige %%%c in formaatstring"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' bevat geen patroon nie"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Ontbrekende of leë gidsnaam"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Geen items meer nie"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d van %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (reël verwyder)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Onder aan 'quickfix' stapel"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Bo aan 'quickfix' stapel"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "foutelys %d van %d; %d foute"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Kan nie skryf nie, 'buftype' opsie is aan"
 
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "Kan nie lêer %s oopmaak nie"
+
+#: ../quickfix.c:3429
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "1 buffer uitgelaai"
+
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E548: syfer verwag"
+
+#: ../regexp.c:359
+#, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: ongeldige item in %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Patroon te lank"
+#: ../regexp.c:374
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E69: Ontbrekende ] na %s%%["
 
-msgid "E50: Too many \\z("
-msgstr "E50: Te veel \\z("
-
-msgid "E51: Too many %s("
-msgstr "E51: Te veel %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Onpaar \\z("
-
+#: ../regexp.c:375
+#, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Onpaar %s%%("
 
+#: ../regexp.c:376
+#, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Onpaar %s("
 
+#: ../regexp.c:377
+#, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Onpaar %s)"
 
-msgid "E56: %s* operand could be empty"
-msgstr "E56: %s* operand mag leeg wees"
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( nie hier toegelaat nie"
 
-msgid "E57: %s+ operand could be empty"
-msgstr "E57: %s+ operand mag leeg wees"
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 e.a. nie hier toegelaat nie"
 
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Ontbrekende ] na %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Leë %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Patroon te lank"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Te veel \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Te veel %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Onpaar \\z("
+
+#: ../regexp.c:1637
+#, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: ongeldige karakter na %s@"
 
-msgid "E58: %s{ operand could be empty"
-msgstr "E58: %s{ operand mag leeg wees"
-
+#: ../regexp.c:1672
+#, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Te veel komplekse %s{...}ies"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Geneste %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Geneste %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: ongeldige gebruik van \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c volg niks"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Ongeldige tru-verwysing"
 
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( nie hier toegelaat nie"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 e.a. nie hier toegelaat nie"
-
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: ongeldige karakter na \\z"
 
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Ontbrekende ] na %s%%["
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E71: Ongeldige karakter na %s%%"
 
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Leë %s%%[]"
-
+#: ../regexp.c:2107
+#, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Ongeldige karakter na %s%%"
 
+#: ../regexp.c:3017
+#, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Sintaksfout in %s{...}"
 
-msgid "E361: Crash intercepted; regexp too complex?"
-msgstr "E361: Ineenstorting onderskep. Patroon te kompleks?"
-
-msgid "E363: pattern caused out-of-stack error"
-msgstr "E363: patroon het lëe-stapel fout veroorsaak"
-
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Eksterne subtreffers:\n"
 
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "+--%3ld reëls gevou "
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Te veel \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Kan nie tydelike lêer vind vir skryf nie"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " VVERVANG"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " VERVANG"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " OMKEER"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INVOEG"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (invoeg)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (vervang)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (vvervang)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebreeus"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabies"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (taal)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (plak)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUELE"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUELE REËL"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUELE BLOK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " KIES"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " KIES REËL"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " KIES BLOK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "besig om op te neem"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "soektog het BO getref, gaan voort van ONDER af"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "soektog het ONDER getref, gaan voort van BO af"
-
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Ongeldige soekstring: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: soektog het BO getref sonder treffer vir: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: soektog het ONDER getref sonder treffer vir: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Verwag '?' of '/' na ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (sluit in vorige gelyste treffer)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Ingeslote lêers"
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "nie gevind nie "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "in pad ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Alreeds gelys)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NIE GEVIND NIE"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Deursoek ingeslote lêer: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "Deursoek ingeslote lêer: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Treffer is op huidige reël"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Alle ingeslote lêers is gevind"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Geen ingeslote lêers nie"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Kon definisie nie vind nie"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Kon patroon nie vind nie"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 vervanging"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+#, fuzzy
+msgid "E759: Format error in spell file"
+msgstr "E297: Skryffout in ruillêer"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:955
+#, fuzzy
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E431: Formaatfout in etiketlêer \"%s\""
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "Gebruik ruillêer \"%s\""
+
+#: ../spell.c:2496
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s lyk nie soos 'n Vim ruillêer nie"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: Skryffout in ruillêer"
+
+#: ../spell.c:3762
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "E519: Opsie is nie ondersteun nie"
+
+#: ../spell.c:4550
+#, fuzzy, c-format
+msgid "Reading affix file %s ..."
+msgstr "Deursoek etiketlêer %s"
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: Duplikaat etiket \"%s\" in lêer %s/%s"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "Te veel redigeer-parameters"
+
+#: ../spell.c:5238
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "Te veel redigeer-parameters"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, fuzzy, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "Deursoek woordeboek: %s"
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "Patroon gevind in elke reël: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, fuzzy, c-format
+msgid "Reading word file %s ..."
+msgstr "Lees nou vanaf stdin... "
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "E573: Ongeldige bediener-id gebruik: %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "Besig om viminfo lêer \"%s\" te stoor"
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+#, fuzzy
+msgid "E754: Only up to 8 regions supported"
+msgstr "E519: Opsie is nie ondersteun nie"
+
+#: ../spell.c:7846
+#, fuzzy, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E15: Ongeldige uitdrukking: %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, fuzzy, c-format
+msgid "Writing spell file %s ..."
+msgstr "Besig om viminfo lêer \"%s\" te stoor"
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, fuzzy, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr " op %<PRId64> reëls"
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, fuzzy, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "Stoor veranderinge na \"%.*s\"?"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: Geen vorige patroon nie"
+
+#: ../spell.c:8925
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: Kieslys nie gevind nie: %s"
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s lyk nie soos 'n Vim ruillêer nie"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Fout tydens lees van 'errorfile'"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Geen Sintaks-items gedefinieer vir hierdie buffer nie"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Ongeldige parameter: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Geen sodanige sintakskluster nie: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Geen Sintaks-items gedefinieer vir hierdie buffer nie"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "sinchroniseer met C-styl kommentaar"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "geen sinchronisering"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "sinchronisasie begin "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " reëls voor boonste lyn"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -4161,6 +5771,7 @@ msgstr ""
 "\n"
 "--- Sintaks sync items ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -4168,6 +5779,7 @@ msgstr ""
 "\n"
 "sinchronisering met items"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -4175,204 +5787,275 @@ msgstr ""
 "\n"
 "--- Sintaks items ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Geen sodanige sintakskluster nie: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimaal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksimaal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; treffer "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " reël breuke"
 
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: bevat parameters nie hier aanvaar nie"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Ongeldige parameter"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: 'group[t]here' nie hier aanvaar nie"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Kon nie omgewingsitem vind vir %s nie"
 
-msgid "E395: contains argument not accepted here"
-msgstr "E395: bevat parameters nie hier aanvaar nie"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: 'containedin' parameter nie hier aanvaar nie"
-
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Lêernaam benodig"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Te veel lêername"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: Ontbrekende '=': %s"
+
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Ontbrekende '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Nie genoeg parameters nie: sintaksomgewing %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Geen sodanige sintakskluster nie: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Geen kluster gespesifiseer nie"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Patroonbegrenser nie gevind nie: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Gemors na patroon: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: sintaks sync: reëlvoortgaanpatroon twee keer gespesifiseer"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Ongeldige parameters: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Ontbrekende gelykaanteken: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Leë parameter: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s nie toegelaat hier nie"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s moet vóór in 'contains' lys wees"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Onbekende groepnaam: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Ongeldige :syntax subbevel %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursiewe lus gedurende laai van syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: uitliggroep nie gevind nie: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Te min parameters: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Te veel parameters: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr ""
 "E414: groep het instellings, uitligskakel ('highlight link') geïgnoreer"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: onverwagte gelykaanteken: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: ontbrekende gelykaanteken: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: ontbrekende parameter: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Ongeldige waarde: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: FG kleur onbekend"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: BG kleur onbekend"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Kleurnaam of -nommer nie herken nie: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminaalkode te lank: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Ongeldige parameter: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Te veel verskillende uitlig-eienskappe in gebruik"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Onvertoonbare karakter in groepnaam"
 
-#. This is an error, but since there previously was no check only
-#. * give a warning.
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Ongeldige karakter groepnaam"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: onderaan etiketstapel"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: bo-aan etiketstapel"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Kan nie vóór eerste etiket-treffer gaan nie"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: etiket nie gevind nie: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri tipe etiket"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "lêer\n"
 
-#.
-#. * Ask to select a tag from the list.
-#. * When using ":silent" assume that <CR> was entered.
-#.
-msgid "Enter nr of choice (<CR> to abort): "
-msgstr "Sleutel nommer van keuse in (<CR> om te stop): "
-
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Daar is slegs een etiket-treffer"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Kan nie verby laaste etiket-treffer gaan nie"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Lêer \"%s\" bestaan nie"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "etiket %d van %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " of meer"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Gaan etiket met ander kas gebruik!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Lêer \"%s\" bestaan nie"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -4380,59 +6063,79 @@ msgstr ""
 "\n"
 "  # NA etiket      VAN reël   in lêer/teks"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Deursoek etiketlêer %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Etiketlêergids afgekap vir %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formaatfout in etiketlêer \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Voor greep %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Etiketlêer ongesorteer: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Geen etiketlêer nie"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Kan nie etiketpatroon vind nie"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Kon nie etiket vind nie, ek raai maar!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "gelaaide fontnaam: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' onbekend. Beskikbare ingeboude terminale is:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "gebruik verstek '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Kan nie 'termcap'-lêer oopmaak nie"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Terminaalinskrywing nie in 'terminfo' gevind nie"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Terminaalinskrywing nie in 'termcap' gevind nie"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Geen \"%s\" inskrywing in termcap nie"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: terminaalvermoë \"cm\" vereis"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -4440,109 +6143,176 @@ msgstr ""
 "\n"
 "--- Terminaal sleutels ---"
 
-msgid "new shell started\n"
-msgstr "nuwe dop begin\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Fout met lees van invoer, verlaat...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Geen herstel moontlik; gaan in elk geval voort"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Kan lêer nie oopmaak vir skryf nie"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Besig om viminfo lêer \"%s\" te stoor"
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Skryffout in ruillêer"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Besig om viminfo lêer \"%s\"%s%s%s te lees"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Kan 'viminfo' lêer nie oopmaak om te lees nie"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E484: Kan nie lêer %s oopmaak nie"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Kan nie lêer %s oopmaak nie"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "%s klaar uitgevoer"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> kon nie gevind word nie"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: reëlnommers foutief"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "1 reël meer"
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "1 reël meer"
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "1 reël minder"
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "%<PRId64> minder reëls"
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "1 verandering"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "%<PRId64> veranderinge"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "1 verandering"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64>R, %<PRId64>K"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "Geen binding gevind nie"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> Kolomme; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s nie toegelaat hier nie"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: herstellys korrup"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: herstelreël ontbreek"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32-bis GUI weergawe"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32-bis GUI version"
-
-msgid " in Win32s mode"
-msgstr " in Win32s modus"
-
-msgid " with OLE support"
-msgstr " met OLE ondersteuning"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bis konsole weergawe"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16-bis weergawe"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32-bis MS-DOS weergawe"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16-bis MS-DOS weergawe"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) weergawe"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X weergawe"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS weergawe"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS weergawe"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -4550,9 +6320,18 @@ msgstr ""
 "\n"
 "Ingeslote laslappies:"
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Eksterne subtreffers:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Gewysig deur "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -4560,9 +6339,11 @@ msgstr ""
 "\n"
 "Gekompileer op "
 
+#: ../version.c:649
 msgid "by "
 msgstr "deur "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -4570,567 +6351,1516 @@ msgstr ""
 "\n"
 "Enorme weergawe "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Groot weergawe "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normale weergawe "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Klein weergawe "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Piepklein weergawe "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "sonder GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "met GTK2-GNOME GUI."
-
-msgid "with GTK-GNOME GUI."
-msgstr "met GTK-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "met GTK2 GUI"
-
-msgid "with GTK GUI."
-msgstr "met GTK GUI"
-
-msgid "with X11-Motif GUI."
-msgstr "met X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "met X11-neXtaw GUI"
-
-msgid "with X11-Athena GUI."
-msgstr "met X11-Athena GUI"
-
-msgid "with BeOS GUI."
-msgstr "met BeOS GUI"
-
-msgid "with Photon GUI."
-msgstr "met Photon GUI."
-
-msgid "with GUI."
-msgstr "met GUI."
-
-msgid "with Carbon GUI."
-msgstr "met Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "met Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "met (klassieke) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Kenmerke in- (+) of uitgesluit (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   stelsel vimrc-lêer: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     gebruiker vimrc-lêer: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2de gebruiker vimrc-lêer \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3de gebruiker vimrc-lêer \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      gebruiker exrc-lêer: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2de gebruiker exrc-lêer: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  stelsel gvimrc-lêer: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    gebruiker gvimrc-lêer: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2de gebruiker gvimrc-lêer: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3de gebruiker gvimrc-lêer: \""
-
-msgid "    system menu file: \""
-msgstr "    stelsel kieslys-lêer: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  bystand vir $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " bystand vir $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilering: "
 
-msgid "Compiler: "
-msgstr "Kompileerder: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Koppeling: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  ONTFOUTINGS-KOMPILERING"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi Met skop"
 
 # njj: :))
+#: ../version.c:769
 msgid "version "
 msgstr "Weergawe "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "deur Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim is vryekode, en vrylik verspreibaar"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Help arm kinders in Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "tik   :help iccf<Enter> vir meer inligting hieroor "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "tik   :q<Enter>               om program verlaat    "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "tik   :help<Enter>  of  <F1>  vir aanlyn hulp       "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "tik   :help version7<Enter>   vir weergawe-inligting"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Voer tans uit in Vi-versoenbare modus"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "tik   :set nocp<Enter>        vir Vim verstekwaardes   "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "tik   :help cp-default<Enter> vir meer inligting hieroor"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu  Hulp->Weeskinders       vir meer inligting hieroor "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Voer modus-loos uit, getikte teks word ingevoeg"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menu  Redigeer->Globale verstellings->Stel en herstel Invoeg Modus"
-
-msgid "                              for two modes      "
-msgstr "                              vir twee modusse   "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menu  Redigeer->Global verstellings->Stel en herstel Vi Versoenbaar"
-
-msgid "                              for Vim defaults   "
-msgstr "                              vir Vim verstekwaardes"
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Borg Vim ontwikkeling!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Word 'n geregistreerde Vim gebruiker!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "tik   :help sponsor<Enter>    vir meer inligting hieroor "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "tik   :help register<Enter>   vir meer inligting hieroor "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu  Hulp->Borg/Registreer   vir meer inligting"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "WAARSKUWING: Windows 95/98/ME bespeur"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "tik   :help windows95<Enter>  vir meer inligting hieroor"
-
-msgid "E441: There is no preview window"
-msgstr "E441: Daar is nie 'n voorskou-venster nie"
-
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: Kan nie bo-links en onder-regs terselfdertyd verdeel nie"
-
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: Kan nie roteer terwyl 'n ander venster verdeel is nie"
-
-msgid "E444: Cannot close last window"
-msgstr "E444: Kan nie laaste venster toemaak nie"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Daar is alreeds slegs een venster"
 
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: Daar is nie 'n voorskou-venster nie"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: Kan nie bo-links en onder-regs terselfdertyd verdeel nie"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: Kan nie roteer terwyl 'n ander venster verdeel is nie"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: Kan nie laaste venster toemaak nie"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Kan nie laaste venster toemaak nie"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Kan nie laaste venster toemaak nie"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Die ander venster bevat veranderinge"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Geen lêernaam onder loper"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Kan lêer \"%s\" nie vind in pad nie"
+#~ msgid "[Error List]"
+#~ msgstr "[Foutlys]"
 
-msgid "E370: Could not load library %s"
-msgstr "E370: Kon nie biblioteek laai nie %s"
+#~ msgid "[No File]"
+#~ msgstr "[Geen lêer]"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Jammer, hierdie bevel is afgeskakel: die Perl biblioteek kon nie gelaai "
-"word nie."
+#~ msgid "Patch file"
+#~ msgstr "Laslap lêer"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Perl evaluasie verbied in die sandput sonder die 'Safe' module"
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: Onbekende veranderlike: \"%s\""
 
-msgid "Edit with &multiple Vims"
-msgstr "Wysig met &meer as een Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Kanselleer"
 
-msgid "Edit with single &Vim"
-msgstr "Wysig met 'n enkel &Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Geen verbinding met Vim bediener"
 
-msgid "&Diff with Vim"
-msgstr "Wys verskille ('&diff') met Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Kon bediener-terugvoer nie lees nie"
 
-msgid "Edit with &Vim"
-msgstr "Wysig met &Vim"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Kan nie na %s stuur nie"
 
-#. Now concatenate
-msgid "Edit with existing Vim - &"
-msgstr "Wysig met bestaande Vim - &"
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: Ongedefinieerde funksie: %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Wysig die gekose lêer(s) met Vim"
+#~ msgid "Save As"
+#~ msgstr "Stoor As"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "FOut met die skep van proses: Kyk of gvim in jou pad is!"
+#~ msgid "Source Vim script"
+#~ msgstr "Voer Vim skrip uit"
 
-msgid "gvimext.dll error"
-msgstr "'gvimext.dll' fout"
+#~ msgid "Edit File"
+#~ msgstr "Verander lêer"
 
-msgid "Path length too long!"
-msgstr "Pad-lengte te lank"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NIE GEVIND NIE)"
 
-msgid "--No lines in buffer--"
-msgstr "--Geen reëls in buffer--"
+#~ msgid "Edit File in new window"
+#~ msgstr "Bewerk lêer in nuwe venster"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Bevel gekanselleer"
+#~ msgid "Append File"
+#~ msgstr "Las aan by lêer"
 
-msgid "E471: Argument required"
-msgstr "E471: Parameter benodig"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Vensterposisie: X %d, Y %d"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ moet gevolg word deur /, ? of &"
+#~ msgid "Save Redirection"
+#~ msgstr "Stoor Herversturing"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ongeldig in bevelreël venster: <CR> voer uit, CTRL-C stop"
+#~ msgid "Save View"
+#~ msgstr "Stoor Oorsig"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Bevel uit exrc/vimrc nie toegelaat in huidige gids- of etiketsoektog nie"
+#~ msgid "Save Session"
+#~ msgstr "Stoor Sessie"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Ontbrekende ':endif'"
+#~ msgid "Save Setup"
+#~ msgstr "Stoor konfigurasie"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Ontbrekende ':endtry'"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Geen digrawe in hierdie weergawe nie"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Ontbrekende ':endwhile'"
+#~ msgid "[NL found]"
+#~ msgstr "[NL gevind]"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: ':endwhile' sonder ':while'"
+#~ msgid "[crypted]"
+#~ msgstr "[gekodeer]"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Lêer bestaan (gebruik ! om te dwing)"
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "[OMSETTINGSFOUT]"
 
-msgid "E472: Command failed"
-msgstr "E472: Bevel het gefaal"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans laat nie skryf toe van onveranderde buffers nie"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Onbekende fontstel: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Gedeeltelike skryf word nie toegelaat vir NetBeans buffers nie"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Onbekende font: %s"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Die hulpbronvurk sal verlore gaan (gebruik ! om te dwing)"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Font \"%s\" is nie 'n vaste-wydte font nie"
+#~ msgid "<cannot open> "
+#~ msgstr "<kan nie oopmaak nie> "
 
-msgid "E473: Internal error"
-msgstr "E473: Interne fout"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: 'vim_SelFile': kan font %s nie kry nie"
 
-msgid "Interrupted"
-msgstr "Onderbreek"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: 'vim_SelFile': Kan nie terugkeer na huidige gids nie"
 
-msgid "E14: Invalid address"
-msgstr "E14: Ongeldige adres"
+#~ msgid "Pathname:"
+#~ msgstr "Gidsnaam:"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Ongeldige parameter"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: Kan nie huidige gids verkry nie"
 
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Ongeldige parameter: %s"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Ongeldige uitdrukking: %s"
+#~ msgid "Cancel"
+#~ msgstr "Kanselleer"
 
-msgid "E16: Invalid range"
-msgstr "E16: Ongeldige omvang"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim dialooghokkie"
 
-msgid "E476: Invalid command"
-msgstr "E476: Ongeldige bevel"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Rolstaafelement: Kon nie pikselmatriks-duimnael se geometrie kry nie"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" is 'n gids"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Kan nie BalloonEval skep met beide boodskap en terugroep nie"
 
-msgid "E18: Unexpected characters before '='"
-msgstr "E18: Onverwagte karakters voor '='"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Kan nie die GUI begin nie"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Biblioteekroep het gefaal vir \"%s\"()"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Kan nie lees uit \"%s\" nie"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Kon nie biblioteek funksie laai nie %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Kan nie GUI begin nie, geen geldige font gevind nie"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Merker het ongeldige reëlnommer"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' ongeldig"
 
-msgid "E20: Mark not set"
-msgstr "E20: Merker nie gestel nie"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Waarde van 'imactivatekey' is ongeldig"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Kan nie wysig nie, 'modifiable' is af"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Kan nie kleur %s toeken nie"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skripte te diep ge-nes"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialooghokkie..."
 
-msgid "E23: No alternate file"
-msgstr "E23: Geen alternatiewe lêer nie"
+#~ msgid "Input _Methods"
+#~ msgstr "Invoer _Metodes"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Afkorting bestaan nie"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Soek en Vervang..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: Geen ! toegelaat nie"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Soek..."
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI kan nie gebruik word nie: Nie tydens kompilering gekies nie"
+#~ msgid "Find what:"
+#~ msgstr "Soek na:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E26: Hebreeus kan nie gebruik word nie: Nie tydens kompilering gekies nie\n"
+#~ msgid "Replace with:"
+#~ msgstr "Vervang met:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E27: Farsi kan nie gebruik word nie: Nie tydens kompilering gekies nie\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Tref slegs presiese woord"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E800: Arabies kan nie gebruik word nie: Nie tydens kompilering gekies nie\n"
+#~ msgid "Match case"
+#~ msgstr "Tref kas"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Geen sodanige uitliggroepnaam nie: %s"
+#~ msgid "Direction"
+#~ msgstr "Rigting"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Nog geen ingevoegde teks nie"
+#~ msgid "Up"
+#~ msgstr "Op"
 
-msgid "E30: No previous command line"
-msgstr "E30: Geen vorige bevelreël nie"
+#~ msgid "Down"
+#~ msgstr "Af"
 
-msgid "E31: No such mapping"
-msgstr "E31: Geen so 'n binding nie"
+#~ msgid "Find Next"
+#~ msgstr "Vind volgende"
 
-msgid "E479: No match"
-msgstr "E479: Geen treffer nie"
+#~ msgid "Replace"
+#~ msgstr "Vervang"
 
-msgid "E480: No match: %s"
-msgstr "E480: Geen treffer: %s"
+#~ msgid "Replace All"
+#~ msgstr "Vervang alles"
 
-msgid "E32: No file name"
-msgstr "E32: Geen lêernaam"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Het die \"die\" opdrag ontvang van sessiebestuurder\n"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Geen vorige vervangingspatroon nie"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Hoofvenster onverwags verwoes\n"
 
-msgid "E34: No previous command"
-msgstr "E34: Geen vorige bevel nie"
+#~ msgid "Font Selection"
+#~ msgstr "Fontkeuse"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Geen vorige patroon nie"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "'CUT_BUFFER0' is gebruik in plaas van leë seleksie"
 
-msgid "E481: No range allowed"
-msgstr "E481: Geen omvang toegelaat nie"
+#~ msgid "Filter"
+#~ msgstr "Filter"
 
-msgid "E36: Not enough room"
-msgstr "E36: Te min plek"
+#~ msgid "Directories"
+#~ msgstr "Gidse"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: geen geregistreerde bediener genaamd \"%s\""
+#~ msgid "Help"
+#~ msgstr "Hulp"
 
-msgid "E482: Can't create file %s"
-msgstr "E482: Kan nie lêer %s skep nie"
+#~ msgid "Files"
+#~ msgstr "Lêers"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Kan nie tydelike lêernaam kry nie"
+#~ msgid "Selection"
+#~ msgstr "Seleksie"
 
-msgid "E484: Can't open file %s"
-msgstr "E484: Kan nie lêer %s oopmaak nie"
+#~ msgid "Undo"
+#~ msgstr "Herroep"
 
-msgid "E485: Can't read file %s"
-msgstr "E485: Kan nie lêer %s lees nie"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Kan nie venster titel vind nie \"%s\""
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Ongeskryf sedert vorige verandering (gebruik ! om te dwing)"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Parameter nie bekend: \"-%s\"; Gebruik die OLE weergawe."
 
-msgid "E38: Null argument"
-msgstr "E38: Nul parameter"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Kon nie venster oopmaak binne 'n MDI toepassing nie"
 
-msgid "E39: Number expected"
-msgstr "E39: Nommer verwag"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Vind string (gebruik '\\\\' om 'n '\\' te vind"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Kan nie foutlêer %s oopmaak nie"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Vind & vervang string (gebruik '\\\\' om 'n '\\' te vind"
 
-msgid "E233: cannot open display"
-msgstr "E233: kan nie vertoonskerm oopmaak nie"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Kan nie kleurkaart-inskrywing toeken nie, sommige kleure mag "
+#~ "verkeerd wees"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Geheue op!"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Fonte vir die volgende karakterstelle ontbreek in fontversameling "
+#~ "%s:"
 
-msgid "Pattern not found"
-msgstr "Patroon nie gevind nie"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Fontstel naam: %s"
 
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Patroon nie gevind nie: %s"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Font '%s' is nie 'n vaste-wydte font nie"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Parameter moet positief wees"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Fonstel naam: %s\n"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Kan nie terug gaan na die vorige gids nie"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E42: No Errors"
-msgstr "E42: Geen Foute"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Beskadige trefferstring"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Font%<PRId64> wydte is nie twee keer díe van font0 nie\n"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Korrupte patroonprogram"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Font0 wydte: %<PRId64>\n"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' opsie is aan (gebruik ! om te dwing)"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Font1 wydte: %<PRId64>\n"
+#~ "\n"
 
-#, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: Kan nie lees-alleen veranderlike stel nie \"%s\""
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul outomatiserings FOUT"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Fout tydens lees van 'errorfile'"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: 'stat' fout"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Nie toegelaat in sandput nie"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Kon nie 'cscope' databasis oopmaak nie: %s"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Nie hier toegelaat nie"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: kan nie 'cscope' databasisinligting kry nie"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Skermmodus instelling nie ondersteun nie"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: maksimum aantal 'cscope' verbindings bereik"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Ongeldige rolgrootte"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Jammer, hierdie bevel is afgeskakel, die Python biblioteek lêer kon "
+#~ "nie gelaai word nie."
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' (dop) opsie is leeg"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Kan nie Python rekursief roep nie"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Fout -- kon nie tekendata lees nie!"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "kan nie 'OutputObject' eienskappe skrap nie"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Sluitfout met ruillêer"
+#~ msgid "softspace must be an integer"
+#~ msgstr "'softspace' moet 'n heelgetal wees"
 
-msgid "E73: tag stack empty"
-msgstr "E73: etiketstapel leeg"
+#~ msgid "invalid attribute"
+#~ msgstr "ongeldige eienskap"
 
-msgid "E74: Command too complex"
-msgstr "E74: Bevel te kompleks"
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "'writelines()' benodig 'n lys van stringe"
 
-msgid "E75: Name too long"
-msgstr "E75: Naam te lank"
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Kon nie I/O objekte inwy nie"
 
-msgid "E76: Too many ["
-msgstr "E76: Te veel ["
+# njj: net 'n voorstel ..
+#~ msgid "invalid expression"
+#~ msgstr "ongeldige uitdrukking"
 
-msgid "E77: Too many file names"
-msgstr "E77: Te veel lêername"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "uitdrukkings afgeskakel tydens kompilering"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Oorbodige karakters"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "poging om na 'n geskrapte buffer te verwys"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Onbekende merker"
+#~ msgid "line number out of range"
+#~ msgstr "reëlnommer buite omvang"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Kan nie plekhouers uitbrei nie"
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffervoorwerp (geskrap) by %8lX>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' kan nie kleiner as 'winminheight' wees nie"
+#~ msgid "invalid mark name"
+#~ msgstr "onbekende merknaam"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' kan nie kleiner as 'winminwidth' wees nie"
+#~ msgid "no such buffer"
+#~ msgstr "buffer bestaan nie"
 
-msgid "E80: Error while writing"
-msgstr "E80: Fout tydens skryfoperasie"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "poging om na geskrapte venster te verwys"
 
-msgid "Zero count"
-msgstr "Nul telling"
+#~ msgid "readonly attribute"
+#~ msgstr "leesalleen eienskap"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Gebruik van '<SID>' buite skripkonteks"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "loperposisie buite buffer"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Ongeldige uitdrukking ontvang"
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<venster voorwerp (geskrap) by %.8lX>"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<verwyder voorwerp (onbekend) by %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<venster %d>"
+
+#~ msgid "no such window"
+#~ msgstr "geen sodanige venster nie"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "kan nie herwin-inligting stoor nie"
+
+#~ msgid "cannot delete line"
+#~ msgstr "kan reël nie verwyder nie"
+
+#~ msgid "cannot replace line"
+#~ msgstr "kan reël nie vervang nie"
+
+#~ msgid "cannot insert line"
+#~ msgstr "kan reël nie byvoeg nie"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "string kan nie 'newlines' bevat nie"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Jammer, hierdie bevel is afgeskakel, die Ruby biblioteeklêer kon "
+#~ "nie gelaai word nie."
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Onbekende 'longjmp' status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Stel en herstel implimentasie/definisie"
+
+#~ msgid "Show base class of"
+#~ msgstr "Wys basisklas van"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Wys vervangde lidfunksie"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Gaan haal uit lêer"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Gaan haal uit projek"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Gaan haal uit alle projekte"
+
+#~ msgid "Retrieve"
+#~ msgstr "Gaan haal"
+
+#~ msgid "Show source of"
+#~ msgstr "Wys kode van"
+
+#~ msgid "Find symbol"
+#~ msgstr "Vind simbool"
+
+#~ msgid "Browse class"
+#~ msgstr "Kyk klas deur"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Wys klas in hiërargie"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Wys klas in beperkte hiërargie"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref verwys na"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref verwys deur"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref het 'n"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref gebruik deur"
+
+#~ msgid "Show docu of"
+#~ msgstr "Wys 'docu' van"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Genereer 'docu' vir"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Kan nie 'n verbinding met 'SNiFF+' maak nie. Kyk of die omgewing reg is "
+#~ "('sniffemacs' moet in '$PATH' gevind word).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Fout gedurende lees. Verbinding gebreek"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ is tans"
+
+#~ msgid "not "
+#~ msgstr "nie "
+
+#~ msgid "connected"
+#~ msgstr "gekonnekteer"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Onbekende SNiFF+ versoek: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Fout in konnekteer met SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ is nie gekonnekteer nie"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Fout gedurende stoor. Verbinding gebreek"
+
+#~ msgid "not implemented yet"
+#~ msgstr "nog nie geïmplementeer nie"
+
+#~ msgid "unknown option"
+#~ msgstr "onbekende opsie"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "kan nie reël(s) stel nie"
+
+#~ msgid "mark not set"
+#~ msgstr "merker nie gestel nie"
+
+#~ msgid "row %d column %d"
+#~ msgstr "ry %d kolom %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "kan nie reël invoeg/aanlas nie"
+
+#~ msgid "unknown flag: "
+#~ msgstr "onbekende vlag: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "onbekende 'vimOption'"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "sleutelbordonderbreking"
+
+#~ msgid "vim error"
+#~ msgstr "vim fout"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "kan nie buffer/venster bevel skep nie: voorwerp word geskrap"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "kan nie terugroepbevel registreer nie: buffer/venster word alreeds geskrap"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATALE FOUT: verwlys korrup!? Rapporteer dit asb. aan <vim-"
+#~ "dev@vim.org>"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "kan terugroepbevel nie registreer nie: buffer/vensterverwysing nie gevind "
+#~ "nie"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Jammer, hierdie bevel is afgeskakel, die Tcl biblioteek kon nie "
+#~ "gelaai word nie."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL FOUT: verlaatkode is nie 'n 'int'!? Rapporteer dit asb. aan "
+#~ "<vim-dev@vim.org>"
+
+#~ msgid "cannot get line"
+#~ msgstr "kan nie reël kry nie"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Kon nie bevelbediener naam registreer nie"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Het gefaal om bevel na doel program te stuur"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM instansie register-kenmerk is swak gevorm. Geskrap!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Hierdie Vim is nie gekompileer met 'diff' funksionaliteit nie."
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistreer hierdie gvim vir OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tOnregistreer gvim vir OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tVoer uit met die GUI (soos \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  of  --nofork\tVoorgrond: Moenie vurk wanneer GUI begin nie"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tOmslagtigheidsgraad"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tMoet nie 'newcli' gebruik om venster oop te maak nie"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <toestel>\t\tGebruik <toestel> vir I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tGebruik <gvimrc> in plaas van enige .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tBewerk geënkripteerde lêers"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tKoppel vim aan hierdie X-bediener"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tMoet nie verbinding met X-bediener maak nie"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <lêers>\tWysig die <lêers> in a Vim bediener indien moontlik"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <lêers>  Dieselfde, moet nie kla as daar nie so 'n "
+#~ "bediener is nie"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <lêers> Soos '--remote', maar wag vir lêers om gewysig te "
+#~ "word"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <lêers>  Dieselfde, moet nie kla as daar nie so 'n "
+#~ "bediener is nie"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <sleutels>\tStuur <sleutels> na 'n Vim-bediener en verlaat"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <expr>\tEvalueer <expr> in 'n Vim-bediener en druk resultaat"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tLys beskikbare Vim-bediener name en verlaat"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <naam>\tStuur na/word die Vim-bediener <naam>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parameters deur gvim herken (Motif weergawe):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parameters deur gvim herken (neXtaw weergawe):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parameters deur gvim herken (Athena weergawe):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tVoer vim op <display> uit"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tBegin vim as ikoon"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\tGebruik hulpbron asof vim <name> was"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Nog nie geïmplementeer nie)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <kleur>\tGebruik <kleur> vir die agtergrond (ook: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-voorgrond <kleur>\tGebruik <kleur> vir normale teks (ook: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tGebruik <font> vir normale teks (ook -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "­boldfont <font>\t Gebruik <font> vir vetletter teks"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\tGebruik <font> vir kursiewe teks"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\tGebruik <geom> vir aanvanklike geometrie"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <wydte>\tGebruik 'n grenswydte van <wydte> (ook: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <wydte>\tGebruik 'n rolstaafwydte van <wydte> (ook: -sw>"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <hoogte>\tGebruik a kieslysstaafhoogte van <hoogte> (ook: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tGebruik tru-video (ook: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tMoet nie tru-video gebruik nie (ook: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <hulpbron>\tStel die gespesifiseerde hulpbron"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parameters wat gvim verstaan (RISC OS weergawe):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <aantal>\tAanvanklike wydte van venster in kolomme"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <aantal>\tAanvanklike hoogte van venster in rye"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parameters wat gvim verstaan (GTK+ weergawe):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <skerm>\tVoer vim op <skerm> uit: (ook --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <rol>\tStel 'n unieke rol om die hoofvenster te identifiseer"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tMaak Vim in 'n ander GTK element oop"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <ouer title>\tMaak Vim oop binne 'n ouer toepassing"
+
+#~ msgid "No display"
+#~ msgstr "Geen vertoonskerm"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Stuur het gefaal.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Stuur het gefaal. Probeer om lokaal uit te voer\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d van %d lêers bewerk"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Geen vertoonskerm: Stuur van uitdrukking het gefaal.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Stuur van uitdrukking het gefaal.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Nie 'n geldige kodeblad nie"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Gefaal met die skep van invoerkonteks"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Gefaal om invoermetode oop te maak"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Waarskuwing: Kon nie uitwis-terugroep na IM stel nie"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: invoermetode ondersteun geen styl nie"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: invoermetode ondersteun nie my voor-bewerking tipe nie"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: oor-die-plek styl vereis fontstel"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Jou GTK+ is ouer as 1.2.3. Statusarea afgeskakel"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Invoermetodebediener voer nie uit nie"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nie bruikbaar met hierdie weergawe van Vim nie]"
+
+#~ msgid ""
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
+#~ msgstr ""
+#~ "&Maak as lees-alleen oop\n"
+#~ "&Bewerk in elk geval\n"
+#~ "&Herwin\n"
+#~ "&Verlaat\n"
+#~ "&Stop\n"
+#~ "S&krap dit"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Skeur die kieslys af"
+
+#~ msgid "[string too long]"
+#~ msgstr "[string te lank]"
+
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "Druk ENTER om voort te gaan"
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: reël, SPACE/b: bladsy, d/u: halwe bladsy, q: los dit"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: reël, SPACE: bladsy, d: halwe bladsy, q: los dit"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Stoor Lêer dialooghokkie"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Maak lêer oop dialooghokkie"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Jammer, lêerblaaier nie beskikbaar in konsole-modus nie"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: bewaar lêers...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Klaar.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "FOUT: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[grepe] totaal 'alloc'-vrygelaat %<PRIu64>-%<PRIu64>, in gebruik "
+#~ "%<PRIu64>, piekgebruik %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[roepe] totaal re/malloc()'s %<PRIu64>, totale free()'s %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Rëel word te lank"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Interne fout: 'lalloc(%<PRId64>, )'"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Ongeldige muisvorm"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Voer enkripsie-sleutel in: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Voer die sleutel weer in: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Sleutels verskil!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Kan nie aan Netbeans #2 koppel nie"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Kan nie aan Netbeans koppel nie"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Verkeerde toegangsmodue vir NetBeans konneksie inligtingslêer: \"%s"
+#~ "\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "lees vanaf Netbeans 'socket'"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: NetBeans konneksie vir buffer %<PRId64> verloor"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "laat %<PRId64> reëls gaan"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Kan nie 'term' verander in GUI nie"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Gebruik \":gui\" om die GUI te begin"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Kan nie 'term' verander in die GTK+ 2 GUI nie"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: kan nie fontstel kies nie"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Ongeldige fontstel"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: kan nie wye font kies nie"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Ongeldige wye font"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Geen muisondersteuning nie"
+
+#~ msgid "cannot open "
+#~ msgstr "kan nie oopmaak nie "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Kan nie venster oopmaak nie!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Benodig Amigados weergawe 2.04 of later\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Benodig %s weergawe %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Kan nie NIL: oopmaak nie\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Kan nie skep nie: "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim stop met %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "kan konsole-modus nie verander nie ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "'mch_get_shellsize': nie 'n konsole nie??\n"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Kan nie uitvoer nie "
+
+#~ msgid "shell "
+#~ msgstr "dop "
+
+#~ msgid " returned\n"
+#~ msgstr " teruggekeer\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "'ANCHOR_BUF_SIZE' is te klein"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O FOUT"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(afgekap)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' is nie 80 nie, kan nie eksterne bevele uitvoer nie"
+
+#~ msgid "to %s on %s"
+#~ msgstr "na %s op %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Onbekende drukker font: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Drukfout: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Druk nou '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Ongeldige karakterstelnaam \"%s\" in fontnaam \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Ongeldige karakter '%c' in fontnaam \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Dubbel sein, staak\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Het dodelike sein %s gevang\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Het dodelike sein gevang\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Om die X-vertoonskerm oop te maak het %<PRId64> msek gevat"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Het X fout ontvang\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Toetsing van die X-vertoonskerm het gefaal"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Oopmaak van die X-vertoonskerm het uitgetel"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan nie dop 'sh' uitvoer nie\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan nie pype skep nie\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan nie vurk nie\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Bevel beëindig\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP het ICE konneksie verloor"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Oopmaak van die X vertoonskerm het gefaal"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP hanteer 'save-yourself' versoek"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP maak nou konneksie oop"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE konneksie beloer het gefaal"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP 'SmcOpenConnection' het gefaal: %s"
+
+#~ msgid "At line"
+#~ msgstr "By reël"
+
+#~ msgid "Could not allocate memory for command line."
+#~ msgstr "Kan nie geheue toeken vir bevelreël nie"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM Fout"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Kon nie 'vim32.dll' laai nie!"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Kon nie funksiewysers na die DLL opstel nie!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "dop het %d gelewer"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Het %s gebeurtenis gevang\n"
+
+#~ msgid "close"
+#~ msgstr "maak toe"
+
+#~ msgid "logoff"
+#~ msgstr "teken uit"
+
+#~ msgid "shutdown"
+#~ msgstr "sit af"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Bevel nie gevind nie"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "'VIMRUN.EXE' nie gevind in '$PATH' nie.\n"
+#~ "Eksterne opdragte sal nie wag na voltooiing nie\n"
+#~ "Sien ':help win32-vimrun' vir meer inligting."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Waarskuwing"
+
+#~ msgid "E56: %s* operand could be empty"
+#~ msgstr "E56: %s* operand mag leeg wees"
+
+#~ msgid "E57: %s+ operand could be empty"
+#~ msgstr "E57: %s+ operand mag leeg wees"
+
+#~ msgid "E58: %s{ operand could be empty"
+#~ msgstr "E58: %s{ operand mag leeg wees"
+
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr "E361: Ineenstorting onderskep. Patroon te kompleks?"
+
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: patroon het lëe-stapel fout veroorsaak"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: 'containedin' parameter nie hier aanvaar nie"
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "Sleutel nommer van keuse in (<CR> om te stop): "
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Etiketlêergids afgekap vir %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "nuwe dop begin\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Geen herstel moontlik; gaan in elk geval voort"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32-bis GUI weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bis GUI version"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " in Win32s modus"
+
+#~ msgid " with OLE support"
+#~ msgstr " met OLE ondersteuning"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bis konsole weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16-bis weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32-bis MS-DOS weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16-bis MS-DOS weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS weergawe"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Groot weergawe "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normale weergawe "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Klein weergawe "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Piepklein weergawe "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "met GTK2-GNOME GUI."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "met GTK-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "met GTK2 GUI"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "met GTK GUI"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "met X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "met X11-neXtaw GUI"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "met X11-Athena GUI"
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "met BeOS GUI"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "met Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "met GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "met Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "met Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "met (klassieke) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  stelsel gvimrc-lêer: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    gebruiker gvimrc-lêer: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2de gebruiker gvimrc-lêer: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3de gebruiker gvimrc-lêer: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    stelsel kieslys-lêer: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompileerder: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu  Hulp->Weeskinders       vir meer inligting hieroor "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Voer modus-loos uit, getikte teks word ingevoeg"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menu  Redigeer->Globale verstellings->Stel en herstel Invoeg Modus"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              vir twee modusse   "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menu  Redigeer->Global verstellings->Stel en herstel Vi Versoenbaar"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              vir Vim verstekwaardes"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "WAARSKUWING: Windows 95/98/ME bespeur"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "tik   :help windows95<Enter>  vir meer inligting hieroor"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Kon nie biblioteek laai nie %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Jammer, hierdie bevel is afgeskakel: die Perl biblioteek kon nie gelaai "
+#~ "word nie."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Perl evaluasie verbied in die sandput sonder die 'Safe' module"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Wysig met &meer as een Vim"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Wysig met 'n enkel &Vim"
+
+#~ msgid "&Diff with Vim"
+#~ msgstr "Wys verskille ('&diff') met Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Wysig met &Vim"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "Wysig met bestaande Vim - &"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Wysig die gekose lêer(s) met Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "FOut met die skep van proses: Kyk of gvim in jou pad is!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "'gvimext.dll' fout"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Pad-lengte te lank"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Onbekende fontstel: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Onbekende font: %s"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Kon nie biblioteek funksie laai nie %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Hebreeus kan nie gebruik word nie: Nie tydens kompilering gekies "
+#~ "nie\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Farsi kan nie gebruik word nie: Nie tydens kompilering gekies nie\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Arabies kan nie gebruik word nie: Nie tydens kompilering gekies "
+#~ "nie\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: geen geregistreerde bediener genaamd \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: kan nie vertoonskerm oopmaak nie"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 
 #~ msgid "function "
 #~ msgstr "funksie "
@@ -5138,14 +7868,8 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 #~ msgid "Run Macro"
 #~ msgstr "Voer Makro uit"
 
-#~ msgid "E221: 'commentstring' is empty"
-#~ msgstr "E221: 'commentstring' opsie is leeg"
-
 #~ msgid "E242: Color name not recognized: %s"
 #~ msgstr "E242: Kleurnaam is onbekend: %s"
-
-#~ msgid "E242: Missing color: %s"
-#~ msgstr "E242: Ontbrekende kleur: %s"
 
 #~ msgid "error reading cscope connection %d"
 #~ msgstr "'cscope' verbinding %d kon nie gelees word nie"
@@ -5190,9 +7914,6 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 #~ msgid "Binary tag search"
 #~ msgstr "Binêre etiketsoek"
 
-#~ msgid "Can't open file %s"
-#~ msgstr "Kan nie lêer %s oopmaak nie"
-
 #~ msgid "E258: no matches found in cscope connections"
 #~ msgstr "E258: geen treffers gevind in 'cscope' verbindings nie"
 
@@ -5208,9 +7929,6 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 #~ msgid "Cannot use :normal from event handler"
 #~ msgstr "Kan ':normal' nie vanuit gebeurtenishanteerder gebruik nie"
 
-#~ msgid "%<PRId64>L, %<PRId64>C"
-#~ msgstr "%<PRId64>R, %<PRId64>K"
-
 #~ msgid "VIM - Help on..."
 #~ msgstr "VIM - Hulp met.."
 
@@ -5222,9 +7940,6 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 
 #~ msgid "locale is not set correctly"
 #~ msgstr "lokaal is nie korrek gestel nie"
-
-#~ msgid "Set LANG environment variable to your locale"
-#~ msgstr "Stel die 'LANG' omgewingsveranderlike na jou lokaal toe"
 
 #~ msgid "For korean:"
 #~ msgstr "Vir Afrikaans:"
@@ -5240,9 +7955,6 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 
 #~ msgid "Your language Font missing"
 #~ msgstr "Jou taal Font ontbreek"
-
-#~ msgid "loaded fontname: %s"
-#~ msgstr "gelaaide fontnaam: %s"
 
 #~ msgid "automata ERROR: internal"
 #~ msgstr "automata FOUT: intern"

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -6,149 +6,217 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-05-24 14:27+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2008-06-06 14:40+0100\n"
 "Last-Translator: Ernest Adrogué <eadrogue@gmx.net>\n"
 "Language-Team: Catalan <ca@dodds.net>\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Porqueria després de l'argument d'opció"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Llista de posicions]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Llista Quickfix]"
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: No s'ha pogut assignar memòria per cap buffer, sortint..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: No s'ha pogut assignar memòria pel buffer, usant-ne un altre..."
 
 # unload: Treu el buffer de la memòria però el deixa a la llista
 # delete: Treu el buffer de la memòria i de la llista de buffers
 # wipe out: Elimina el buffer amb totes les opcions, marques, etc.
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: No s'ha alliberat cap buffer"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: No s'ha eliminat cap buffer"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: No s'ha destruït cap buffer"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "S'ha alliberat 1 buffer"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "S'han alliberat %d buffers"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "S'ha eliminat 1 buffer"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "S'han eliminat %d buffers"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "S'ha destruït 1 buffer"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "S'han destruït %d buffers"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: No es pot alliberar l'últim buffer"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: No s'ha trobat cap buffer modificat"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: No hi ha cap buffer a la llista"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: El buffer %<PRId64> no existeix"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: No es pot anar més enllà de l'últim buffer"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: No es pot anar més enllà del primer buffer"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: No s'ha desat el buffer %<PRId64> (afegiu ! per confirmar)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: No es pot alliberar l'últim buffer"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Atenció: S'ha desbordat la llista de noms de fitxers"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: No s'ha trobat el buffer %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Hi ha més d'una coincidència per a %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: No hi ha cap coincidència per a %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "línia %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Ja existeix un buffer amb aquest nom"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modificat]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[No editat]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Fitxer nou]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Errors de lectura]"
 
+# eac  només-lectura (nl)
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[NL]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[només lectura]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 línia --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> línies --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "línia %<PRId64> de %<PRId64> --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Sense nom]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ajuda"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Ajuda]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Vista prèvia]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Tot"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Baix"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Dalt"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -156,12 +224,11 @@ msgstr ""
 "\n"
 "# Llista de buffers:\n"
 
-msgid "[Location List]"
-msgstr "[Llista de posicions]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[Quickfix List]"
-msgstr "[Llista Quickfix]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -169,146 +236,214 @@ msgstr ""
 "\n"
 "--- Senyals ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Senyals per a %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    línia=%<PRId64>  id=%d  nom=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Falta un caràcter \":\""
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Mode il·legal"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: S'esperava un dígit"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Percentatge il·legal"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: No es poden mostrar diferències amb més de %<PRId64> buffers"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: No s'ha pogut obrir el fitxer termcap"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: No s'han pogut mostrar les diferències"
 
-# És el nom d'un diàleg. Menú "Split patched by..."
-msgid "Patch file"
-msgstr "Fitxer de diferències"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: No s'ha pogut llegir la sortida de diff"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: No s'ha pogut llegir la sortida de diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: El buffer actual no es troba en mode diff"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: No hi ha cap altre buffer en mode diff que sigui modificable"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: No hi ha cap altre buffer en mode diff"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Hi ha més de 2 buffers en mode diff, no se sap quin usar"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: No s'ha trobat el buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: El buffer \"%s\" no es troba en mode diff"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: El buffer ha canviat inesperadament"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: No es permeten caràcters d'escapada en un dígraf"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: No s'ha trobat el fitxer de mapa de tecles"
 
 # traducció de «sourced file».  eac
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: L'ordre :loadkeymap només es pot usar en fitxers"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Entrada al mapa de tecles no conté res"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Compleció de paraules clau (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Mode ^X (^]^D^E^F^|^K^L^N^O^Ps^U^V^Y)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Compleció de línies senceres (^L^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Compleció de noms de fitxer (^F^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Compleció d'etiquetes (^]^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Compleció d'ubicacions (^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Compleció de definicions (^D^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Compleció de paraules de diccionari (^K^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Compleció de sinònims (^T^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Compleció d'ordres (^V^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Compleció definida per l'usuari (^U^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-compleció (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr "Suggeriment ortogràfic (s^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Compleció de paraules clau locals (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "S'ha arribat al final del paràgraf"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "L'opció 'dictionary' no està definida"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "L'opció 'thesaurus' no està definida"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "S'està examinant el diccionari: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (inserir) Desplaçar (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (substituir) Desplaçar (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Examinant: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Examinant les etiquetes."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Afegint"
 
@@ -316,397 +451,592 @@ msgstr " Afegint"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Cercant..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Original"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Paraula d'una altra línia"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "L'única coincidència"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "coincidència %d de %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "coincidència %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caràcters inesperats :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: índex de llista fora d'abast: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Variable no definida: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Falta un ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: L'argument de %s ha de ser una llista"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: L'argument de %s ha de ser una llista o un diccionari"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Els diccionaris no admeten claus buides"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Es requereix una llista"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Es requereix un diccionari"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Massa arguments per a la funció: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: La clau no existeix al diccionari: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: La funció %s ja existeix, afegiu ! per substituir-la"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Ja existeix l'entrada al diccionari"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Es requereix una referència de funció"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: No es pot usar [:] amb un diccionari"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Tipus de variable incorrecte per a %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Funció desconeguda: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: El nom de la variable és il·legal: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: ús d'una llista com a cadena"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Hi ha menys valors objectiu que elements a la llista"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Hi ha més valors objectiu que elements a la llista"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Doble ; a la llista de variables"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: No es poden llistar les variables per a %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Només admeten índexs les llistes i els diccionaris"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] ha d'anar al final"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] requereix un valor tipus llista"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: La llista té més elements que valors objectiu"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: La llista no té prou elements"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Falta un \"in\" després de :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Falten claus '{}': %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: No existeix tal variable: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variable està massa imbricada per a (des)bloquejar-la"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Falta un ':' després de '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Una llista només es pot comparar amb una llista"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Operació no vàlida en llistes"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Un diccionari només es pot comparar amb un diccionari"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Operació no vàlida en diccionaris"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
-msgstr "E693: Una referència de funció només es pot comparar amb una referència de funció"
+msgstr ""
+"E693: Una referència de funció només es pot comparar amb una referència de "
+"funció"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Operació no vàlida per a referències de funcions"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: No es pot usar [:] amb un diccionari"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Falta un ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: No es pot indexar una referència de funció"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Falta el nom de l'opció: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Opció desconeguda: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Falten cometes: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Falten cometes: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Falta una coma a la llista: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Falta un final de llista ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Falta un caràcter de dos punts al diccionari: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Clau duplicada al diccionari: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Falta una coma al diccionari: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Falta un final de diccionari '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variable imbricada massa profundament per a mostrar-la"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Massa arguments per a la funció: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: Massa arguments per a la funció: %s"
+
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Funció desconeguda: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Falten arguments per a la funció: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Ús de <SID> en un context no vàlid: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Crida a una funció dict sense diccionari: %s"
 
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Es requereix un número després de ="
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c argument"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Sobren arguments"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() només es pot utilitzar en el mode d'inserció"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&D'acord"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: La clau ja existeix: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd argument"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c argument"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c argument"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld línies: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Funció desconeguda: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&D'acord\n"
-"&Cancel·la"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "s'ha cridat inputrestore() més sovint que inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c argument"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Interval no permès"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: El tipus per a len() no és vàlid"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: L'increment entre passos és zero"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Inici més enllà del final"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<buit>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: No hi ha connexió amb el servidor Vim"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd argument"
 
-# «res» ?  eac
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: No s'ha pogut enviar a %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: No s'ha pogut llegir la resposta del servidor"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Massa enllaços simbòlics (circulars?)"
 
-# «res» ?  eac
-msgid "E258: Unable to send to client"
-msgstr "E258: No s'ha pogut enviar al client"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c argument"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c argument"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c argument"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: La funció ordena-compara ha fallat"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: La funció ordena-compara ha fallat"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(No vàlid)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Error en escriure el fitxer temporal"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Ús d'una llista com a número"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Ús d'una referència de funció com a número"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Ús d'una llista com a número"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Ús d'un diccionari com a número"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: ús d'una referència de funció com a cadena"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: ús d'una llista com a cadena"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: ús d'un diccionari com a cadena"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: El nom d'una variable Funcref ha de començar en majúscula: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: El nom de la variable entra en conflicte amb una funció existent: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Tipus de variables no coincidents: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: No s'ha pogut eliminar la variable %s"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: El nom d'una variable Funcref ha de començar en majúscula: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+"E705: El nom de la variable entra en conflicte amb una funció existent: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: El valor està bloquejat: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Desconegut"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: No s'ha pogut canviar el valor de %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: la variable està massa imbricada per fer-ne una còpia"
 
+#: ../eval.c:17249
+#, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E123: La funció no està definida: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Falta un '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: No s'han pogut establir els valors del context d'entrada"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Argument il·legal: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Argument il·legal: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Falta un :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: El nom de la funció no coincideix amb el nom de l'script: %s"
+
+#: ../eval.c:17549
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E127: No s'ha pogut redefinir la funció %s: s'està utilitzant"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: El nom de la funció no coincideix amb el nom de l'script: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Es necessita un nom de funció"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
-msgstr "E128: El nom de la funció ha de començar en majúscula o contenir dos punts: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: El nom de la funció ha de començar en majúscula o contenir dos punts: "
+"%s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: El nom de la funció ha de començar en majúscula o contenir dos punts: "
+"%s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: No s'ha pogut eliminar la funció %s: S'està utilitzant"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Profunditat de crides a funcions superior a 'maxfuncdeptg'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "cridant %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "s'ha avortat %s"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s ha retornat #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s ha retornat \"%s\""
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "continuant a %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return fora d'una funció"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -714,6 +1044,7 @@ msgstr ""
 "\n"
 "# variables globals:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -721,217 +1052,110 @@ msgstr ""
 "\n"
 "\tDefinit per últim cop a "
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Entrant en mode de depuració. Escriviu \"cont\" per a continuar."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "línia %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "ordre: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Punt de ruptura a \"%s%s\" línia %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Punt de ruptura no trobat: %s"
-
-msgid "No breakpoints defined"
-msgstr "No s'han definit punts de ruptura"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  línia %<PRId64>"
-
-msgid "E750: First use :profile start <fname>"
-msgstr "E750: Primer useu :profile start <nomfitxer>"
-
-# Títol d'un diàleg [:browse w].  eac
-msgid "Save As"
-msgstr "Anomena i desa"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Voleu desar els canvis a \"%s\"?"
-
-msgid "Untitled"
-msgstr "Sense-nom"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: No s'han desat els canvis en el buffer \"%s\""
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Atenció: S'ha canviat de buffer inesperadament (reviseu les auto-ordres)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Només hi ha un fitxer per editar"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: No es pot anar més enllà del primer fitxer"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: No es pot anar més enllà de l'últim fitxer"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: el compilador no està suportat: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Cercant \"%s\" a \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Cercant \"%s\""
-
-# «runtimepath».  eac
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "no s'ha trobat en el 'runtimepath': \"%s\""
-
-# Títol d'un diàleg [:browse source].  eac
-msgid "Source Vim script"
-msgstr "Interpreta un script Vim"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "No es pot interpretar un directori: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "no s'ha pogut interpretar \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "línia %<PRId64>: no s'ha pogut interpretar \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "interpretant \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "línia %<PRId64>: interpretant \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "ha finalitzat l'interpretació de %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-msgid "--cmd argument"
-msgstr "--cmd argument"
-
-msgid "-c argument"
-msgstr "-c argument"
-
-msgid "environment variable"
-msgstr "variable d'entorn"
-
-msgid "error handler"
-msgstr "gestor d'errors"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Atenció: El separador de línia no és vàlid, potser falta un ^M"
-
-# «sourced file».  eac
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: L'ordre :scriptencoding només es pot utilitzar en scripts"
-
-# «sourced file».  eac
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: L'ordre :finish només es pot utilitzar en scripts"
-
-# les cadenes substituïdes no es poden traduïr.  eac
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Idioma actual ( %s): \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: No s'ha pogut canviar l'idioma a \"%s\""
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "No hi han fitxers inclosos"
 
 # E.G: :ascii
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
 # E.G: :ascii
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
 # E.G: :ascii
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: No es poden moure línies cap a elles mateixes"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 línia desplaçada"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> línies desplaçades"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> línies filtrades"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Les auto-ordres *Filter* no poden canviar el buffer actual"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[No s'han desat els últims canvis]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s a la línia: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Hi ha massa errors, s'omet la resta del fitxer"
 
 # les tres següents van juntes.  eac
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Llegint el fitxer viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " per info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " per marques"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "No hi han fitxers inclosos"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " ERROR"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: El fitxer viminfo no és modificable: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: No s'ha pogut escriure el fitxer viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Escrivint el fitxer viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Aquest fitxer viminfo ha estat generat pel Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -939,38 +1163,47 @@ msgstr ""
 "# El podeu editar si aneu amb compte!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Valor de 'encoding' en el moment d'escriure aquest fitxer\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Caràcter inicial il·legal"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Voleu escriure un fitxer parcial?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Useu ! per desar una part del buffer"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Voleu sobrescriure el fitxer existent \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "El fitxer d'intercanvi \"%s\" existeix, sobreescriure igualment?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: El fitxer d'intercanvi existeix: %s (:silent! per a confirmar)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: No hi ha nom de fitxer per al buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: No s'ha escrit el fitxer: L'opció 'write' ho impedeix"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -979,63 +1212,92 @@ msgstr ""
 "L'opció 'readonly' està definida per a \"%s\".\n"
 "Voleu escriure de totes maneres?"
 
-# és un títol de diàleg [:browse edit].  eac
-msgid "Edit File"
-msgstr "Edita un fitxer"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "és un fitxer de només lectura (afegiu ! per confirmar)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Una auto-ordre ha eliminat el buffer nou %s inesperadament"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Argument no numèric per a :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Les ordres shell no estan permeses en l'rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Les expressions regulars no poden estar delimitades per lletres"
 
 # «amb» o «per» + tecles.  eac
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "substituir amb %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Interromput) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 coincidència "
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 substitució"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> coincidències"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> substitucions"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " en 1 línia"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " en %<PRId64> línies"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: No es pot executar una ordre global de forma recursiva"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Les ordres globals requereixen una expressió regular"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "S'ha trobat el patró a cada línia: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "No s'ha trobat el patró"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1045,137 +1307,341 @@ msgstr ""
 "# Última cadena substituïda:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Calma!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: No hi ha ajuda en '%s' per a %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: No hi ha ajuda per %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "El fitxer d'ajuda \"%s\" no s'ha trobat"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: No és un directori: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: No s'ha pogut obrir %s amb permís d'escriptura"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: No s'ha pogut obrir %s amb permís de lectura"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Conjunts de caràcters diferents dins del mateix idioma: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: L'etiqueta \"%s\" està duplicada en el fitxer %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Ordre de senyalització desconeguda: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Falta el nom del senyal"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: S'han definit massa senyals"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: El text del senyal no és vàlid: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: El senyal és desconegut: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Falta el número del senyal"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: El nom del buffer no és vàlid: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: L'ID del senyal no és vàlida: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NO TROBAT)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (no suportat)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Eliminat]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Entrant en mode de depuració. Escriviu \"cont\" per a continuar."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "línia %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "ordre: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punt de ruptura a \"%s%s\" línia %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Punt de ruptura no trobat: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "No s'han definit punts de ruptura"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  línia %<PRId64>"
+
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Primer useu :profile start <nomfitxer>"
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Voleu desar els canvis a \"%s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Sense-nom"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: No s'han desat els canvis en el buffer \"%s\""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr ""
+"Atenció: S'ha canviat de buffer inesperadament (reviseu les auto-ordres)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Només hi ha un fitxer per editar"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: No es pot anar més enllà del primer fitxer"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: No es pot anar més enllà de l'últim fitxer"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: el compilador no està suportat: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Cercant \"%s\" a \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Cercant \"%s\""
+
+# «runtimepath».  eac
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "no s'ha trobat en el 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "No es pot interpretar un directori: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "no s'ha pogut interpretar \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "línia %<PRId64>: no s'ha pogut interpretar \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "interpretant \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "línia %<PRId64>: interpretant \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "ha finalitzat l'interpretació de %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd argument"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "variable d'entorn"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "gestor d'errors"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Atenció: El separador de línia no és vàlid, potser falta un ^M"
+
+# «sourced file».  eac
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: L'ordre :scriptencoding només es pot utilitzar en scripts"
+
+# «sourced file».  eac
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: L'ordre :finish només es pot utilitzar en scripts"
+
+# les cadenes substituïdes no es poden traduïr.  eac
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Idioma actual ( %s): \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: No s'ha pogut canviar l'idioma a \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Mode Ex. Escriviu \"visual\" per tornar al mode Normal."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Final del fitxer"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: L'ordre és massa recursiva"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: No s'ha interceptat l'excepció: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Final del fitxer interpretat"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Final de la funció"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Ús ambigu d'una ordre definida per l'usuari"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: No és una ordre d'edició"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Heu especificat un interval decreixent"
 
 # és una pregunta.  eac
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Heu especificat un interval decreixent. El voleu invertir"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Useu w o bé w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Aquesta ordre no està disponible en aquesta versió"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Només està permès un nom de fitxer"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Queda 1 fitxer per editar. Voleu sortir de totes maneres?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Queden %d fitxers per editar. Voleu sortir de totes maneres?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Queda 1 fitxer per editar"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Queden %<PRId64> fitxers per editar"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: L'ordre ja existeix: afegiu ! per substituir-la"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1183,286 +1649,352 @@ msgstr ""
 "\n"
 "    Nom         Args Abast Completar Definició"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "No s'han trobat ordres definides per l'usuari"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: No heu especificat cap atribut"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: El nombre d'arguments no és vàlid"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: El comptador no es pot especificar dos cops"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: El valor per omissió del comptador no és vàlid"
 
 # «completar»  eac
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete requereix un argument"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: L'atribut no és vàlid: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: El nom de l'ordre no és vàlid"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Les ordres definides per l'usuari han de començar en majúscula"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Ús ambigu d'una ordre definida per l'usuari"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: No existeix tal ordre definida per l'usuari: %s"
 
 # «completar»  eac
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: El valor per la funció completar no és vàlid: %s"
 
 # «completar»  eac
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: L'argument de completar només està permès en esquemes personalitzats"
+msgstr ""
+"E468: L'argument de completar només està permès en esquemes personalitzats"
 
 # «completar»  eac
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Els esquemes de completar requereixen una funció com a argument"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: No s'ha trobat l'esquema de colors %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Salutacions, usuari de Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: No es pot tancar l'última pestanya"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Només hi ha una pestanya"
 
-# Títol d'un diàleg [:browse split]  eac
-msgid "Edit File in new window"
-msgstr "Edita un fitxer en una finestra nova"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Pestanya %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "No hi ha fitxer d'intercanvi"
 
-# És un títol d'un diàleg [:browse read]  eac
-msgid "Append File"
-msgstr "Afegeix un fitxer"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr ""
+"E747: No es pot canviar de directori, el buffer ha estat modificat (afegiu ! "
+"per confirmar)"
 
-msgid "E747: Cannot change directory, buffer is modifed (add ! to override)"
-msgstr "E747: No es pot canviar de directori, el buffer ha estat modificat (afegiu ! per confirmar)"
-
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: No hi ha cap directori anterior"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Desconegut"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: L'ordre :winsize requereix dos arguments numèrics"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Posició de la finestra: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
-msgstr "E188: En aquesta plataforma no es pot obtenir la posició de la finestra"
+msgstr ""
+"E188: En aquesta plataforma no es pot obtenir la posició de la finestra"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: L'ordre :winpos requereix dos arguments numèrics"
 
-# És el títol d'un diàleg.  eac
-msgid "Save Redirection"
-msgstr "Desa la redirecció"
-
-# És el títol d'un diàleg.  eac
-msgid "Save View"
-msgstr "Desa la vista"
-
-# És el títol d'un diàleg.  eac
-msgid "Save Session"
-msgstr "Desa la sessió"
-
-# És el títol d'un diàleg.  eac
-msgid "Save Setup"
-msgstr "Desa la configuració"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: No s'ha pogut crear el directori: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existeix (afegiu ! per confirmar)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: No s'ha pogut obrir \"%s\" amb permís d'escriptura"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: L'argument ha de ser una lletra o bé un accent obert o tancat"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Ús recursiu de :normal massa profund"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: No hi ha cap nom de fitxer alternatiu per substituir '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
-msgstr "E495: No hi ha cap nom de fitxer d'auto-ordres per substituir \"<afile>\""
+msgstr ""
+"E495: No hi ha cap nom de fitxer d'auto-ordres per substituir \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
-msgstr "E496: No hi ha cap nombre de buffer d'auto-ordres per substituir \"<abuf>\""
+msgstr ""
+"E496: No hi ha cap nombre de buffer d'auto-ordres per substituir \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: No hi ha cap nom d'auto-ordre per substituir \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: No hi ha cap script per substituir \"<sfile>\""
 
-#, no-c-format
-msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
-msgstr "E499: El nom de fitxer per '%' o '#' està buit, només funciona amb \":p:h\""
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: No hi ha cap script per substituir \"<sfile>\""
 
+#: ../ex_docmd.c:7903
+#, c-format
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
+msgstr ""
+"E499: El nom de fitxer per '%' o '#' està buit, només funciona amb \":p:h\""
+
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: S'evalua com a cadena buida"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: No s'ha pogut obrir el fitxer viminfo amb permís de lectura"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Aquesta versió no suporta dígrafs"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: No es poden generar exepcions amb el prefix 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Excepció generada: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Exepció finalitzada: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Exepció descartada: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, línia %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Excepció interceptada: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s està pendent"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s s'ha continuat"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s s'ha descartat"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Exepció"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Error i interrupció"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Error"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Interrupció"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Imbricació de :if massa profunda"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: Declaració :endif sense :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: Declaració :else sense :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: Declaració :elseif sense :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Múltiples :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: Declaració :elseif després de :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Imbricació de :while/:for massa profunda"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue sense :while o :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break sense :while"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Ús incorrecte de :endfor amb :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Ús incorrecte de :endwhile amb :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Imbricació de :try massa profunda"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: Declaració :catch sense :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: Declaració :catch després de :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: Declaració :finally sense :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Múltiples :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: Declaració :endtry sense :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: Declaració :endfunction fora d'una funció"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: No podeu editar un altre buffer ara"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: No podeu editar un altre buffer ara"
+
 # context?  eac
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nom de l'etiqueta"
 
 # context?  eac
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " tipus de fitxer\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "l'opció 'history' és zero"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1471,213 +2003,308 @@ msgstr ""
 "\n"
 "# Historial %s (de més a menys recent):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "d'ordres"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "de cadenes cercades"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "d'expressions"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "de línies d'entrada"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar fora de l'àrea de l'ordre"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: S'ha eliminat la finestra o el buffer actiu"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Path no vàlid: '**[núm]' ha d'estar al final del path, o seguit de '%s'"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: No s'ha trobat el directori \"%s\" en el cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: No s'ha trobat el fitxer \"%s\" en el path"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: No s'ha trobat cap més directori \"%s\" en el cdpath"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: No s'ha trobat cap més fitxer \"%s\" en el path"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: Les auto-ordres *Filter* no poden canviar el buffer actual"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "El nom de fitxer és il·legal"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "és un directori"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "no és un fitxer"
 
-msgid "is a device (disabled with 'opendevice' option"
-msgstr "és un dispositiu (deshabilitat amb l'opció 'opendevice'"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Fitxer nou]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nou DIRECTORI]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Fitxer massa gran]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Permís denegat]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Auto-ordres *ReadPre han deixat el fitxer illegible"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Les auto-ordres *ReadPre no poden canviar el buffer actual"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Llegint l'entrada estàndard...\n"
 
-msgid "Reading from stdin..."
-msgstr "Llegint l'entrada estàndard..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: La conversió ha deixat el fitxer illegible!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-# eac  només-lectura (nl)
-msgid "[RO]"
-msgstr "[NL]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 caràcter"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[falten caràcters CR]"
 
-# entra en conflicte amb NL (només lectura)
-msgid "[NL found]"
-msgstr "[s'han trobat caràcters NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[línies llargues partides]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NO convertit]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[convertit]"
 
-msgid "[crypted]"
-msgstr "[xifrat]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ERROR DE CONVERSIÓ a la línia %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[OCTET IL·LEGAL a la línia %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ERRORS DE LECTURA]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "No s'ha trobat el fitxer temporal per la conversió"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "La conversió amb 'charconvert' ha fallat"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "No s'ha pogut llegir la sortida de 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: No hi ha cap auto-ordre coincident per al buffer acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Auto-ordres han eliminat o alliberat el buffer a escriure"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
-msgstr "E204: Una auto-ordre ha canviat el nombre de línies de forma inesperada"
+msgstr ""
+"E204: Una auto-ordre ha canviat el nombre de línies de forma inesperada"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans no permet escriure buffers no modificats"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "L'escriptura parcial no està permesa en buffers NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "no és un fitxer o dispositiu que es pugui escriure"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "escriptura a un dispositiu deshabilitat amb l'opció 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "és un fitxer de només lectura (afegiu ! per confirmar)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
-msgstr "E506: No s'ha pogut escriure la còpia de seguretat (afegiu ! per confirmar)"
+msgstr ""
+"E506: No s'ha pogut escriure la còpia de seguretat (afegiu ! per confirmar)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
-msgstr "E507: Error en tancar el fitxer còpia de seguretat (afegiu ! per confirmar)"
+msgstr ""
+"E507: Error en tancar el fitxer còpia de seguretat (afegiu ! per confirmar)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
-msgstr "E508: Error de lectura en fer la còpia de seguretat (afegiu ! per confirmar)"
+msgstr ""
+"E508: Error de lectura en fer la còpia de seguretat (afegiu ! per confirmar)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
-msgstr "E509: No s'ha pogut crear la còpia de seguretat (afegiu ! per confirmar)"
+msgstr ""
+"E509: No s'ha pogut crear la còpia de seguretat (afegiu ! per confirmar)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: No s'ha pogut fer la còpia de seguretat (afegiu ! per confirmar)"
 
-# «resource fork» (MacOS) ?
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: La bifurcació de recursos es perdrà (afegiu ! per confirmar)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: No s'ha trobat el fitxer temporal per escriure-hi"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: No s'ha pogut convertir (afegiu ! per desar sense conversió)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: No s'ha pogut obrir el fitxer enllaçat per escriure-hi"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: No s'ha pogut obrir el fitxer amb permís d'escriptura"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync ha fallat"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Error en tancar"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: error d'escriptura, conversió fallida (anul·leu 'fenc' per a ometre)"
+msgstr ""
+"E513: error d'escriptura, conversió fallida (anul·leu 'fenc' per a ometre)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: error d'escriptura, conversió fallida (anul·leu 'fenc' per a ometre)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Error d'escriptura (sistema de fitxers ple?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ERROR DE CONVERSIÓ"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "línia %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Dispositiu]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nou]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " afegits"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [e]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " escrits"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: no s'ha pogut desar el fitxer original"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: no s'ha pogut tocar el fitxer original buit"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: No s'ha pogut eliminar la còpia de seguretat"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1685,108 +2312,144 @@ msgstr ""
 "\n"
 "ATENCIÓ: El fitxer original es pot haver fet malbé\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "no sortiu de l'editor fins que s'hagi desat el fitxer amb èxit!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[format dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[format mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[format unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 línia, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> línies, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 caràcter"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> caràcters"
 
 # «no final de línia»  eac
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[nofl]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Última línia incompleta]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ATENCIÓ: El fitxer ha canviat des de que s'ha llegit!!!"
 
 # pregunta ask_yesno()   eac
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Esteu segurs que voleu escriure'l"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Error en escriure \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Error en tancar \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Error en llegir \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: L'auto-ordre FileChangedShell ha eliminat el buffer"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: El fitxer \"%s\" ha deixat d'estar disponible"
 
+#: ../fileio.c:4906
 #, c-format
-msgid "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as well"
+msgid ""
+"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
+"well"
 msgstr "W12: Atenció: Tant el fitxer \"%s\" com el buffer del Vim han canviat"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Vegeu \":help W12\" per a més info."
 
 # massa llarg?  eac
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
-msgstr "W11: Atenció: El fitxer \"%s\" ha canviat des de que s'ha començat a editar"
+msgstr ""
+"W11: Atenció: El fitxer \"%s\" ha canviat des de que s'ha començat a editar"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Vegeu \":help W11\" per a més info."
 
 # massa llarg?  eac
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
-msgstr "W16: Atenció: Els permisos de \"%s\" han canviat des que s'ha començat a editar"
+msgstr ""
+"W16: Atenció: Els permisos de \"%s\" han canviat des que s'ha començat a "
+"editar"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Vegeu \":help W16\" per a més info."
 
 # massa llarg?  eac
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
-msgstr "W13: Atenció: El fitxer \"%s\" ha estat creat després que s'ha començat a editar"
+msgstr ""
+"W13: Atenció: El fitxer \"%s\" ha estat creat després que s'ha començat a "
+"editar"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Atenció"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1794,39 +2457,48 @@ msgstr ""
 "&D'acord\n"
 "&Carrega el fitxer"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: No s'han pogut fer les preparacions per rellegir \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: No s'ha pogut rellegir \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Eliminat--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "auto-eliminant auto-ordre: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: No existeix tal grup: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Caràcter il·legal després de *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: No existeix tal esdeveniment: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: No existeix tal grup o esdeveniment: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1834,565 +2506,801 @@ msgstr ""
 "\n"
 "--- Auto-ordres ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: número de buffer no vàlid"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: No es poden executar auto-ordres per TOTS els esdeveniments"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "No coincideix cap auto-ordre"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Imbricació d'auto-ordres massa profunda"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "auto-ordres %s per \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Executant %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "auto-ordre %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Falta un {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Falta un }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: No s'ha trobat cap plec"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: No es pot crear cap plec amb el 'foldmethod' actual"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: No pot eliminar el plec amb el 'foldmethod' actual"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld línies plegades "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: No es pot modificar un buffer de lectura"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: assignació recursiva"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: ja existeix una abreviació global per %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: ja existeix una assignació global per %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: ja existeix una abreviació per %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: ja existeix una assignació per %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "No s'ha trobat cap abreviació"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "No s'ha trobat cap assignació"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Mode il·legal"
 
-msgid "<cannot open> "
-msgstr "<no es pot obrir> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Cap línia en el buffer--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: no s'ha pogut obtenir la fosa %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: S'ha avortat l'ordre"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: no s'ha pogut tornar al directori actual"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Es requereix un argument"
 
-msgid "Pathname:"
-msgstr "Ubicació:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ hauria de continuar amb /, ? o &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: no s'ha pogut obtenir el directori actual"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: No és vàlid a la línia d'ordres: <ENTRAR> executa, CTRL-C surt"
 
-msgid "OK"
-msgstr "D'acord"
-
-msgid "Cancel"
-msgstr "Cancel·la"
-
-msgid "Vim dialog"
-msgstr "Diàleg del Vim"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Barra de desplaçament: No s'ha pogut obtenir la mida del mapa de bits."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: No es pot crear un BalloonEval amb missatge i callback alhora"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: No s'ha pogut iniciar l'interfície gràfica"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: No s'ha pogut llegir \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: No es pot iniciar l'IUG, no s'ha trobat cap fosa vàlida"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: El valor de 'guifontwide' no és vàlid"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: El valor de 'imactivatekey' no és vàlid"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: No s'ha pogut assignar memòria pel color %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Cap coincidència al cursor, cercant la següent"
-
-msgid "Vim dialog..."
-msgstr "Diàleg del Vim..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Sí\n"
-"&No\n"
-"&Cancel·la"
+"E12: Ordre en exrc/vimrc no permesa en l'actual cerca d'etiquetes o "
+"directoris"
 
-msgid "Input _Methods"
-msgstr "_Mètodes d'entrada"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Falta una declaració :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Cerca i substitueix..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Falta una declaració :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Cerca..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Falta una declaració :endwhile"
 
-msgid "Find what:"
-msgstr "Cerca:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Falta un :endfor"
 
-msgid "Replace with:"
-msgstr "Substituieix amb:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: Declaració :endwhile sense :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Només paraules senceres"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor sense :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Sensible a les majúscules"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: El fitxer existeix (afegiu ! per confirmar)"
 
-msgid "Direction"
-msgstr "Direcció"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: L'ordre ha fallat"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Amunt"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Error intern"
 
-msgid "Down"
-msgstr "Avall"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Interromput"
 
-msgid "Find Next"
-msgstr "Cerca el següent"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: L'adreça no és vàlida"
 
-msgid "Replace"
-msgstr "Substitueix"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: L'argument no és vàlid"
 
-msgid "Replace All"
-msgstr "Substitueix-les totes"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: S'ha rebut una petició \"die\" del gestor de sessions\n"
-
-msgid "Close"
-msgstr "Tanca"
-
-msgid "New tab"
-msgstr "Nova pestanya"
-
-msgid "Open Tab..."
-msgstr "Obre una pestanya..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: La finestra principal ha estat destruïda inesperadament\n"
-
-msgid "Font Selection"
-msgstr "Selecció de fosa"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "S'ha usat CUT_BUFFER0 en lloc d'una selecció buida"
-
-msgid "&Filter"
-msgstr "&Filtre"
-
-msgid "&Cancel"
-msgstr "&Cancel·la"
-
-msgid "Directories"
-msgstr "Directoris"
-
-msgid "Filter"
-msgstr "Filtre"
-
-msgid "&Help"
-msgstr "&Ajuda"
-
-msgid "Files"
-msgstr "Fitxers"
-
-msgid "&OK"
-msgstr "&D'acord"
-
-msgid "Selection"
-msgstr "Selecció"
-
-msgid "Find &Next"
-msgstr "Cerca el &següent"
-
-msgid "&Replace"
-msgstr "&Substitueix"
-
-msgid "Replace &All"
-msgstr "Substitueix-les &totes"
-
-msgid "&Undo"
-msgstr "&Desfés"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: No s'ha trobat el títol de finestra \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: L'argument no és vàlid: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument no suportat: \"-%s\"; Useu la versió OLE."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: L'expressió no és vàlida: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: No s'ha pogut obrir una finestra dins l'aplicació MDI"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: L'interval no és vàlid"
 
-msgid "Close tab"
-msgstr "Tanca la pestanya"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: L'ordre no és vàlida"
 
-msgid "Open tab..."
-msgstr "Obre una pestanya..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Cerca una cadena (useu '\\\\' per cercar '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Cerca i substitueix (useu '\\\\' per cercar '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "No Usat"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Directori\t*.res\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: No s'ha pogut assignar memòria per colors, poden ser incorrectes"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: En el conjunt %s falten tipus pels següents jocs de caràcters:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" és un directori"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nom del conjunt de tipus: %s"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: La distància de desplaçament no és vàlida"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "La fosa '%s' no és d'amplada fixa"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Nom del conjunt de tipus: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Fosa0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Fosa1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "L'amplada de la fosa%<PRId64> no és el doble que la de la fosa0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Amplada de de la Fosa0: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Amplada de la Fosa1: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Especificació de fosa no vàlida"
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
-msgid "&Dismiss"
-msgstr "&Ignora"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: La crida a la biblioteca a fallat per \"%s()\""
 
-msgid "no specific match"
-msgstr "cap coincidència específica"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Marca amb un número de línia no vàlid"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Selector de fosa"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Marca no establerta"
 
-msgid "Name:"
-msgstr "Nom:"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: No es poden fer canvis, l'opció 'modifiable' està desactivada"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Mostra la mida en punts"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Imbricació d'scripts massa profunda"
 
-msgid "Encoding:"
-msgstr "Codificació:"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: No hi ha cap fitxer alternatiu"
 
-msgid "Font:"
-msgstr "Fosa:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: No existeix tal abreviació"
 
-msgid "Style:"
-msgstr "Estil:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! no permès"
 
-msgid "Size:"
-msgstr "Mida:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: No es pot usar la GUI: No ha estat compilada"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ERROR de l'autòmata hangul"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: No existeix tal grup de ressalt: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Encara no s'ha inserit text"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: No hi ha cap ordre anterior"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: No existeix tal assignació"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Cap coincidència"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Cap coincidència: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Falta un nom de fitxer"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: No hi ha cap expressió de substitució anterior"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: No hi ha cap ordre anterior"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: No hi ha cap expressió regular anterior"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: No es permet cap interval"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: No hi ha prou espai"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: No es pot crear el fitxer %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: No s'ha pogut obtenir el nom del fitxer temporal"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: No es pot obrir el fitxer %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: No es pot llegir el fitxer %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: No s'han desat els canvis (afegiu ! per confirmar)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[No s'han desat els últims canvis]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Argument nul"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: S'esperava un número"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: No s'ha pogut obrir el fitxer d'errors %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Memòria exhaurida!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "No s'ha trobat el patró"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: No s'ha trobat el patró: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: L'argument ha de ser un número positiu"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: No es pot tornar al directori anterior"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: No hi han errors"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: No hi ha cap llista de posicions"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: S'ha corromput la cadena amb l'expressió regular"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: S'ha corromput el programa d'expressió regular"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: L'opció 'readonly' està definida (afegiu ! per confirmar)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: No s'ha pogut canviar la variable de només lectura \"%s\""
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: No s'ha pogut definir la variable dins la gàbia: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Error en llegir el fitxer d'errors"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: No està permès dins d'una gàbia"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: No està permès aquí"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: La funció d'ajustar el mode de pantalla no està suportada"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: La distància de desplaçament no és vàlida"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: L'opció 'shell' no conté res"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: No s'han pogut llegir les dades del senyal!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Error en tancar el fitxer d'intercanvi"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: La pila d'etiquetes està buida"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: L'ordre és massa complexa"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: El nom és massa llarg"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Sobren caràcters ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Sobren noms de fitxer"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Sobren caràcters"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: La marca és desconeguda"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: No s'ha pogut expandir el nom de fitxer"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: L'opció 'winheight' no pot ser menor que 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: L'opció 'winwidth' no pot ser menor que 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Error d'escriptura"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Comptador a zero"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Ús de <SID> en un context equivocat"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Error intern: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: el patró usa més memòria que 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: buffer buit"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Patró de cerca o delimitador no vàlid"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: El fitxer està carregat en un altre buffer"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: L'opció '%s' no està definida"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: El nom de registre no és vàlid: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "la cerca ha arribat a DALT, es continua a BAIX"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "la cerca ha arribat a BAIX, es continua a DALT"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Falta un caràcter \":\""
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Component il·legal"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: S'esperava un dígit"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Pàgina %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "No hi ha text per imprimir"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "S'està imprimint la pàgina %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Còpia %d de %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "S'ha imprès: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "S'ha avortat l'impressió"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Error en escriure el fitxer PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: No s'ha pogut obrir el fitxer \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: No s'ha pogut llegir el fitxer de recursos PostScript \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: El fitxer \"%s\" no és un fitxer de recursos PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: El fitxer de recursos PostScript \"%s\" no està suportat"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: La versió del fitxer de recursos \"%s\" no és vàlida"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Joc de caràcters i codificació multi-octet no compatibles."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
-msgstr "E674: printmbcharset no pot estar buit si la codificació és multi-octet"
+msgstr ""
+"E674: printmbcharset no pot estar buit si la codificació és multi-octet"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
-msgstr "E675: No heu especificat cap fosa per defecte per a la impressió multi-octet."
+msgstr ""
+"E675: No heu especificat cap fosa per defecte per a la impressió multi-octet."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: No s'ha pogut obrir el fitxer PostScript generat"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: No s'ha pogut obrir el fitxer \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: No s'ha trobat el fitxer de recursos PostScript \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: No s'ha trobat el fitxer de recursos PostScript \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: No s'ha trobat el fitxer de recursos PostScript \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: No s'ha pogut convertir a la codificació d'impressió \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "S'està enviant a la impressora..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Error en imprimir el fitxer PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "S'ha enviat la tasca d'impressió."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Afegeix una base de dades nova"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Consulta un patró"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Mostra aquest missatge"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Talla una connexió"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Reinicia totes les connexions"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Mostra les connexions"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Forma d'ús: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Aquesta ordre de cscope no suporta divisió de finestres.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Forma d'ús: cstag <despl>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: No s'ha trobat l'etiqueta"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: Error de stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: Error de stat()"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s no és un directori o una base de dades de cscope vàlida"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "S'ha afegit la base de dades cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Error en llegir la connexió cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Tipus de cerca cscope desconeguda"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: No s'han pogut crear canonades cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: No s'ha pogut bifurcar el procés cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "l'execució de cs_create_connection ha fallat"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "l'execució de cs_create_connection ha fallat"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: No s'ha pogut generar un procés per cscope"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen per to_fp ha fallat"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen per fr_fp ha fallat"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: No s'ha pogut generar un procés per cscope"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: No hi han connexions cscope"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: Cap resultat per la consulta cscope %s de %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: El senyal cscopequickfix %c no és vàlid per %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: Cap resultat per la consulta cscope %s de %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "ordres de cscope:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Forma d'ús: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: No s'ha pogut obrir la base de dades cscope: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: No s'ha pogut obtenir l'informació de la base de dades cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: No s'ha afegit una base de dades cscope duplicada"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: S'ha assolit el màxim nombre de connexions cscope"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: No s'ha trobat la connexió cscope %s"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "s'ha tancat la connexió cscope %s"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Error fatal a cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Etiqueta cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2400,372 +3308,87 @@ msgstr ""
 "\n"
 "   #   línia"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "fitxer / context / línia\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Error de cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "S'han reiniciat totes les bases de dades cscope"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "no hi ha connexions cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    base de dades                       prefix d'ubicació\n"
 
-msgid "???: Sorry, this command is disabled, the MzScheme library could not be loaded."
-msgstr "???: Aquesta ordre no està habilitada, la biblioteca MzScheme no s'ha pogut carregar."
-
-msgid "invalid expression"
-msgstr "l'expressió no és vàlida"
-
-msgid "expressions disabled at compile time"
-msgstr "no s'ha compilat suport per expressions"
-
-msgid "hidden option"
-msgstr "opció amagada"
-
-msgid "unknown option"
-msgstr "opció desconeguda"
-
-msgid "window index is out of range"
-msgstr "índex de finestra fora d'abast"
-
-msgid "couldn't open buffer"
-msgstr "no s'ha pogut obrir el buffer"
-
-msgid "cannot save undo information"
-msgstr "no s'ha pogut desar l'informació de desfer"
-
-msgid "cannot delete line"
-msgstr "no s'ha pogut esborrar la línia"
-
-msgid "cannot replace line"
-msgstr "no s'ha pogut substituir la línia"
-
-msgid "cannot insert line"
-msgstr "no s'ha pogut inserir la línia"
-
-msgid "string cannot contain newlines"
-msgstr "la cadena no pot contenir salts de línia"
-
-msgid "Vim error: ~a"
-msgstr "Error del Vim: ~a"
-
-msgid "Vim error"
-msgstr "Error del Vim"
-
-msgid "buffer is invalid"
-msgstr "el buffer no és vàlid"
-
-msgid "window is invalid"
-msgstr "la finestra no és vàlida"
-
-msgid "linenr out of range"
-msgstr "nombre de línia fora d'abast"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "no permès a la gàbia del Vim"
-
-msgid "E263: Sorry, this command is disabled, the Python library could not be loaded."
-msgstr "E263: Aquesta ordre està deshabilitada, no s'ha pogut carregar Python."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: No es pot invocar Python de forma recursiva"
-
-msgid "can't delete OutputObject attributes"
-msgstr "no s'han pogut eliminar els atributs de l'OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "'softspace' ha de ser un nombre enter"
-
-msgid "invalid attribute"
-msgstr "l'atribut no és vàlid"
-
-msgid "writelines() requires list of strings"
-msgstr "la funció writelines() requereix una llista de cadenes"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Error en inicialitzar els objectes d'E/S"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "intent de referència a un buffer eliminat"
-
-msgid "line number out of range"
-msgstr "nombre de línia fora d'abast"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<objecte buffer (eliminat) a %8lX>"
-
-msgid "invalid mark name"
-msgstr "nom de marca no vàlid"
-
-msgid "no such buffer"
-msgstr "no existeix tal buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "intent de referir-se a una finestra eliminada"
-
-msgid "readonly attribute"
-msgstr "atribut de només lectura"
-
-msgid "cursor position outside buffer"
-msgstr "posició del cursor fora del buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<objecte finestra (eliminat) a %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<objecte finestra (desconegut) a %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<finestra %d>"
-
-msgid "no such window"
-msgstr "no existeix tal finestra"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ ha de ser una instància d'una cadena"
-
-msgid "E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: Ordre deshabilitada, no s'ha pogut carregar la biblioteca Ruby."
-
-msgid "E267: unexpected return"
-msgstr "E267: retorn inesperat"
-
-msgid "E268: unexpected next"
-msgstr "E268: 'next' inesperat"
-
-msgid "E269: unexpected break"
-msgstr "E269: tall inesperat"
-
-msgid "E270: unexpected redo"
-msgstr "E270: 'redo' inesperat"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: 'retry' fora d'una clàusula de rescat"
-
-msgid "E272: unhandled exception"
-msgstr "E272: excepció no manejada"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: estat de longjmp desconegut %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Commuta implementació/definició"
-
-msgid "Show base class of"
-msgstr "Mostra la classe base de"
-
-msgid "Show overridden member function"
-msgstr "Mostra el membre de la funció invalidat"
-
-msgid "Retrieve from file"
-msgstr "Obtenir d'un fitxer"
-
-msgid "Retrieve from project"
-msgstr "Obtenir d'un projecte"
-
-msgid "Retrieve from all projects"
-msgstr "Obtenir de tots els projectes"
-
-msgid "Retrieve"
-msgstr "Obtenir"
-
-msgid "Show source of"
-msgstr "Mostra el codi font de"
-
-msgid "Find symbol"
-msgstr "Cerca un símbol"
-
-msgid "Browse class"
-msgstr "Explora les classes"
-
-msgid "Show class in hierarchy"
-msgstr "Mostra la jerarquia de classes"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Mostra la jerarquia de classes restringida"
-
-msgid "Xref refers to"
-msgstr "Xref es refereix a"
-
-msgid "Xref referred by"
-msgstr "Xref referenciada per"
-
-msgid "Xref has a"
-msgstr "Xref té un"
-
-msgid "Xref used by"
-msgstr "Xref usada per"
-
-msgid "Show docu of"
-msgstr "Mostra docu de"
-
-msgid "Generate docu for"
-msgstr "Genera docu per"
-
-msgid "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in $PATH).\n"
-msgstr "No s'ha pogut connectar amb SNiFF+. Reviseu l'entorn (sniffemacs ha d'estar en el $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Error de lectura. Desconnectat"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ "
-
-msgid "not "
-msgstr "no "
-
-msgid "connected"
-msgstr "està connectat"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Petició SNiFF+ desconeguda: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Error en connectar a SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ no connectat"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: No és un buffer SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Error d'escriptura. Desconnectat"
-
-msgid "invalid buffer number"
-msgstr "nombre de buffer no vàlid"
-
-msgid "not implemented yet"
-msgstr "no implementat (encara)"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "no s'ha pogut establir el nombre de línies"
-
-msgid "mark not set"
-msgstr "marca no establerta"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "fila %d columna %d"
-
-msgid "cannot insert/append line"
-msgstr "no s'ha pogut inserir/afegir la línia"
-
-msgid "unknown flag: "
-msgstr "senyal desconegut: "
-
-msgid "unknown vimOption"
-msgstr "vimOption desconeguda"
-
-msgid "keyboard interrupt"
-msgstr "interrupció de teclat"
-
-msgid "vim error"
-msgstr "error de vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "no s'ha pogut crear l'ordre de buffer/finestra: l'objecte està siguent eliminat"
-
-msgid "cannot register callback command: buffer/window is already being deleted"
-msgstr "no s'ha pogut registrar l'ordre callback: el búfer/finestra ja està sent eliminat"
-
-#. This should never happen.  Famous last word?
-msgid "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"
-msgstr "E280: ERROR FATAL DE TCL: llista de referències corrupta!? Comuniqueu-ho a vim-dev@vim.org."
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "no s'ha pogut registrar l'ordre callback: referència del búfer/finestra no trobada"
-
-msgid "E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: Aquesta ordre està deshabilitada: No s'ha pogut carregar la llibreria Tcl."
-
-msgid "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: ERROR DE TCL: el codi de retorn no és un enter!? Comuniqueu-ho a vim-dev@vim.org."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: codi de sortida %d"
-
-msgid "cannot get line"
-msgstr "no s'ha pogut obtenir la línia"
-
-msgid "Unable to register a command server name"
-msgstr "No s'ha pogut registrar un nom de servidor d'ordres"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: No s'ha pogut enviar l'ordre al programa destinatari"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: S'ha usat una ID de servidor no vàlida: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: El registre de l'instància de VIM està mal format. S'ha esborrat!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Argument d'opció desconegut"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Massa arguments d'edició"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Falta un argument després de"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Porqueria després de l'argument d'opció"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Massa arguments \"+ordre\", \"-c ordre\" o \"--cmd ordre\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Argument no vàlid per"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d fitxers per editar\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Aquest Vim no ha estat compilat amb suport per diff."
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Reintent d'obrir l'script: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "No s'ha pogut obrir amb permís de lectura: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "No s'ha pogut obrir per desar-hi l'exida de l'script: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Error: Ha fallat l'arrencada del gvim des de NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Atenció: La sortida no està connectada a un terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Atenció: L'entrada no està connectada a un terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "línia d'ordres pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: No s'ha pogut llegir \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2773,18 +3396,23 @@ msgstr ""
 "\n"
 "Més informació amb: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[fitxer ...]    edita el(s) fitxer(s) especificat(s)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               edita el text de l'entrada estàndard"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t etiqueta     edita el fitxer on hi ha l'etiqueta"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [ftxerrors]  edita el fitxer on hi ha el primer error"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2794,9 +3422,11 @@ msgstr ""
 "\n"
 "  ús:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [arguments] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2804,13 +3434,7 @@ msgstr ""
 "\n"
 "o bé:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"On s'ignora la capitalizació, afegiu el prefix / per a indicar majúscules"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2820,316 +3444,189 @@ msgstr ""
 "\n"
 "Arguments:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tDesprés d'això només noms de fitxers"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNo expandeix patrons de noms"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistra aquest gvim per OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tDesregistra aquest gvim per OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tUsa una interfície gràfica (com \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  o   --nofork\tNo crea un procés nou per la GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tMode Vi (com \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tMode Ex (com \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tMode silenciós (només per \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tMode diff (com \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tMode senzill (com \"evim\", sense modes)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMode només lectura (com \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tMode restringit (com \"rvim)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tNo permet modificar (escriure) fitxers"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tNo permet modificar el text"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tMode binari"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tMode Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tCompatible amb Vi"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNo del tot compatible amb Vi"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][nomf]\t\tLoquacitat [nivell N] [desa els missatges a nomf]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tMode de depuració"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNo usa fitxers d'intercanvi, només memòria"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tLlista els fitxers d'intercanvi i surt"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (amb nom de fitxer)  Recupera una sessió accidentada"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tIgual que -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNo obre una finestra nova amb newcli"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <dispositiu>\t\tUsa <dispositiu> per l'E/S"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tComença en mode àrab"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tComença en mode hebreu"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\t Comença en mode farsi"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tDefineix el tipus de terminal"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tUsa <vimrc> en lloc de qualsevol altre .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tUsa <gvimrc> en lloc de qualsevol altre .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNo carrega cap plugin"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tObre N pestanyes (per omissió: una per fitxer)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tObre N finestres (per omissió: una per fitxer)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tCom -o però amb divisions verticals"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tComença al final del fitxer"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnúm>\t\tComença a la línia <lnúm>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <ordre>\tExecuta <ordre> abans de llegir els fitxers vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <ordre>\t\tExecuta <ordre> després de carregar el primer fitxer"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <fitxer>\t\tEvalua <fitxer> un cop carregat el primer fitxer"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <script>\t\tLlegeix ordres del mode Normal del fitxer <script>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <script>\t\tAfegeix totes les ordres executades al fitxer <script>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <script>\t\tEscriu totes les ordres executades al fitxer <script>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEdita fitxers amb xifrat"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
 
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <pantalla>\tConnecta el Vim a un servidor X particular"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNo es connecta a cap servidor X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <fitxers>\tEdita <fitxers> en un servidor Vim, si és possible"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <fitxers>  Igual, no es queixa si no hi ha servidor"
-
-msgid "--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <fitxers>  Com --remote, però espera que s'editin els fitxers"
-
-msgid "--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <fitxers>  Igual, no es queixa si no hi ha servidor"
-
-msgid "--remote-tab <files>  As --remote but open tab page for each file"
-msgstr "--remote-tab <fitxers>  Com --remote, però obre una pestanya per fitxer"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <tecles>  Envia <tecles> a un servidor Vim i surt"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\tEvaula <expr> en un servidor Vim i mostra el resultat"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tLlista els noms dels servidors Vim accessibles"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nom>\tEnvia a o es converteix en servidor Vim <nom>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUsa <viminfo> en lloc de .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  o   --help\tMostra aquesta ajuda i surt"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tMostra informació sobre la versió i surt"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Arguments reconeguts pel gvim (versió Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Arguments reconeguts pel gvim (versió neXtaw>:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Arguments reconeguts pel gvim (versió Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <pantalla>\tExecuta vim a <pantalla>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tComença iconificat"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <nom>\t\tUsa els recursos com si vim fós <nom>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t (No implementat)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\tUsa <color> pel fons (també: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\tUsa <color> pel text normal (també: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <fosa>\tUsa <fosa> pel text normal (també: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <fosa>\tUsa <fosa> pel text en negreta"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <fosa>\tUsa <fosa> pel text en cursiva"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\tUsa <geom> com a geometria inicial (també: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <amplada>\tUsa un marge d'amplada <amplada> (també: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <amplada>  Amplada de la barra de desplaçament (també: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <alçada>\tAlçada de la barra de menú (també: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tUsa el mode de video invers (també: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNo usa el mode de video invers (també: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <recurs>\tEstableix el recurs especificat"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Arguments reconeguts pel gvim (versió RISC OS):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <nombre>\tAmplada inicial de la finestra en columnes"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <nombre>\tAlçada inicial de la finestra en files"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Arguments reconeguts pel gvim (versió GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <pantalla>\tExecuta vim a <pantalla> (també: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <rol>\t\tUsa un únic rol per identificar la finestra principal"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tObre el vim dins d'una altra aplicació GTK"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <títol pare>\tObre el Vim en una aplicació pare"
-
-msgid "No display"
-msgstr "No hi ha cap pantalla"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Error en enviar.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Error en enviar. Intentant l'execució local\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "editat %d de %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "No hi ha cap pantalla: Error en enviar l'expressió.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Error en enviar l'expressió.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "No hi ha marques definides"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Cap marca coincideix amb \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3138,6 +3635,7 @@ msgstr ""
 "marca lín  col fitxer/text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3146,6 +3644,7 @@ msgstr ""
 " salt  lín  col fitxer/text"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3153,7 +3652,7 @@ msgstr ""
 "\n"
 "canvi  línia col text"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3162,7 +3661,7 @@ msgstr ""
 "# Marques de fitxer:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3170,7 +3669,7 @@ msgstr ""
 "\n"
 "# Llista de salts (de més a menys recent):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3178,94 +3677,85 @@ msgstr ""
 "\n"
 "# Historial de marques en fitxers (de més a menys recent):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Falta un '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: No és un codi de pàgina vàlid"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: No s'han pogut establir els valors del context d'entrada"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Error en crear el context d'entrada"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Error en obrir el mètode d'entrada"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Atenció: No s'ha pogut establir el callback de destrucció a IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: el mètode d'entrada no suporta cap estil"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: el mètode d'entrada no suporta el tipus de preedició"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: L'estil over-the-spot requereix un conjunt de tipus"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: La llibreria GTK+ és anterior a 1.2.3. Es deshabilita l'àrea d'estat"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: El servidor de mètodes d'entrada (IMS) no està funcionant"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: El bloc no estava bloquejat"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Error de posició quan es llegia el fitxer d'intercanvi"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Error de lectura en el fitxer d'intercanvi"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Error de posició quan s'escrivia el fitxer d'intercanvi"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Error d'escriptura en el fitxer d'intercanvi"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: El fitxer d'intercanvi encara existeix"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: No s'ha pogut obtenir el bloc 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: No s'ha pogut obtenir el bloc 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: No s'ha pogut obtenir el bloc 3?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ep! El fitxer d'intercanvi s'ha perdut!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: No s'ha pogut reanomenar el fitxer d'intercanvi"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
-msgstr "E303: Error en obrir el fitxer d'intercanvi de \"%s\", no es podrà recuperar"
+msgstr ""
+"E303: Error en obrir el fitxer d'intercanvi de \"%s\", no es podrà recuperar"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): No s'ha obtingut el bloc 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: No s'ha trobat el fitxer d'intercanvi de %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Entreu el número del fitxer d'intercanvi a utilitzar (0 per sortir): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: No s'ha pogut obrir %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "No s'ha pogut llegir el bloc 0 de "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3273,22 +3763,28 @@ msgstr ""
 "\n"
 "O bé no s'han fet canvis, o el Vim no ha actualitzat el fitxer d'intercanvi."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " no es pot utilitzar amb aquesta versió de Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Useu Vim versió 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s no sembla un fitxer d'intercanvi de Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " no es pot utilitzar en aquest ordinador.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "El fitxer va ser creat el "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3296,64 +3792,85 @@ msgstr ""
 ",\n"
 "o el fitxer està fet malbé."
 
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " ha estat danyat (la mida de pàgina és inferior al valor mínim).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "S'està utilitzant el fitxer d'intercanvi \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Fitxer original \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Atenció: El fitxer original pot haver canviat"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: No s'ha pogut llegir el bloc 1 de %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???FALTEN MOLTES LÍNIES"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???RECOMPTE DE LÍNIES INCORRECTE"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???BLOC BUIT"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???FALTEN LÍNIES"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: L'ID del bloc 1 no és correcta (%s no és un fitxer .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???FALTA UN BLOC"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? Des d'aquí fins ???FINAL les línies poden estar equivocades"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? Des d'aquí fins ???FINAL hi pot haver línies inserides/eliminades"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???FINAL"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: S'ha interromput la recuperació"
 
-msgid "E312: Errors detected while recovering; look for lines starting with ???"
+#: ../memline.c:1243
+msgid ""
+"E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: S'han detectat errors en la recuperació; busqueu línies amb ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Vegeu \":help E312\" per a més informació."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
-msgstr "S'ha completat la recuperació. Haurieu de revisar que tot sigui correcte."
+msgstr ""
+"S'ha completat la recuperació. Haurieu de revisar que tot sigui correcte."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3361,50 +3878,71 @@ msgstr ""
 "\n"
 "(Potser voleu desar aquest fitxer amb un altre nom\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "i fer un diff amb el fitxer original per veure els canvis)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Elimina el fitxer .swp tot seguit.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Fitxers d'intercanvi trobats:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   En el directori actual:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Usant el nom especificat:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   En el directori "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- cap --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "      propietat de: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   amb data: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "          amb data: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [del Vim versió 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [no sembla un fitxer d'intercanvi de Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "    nom del fitxer: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3412,12 +3950,15 @@ msgstr ""
 "\n"
 "         modificat: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "SÍ"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "no"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3425,9 +3966,11 @@ msgstr ""
 "\n"
 "   nom de l'usuari: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "    màquina: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3435,6 +3978,7 @@ msgstr ""
 "\n"
 "           màquina: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3442,16 +3986,11 @@ msgstr ""
 "\n"
 "     ID del procés: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (encara funcionant)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"          [no usable amb aquesta versió de Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3459,75 +3998,97 @@ msgstr ""
 "\n"
 "          [no usable en aquesta computadora]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [no es pot llegir]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [no es pot obrir]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: No s'ha pogut preservar, no hi ha fitxer d'intercanvi"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "S'ha preservat el fitxer"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: La preservació ha fallat"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: lnum no vàlid: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: no s'ha trobat la línia %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Punter a la id d'un bloc incorrecte 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx hauria de ser 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: S'han actualitzat massa blocs?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Punter a la id d'un bloc incorrecte 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "s'ha eliminat el bloc 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: No s'ha trobat la línia %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Punter a la id d'un bloc incorrecte"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "po_line_count és zero"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Nombre de línia fora d'abast: %<PRId64> passat el final"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Comptador de línia incorrecte al bloc %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "La mida de la pila s'incrementa"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Punter a la id d'un bloc incorrecte 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Bucle d'enllaços simbòlics per a \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ATENCIÓ"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3535,38 +4096,44 @@ msgstr ""
 "\n"
 "S'ha trobat un fitxer d'intercanvi de nom \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Mentre s'obria el fitxer \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      MÉS NOU que el fitxer d'intercanvi!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Un altre programa pot estar editant aquest mateix fitxer.\n"
 "    En aquest cas, aneu amb compte de no acabar amb dues\n"
 "    instàncies diferents del mateix fitxer quan feu canvis.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Sortiu, o continueu amb precaució.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) El Vim s'ha estrellat mentre s'editava aquest fitxer.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    En aquest cas, useu \":recover\" o bé \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3574,9 +4141,11 @@ msgstr ""
 "\"\n"
 "    per recuperar els canvis (vegeu \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Si ja ho heu fet, elimineu el fitxer \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3584,18 +4153,23 @@ msgstr ""
 "\"\n"
 "    per evitar aquest missatge.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "El fitxer d'intercanvi \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ja existeix!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ATENCIÓ"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "El fitxer d'intercanvi ja existeix!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3609,6 +4183,7 @@ msgstr ""
 "&Sortir\n"
 "&Avortar"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3624,34 +4199,56 @@ msgstr ""
 "&Sortir\n"
 "&Avortar"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: S'han trobat massa fitxers d'intercanvi"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Memòria exhaurida! (assignant %<PRIu64> octets)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Part de l'ubicació del menú no és submenú"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: El menú només existeix en un altre mode"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: No hi ha cap menú \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Nom de menú buit"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: L'ubicació del menú no pot portar a un submenú"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: No es poden afegir ítems de menú directament a la barra de menú"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Un separador no pot formar part de l'ubicació de menú"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3659,60 +4256,73 @@ msgstr ""
 "\n"
 "--- Menús ---"
 
-msgid "Tear off this menu"
-msgstr "Estripa aquest menú"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: L'ubicació de menú ha de portar a un ítem de menú"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: No s'ha trobat el menú: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: El menú no està definit pel mode %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: L'ubicació de menú ha de portar a un submenú"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: No s'ha trobat el menú - reviseu els noms dels menús"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "S'ha detectat un error en processar %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "línia %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: El nom de registre no és vàlid: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Traducció dels missatges: Ernest Adrogué <eadrogue@gmx.net>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Interrupció: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Premeu ENTRAR o introduïu una ordre per a continuar"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s línia %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Més --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " ESPAI/d/j: pantalla/pàgina/línia avall, b/u/k: amunt, q: sortir "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Pregunta"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3720,6 +4330,17 @@ msgstr ""
 "&Sí\n"
 "&No"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Sí\n"
+"&No\n"
+"&Cancel·la"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3733,256 +4354,179 @@ msgstr ""
 "&Descarta-ho tot\n"
 "&Cancel·la"
 
-msgid "Select Directory dialog"
-msgstr "Diàleg de selecció de directori"
-
-msgid "Save File dialog"
-msgstr "Diàleg de desar fitxer"
-
-msgid "Open File dialog"
-msgstr "Diàleg d'obrir fitxer"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: No hi ha un explorador de fitxers en mode consola"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Falten arguments per a printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Falten arguments per a printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Sobren arguments per a printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Atenció: S'està canviant un fitxer de només lectura"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
-msgstr "Introduïu un número o feu clic amb el ratolí (<Entrar> per a cancel·lar): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+"Introduïu un número o feu clic amb el ratolí (<Entrar> per a cancel·lar): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Trieu un número (<Entrar> per a cancel·lar): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 línia més"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 línia menys"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> línies més"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> línies menys"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Interromput)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Bip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: preservant els fitxers...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Finalitzat.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "ERROR: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[octets] total assignat-alliberat %<PRIu64>-%<PRIu64>, en ús %<PRIu64>, màxim ús %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[crides] total re/malloc() %<PRIu64>, total free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: La línia s'està tornant massa llarga"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Error intern: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Memòria exhaurida! (assignant %<PRIu64> octets)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "S'està cridant l'intèrpret d'ordres per executar: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Falta un caràcter \":\""
-
-msgid "E546: Illegal mode"
-msgstr "E546: Mode il·legal"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: La forma del punter del ratolí és il·legal"
-
-msgid "E548: digit expected"
-msgstr "E548: S'esperava un dígit"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Percentatge il·legal"
-
-msgid "Enter encryption key: "
-msgstr "Introduïu la clau de xifrat: "
-
-msgid "Enter same key again: "
-msgstr "Introduïu la mateixa clau un altre cop: "
-
-msgid "Keys don't match!"
-msgstr "La claus no coincideixen!"
-
-#, c-format
-msgid "E343: Invalid path: '**[number]' must be at the end of the path or be followed by '%s'."
-msgstr "E343: Path no vàlid: '**[núm]' ha d'estar al final del path, o seguit de '%s'"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: No s'ha trobat el directori \"%s\" en el cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: No s'ha trobat el fitxer \"%s\" en el path"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: No s'ha trobat cap més directori \"%s\" en el cdpath"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: No s'ha trobat cap més fitxer \"%s\" en el path"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "No s'ha pogut connectar amb Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "No s'ha pogut connectar amb Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Mode d'accés incorrecte per al fitxer d'info de la connexió NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "lectura d'un socket Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: S'ha perdut la connexió NetBeans per al buffer %<PRId64>"
-
-msgid "E505: "
-msgstr "E505:"
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' no conté res"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: La funció eval no està disponible"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Atenció: el terminal no suporta ressalt"
-
-msgid "E348: No string under cursor"
-msgstr "E348: No hi ha cap cadena sota el cursor"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: No hi ha cap identificador sota el cursor"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' no conté res"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Atenció: el terminal no suporta ressalt"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: No hi ha cap cadena sota el cursor"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: No es poden eliminar plecs amb el 'foldmethod' actual"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: La llista de canvis no conté res"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: A l'inici de la llista de canvis"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: A l'inici de la llista de canvis"
 
 # amplada 53 caràcters
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Feu  :quit<Entrar>  per sortir"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 línia %sada 1 vegada"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 línia %sada %d vegades"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> línies %sades 1 vegada"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> línies %sades %d vegades"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> línies a sagnar... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 línia sagnada "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> línies sagnades "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: No hi ha cap registre usat amb anterioritat"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "no s'ha pogut copiar; voleu elimiar el text de totes maneres"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 línia canviada"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> línies canviades"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "alliberant %<PRId64> línies"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "bloc d'1 línia copiat"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 línia copiada"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "bloc de %<PRId64> línies copiat"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> línies copiades"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: No hi ha res en el registre %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3990,10 +4534,11 @@ msgstr ""
 "\n"
 "--- Registres ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "El nom de registre és il·legal"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4001,149 +4546,194 @@ msgstr ""
 "\n"
 "# Registres:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: El tipus de registre %d és desconegut"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Cols; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selecció %s%<PRId64> de %<PRId64> Línies; %<PRId64> de %<PRId64> Paraules; %<PRId64> de %<PRId64> Octets"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Selecció %s%<PRId64> de %<PRId64> Línies; %<PRId64> de %<PRId64> Paraules; "
+"%<PRId64> de %<PRId64> Octets"
 
+#: ../ops.c:5105
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selecció %s%<PRId64> de %<PRId64> Línies; %<PRId64> de %<PRId64> Paraules; %<PRId64> de %<PRId64> Caràcters; %<PRId64> de %<PRId64> Octets"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Selecció %s%<PRId64> de %<PRId64> Línies; %<PRId64> de %<PRId64> Paraules; "
+"%<PRId64> de %<PRId64> Caràcters; %<PRId64> de %<PRId64> Octets"
 
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col %s de %s; Línia %<PRId64> de %<PRId64>; Paraula %<PRId64> de %<PRId64>; Octet %<PRId64> de %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s de %s; Línia %<PRId64> de %<PRId64>; Paraula %<PRId64> de %<PRId64>; "
+"Octet %<PRId64> de %<PRId64>"
 
+#: ../ops.c:5133
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col %s de %s; Línia %<PRId64> de %<PRId64>; Paraula %<PRId64> de %<PRId64>; Caràcter %<PRId64> de %<PRId64>; Octet %<PRId64> de %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s de %s; Línia %<PRId64> de %<PRId64>; Paraula %<PRId64> de %<PRId64>; "
+"Caràcter %<PRId64> de %<PRId64>; Octet %<PRId64> de %<PRId64>"
 
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> per la BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Pàgina %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Gràcies per utilitzar el Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: L'opció és desconeguda"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: L'opció no està suportada"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: No està permès en una línia de mode"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Es requereix un número després de ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: No s'ha trobat a la base de dades termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Caràcter il·legal <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: No es pot definir 'term' com a cadena buida"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: No es pot canviar de terminal en mode GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Useu \":gui\" per ininciar l'interfície d'usuari gràfica"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: Les opcions 'backupext' i 'patchmode' coincideixen"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: L'interfície GTK+ 2 no permet canviar la codificació"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Falta un caràcter \":\""
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: La llargada de la cadena és zero"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Falta un número després de <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Falta una coma"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Heu d'especificar un valor '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Conté un caràcter no imprimible o ample"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Fosa no vàlida"
-
-msgid "E597: can't select fontset"
-msgstr "E597: No s'ha pogut seleccionar el conjunt de tipus"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: El conjunt de tipus de lletra no és vàlid"
-
-msgid "E533: can't select wide font"
-msgstr "E533: No s'ha pogut seleccionar una fosa ampla"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Fosa ampla no vàlida"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Caràcter il·legal després de <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Es requereix una coma"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: L'opció 'commentstring' ha d'estar indefinida o contenir %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: No hi ha suport per ratolí"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: La seqüència d'expressions no està acabada"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Hi han massa ítems"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Grups desequilibrats"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Ja hi ha una finestra de vista prèvia"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: L'àrab requereix UTF-8, feu ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Es necessiten com a mínim %d línies"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Es necessiten com a mínim %d columnes"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: L'opció és desconeguda: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Es requereix un número després de ="
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4151,6 +4741,7 @@ msgstr ""
 "\n"
 "--- Codis de terminal ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4158,6 +4749,7 @@ msgstr ""
 "\n"
 "--- Valors de les opcions globals ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4165,6 +4757,7 @@ msgstr ""
 "\n"
 "--- Valors de les opcions locals ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4172,130 +4765,21 @@ msgstr ""
 "\n"
 "--- Opcions ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: Error en get_varp()"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': No s'ha trobat el caràcter corresponent a %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Sobren caràcters després del punt i coma: %s"
 
-msgid "cannot open "
-msgstr "no s'ha pogut obrir "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: No s'ha pogut obrir la finestra!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Es requereix Amigados versió 2.04 o posterior\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Es requereix %s versió %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "No s'ha pogut obrir NIL:\n"
-
-msgid "Cannot create "
-msgstr "No s'ha pogut crear "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim ha finalitzat amb %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "no s'ha pogut canviar el mode de consola ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: no és una consola??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: No s'ha pogut executar l'intèrpret d'ordres amb l'opció -f"
-
-msgid "Cannot execute "
-msgstr "No s'ha pogut executar "
-
-msgid "shell "
-msgstr "l'intèrpret d'ordres "
-
-msgid " returned\n"
-msgstr " ha retornat\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "un valor ANCHOR_BUF_SIZE massa petit."
-
-msgid "I/O ERROR"
-msgstr "ERROR d'E/S"
-
-msgid "Message"
-msgstr "Missatge"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "L'opció 'columns' no és 80, no es poden executar ordres externes"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: La selecció d'impressora ha fallat"
-
-# a IMPRESSORA a PORT ?
-#, c-format
-msgid "to %s on %s"
-msgstr "a %s a %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Fosa d'impressió desconeguda: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Error d'impressió: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "S'està imprimint '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Conjunt de caràcters \"%s\" il·legal en el tipus \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Caràcter '%c' il·legal en el tipus \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: S'ha rebut un doble senyal, sortint\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: S'ha rebut un senyal letal %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: S'ha rebut un senyal letal\n"
-
-# display
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "S'ha trigat %<PRId64> mseg en obrir el display X"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Error de X\n"
-
-# display
-msgid "Testing the X display failed"
-msgstr "Ha fallat la comprovació del display X"
-
-# display
-msgid "Opening the X display timed out"
-msgstr "S'ha esgotat el temps mentre es tractava d'obrir el display X"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4303,13 +4787,7 @@ msgstr ""
 "\n"
 "No s'ha pogut executar la shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"No s'ha pogut executar la shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4317,364 +4795,470 @@ msgstr ""
 "\n"
 "la shell ha retornat "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"No s'han pogut crear canonades\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"No s'ha pogut bifurcar\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"L'ordre ha finalitzat\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP: s'ha perdut la connexió ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-# display
-msgid "Opening the X display failed"
-msgstr "Ha fallat l'obertura del display X"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP: s'està duent a terme la petició save-yourself"
-
-msgid "XSMP opening connection"
-msgstr "XSMP: obrint la connexió"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP: Ha fallat l'inspecció de la connexió ICE"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP: Ha fallat la rutina SmcOpenConnection: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: No s'ha trobat el fitxer \"%s\" en el path"
 
-msgid "At line"
-msgstr "A la línia"
-
-msgid "Could not load vim32.dll!"
-msgstr "No s'ha pogut carregar vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Error del VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "No s'han pogut reassignar els punters de funcions a la DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "la shell ha retornat %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: S'ha rebut un event %s\n"
-
-msgid "close"
-msgstr "de finalització"
-
-msgid "logoff"
-msgstr "de final de sessió"
-
-msgid "shutdown"
-msgstr "d'apagament del sistema"
-
-msgid "E371: Command not found"
-msgstr "E371: No s'ha trobat l'ordre"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"El programa VIMRUN.EXE no es troba en el $PATH.\n"
-"Les ordres externes no faran una pausa un cop finalitzades.\n"
-"Vegeu  :help win32-vimrun  per a més informació."
-
-msgid "Vim Warning"
-msgstr "Vim Atenció"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Sobren %%%c a la cadena de format"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: %%%c inesperat a la cadena de format"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Falta un ] a la cadena de format"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c no suportat a la cadena de format"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: %%%c no vàlid en el prefix de la cadena de format"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: %%%c no vàlid a la cadena de format"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: L'opció 'errorformat' no conté cap patró"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Falta un nom de directori"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: No hi ha més ítems"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d de %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (línia eliminada)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Baix de la pila quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Dalt de la pila quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "llista d'errors %d de %d; %d errors"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: No s'ha pogut escriure, l'opció 'buftype' no està definida"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Falta el nom de fitxer o el patró no és vàlid"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "No s'ha pogut obrir el fitxer \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: El buffer no està carregat"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: S'esperava una cadena o una llista"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Ítem no vàlid a %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: El patró és massa llarg"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Sobren \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Sobren %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: \\z( desequilibrat"
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: %s%%( desequilibrat"
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: %s( desequilibrat"
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: %s) desequilibrat"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Hi ha un caràcter no vàlid després de %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: La construcció %s{...} és massa complexa"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: %s* imbricats"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: %s%c imbricats"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: Ús no vàlid de \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: No ha ha res abans de %s%c"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Referència il·legal a l'element anterior"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( no està permès aquí"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 et al. no estan permesos aquí"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Hi ha un caràcter no vàlid després de \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Falta un ] després de %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Element %s%%[] buit"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Caràcter invàlid després de %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Hi ha un caràcter invàlid després de %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Falta un ] després de %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: %s%%( desequilibrat"
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: %s( desequilibrat"
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: %s) desequilibrat"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( no està permès aquí"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 et al. no estan permesos aquí"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Falta un ] després de %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Element %s%%[] buit"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: El patró és massa llarg"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Sobren \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Sobren %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: \\z( desequilibrat"
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: Hi ha un caràcter no vàlid després de %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: La construcció %s{...} és massa complexa"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: %s* imbricats"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: %s%c imbricats"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Ús no vàlid de \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: No ha ha res abans de %s%c"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Referència il·legal a l'element anterior"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Hi ha un caràcter no vàlid després de \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Caràcter invàlid després de %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Hi ha un caràcter invàlid després de %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Error de sintaxi a %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Subcoincidències externes:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Sobren \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: No s'ha trobat el fitxer temporal per escriure-hi"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " SUBSTITUIRV"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " SUBSTITUIR"
 
 # En el mode d'escriptura de dreta a esquerra
 # surt el missatge «REVERSE INSERT»
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " INVERS"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERIR"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (inserir)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (substituir)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (substituirv)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebreu"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Àrab"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lang)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (enganxar)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUAL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUAL LÍNIA"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUAL BLOC"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " SELECCIONAR"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " SELECCIÓ LÍNIA"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " SELECCIÓ BLOC"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "enregistrant"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Cadena de cerca no vàlida: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: la cerca ha arribat a DALT sense resultats per: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: la cerca ha arribat a BAIX sense resultats per: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: S'esperava '?' o '/' després de ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (inclou resultats llistats anteriorment)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Fitxers inclosos "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "no s'ha trobat"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "en el path ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Ja s'havia llistat)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NO TROBAT"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Examinant el fitxer inclòs: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Cercant al fitxer inclòs %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: El resultat es troba a la línia actual"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "S'han trobat tots els fitxers inclosos"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "No hi han fitxers inclosos"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: No s'ha trobat la definició"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: No s'ha trobat el patró"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 substitució"
+
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4685,379 +5269,492 @@ msgstr ""
 "# Últim %sPatró de Cerca:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Error de format en el fitxer d'ortografia"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Fitxer d'ortografia truncat"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Text sobrant a %s línia %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "El nom de l'afix és massa llarg a %s línia %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Error de format en el fitxer d'afixos FOL, LOW o UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Caràcter a FOL, LOW o UPP fora d'abast"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Comprimint l'arbre de paraules..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: La correcció ortogràfica no està activada"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr "Atenció: No s'ha trobat la llista de paraules \"%s.%s.spl\" o \"%s.ascii.spl\""
+msgstr ""
+"Atenció: No s'ha trobat la llista de paraules \"%s.%s.spl\" o \"%s.ascii.spl"
+"\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Llegint el fitxer d'ortografia \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Això no té pinta de ser un fitxer d'ortografia"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Fitxer d'ortografia vell, ha de ser actualitzat"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: El fitxer d'ortografia és per a una versió més recent del Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Secció en el fitxer d'ortografia no suportada"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Atenció: la regió %s no està suportada"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Llegint el fitxer d'afixos %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "No s'ha pogut convertir una paraula a %s línia %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "La conversió a %s no està suportada: de %s a %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Conversió a %s no suportada"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Valor de marca no vàlid a %s línia %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG després d'usar marques a %s línia %d: %s"
 
+#: ../spell.c:4723
 #, c-format
-msgid "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line %d"
-msgstr "Definir COMPOUNDFORBIDFLAG després de l'element PFX pot tenir resultats inesperats a %s línia %d"
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+"Definir COMPOUNDFORBIDFLAG després de l'element PFX pot tenir resultats "
+"inesperats a %s línia %d"
 
+#: ../spell.c:4731
 #, c-format
-msgid "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line %d"
-msgstr "Definir COMPOUNDPERMITFLAG després de l'element PFX pot tenir resultats inesperats a %s línia %d"
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+"Definir COMPOUNDPERMITFLAG després de l'element PFX pot tenir resultats "
+"inesperats a %s línia %d"
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "Valor de COMPOUNDMIN incorrecte a %s línia %d: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Valor de COMPOUNDWORDMAX incorrecte a %s línia %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Valor de COMPOUNDMIN incorrecte a %s línia %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Valor de COMPOUNDSYLMAX incorrecte a %s línia %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Valor de CHECKCOMPOUNDPATTERN incorrecte a %s línia %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr "Marca de combinació diferent en bloc continuat d'afixos a %s línia %d: %s"
+msgstr ""
+"Marca de combinació diferent en bloc continuat d'afixos a %s línia %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Afix duplicat a %s línia %d: %s"
 
+#: ../spell.c:4871
 #, c-format
-msgid "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s line %d: %s"
-msgstr "Afix també utilitzat per a BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST a %s línia %d: %s"
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+"Afix també utilitzat per a BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
+"NOSUGGEST a %s línia %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "S'esperava Y o N a %s línia %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Condició errònia a %s línia %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "S'esperava recompte REP(SAL) a %s línia %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "S'esperava un recompte MAP a %s línia %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Caràcter duplicat en un element MAP a %s línia %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Element duplicat o no reconegut a %s línia %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Falta una línia FOL/LOW/UPP a %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "Element COMPOUNDSYLMAX sense síl·laba"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Sobren prefixes posposats"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Sobren marques de composició"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Massa prefixes posposats i/o marques de composició"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Falta una línia SOFO%s a %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Línies SAL i SOFO a %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "La marca no és un número a %s línia %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Marca il·legal a %s línia %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "el valor %s difereix de l'usat en un altre fitxer .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Llefint el fitxer de diccionari %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: No hi ha recompte de paraules a %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "línia %6d, paraula %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Paraula duplicada a %s línia %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Primera paraula duplicada a %s línia %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d paraula/es duplada/es a %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "%d paraula/es ignorada/es amb caràcters no-ASCII a %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Llegint el fitxer de paraules %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "S'ignora la línia /encoding= duplicada a %s línia %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "S'ignora una línia /encoding= després d'una paraula a %s línia %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "S'ignora la línia /regions= duplicada a %s línia %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Massa regions a %s línia %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Línia / ignorada a %s línia %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Número de regió no vàlid a %s línia %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Marques no reconegudes a %s línia %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "S'ignoren %d paraules amb caràcters no-ASCII"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Comprimits %d de %d nodes; %d (%d%%) pendents"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Tornant a llegir el fitxer d'ortografia..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Efectuant expansió per similitud fonètica..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
-msgstr "Nombre de paraules després de l'expansió per similitud fonètica: %<PRId64>"
+msgstr ""
+"Nombre de paraules després de l'expansió per similitud fonètica: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Nombre total de paraules: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Escrivint el fitxer de suggeriments %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Ús estimat de memòria en funcionament: %d octets"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: El fitxer de sortida no pot tenir un nom de regió"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Només es suporten fins a 8 regions"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Regió no vàlida a %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Atenció: heu especificat composició i NOBREAK alhora"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Escrivint el fitxer d'ortografia %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Fet!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' no té %<PRId64> entrades"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Paraula eliminada de %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Paraula afegida a %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Els caràcters de paraula difereixen entre fitxers d'ortografia"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Cap suggeriment"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Llàstima, només %<PRId64> suggeriments"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Canviar \"%.*s\" per:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: No hi ha cap correcció ortogràfica anterior"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: No trobat: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: No sembla pas un fitxer .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Fitxer .sug antic, ha de ser actualitzat: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: El fitxer .sug és per a una versió més nova del Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: El fitxer .sug no coincideix amb el fitxer .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: error en llegir el fitxer .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Caràcter duplicat a l'entrada MAP"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "No hi ha ítems de sintaxi definits en aquest buffer"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: L'argument és il·legal: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: No existeix tal grup de sintaxi: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "No hi ha ítems de sintaxi definits en aquest buffer"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "s'està sincronitzant a partir de comentaris estil C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "no es sincronitza"
 
 # va junta amb la següent
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "comença la sincronització"
 
 # va junta amb l'anterior
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " línies abans de la línia superior"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5065,6 +5762,7 @@ msgstr ""
 "\n"
 "--- Ítems de sincronització de sintaxi ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5072,6 +5770,7 @@ msgstr ""
 "\n"
 "s'està sincronitzant a partir d'ítems"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5079,199 +5778,275 @@ msgstr ""
 "\n"
 "--- Ítems de sintaxi ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: No existeix tal grup de sintaxi: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "mínim "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "màxim "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; coincidència "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " salts de línia"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: Conté un argument que no s'accepta aquí"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: L'argument 'containedin' no s'accepta aquí"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: L'argument no és vàlid"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: L'opció group[t]here no s'accepta aquí"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: No s'ha trobat cap regió d'ítems per %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Es requereix un nom de fitxer"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Sobren noms de fitxer"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Falta un ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Falta un '=': %s"
 
 # 'syntax region' és una ordre
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Falten arguments: syntax region %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: No existeix tal grup de sintaxi: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: No heu especificat cap grup"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: No s'ha trobat el patró de delimitació: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Hi ha porqueria després del patró: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: el patró de continuació de línia està repetit"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Arguments il·legals: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Falta un signe d'igual: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Argument buit: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s no està permès aquí"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s ha d'anar al principi de la llista 'contains'"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: El nom del grup és desconegut: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Sub-ordre de sintaxi no vàlida: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Iteració recursiva en carregar syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: No s'ha trobat el grup de ressalt: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Falten arguments: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Sobren arguments: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: El grup ja ha estat definit, s'ignora l'enllaç de ressalt"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Signe d'igual inesperat: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Falta un signe d'igual: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Falta un argument: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: El valor és il·legal: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Color de primer terme desconegut"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Color de fons desconegut"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nom o número de color no identificat: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: El codi de terminal és massa llarg: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: L'argument és il·legal: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Hi ha massa atributs de ressalt diferents en ús"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Caràcter no imprimible en el nom del grup"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Hi ha un caràcter no vàlid en el nom del grup"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: Baix de la pila d'etiquetes"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: Dalt de la pila d'etiquetes"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: No es pot anar abans de la primera etiqueta coincident"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: No s'ha trobat l'etiqueta: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri tip  etiqueta"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "fitxer\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Només hi ha una sola etiqueta que coincideixi"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: No es pot anar més enllà de l'última etiqueta coincident"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "El fitxer \"%s\" no existeix"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "etiqueta %d de %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " o més"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  No es fa distinció entre majúscules i minúscules!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: El fitxer \"%s\" no existeix"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5279,60 +6054,80 @@ msgstr ""
 "\n"
 "  #  A etiq     DES DE línia  en fitxer/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Cercant en el fitxer d'etiquetes %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: S'ha truncat l'ubicació del fitxer d'etiquetes per %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Error de format en el fitxer d'etiquetes \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Abans de l'octet %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: El fitxer d'etiquetes no està ordenat: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: No hi ha cap fitxer d'etiquetes"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: No s'ha trobat l'etiqueta"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: No s'ha trobat l'etiqueta exacta!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Afix duplicat a %s línia %d: %s"
+
 # «terminal» és masculí
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' no identificat. Els terminals disponibles són:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "per omissió '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: No s'ha pogut obrir el fitxer termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: No s'ha trobat l'informació del terminal a terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: No s'ha trobat l'informació del terminal a termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: No hi ha cap entrada \"%s\" a termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Es requereix la capacitat \"cm\" per part del terminal"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5340,160 +6135,169 @@ msgstr ""
 "\n"
 "--- Tecles del terminal ---"
 
-msgid "new shell started\n"
-msgstr "s'ha iniciat una nova shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Error en llegir l'entrada, sortint...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "No es pot desfer res; voleu continuar"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: El buffer ha canviat inesperadament"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: No s'ha pogut obrir el fitxer amb permís d'escriptura"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Escrivint el fitxer viminfo \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Error d'escriptura en el fitxer d'intercanvi"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Llegint el fitxer de paraules %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: No s'ha pogut obrir el fitxer viminfo amb permís de lectura"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: No trobat: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: No es pot obrir el fitxer %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "ha finalitzat l'interpretació de %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Ja sou en el canvi més vell"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Ja sou en el canvi més recent"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "Línia de desfer número %<PRId64> no trobada"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: els nombres de línia no són correctes"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "línia més"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "línies més"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "línia menys"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "línies menys"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "canvi"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "canvis"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "abans"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "després"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "No hi ha res per desfer"
 
-msgid "number changes  time"
-msgstr "número canvis   hora"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "fa %<PRId64> segons"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin no està permès després de undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: La llista de desfer està corrompuda"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Falta una línia de desfer"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Versió GUI per MS-Windows 16/32 bits"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Versió GUI per a MS-Windows 64 bits"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Versió GUI per MS-Windows 32 bits"
-
-msgid " in Win32s mode"
-msgstr " en mode Win32s"
-
-msgid " with OLE support"
-msgstr " amb suport per OLE"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Versió consola per MS-Windows 32 bits"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Versió per MS-Windows 16 bits"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versió per MS-DOS 32 bits"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versió per MS-DOS 16 bits"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Versió per MacOS X (Unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Versió per MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Versió per MacOS"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"Versió per RISC OS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5501,9 +6305,18 @@ msgstr ""
 "\n"
 "Modificacions incloses: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Subcoincidències externes:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modificat per "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5511,9 +6324,11 @@ msgstr ""
 "\n"
 "Compilat "
 
+#: ../version.c:649
 msgid "by "
 msgstr "per "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5521,681 +6336,1758 @@ msgstr ""
 "\n"
 "Versió enorme "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Versió gran "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Versió normal "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Versió reduïda "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Versió mínima "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "sense GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "amb GUI GTK2-GNOME."
-
-msgid "with GTK-GNOME GUI."
-msgstr "amb GUI GTK-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "amb GUI GTK2."
-
-msgid "with GTK GUI."
-msgstr "amb GUI GTK."
-
-msgid "with X11-Motif GUI."
-msgstr "amb GUI X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "amb GUI X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "amb GUI X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "amb GUI Photon."
-
-msgid "with GUI."
-msgstr "amb GUI."
-
-msgid "with Carbon GUI."
-msgstr "amb GUI Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "amb GUI Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "amb GUI (clàssic)."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Funcions incloses (+) o excloses (-):\n"
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "    fitxer vimrc del sistema: \""
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "    fitxer vimrc de l'usuari: \""
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2n fitxer vimrc de l'usuari: \""
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3r fitxer vimrc de l'usuari: \""
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "     fitxer exrc de l'usuari: \""
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2n fitxer exrc de l'usuari: \""
 
 # 29 caràcters fins el ":" (inclòs)
-msgid "  system gvimrc file: \""
-msgstr "   fitxer gvimrc del sistema: \""
-
-# 29 caràcters fins el ":" (inclòs)
-msgid "    user gvimrc file: \""
-msgstr "   fitxer gvimrc de l'usuari: \""
-
-# 29 caràcters fins el ":" (inclòs)
-msgid "2nd user gvimrc file: \""
-msgstr "2n fitxer gvimrc de l'usuari: \""
-
-# 29 caràcters fins el ":" (inclòs)
-msgid "3rd user gvimrc file: \""
-msgstr "3r fitxer gvimrc de l'usuari: \""
-
-# 29 caràcters fins el ":" (inclòs)
-msgid "    system menu file: \""
-msgstr "  fitxer de menú del sistema: \""
-
-# 29 caràcters fins el ":" (inclòs)
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "      alternativa per a $VIM: \""
 
 # 29 caràcters fins el ":" (inclòs)
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "       alt per a $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Compilat amb: "
 
-msgid "Compiler: "
-msgstr "Compilador: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Enllaçat amb: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  VERSIÓ DE DEPURACIÓ"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versió "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "per Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim és un programa obert i lliure distribució"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Ajudeu els nens pobres d'Uganda!"
 
 # amplada 53 caràcters
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "feu  :help iccf<Entrar>          per a més informació     "
 
 # amplada 53 caràcters
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "feu  :q<Entrar>                  per a sortir             "
 
 # amplada 53 caràcters
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "feu  :help<Entrar> o <F1>        per a obtenir ajuda      "
 
 # amplada 53 caràcters
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "feu  :help version7<Entrar>      per a info de la versió  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Funcionant en mode compatible amb Vi"
 
 # amplada 53 caràcters
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "feu  :set nocp<Entrar>           per al mode no compatible"
 
 # amplada 53 caràcters
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "feu  :help cp-default<Entrar>    per a info sobre el tema "
 
-# amplada 53 caràcters
-msgid "menu  Help->Orphans           for information    "
-msgstr "menú  Ajuda->Orfes               per a informació      "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Funcionant sense modes, el text escrit s'insereix"
-
-# Això ha de lligar amb la traducció del menú
-# amplada 53 caràcters
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menú  Edita->Opcions globals->Mode d'inserció          "
-
-# amplada 53 caràcters
-msgid "                              for two modes      "
-msgstr "                                 per a dos modes       "
-
-# Això ha de lligar amb la traducció del menú
-# amplada 53 caràcters
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menú  Edita->Opcions globals->Compatible amb Vi        "
-
-# amplada 53 caràcters
-msgid "                              for Vim defaults   "
-msgstr "                                 per al mode compatible"
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Patrocineu el desenvolupament del Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Feu-vos usuari de Vim registrat!"
 
 # amplada 53 caràcters
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "feu  :help sponsor<Entrar>       per a informació         "
 
 # amplada 53 caràcters
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "feu  :help register<Entrar>      per a informació         "
 
 # amplada 53 caràcters
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menú  Ajuda->Patrocini/Registre  per a informació      "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ATENCIÓ: S'ha detectat Windows 95/98/ME"
-
-# amplada 53 caràcters
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "feu  :help windows95<Entrar>     per a info sobre el tema "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Només hi ha una finestra"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: No hi ha cap finestra de previsualització"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: No es pot dividir horitzontal i verticalment al mateix temps"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: No hi pot haver rotació quan hi ha finestres dividides"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: No es pot tancar l'última finestra"
 
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: No es pot tancar l'última finestra"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: No es pot tancar l'última finestra"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Hi han altres finestres que contenen canvis"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: No hi ha cap nom de fitxer sota el cursor"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: No s'ha trobat el fitxer \"%s\" en el path"
+# És el nom d'un diàleg. Menú "Split patched by..."
+#~ msgid "Patch file"
+#~ msgstr "Fitxer de diferències"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: No s'ha pogut carregar la biblioteca %s"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&D'acord\n"
+#~ "&Cancel·la"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Aquesta ordre no està habilitada: no s'ha pogut carregar la biblioteca Perl."
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: No hi ha connexió amb el servidor Vim"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Avaluació Perl en una gàbia no permesa sense el mòdul Safe"
+# «res» ?  eac
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: No s'ha pogut enviar a %s"
 
-msgid "Edit with &multiple Vims"
-msgstr "Edita en &múltiples Vims"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: No s'ha pogut llegir la resposta del servidor"
 
-msgid "Edit with single &Vim"
-msgstr "Edita en un sol &Vim"
+# «res» ?  eac
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: No s'ha pogut enviar al client"
 
-msgid "Diff with Vim"
-msgstr "Mostra les diferències amb Vim"
+# Títol d'un diàleg [:browse w].  eac
+#~ msgid "Save As"
+#~ msgstr "Anomena i desa"
 
-msgid "Edit with &Vim"
-msgstr "Edita amb el &Vim"
+# Títol d'un diàleg [:browse source].  eac
+#~ msgid "Source Vim script"
+#~ msgstr "Interpreta un script Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Edita amb un Vim existent - "
+# és un títol de diàleg [:browse edit].  eac
+#~ msgid "Edit File"
+#~ msgstr "Edita un fitxer"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Edita el(s) fitxer(s) seleccionat(s) amb el Vim"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NO TROBAT)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Error en crear el procés: Comproveu que gvim es trobi en el path!"
+# Títol d'un diàleg [:browse split]  eac
+#~ msgid "Edit File in new window"
+#~ msgstr "Edita un fitxer en una finestra nova"
 
-msgid "gvimext.dll error"
-msgstr "error de la biblioteca gvimext.dll"
+# És un títol d'un diàleg [:browse read]  eac
+#~ msgid "Append File"
+#~ msgstr "Afegeix un fitxer"
 
-msgid "Path length too long!"
-msgstr "La llargada del path és excessiva"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Posició de la finestra: X %d, Y %d"
 
-msgid "--No lines in buffer--"
-msgstr "--Cap línia en el buffer--"
+# És el títol d'un diàleg.  eac
+#~ msgid "Save Redirection"
+#~ msgstr "Desa la redirecció"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: S'ha avortat l'ordre"
+# És el títol d'un diàleg.  eac
+#~ msgid "Save View"
+#~ msgstr "Desa la vista"
 
-msgid "E471: Argument required"
-msgstr "E471: Es requereix un argument"
+# És el títol d'un diàleg.  eac
+#~ msgid "Save Session"
+#~ msgstr "Desa la sessió"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ hauria de continuar amb /, ? o &"
+# És el títol d'un diàleg.  eac
+#~ msgid "Save Setup"
+#~ msgstr "Desa la configuració"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: No és vàlid a la línia d'ordres: <ENTRAR> executa, CTRL-C surt"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Aquesta versió no suporta dígrafs"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: Ordre en exrc/vimrc no permesa en l'actual cerca d'etiquetes o directoris"
+#~ msgid "is a device (disabled with 'opendevice' option"
+#~ msgstr "és un dispositiu (deshabilitat amb l'opció 'opendevice'"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Falta una declaració :endif"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Llegint l'entrada estàndard..."
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Falta una declaració :endtry"
+# entra en conflicte amb NL (només lectura)
+#~ msgid "[NL found]"
+#~ msgstr "[s'han trobat caràcters NL]"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Falta una declaració :endwhile"
+#~ msgid "[crypted]"
+#~ msgstr "[xifrat]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Falta un :endfor"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans no permet escriure buffers no modificats"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: Declaració :endwhile sense :while"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "L'escriptura parcial no està permesa en buffers NetBeans"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor sense :for"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "escriptura a un dispositiu deshabilitat amb l'opció 'opendevice'"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: El fitxer existeix (afegiu ! per confirmar)"
+# «resource fork» (MacOS) ?
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: La bifurcació de recursos es perdrà (afegiu ! per confirmar)"
 
-msgid "E472: Command failed"
-msgstr "E472: L'ordre ha fallat"
+#~ msgid "<cannot open> "
+#~ msgstr "<no es pot obrir> "
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Conjunt de tipus desconegut: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: no s'ha pogut obtenir la fosa %s"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Fosa desconeguda: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: no s'ha pogut tornar al directori actual"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: La fosa \"%s\" no és d'amplada fixa"
+#~ msgid "Pathname:"
+#~ msgstr "Ubicació:"
 
-msgid "E473: Internal error"
-msgstr "E473: Error intern"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: no s'ha pogut obtenir el directori actual"
 
-msgid "Interrupted"
-msgstr "Interromput"
+#~ msgid "OK"
+#~ msgstr "D'acord"
 
-msgid "E14: Invalid address"
-msgstr "E14: L'adreça no és vàlida"
+#~ msgid "Cancel"
+#~ msgstr "Cancel·la"
 
-msgid "E474: Invalid argument"
-msgstr "E474: L'argument no és vàlid"
+#~ msgid "Vim dialog"
+#~ msgstr "Diàleg del Vim"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: L'argument no és vàlid: %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Barra de desplaçament: No s'ha pogut obtenir la mida del mapa de bits."
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: L'expressió no és vàlida: %s"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: No es pot crear un BalloonEval amb missatge i callback alhora"
 
-msgid "E16: Invalid range"
-msgstr "E16: L'interval no és vàlid"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: No s'ha pogut iniciar l'interfície gràfica"
 
-msgid "E476: Invalid command"
-msgstr "E476: L'ordre no és vàlida"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: No s'ha pogut llegir \"%s\""
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" és un directori"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: No es pot iniciar l'IUG, no s'ha trobat cap fosa vàlida"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: La crida a la biblioteca a fallat per \"%s()\""
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: El valor de 'guifontwide' no és vàlid"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: No s'ha pogut carregar la funció %s"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: El valor de 'imactivatekey' no és vàlid"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Marca amb un número de línia no vàlid"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: No s'ha pogut assignar memòria pel color %s"
 
-msgid "E20: Mark not set"
-msgstr "E20: Marca no establerta"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Cap coincidència al cursor, cercant la següent"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: No es poden fer canvis, l'opció 'modifiable' està desactivada"
+#~ msgid "Vim dialog..."
+#~ msgstr "Diàleg del Vim..."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Imbricació d'scripts massa profunda"
+#~ msgid "Input _Methods"
+#~ msgstr "_Mètodes d'entrada"
 
-msgid "E23: No alternate file"
-msgstr "E23: No hi ha cap fitxer alternatiu"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Cerca i substitueix..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: No existeix tal abreviació"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Cerca..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! no permès"
+#~ msgid "Find what:"
+#~ msgstr "Cerca:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: No es pot usar la GUI: No ha estat compilada"
+#~ msgid "Replace with:"
+#~ msgstr "Substituieix amb:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: No es pot usar el mode Hebreu: No ha estat compilat\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Només paraules senceres"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: No es pot usar el mode Farsi: No ha estat compilat\n"
+#~ msgid "Match case"
+#~ msgstr "Sensible a les majúscules"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: No es pot usar el mode àrab: No ha estat compilat\n"
+#~ msgid "Direction"
+#~ msgstr "Direcció"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: No existeix tal grup de ressalt: %s"
+#~ msgid "Up"
+#~ msgstr "Amunt"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Encara no s'ha inserit text"
+#~ msgid "Down"
+#~ msgstr "Avall"
 
-msgid "E30: No previous command line"
-msgstr "E30: No hi ha cap ordre anterior"
+#~ msgid "Find Next"
+#~ msgstr "Cerca el següent"
 
-msgid "E31: No such mapping"
-msgstr "E31: No existeix tal assignació"
+#~ msgid "Replace"
+#~ msgstr "Substitueix"
 
-msgid "E479: No match"
-msgstr "E479: Cap coincidència"
+#~ msgid "Replace All"
+#~ msgstr "Substitueix-les totes"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Cap coincidència: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: S'ha rebut una petició \"die\" del gestor de sessions\n"
 
-msgid "E32: No file name"
-msgstr "E32: Falta un nom de fitxer"
+#~ msgid "Close"
+#~ msgstr "Tanca"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: No hi ha cap expressió de substitució anterior"
+#~ msgid "New tab"
+#~ msgstr "Nova pestanya"
 
-msgid "E34: No previous command"
-msgstr "E34: No hi ha cap ordre anterior"
+#~ msgid "Open Tab..."
+#~ msgstr "Obre una pestanya..."
 
-msgid "E35: No previous regular expression"
-msgstr "E35: No hi ha cap expressió regular anterior"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: La finestra principal ha estat destruïda inesperadament\n"
 
-msgid "E481: No range allowed"
-msgstr "E481: No es permet cap interval"
+#~ msgid "Font Selection"
+#~ msgstr "Selecció de fosa"
 
-msgid "E36: Not enough room"
-msgstr "E36: No hi ha prou espai"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "S'ha usat CUT_BUFFER0 en lloc d'una selecció buida"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: No hi ha cap servidor registrat amb aquest nom \"%s\""
+#~ msgid "&Filter"
+#~ msgstr "&Filtre"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: No es pot crear el fitxer %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Cancel·la"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: No s'ha pogut obtenir el nom del fitxer temporal"
+#~ msgid "Directories"
+#~ msgstr "Directoris"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: No es pot obrir el fitxer %s"
+#~ msgid "Filter"
+#~ msgstr "Filtre"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: No es pot llegir el fitxer %s"
+#~ msgid "&Help"
+#~ msgstr "&Ajuda"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: No s'han desat els canvis (afegiu ! per confirmar)"
+#~ msgid "Files"
+#~ msgstr "Fitxers"
 
-msgid "E38: Null argument"
-msgstr "E38: Argument nul"
+#~ msgid "&OK"
+#~ msgstr "&D'acord"
 
-msgid "E39: Number expected"
-msgstr "E39: S'esperava un número"
+#~ msgid "Selection"
+#~ msgstr "Selecció"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: No s'ha pogut obrir el fitxer d'errors %s"
+#~ msgid "Find &Next"
+#~ msgstr "Cerca el &següent"
 
-msgid "E233: cannot open display"
-msgstr "E233: No s'ha pogut obrir la pantalla"
+#~ msgid "&Replace"
+#~ msgstr "&Substitueix"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Memòria exhaurida!"
+#~ msgid "Replace &All"
+#~ msgstr "Substitueix-les &totes"
 
-msgid "Pattern not found"
-msgstr "No s'ha trobat el patró"
+#~ msgid "&Undo"
+#~ msgstr "&Desfés"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: No s'ha trobat el patró: %s"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: No s'ha trobat el títol de finestra \"%s\""
 
-msgid "E487: Argument must be positive"
-msgstr "E487: L'argument ha de ser un número positiu"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument no suportat: \"-%s\"; Useu la versió OLE."
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: No es pot tornar al directori anterior"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: No s'ha pogut obrir una finestra dins l'aplicació MDI"
 
-msgid "E42: No Errors"
-msgstr "E42: No hi han errors"
+#~ msgid "Close tab"
+#~ msgstr "Tanca la pestanya"
 
-msgid "E776: No location list"
-msgstr "E776: No hi ha cap llista de posicions"
+#~ msgid "Open tab..."
+#~ msgstr "Obre una pestanya..."
 
-msgid "E43: Damaged match string"
-msgstr "E43: S'ha corromput la cadena amb l'expressió regular"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Cerca una cadena (useu '\\\\' per cercar '\\')"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: S'ha corromput el programa d'expressió regular"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Cerca i substitueix (useu '\\\\' per cercar '\\')"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: L'opció 'readonly' està definida (afegiu ! per confirmar)"
+#~ msgid "Not Used"
+#~ msgstr "No Usat"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: No s'ha pogut canviar la variable de només lectura \"%s\""
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Directori\t*.res\n"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: No s'ha pogut definir la variable dins la gàbia: \"%s\""
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: No s'ha pogut assignar memòria per colors, poden ser incorrectes"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Error en llegir el fitxer d'errors"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: En el conjunt %s falten tipus pels següents jocs de caràcters:"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: No està permès dins d'una gàbia"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nom del conjunt de tipus: %s"
 
-msgid "E523: Not allowed here"
-msgstr "E523: No està permès aquí"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "La fosa '%s' no és d'amplada fixa"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: La funció d'ajustar el mode de pantalla no està suportada"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Nom del conjunt de tipus: %s\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: La distància de desplaçament no és vàlida"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Fosa0: %s\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: L'opció 'shell' no conté res"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Fosa1: %s\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: No s'han pogut llegir les dades del senyal!"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "L'amplada de la fosa%<PRId64> no és el doble que la de la fosa0\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Error en tancar el fitxer d'intercanvi"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Amplada de de la Fosa0: %<PRId64>\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: La pila d'etiquetes està buida"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Amplada de la Fosa1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: L'ordre és massa complexa"
+#~ msgid "Invalid font specification"
+#~ msgstr "Especificació de fosa no vàlida"
 
-msgid "E75: Name too long"
-msgstr "E75: El nom és massa llarg"
+#~ msgid "&Dismiss"
+#~ msgstr "&Ignora"
 
-msgid "E76: Too many ["
-msgstr "E76: Sobren caràcters ["
+#~ msgid "no specific match"
+#~ msgstr "cap coincidència específica"
 
-msgid "E77: Too many file names"
-msgstr "E77: Sobren noms de fitxer"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Selector de fosa"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Sobren caràcters"
+#~ msgid "Name:"
+#~ msgstr "Nom:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: La marca és desconeguda"
+#~ msgid "Show size in Points"
+#~ msgstr "Mostra la mida en punts"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: No s'ha pogut expandir el nom de fitxer"
+#~ msgid "Encoding:"
+#~ msgstr "Codificació:"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: L'opció 'winheight' no pot ser menor que 'winminheight'"
+#~ msgid "Font:"
+#~ msgstr "Fosa:"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: L'opció 'winwidth' no pot ser menor que 'winminwidth'"
+#~ msgid "Style:"
+#~ msgstr "Estil:"
 
-msgid "E80: Error while writing"
-msgstr "E80: Error d'escriptura"
+#~ msgid "Size:"
+#~ msgstr "Mida:"
 
-msgid "Zero count"
-msgstr "Comptador a zero"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ERROR de l'autòmata hangul"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Ús de <SID> en un context equivocat"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: Error de stat()"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: S'ha rebut una expressió no vàlida"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: No s'ha pogut obrir la base de dades cscope: %s"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: La regió està protegida, no es pot modificar"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: No s'ha pogut obtenir l'informació de la base de dades cscope"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans no permet canvis a fitxers de només-lectura"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: S'ha assolit el màxim nombre de connexions cscope"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Error intern: %s"
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Aquesta ordre no està habilitada, la biblioteca MzScheme no s'ha "
+#~ "pogut carregar."
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: el patró usa més memòria que 'maxmempattern'"
+#~ msgid "invalid expression"
+#~ msgstr "l'expressió no és vàlida"
 
-msgid "E749: empty buffer"
-msgstr "E749: buffer buit"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "no s'ha compilat suport per expressions"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Patró de cerca o delimitador no vàlid"
+#~ msgid "hidden option"
+#~ msgstr "opció amagada"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: El fitxer està carregat en un altre buffer"
+#~ msgid "unknown option"
+#~ msgstr "opció desconeguda"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: L'opció '%s' no està definida"
+#~ msgid "window index is out of range"
+#~ msgstr "índex de finestra fora d'abast"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "la cerca ha arribat a DALT, es continua a BAIX"
+#~ msgid "couldn't open buffer"
+#~ msgstr "no s'ha pogut obrir el buffer"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "la cerca ha arribat a BAIX, es continua a DALT"
+#~ msgid "cannot save undo information"
+#~ msgstr "no s'ha pogut desar l'informació de desfer"
+
+#~ msgid "cannot delete line"
+#~ msgstr "no s'ha pogut esborrar la línia"
+
+#~ msgid "cannot replace line"
+#~ msgstr "no s'ha pogut substituir la línia"
+
+#~ msgid "cannot insert line"
+#~ msgstr "no s'ha pogut inserir la línia"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "la cadena no pot contenir salts de línia"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Error del Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Error del Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "el buffer no és vàlid"
+
+#~ msgid "window is invalid"
+#~ msgstr "la finestra no és vàlida"
+
+#~ msgid "linenr out of range"
+#~ msgstr "nombre de línia fora d'abast"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "no permès a la gàbia del Vim"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Aquesta ordre està deshabilitada, no s'ha pogut carregar Python."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: No es pot invocar Python de forma recursiva"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "no s'han pogut eliminar els atributs de l'OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "'softspace' ha de ser un nombre enter"
+
+#~ msgid "invalid attribute"
+#~ msgstr "l'atribut no és vàlid"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "la funció writelines() requereix una llista de cadenes"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Error en inicialitzar els objectes d'E/S"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "intent de referència a un buffer eliminat"
+
+#~ msgid "line number out of range"
+#~ msgstr "nombre de línia fora d'abast"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<objecte buffer (eliminat) a %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "nom de marca no vàlid"
+
+#~ msgid "no such buffer"
+#~ msgstr "no existeix tal buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "intent de referir-se a una finestra eliminada"
+
+#~ msgid "readonly attribute"
+#~ msgstr "atribut de només lectura"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "posició del cursor fora del buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<objecte finestra (eliminat) a %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<objecte finestra (desconegut) a %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<finestra %d>"
+
+#~ msgid "no such window"
+#~ msgstr "no existeix tal finestra"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ ha de ser una instància d'una cadena"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Ordre deshabilitada, no s'ha pogut carregar la biblioteca Ruby."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: retorn inesperat"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: 'next' inesperat"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: tall inesperat"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: 'redo' inesperat"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: 'retry' fora d'una clàusula de rescat"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: excepció no manejada"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: estat de longjmp desconegut %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Commuta implementació/definició"
+
+#~ msgid "Show base class of"
+#~ msgstr "Mostra la classe base de"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Mostra el membre de la funció invalidat"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Obtenir d'un fitxer"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Obtenir d'un projecte"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Obtenir de tots els projectes"
+
+#~ msgid "Retrieve"
+#~ msgstr "Obtenir"
+
+#~ msgid "Show source of"
+#~ msgstr "Mostra el codi font de"
+
+#~ msgid "Find symbol"
+#~ msgstr "Cerca un símbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Explora les classes"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Mostra la jerarquia de classes"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Mostra la jerarquia de classes restringida"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref es refereix a"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref referenciada per"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref té un"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref usada per"
+
+#~ msgid "Show docu of"
+#~ msgstr "Mostra docu de"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Genera docu per"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "No s'ha pogut connectar amb SNiFF+. Reviseu l'entorn (sniffemacs ha "
+#~ "d'estar en el $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Error de lectura. Desconnectat"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ "
+
+#~ msgid "not "
+#~ msgstr "no "
+
+#~ msgid "connected"
+#~ msgstr "està connectat"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Petició SNiFF+ desconeguda: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Error en connectar a SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ no connectat"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: No és un buffer SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Error d'escriptura. Desconnectat"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "nombre de buffer no vàlid"
+
+#~ msgid "not implemented yet"
+#~ msgstr "no implementat (encara)"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "no s'ha pogut establir el nombre de línies"
+
+#~ msgid "mark not set"
+#~ msgstr "marca no establerta"
+
+#~ msgid "row %d column %d"
+#~ msgstr "fila %d columna %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "no s'ha pogut inserir/afegir la línia"
+
+#~ msgid "unknown flag: "
+#~ msgstr "senyal desconegut: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "vimOption desconeguda"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "interrupció de teclat"
+
+#~ msgid "vim error"
+#~ msgstr "error de vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "no s'ha pogut crear l'ordre de buffer/finestra: l'objecte està siguent "
+#~ "eliminat"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "no s'ha pogut registrar l'ordre callback: el búfer/finestra ja està sent "
+#~ "eliminat"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ERROR FATAL DE TCL: llista de referències corrupta!? Comuniqueu-ho "
+#~ "a vim-dev@vim.org."
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "no s'ha pogut registrar l'ordre callback: referència del búfer/finestra "
+#~ "no trobada"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Aquesta ordre està deshabilitada: No s'ha pogut carregar la "
+#~ "llibreria Tcl."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: ERROR DE TCL: el codi de retorn no és un enter!? Comuniqueu-ho a "
+#~ "vim-dev@vim.org."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: codi de sortida %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "no s'ha pogut obtenir la línia"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "No s'ha pogut registrar un nom de servidor d'ordres"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: No s'ha pogut enviar l'ordre al programa destinatari"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: S'ha usat una ID de servidor no vàlida: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: El registre de l'instància de VIM està mal format. S'ha esborrat!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Aquest Vim no ha estat compilat amb suport per diff."
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Error: Ha fallat l'arrencada del gvim des de NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "On s'ignora la capitalizació, afegiu el prefix / per a indicar majúscules"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistra aquest gvim per OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tDesregistra aquest gvim per OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tUsa una interfície gràfica (com \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  o   --nofork\tNo crea un procés nou per la GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNo obre una finestra nova amb newcli"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <dispositiu>\t\tUsa <dispositiu> per l'E/S"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tUsa <gvimrc> en lloc de qualsevol altre .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEdita fitxers amb xifrat"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <pantalla>\tConnecta el Vim a un servidor X particular"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNo es connecta a cap servidor X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <fitxers>\tEdita <fitxers> en un servidor Vim, si és possible"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <fitxers>  Igual, no es queixa si no hi ha servidor"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <fitxers>  Com --remote, però espera que s'editin els "
+#~ "fitxers"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <fitxers>  Igual, no es queixa si no hi ha servidor"
+
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr ""
+#~ "--remote-tab <fitxers>  Com --remote, però obre una pestanya per fitxer"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <tecles>  Envia <tecles> a un servidor Vim i surt"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <expr>\tEvaula <expr> en un servidor Vim i mostra el "
+#~ "resultat"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tLlista els noms dels servidors Vim accessibles"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nom>\tEnvia a o es converteix en servidor Vim <nom>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconeguts pel gvim (versió Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconeguts pel gvim (versió neXtaw>:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconeguts pel gvim (versió Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <pantalla>\tExecuta vim a <pantalla>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tComença iconificat"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <nom>\t\tUsa els recursos com si vim fós <nom>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t (No implementat)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\tUsa <color> pel fons (també: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\tUsa <color> pel text normal (també: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <fosa>\tUsa <fosa> pel text normal (també: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <fosa>\tUsa <fosa> pel text en negreta"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <fosa>\tUsa <fosa> pel text en cursiva"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\tUsa <geom> com a geometria inicial (també: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <amplada>\tUsa un marge d'amplada <amplada> (també: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <amplada>  Amplada de la barra de desplaçament (també: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <alçada>\tAlçada de la barra de menú (també: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tUsa el mode de video invers (també: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNo usa el mode de video invers (també: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <recurs>\tEstableix el recurs especificat"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconeguts pel gvim (versió RISC OS):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <nombre>\tAmplada inicial de la finestra en columnes"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <nombre>\tAlçada inicial de la finestra en files"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconeguts pel gvim (versió GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <pantalla>\tExecuta vim a <pantalla> (també: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <rol>\t\tUsa un únic rol per identificar la finestra principal"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tObre el vim dins d'una altra aplicació GTK"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <títol pare>\tObre el Vim en una aplicació pare"
+
+#~ msgid "No display"
+#~ msgstr "No hi ha cap pantalla"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Error en enviar.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Error en enviar. Intentant l'execució local\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "editat %d de %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "No hi ha cap pantalla: Error en enviar l'expressió.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Error en enviar l'expressió.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: No és un codi de pàgina vàlid"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Error en crear el context d'entrada"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Error en obrir el mètode d'entrada"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Atenció: No s'ha pogut establir el callback de destrucció a IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: el mètode d'entrada no suporta cap estil"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: el mètode d'entrada no suporta el tipus de preedició"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: L'estil over-the-spot requereix un conjunt de tipus"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr ""
+#~ "E291: La llibreria GTK+ és anterior a 1.2.3. Es deshabilita l'àrea d'estat"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: El servidor de mètodes d'entrada (IMS) no està funcionant"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "          [no usable amb aquesta versió de Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Estripa aquest menú"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Diàleg de selecció de directori"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Diàleg de desar fitxer"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Diàleg d'obrir fitxer"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: No hi ha un explorador de fitxers en mode consola"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: preservant els fitxers...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Finalitzat.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ERROR: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[octets] total assignat-alliberat %<PRIu64>-%<PRIu64>, en ús %<PRIu64>, "
+#~ "màxim ús %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[crides] total re/malloc() %<PRIu64>, total free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: La línia s'està tornant massa llarga"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Error intern: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: La forma del punter del ratolí és il·legal"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Introduïu la clau de xifrat: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Introduïu la mateixa clau un altre cop: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "La claus no coincideixen!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "No s'ha pogut connectar amb Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "No s'ha pogut connectar amb Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Mode d'accés incorrecte per al fitxer d'info de la connexió "
+#~ "NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "lectura d'un socket Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: S'ha perdut la connexió NetBeans per al buffer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505:"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: La funció eval no està disponible"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "alliberant %<PRId64> línies"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: No es pot canviar de terminal en mode GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Useu \":gui\" per ininciar l'interfície d'usuari gràfica"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: L'interfície GTK+ 2 no permet canviar la codificació"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Fosa no vàlida"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: No s'ha pogut seleccionar el conjunt de tipus"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: El conjunt de tipus de lletra no és vàlid"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: No s'ha pogut seleccionar una fosa ampla"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Fosa ampla no vàlida"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: No hi ha suport per ratolí"
+
+#~ msgid "cannot open "
+#~ msgstr "no s'ha pogut obrir "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: No s'ha pogut obrir la finestra!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Es requereix Amigados versió 2.04 o posterior\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Es requereix %s versió %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "No s'ha pogut obrir NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "No s'ha pogut crear "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim ha finalitzat amb %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "no s'ha pogut canviar el mode de consola ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: no és una consola??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: No s'ha pogut executar l'intèrpret d'ordres amb l'opció -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "No s'ha pogut executar "
+
+#~ msgid "shell "
+#~ msgstr "l'intèrpret d'ordres "
+
+#~ msgid " returned\n"
+#~ msgstr " ha retornat\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "un valor ANCHOR_BUF_SIZE massa petit."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ERROR d'E/S"
+
+#~ msgid "Message"
+#~ msgstr "Missatge"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "L'opció 'columns' no és 80, no es poden executar ordres externes"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: La selecció d'impressora ha fallat"
+
+# a IMPRESSORA a PORT ?
+#~ msgid "to %s on %s"
+#~ msgstr "a %s a %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Fosa d'impressió desconeguda: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Error d'impressió: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "S'està imprimint '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Conjunt de caràcters \"%s\" il·legal en el tipus \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Caràcter '%c' il·legal en el tipus \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: S'ha rebut un doble senyal, sortint\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: S'ha rebut un senyal letal %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: S'ha rebut un senyal letal\n"
+
+# display
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "S'ha trigat %<PRId64> mseg en obrir el display X"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Error de X\n"
+
+# display
+#~ msgid "Testing the X display failed"
+#~ msgstr "Ha fallat la comprovació del display X"
+
+# display
+#~ msgid "Opening the X display timed out"
+#~ msgstr "S'ha esgotat el temps mentre es tractava d'obrir el display X"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "No s'ha pogut executar la shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "No s'han pogut crear canonades\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "No s'ha pogut bifurcar\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "L'ordre ha finalitzat\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP: s'ha perdut la connexió ICE"
+
+# display
+#~ msgid "Opening the X display failed"
+#~ msgstr "Ha fallat l'obertura del display X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP: s'està duent a terme la petició save-yourself"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP: obrint la connexió"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP: Ha fallat l'inspecció de la connexió ICE"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP: Ha fallat la rutina SmcOpenConnection: %s"
+
+#~ msgid "At line"
+#~ msgstr "A la línia"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "No s'ha pogut carregar vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Error del VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "No s'han pogut reassignar els punters de funcions a la DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "la shell ha retornat %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: S'ha rebut un event %s\n"
+
+#~ msgid "close"
+#~ msgstr "de finalització"
+
+#~ msgid "logoff"
+#~ msgstr "de final de sessió"
+
+#~ msgid "shutdown"
+#~ msgstr "d'apagament del sistema"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: No s'ha trobat l'ordre"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "El programa VIMRUN.EXE no es troba en el $PATH.\n"
+#~ "Les ordres externes no faran una pausa un cop finalitzades.\n"
+#~ "Vegeu  :help win32-vimrun  per a més informació."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Atenció"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Conversió a %s no suportada"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: L'argument 'containedin' no s'accepta aquí"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: S'ha truncat l'ubicació del fitxer d'etiquetes per %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "s'ha iniciat una nova shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "No es pot desfer res; voleu continuar"
+
+#~ msgid "number changes  time"
+#~ msgstr "número canvis   hora"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió GUI per MS-Windows 16/32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió GUI per a MS-Windows 64 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió GUI per MS-Windows 32 bits"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " en mode Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " amb suport per OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió consola per MS-Windows 32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per MS-Windows 16 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per MS-DOS 32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per MS-DOS 16 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per MacOS X (Unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versió per RISC OS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versió gran "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versió normal "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versió reduïda "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versió mínima "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "amb GUI GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "amb GUI GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "amb GUI GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "amb GUI GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "amb GUI X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "amb GUI X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "amb GUI X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "amb GUI Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "amb GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "amb GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "amb GUI Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "amb GUI (clàssic)."
+
+# 29 caràcters fins el ":" (inclòs)
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "   fitxer gvimrc del sistema: \""
+
+# 29 caràcters fins el ":" (inclòs)
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "   fitxer gvimrc de l'usuari: \""
+
+# 29 caràcters fins el ":" (inclòs)
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2n fitxer gvimrc de l'usuari: \""
+
+# 29 caràcters fins el ":" (inclòs)
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3r fitxer gvimrc de l'usuari: \""
+
+# 29 caràcters fins el ":" (inclòs)
+#~ msgid "    system menu file: \""
+#~ msgstr "  fitxer de menú del sistema: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Compilador: "
+
+# amplada 53 caràcters
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menú  Ajuda->Orfes               per a informació      "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Funcionant sense modes, el text escrit s'insereix"
+
+# Això ha de lligar amb la traducció del menú
+# amplada 53 caràcters
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menú  Edita->Opcions globals->Mode d'inserció          "
+
+# amplada 53 caràcters
+#~ msgid "                              for two modes      "
+#~ msgstr "                                 per a dos modes       "
+
+# Això ha de lligar amb la traducció del menú
+# amplada 53 caràcters
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menú  Edita->Opcions globals->Compatible amb Vi        "
+
+# amplada 53 caràcters
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                 per al mode compatible"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ATENCIÓ: S'ha detectat Windows 95/98/ME"
+
+# amplada 53 caràcters
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "feu  :help windows95<Entrar>     per a info sobre el tema "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: No s'ha pogut carregar la biblioteca %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Aquesta ordre no està habilitada: no s'ha pogut carregar la biblioteca "
+#~ "Perl."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: Avaluació Perl en una gàbia no permesa sense el mòdul Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Edita en &múltiples Vims"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Edita en un sol &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Mostra les diferències amb Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Edita amb el &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Edita amb un Vim existent - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Edita el(s) fitxer(s) seleccionat(s) amb el Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Error en crear el procés: Comproveu que gvim es trobi en el path!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "error de la biblioteca gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "La llargada del path és excessiva"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Conjunt de tipus desconegut: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Fosa desconeguda: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: La fosa \"%s\" no és d'amplada fixa"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: No s'ha pogut carregar la funció %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: No es pot usar el mode Hebreu: No ha estat compilat\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: No es pot usar el mode Farsi: No ha estat compilat\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: No es pot usar el mode àrab: No ha estat compilat\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: No hi ha cap servidor registrat amb aquest nom \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: No s'ha pogut obrir la pantalla"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: S'ha rebut una expressió no vàlida"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: La regió està protegida, no es pot modificar"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans no permet canvis a fitxers de només-lectura"
 
 #~ msgid "[Error List]"
 #~ msgstr "[Llista d'errors]"
+
 #~ msgid "[No File]"
 #~ msgstr "[Cap fitxer]"
+
 #~ msgid "E106: Unknown variable: \"%s\""
 #~ msgstr "E106: La variable és desconeguda: \"%s\""
-#~ msgid "E123: Undefined function: %s"
-#~ msgstr "E123: La funció no està definida: %s"
-#~ msgid "E127: Cannot redefine function %s: It is in use"
-#~ msgstr "E127: No s'ha pogut redefinir la funció %s: s'està utilitzant"
+
 #~ msgid "E130: Undefined function: %s"
 #~ msgstr "E130: La funció no està definida: %s"
+
 #~ msgid "\"\n"
 #~ msgstr "\"\n"
+
 #~ msgid "-V[N]\t\tVerbose level"
 #~ msgstr "-V[N]\t\tNivell de loquacitat"
+
 #~ msgid "--help\t\tShow Gnome arguments"
 #~ msgstr "--help\t\tMostra els arguments per Gnome"
+
 #~ msgid "[string too long]"
 #~ msgstr "[cadena massa llarga]"
+
 #~ msgid "Hit ENTER to continue"
 #~ msgstr "Premeu ENTRAR per continuar"
+
 #~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
 #~ msgstr ""
 #~ " (ENTRAR/RETROCÉS: línia, ESPAI/b; pàgina, d/u; mitja pàgina, q: surt)"
+
 #~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
 #~ msgstr " (ENTRAR: línia, ESPAI: pàgina, d: mitja pàgina, q: surt)"
+
 #~ msgid "...(truncated)"
 #~ msgstr "...(truncat)"
+
 #~ msgid "Could not allocate memory for command line."
 #~ msgstr "No s'ha pogut assignar memòria per la línia d'ordres."
+
 #~ msgid "E56: %s* operand could be empty"
 #~ msgstr "E56: L'operand %s* podria estar buit"
+
 #~ msgid "E57: %s+ operand could be empty"
 #~ msgstr "E57: L'operand %s+ podria estar buit"
+
 #~ msgid "E58: %s{ operand could be empty"
 #~ msgstr "E58: L'operand %s{ podria estar buit"
+
 #~ msgid "E361: Crash intercepted; regexp too complex?"
 #~ msgstr "E361: Programa inestable; expressió regular massa complexa?"
+
 #~ msgid "E363: pattern caused out-of-stack error"
 #~ msgstr "E363: El patró ha provocat un error de desbordament de pila"
+
 #~ msgid " BLOCK"
 #~ msgstr " BLOC"
+
 #~ msgid " LINE"
 #~ msgstr " LÍNIA"
+
 #~ msgid "Enter nr of choice (<CR> to abort): "
 #~ msgstr "Entreu un número (<Entrar> per avortar): "
+
 #~ msgid "with BeOS GUI."
 #~ msgstr "amb GUI BeOS."
-

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -6,6 +6,8 @@
 
 if 1	" Only execute this if the eval feature is available.
 
+redir! > check.log
+
 " Function to get a split line at the cursor.
 " Used for both msgid and msgstr lines.
 " Removes all text except % items and returns the result.
@@ -81,6 +83,8 @@ endif
 if error == 0
   echo "OK"
 endif
+
+redir END
 
 let &wrapscan = s:save_wrapscan
 unlet s:save_wrapscan

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -8,142 +8,219 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: vim-6.0\n"
-"POT-Creation-Date: 2001-10-08 08:27-0700\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2002-02-06 22:29+0100\n"
 "Last-Translator: Jiøí Pavlovskı <jpavlovsky@mbox.vol.cz>\n"
 "Language-Team: Czech <cs@li.org>\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=cp1250\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "E258: Nelze pøedat klientovi"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nelze alokovat ádnı buffer, konèím..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nelze alokovat buffer, pouiji jinı..."
 
-msgid "No buffers were unloaded"
+#: ../buffer.c:763
+#, fuzzy
+msgid "E515: No buffers were unloaded"
 msgstr "ádnı buffer nebyl deaktivován"
 
-msgid "No buffers were deleted"
+#: ../buffer.c:765
+#, fuzzy
+msgid "E516: No buffers were deleted"
 msgstr "ádnı buffer nebyl smazán"
 
-msgid "No buffers were wiped out"
+#: ../buffer.c:767
+#, fuzzy
+msgid "E517: No buffers were wiped out"
 msgstr "ádnı buffer nebyl zahozen"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Poèet deaktivovanıch bufferù: 1"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Poèet deaktivovanıch bufferù: %d"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Poèet smazanıch bufferù: 1"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Poèet smazanıch bufferù: %d"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Poèet zahozenıch bufferù: 1"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Poèet zahozenıch bufferù: %d"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Poslední buffer nelze deaktivovat"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nebyl nalezen ádnı zmìnìnı buffer"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Seznam bufferù je prázdnı"
 
-#, c-format
-msgid "E86: Cannot go to buffer %<PRId64>"
-msgstr "E86: Nelze pøeskoèit na buffer %<PRId64>"
+#: ../buffer.c:913
+#, fuzzy, c-format
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E92: Buffer %<PRId64> nenalezen"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za poslední buffer nelze pøeskoèit"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pøed první buffer nelze pøeskoèit"
 
-#, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (use ! to override)"
+#: ../buffer.c:945
+#, fuzzy, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Zmìny v bufferu %<PRId64> nebyly uloeny (! pro vynucení)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Poslední buffer nelze deaktivovat"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varování: pøeteèení seznamu s názvy souborù"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Buffer %<PRId64> nenalezen"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Vzoru %s vyhovuje více bufferù"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje ádnı buffer"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "øádek %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer tohoto jména ji existuje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmìnìnı]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Needitovanı]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Novı soubor]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Chyby pøi ètení]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[Pouze pro ètení]"
 
+#: ../buffer.c:2524
+#, c-format
 msgid "1 line --%d%%--"
 msgstr "øádkù: --%d%%--"
 
+#: ../buffer.c:2526
+#, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "øádkù: %<PRId64> --%d%%--"
 
+#: ../buffer.c:2530
+#, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "øádek %<PRId64>/%<PRId64> --%d%%-- sloupec"
 
-msgid "[No file]"
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+#, fuzzy
+msgid "[No Name]"
 msgstr "[ádnı soubor]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "nápovìda"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[nápovìda]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[náhled]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Vše"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Konec"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Zaèátek"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -151,12 +228,11 @@ msgstr ""
 "\n"
 "# Seznam bufferù:\n"
 
-msgid "[Error List]"
-msgstr "[seznam chyb]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[No File]"
-msgstr "[ádnı soubor]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -164,115 +240,221 @@ msgstr ""
 "\n"
 "--- Znaky ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaky pro %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    øádek=%<PRId64> id=%d jméno=%s"
 
+#: ../cursor_shape.c:68
+#, fuzzy
+msgid "E545: Missing colon"
+msgstr "Chybí dvojteèka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+#, fuzzy
+msgid "E546: Illegal mode"
+msgstr "nepøípustnı mód"
+
+#: ../cursor_shape.c:134
+#, fuzzy
+msgid "E548: digit expected"
+msgstr "oèekávána èíslice"
+
+#: ../cursor_shape.c:138
+#, fuzzy
+msgid "E549: Illegal percentage"
+msgstr "nepøípustné procento"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nelze pøekroèit maximální poèet %<PRId64> diff bufferù"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E164: Pøed první soubor nelze pøeskoèit"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nelze vytvoøit diffy"
 
-msgid "Patch file"
-msgstr "Soubor se záplatou"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Nelze èíst vıstup programu diff"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nelze èíst vıstup programu diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktuální buffer není v diff reimu"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: To byl poslední buffer v diff reimu"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: To byl poslední buffer v diff reimu"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
-msgstr "E101: V diff reimu jsou více ne dva buffery. Nevím, kterı mám pouít."
+msgstr ""
+"E101: V diff reimu jsou více ne dva buffery. Nevím, kterı mám pouít."
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nelze nalézt buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffer \"%s\" není v diff reimu"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: digraph nesmí obsahovat Escape"
 
-msgid "Keymap file not found"
+#: ../digraph.c:1760
+#, fuzzy
+msgid "E544: Keymap file not found"
 msgstr "Soubor s mapou klávesnice nebyl nalezen"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap mimo interpretovanı soubor"
 
-msgid " Keyword completion (^N/^P)"
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
+#, fuzzy
+msgid " Keyword completion (^N^P)"
 msgstr " Doplòování klíèovıch slov (^N/^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^E/^Y/^L/^]/^F/^I/^K/^D/^V/^N/^P)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X reim (^E/^Y/^L/^]/^F/^I/^K/^D/^V/^N/^P)"
 
-#. Scroll has it's own msgs, in it's place there is the msg for local
-#. * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-msgid " Keyword Local completion (^N/^P)"
-msgstr " Lokální doplòování klíèovıch slov (^N/^P)"
-
-msgid " Whole line completion (^L/^N/^P)"
+#: ../edit.c:85
+#, fuzzy
+msgid " Whole line completion (^L^N^P)"
 msgstr " Doplòování celıch øádkù (^L/^N/^P)"
 
-msgid " File name completion (^F/^N/^P)"
+#: ../edit.c:86
+#, fuzzy
+msgid " File name completion (^F^N^P)"
 msgstr " Doplòování názvù souborù (^F/^N/^P)"
 
-msgid " Tag completion (^]/^N/^P)"
+#: ../edit.c:87
+#, fuzzy
+msgid " Tag completion (^]^N^P)"
 msgstr " Doplòování tagù (^I/^N/^P)"
 
-msgid " Path pattern completion (^N/^P)"
+#: ../edit.c:88
+#, fuzzy
+msgid " Path pattern completion (^N^P)"
 msgstr " Doplòování vzoru cest (^N/^P)"
 
-msgid " Definition completion (^D/^N/^P)"
+#: ../edit.c:89
+#, fuzzy
+msgid " Definition completion (^D^N^P)"
 msgstr " Doplòování definic (^D/^N/^P)"
 
-msgid " Dictionary completion (^K/^N/^P)"
+#: ../edit.c:91
+#, fuzzy
+msgid " Dictionary completion (^K^N^P)"
 msgstr " Doplòování podle slovníku (^K/^N/^P)"
 
-msgid " Thesaurus completion (^T/^N/^P)"
+#: ../edit.c:92
+#, fuzzy
+msgid " Thesaurus completion (^T^N^P)"
 msgstr " Doplòování podle tezauru (^T/^N/^P)"
 
-msgid " Command-line completion (^V/^N/^P)"
+#: ../edit.c:93
+#, fuzzy
+msgid " Command-line completion (^V^N^P)"
 msgstr " Doplòování pøíkazové øádky (^I/^N/^P)"
 
+#: ../edit.c:94
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " Doplòování celıch øádkù (^L/^N/^P)"
+
+#: ../edit.c:95
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " Doplòování tagù (^I/^N/^P)"
+
+#: ../edit.c:96
+msgid " Spelling suggestion (s^N^P)"
+msgstr ""
+
+#: ../edit.c:97
+#, fuzzy
+msgid " Keyword Local completion (^N^P)"
+msgstr " Lokální doplòování klíèovıch slov (^N/^P)"
+
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Konec odstavce"
 
-msgid "'thesaurus' option is empty"
-msgstr "volba 'thesaurus' je prázdná"
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
 
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "volba 'dictionary' je prázdná"
 
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr "volba 'thesaurus' je prázdná"
+
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Prohledávám slovník %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (insert) Rolování (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (replace) Rolování (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Prohledávám %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Prohledávám tagy"
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr "Pøidávám"
 
@@ -280,179 +462,600 @@ msgstr "Pøidávám"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Hledám..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Vıchozí podoba"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Slovo z jiného øádku"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jediná shoda"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "shoda %d/%d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "shoda %d"
 
-#, c-format
-msgid "E106: Unknown variable: \"%s\""
-msgstr "E106: Neznámá promìnná: \"%s\""
+#: ../eval.c:137
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: Neoèekávané znaky pøed '='"
 
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: Chybí závorky: %s"
+#: ../eval.c:138
+#, fuzzy, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E322: poèet øádkù mimo rozsah: %<PRId64> > celkovı poèet øádkù"
 
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: Promìnná \"%s\" neexistuje"
-
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: Po '?' chybí ':'"
-
-msgid "E110: Missing ')'"
-msgstr "E110: Chybìjící ')'"
-
-msgid "E111: Missing ']'"
-msgstr "E111: Chybìjící ']'"
-
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: Chybí jméno volby: %s"
-
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: Neznámá volba: %s"
-
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: Chybí uvozovky: %s"
-
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: Chybí uvozovky: %s"
-
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: Chybné argumenty pro funkci %s"
-
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: Neznámá funkce: %s"
-
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: Pøíliš mnoho argumentù pro funkci %s"
-
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Pøíliš málo argumentù pro funkci %s"
-
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: Pouití <SID> mimo kontext skriptu: %s"
-
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld øádkù:"
-
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zrušit"
-
-msgid "E240: No connection to Vim server"
-msgstr "E240: Neexistuje pøipojení k Vim serveru"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nelze èíst odpovìï serveru"
-
-msgid "E258: Unable to send to client"
-msgstr "E258: Nelze pøedat klientovi"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nelze pøedat do %s"
-
-msgid "(Invalid)"
-msgstr "(Chybnı)"
-
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nedefinovaná promìnná: %s"
 
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr "E111: Chybìjící ']'"
+
+#: ../eval.c:141
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "Argument musí bıt kladnı"
+
+#: ../eval.c:143
 #, c-format
-msgid "E122: Function %s already exists, use ! to replace"
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: Nelze najít doèasnı temp soubor pro zápis"
+
+#: ../eval.c:145
+#, fuzzy
+msgid "E714: List required"
+msgstr "E397: Vyadován název souboru"
+
+#: ../eval.c:146
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: Je vyadováno jméno funkce"
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Pøíliš mnoho argumentù pro funkci %s"
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
+#, fuzzy, c-format
+msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkce %s ji existuje. Pouijte ! pro její nahrazení."
 
+#: ../eval.c:151
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: Buffer tohoto jména ji existuje"
+
+#: ../eval.c:152
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: Je vyadováno jméno funkce"
+
+#: ../eval.c:153
+#, fuzzy
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E360: Nelze spustit shell s parametrem -f"
+
+#: ../eval.c:154
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr ""
+
+#: ../eval.c:155
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: Neznámá funkce: %s"
+
+#: ../eval.c:156
+#, fuzzy, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E418: nepøípustná hodnota: %s"
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E235: Nelze pouít font %s"
+
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: Chybí závorky: %s"
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: Promìnná \"%s\" neexistuje"
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+#, fuzzy
+msgid "E692: Invalid operation for Lists"
+msgstr "E15: Chybnı vıraz: %s"
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: Chybné argumenty pro funkci %s"
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: Chybné argumenty pro funkci %s"
+
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: Nelze spustit shell s parametrem -f"
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr "E110: Chybìjící ')'"
+
+#: ../eval.c:4609
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: Poslední buffer nelze deaktivovat"
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: Chybí jméno volby: %s"
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: Neznámá volba: %s"
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: Chybí uvozovky: %s"
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: Chybí uvozovky: %s"
+
+#: ../eval.c:5084
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: Chybí rovnítko: %s"
+
+#: ../eval.c:5091
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: Chybí '=': %s"
+
+#: ../eval.c:6475
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E242: Chybí barva: %s"
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E242: Chybí barva: %s"
+
+#: ../eval.c:6524
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: Chybí :endfunction"
+
+#: ../eval.c:6555
+#, fuzzy
+msgid "E724: variable nested too deep for displaying"
+msgstr "E22: Skript vnoøen pøíliš hluboko"
+
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Pøíliš mnoho argumentù pro funkci %s"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: Chybné argumenty pro funkci %s"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Neznámá funkce: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Pøíliš málo argumentù pro funkci %s"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: Pouití <SID> mimo kontext skriptu: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+msgid "E808: Number or Float required"
+msgstr ""
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:7907
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "Pøíliš mnoho edit argumentù"
+
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: Nabídka existuje pouze v jiném módu"
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr "&Ok"
+
+#: ../eval.c:8676
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: pro %s ji mapování ji existuje"
+
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld øádkù:"
+
+#: ../eval.c:9291
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: Neznámá funkce: %s"
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr ""
+
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E407: %s zde není povoleno"
+
+#: ../eval.c:11140
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E178: Chybná implicitní hodnota pro poèet"
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:12466
+#, fuzzy
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E255: Nastaveno pøíliš mnoho voleb"
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "Chybnı argument"
+
+#: ../eval.c:13776
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: Nelze zvolit tiskárnu"
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr "(Chybnı)"
+
+#: ../eval.c:14590
+#, fuzzy
+msgid "E677: Error writing temp file"
+msgstr "E208: Chyba pøi zápisu do \"%s\""
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+#, fuzzy
+msgid "E730: using List as a String"
+msgstr "E374: Ve formátovacím øetìzci chybí ]"
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, fuzzy, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E93: Vzoru %s vyhovuje více bufferù"
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+
+#: ../eval.c:16724
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: Název funkce musí zaèínat velkım písmenem: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr "Neznámı"
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E284: Nelze nastavit IC hodnoty"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Nedefinovaná funkce: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Chybí '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Nelze nastavit IC hodnoty"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Nepøípustnı argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: Duplicitní tag \"%s\" v souboru %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Chybí :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: Název funkce musí zaèínat velkım písmenem: %s"
+
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Nelze pøedefinovat funkci %s: je pouívána"
 
-#, c-format
-msgid "E128: Function name must start with a capital: %s"
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
 msgstr "E128: Název funkce musí zaèínat velkım písmenem: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Je vyadováno jméno funkce"
 
-msgid "function "
-msgstr "funkce "
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr "E128: Název funkce musí zaèínat velkım písmenem: %s"
 
-#, c-format
-msgid "E130: Undefined function: %s"
-msgstr "E130: Nedefinovaná funkce: %s"
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Název funkce musí zaèínat velkım písmenem: %s"
 
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nelze smazat funkci %s: je ji pouívána"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zanoøení funkce je hlubší ne 'maxfuncdepth'"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "volám %s"
 
-#. always scroll up, don't overwrite
-#, c-format
-msgid "continuing in %s"
-msgstr "pokraèuji v %s"
+#: ../eval.c:18651
+#, fuzzy, c-format
+msgid "%s aborted"
+msgstr "Pøíkaz pøerušen"
 
-msgid "E133: :return not inside a function"
-msgstr "E133: :return mimo funkci"
-
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "dokonèeno provádìní %s. Návratová hodnota #%<PRId64>"
 
-#, c-format
-msgid "%s returning \"%s\""
+#: ../eval.c:18670
+#, fuzzy, c-format
+msgid "%s returning %s"
 msgstr "dokonèeno provádìní %s. Návratová hodnota \"%s\""
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
+#, c-format
+msgid "continuing in %s"
+msgstr "pokraèuji v %s"
+
+#: ../eval.c:18795
+msgid "E133: :return not inside a function"
+msgstr "E133: :return mimo funkci"
+
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -460,66 +1063,114 @@ msgstr ""
 "\n"
 "# globální promìnné:\n"
 
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+"\n"
+"\tNaposledy nastavena z "
+
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "ádné vloené soubory"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  šestnáctkovì %02x,  osmièkovì %03o"
 
+#: ../ex_cmds.c:145
+#, fuzzy, c-format
+msgid "> %d, Hex %04x, Octal %o"
+msgstr "<%s>%s%s  %d,  šestnáctkovì %02x,  osmièkovì %03o"
+
+#: ../ex_cmds.c:146
+#, fuzzy, c-format
+msgid "> %d, Hex %08x, Octal %o"
+msgstr "<%s>%s%s  %d,  šestnáctkovì %02x,  osmièkovì %03o"
+
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Nelze pøesunout øádky na pùvodní místo"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "poèet pøesunutıch øádkù: 1"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Poèet pøesunutıch øádkù: %<PRId64>"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Poèet filtrovanıch øádkù: %<PRId64>"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické pøíkazy *Filter* nesmí mìnit aktuální buffer"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Neuloené zmìny]\n"
 
-#, c-format
-msgid "viminfo: %s in line: "
+#: ../ex_cmds.c:1424
+#, fuzzy, c-format
+msgid "%sviminfo: %s in line: "
 msgstr "viminfo: %s na øádku: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: pøíliš mnoho chyb, pøeskakuji zbytek souboru"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Ètu viminfo soubor \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informace"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " znaèky"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "ádné vloené soubory"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " se nezdaøilo"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: do viminfo souboru %s nelze zapisovat"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nelze uloit viminfo soubor %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Ukládám viminfo souboru \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
+#, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tento viminfo soubor byl vytvoøen editorem Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -527,92 +1178,141 @@ msgstr ""
 "# Pokud budete opatrnı, mùete jej upravovat.\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Hodnota volby 'encoding' v dobì uloení tohoto souboru\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Nepøípustnı poèáteèní znak"
 
-msgid "Save As"
-msgstr "Uloit jako"
-
-#. Overwriting a file that is loaded in another buffer is not a
-#. * good idea.
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Soubor je nahrán v jiném bufferu"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Uloit neúplnı soubor?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Pouijte ! pro uloení neúplného bufferu"
 
-#, c-format
-msgid "Overwrite existing file \"%.*s\"?"
+#: ../ex_cmds.c:2281
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
 msgstr "Pøepsat soubor \"%.*s\"?"
 
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: Soubor existuje (pouijte ! pro vynucení)"
+
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: ádnı název souboru pro buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Soubor nebyl uloen: Ukládání je zakázáno volbou 'write'"
 
-#, c-format
+#: ../ex_cmds.c:2434
+#, fuzzy, c-format
 msgid ""
-"'readonly' option is set for \"%.*s\".\n"
+"'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "Pro \"%.*s\" je nastavena volba 'readonly'.\n"
 "Pøejete si ji potlaèit?"
 
-msgid "Edit File"
-msgstr "Editovat soubor"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "je pouze pro ètení (pouijte ! pro vynucení)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Automatické pøíkazy neoèekávanì smazaly novı buffer %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselnı argument pro :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim nepovoluje pouití pøíkazù shellu"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulární vırazy nesmí bıt oddìleny písmeny"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "nahradit za %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Pøerušeno) "
 
+#: ../ex_cmds.c:4384
+#, fuzzy
+msgid "1 match"
+msgstr "ádná shoda"
+
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 nahrazení"
 
+#: ../ex_cmds.c:4387
+#, fuzzy, c-format
+msgid "%<PRId64> matches"
+msgstr "poèet zmìn: %<PRId64>"
+
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> nahrazení"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " na jednom øádku"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " na %<PRId64> øádcích"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global nelze volat rekurzivnì"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: U pøíkazu 'global' chybí regulární vıraz"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Vzor nalezen na kadém øádku: %s"
 
+#: ../ex_cmds.c:4510
+#, c-format
+msgid "Pattern not found: %s"
+msgstr "Vzor nenalezen: %s"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -622,263 +1322,350 @@ msgstr ""
 "# Poslední nahrazující øetìzec:\n"
 "$"
 
+#: ../ex_cmds.c:4679
+#, fuzzy
+msgid "E478: Don't panic!"
+msgstr "Nepanikaøte!"
+
+#: ../ex_cmds.c:4717
+#, fuzzy, c-format
+msgid "E661: Sorry, no '%s' help for %s"
+msgstr "E149: Lituji, pro %s není ádná nápovìda"
+
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Lituji, pro %s není ádná nápovìda"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Lituji, soubor \"%s\" s nápovìdou nebyl nalezen"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s není adresáøem"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Nelze otevøít %s pro zápis"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Nelze otevøít %s pro zápis"
 
+#: ../ex_cmds.c:5500
 #, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s"
+msgid "E670: Mix of help file encodings within a language: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5565
+#, fuzzy, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplicitní tag \"%s\" v souboru %s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Neznámá volba pøíkazu: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Chybí jméno volby"
 
-msgid "E255: Too many signs defined"
+#: ../ex_cmds.c:5746
+#, fuzzy
+msgid "E612: Too many signs defined"
 msgstr "E255: Nastaveno pøíliš mnoho voleb"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Neplatnı text volby: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Neznámá volba: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Chybí identifikátor volby"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: chybné jméno bufferu: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Chybné ID volby: %<PRId64>"
 
+#: ../ex_cmds.c:6066
+#, fuzzy
+msgid " (not supported)"
+msgstr "Volba není podporována"
+
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Vymazáno]"
 
-msgid "Entering Debug mode.  Type \"cont\" to leave."
+#: ../ex_cmds2.c:139
+#, fuzzy
+msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Spouštím ladící reim. Pro ukonèení napište \"cont\"."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "øádek %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "pøíkaz: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Bod pøerušení v \"%s%s\" na øádku %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Bod pøerušení nenalezen: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Nebyly definovánu ádné body pøerušení"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  øádek %<PRId64>"
 
-#, c-format
-msgid "Save changes to \"%.*s\"?"
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
 msgstr "Uloit zmìny do \"%.*s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Nepojmenováno"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Buffer \"%s\" obsahuje neuloené zmìny"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Varování: Neèekanı vstup do jiného bufferu (zkontrolujte automatické pøíkazy)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Pro editaci byl zadán pouze jeden soubor"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Pøed první soubor nelze pøeskoèit"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Za poslední soubor nelze pøeskoèit"
 
+#: ../ex_cmds2.c:2175
+#, fuzzy, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E432: Obsah soubor tagù %s není seøazen"
+
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Hledám \"%s\" v \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Hledám \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "soubor \"%s\" nebyl nalezen v 'runtimepath'"
 
-msgid "Run Macro"
-msgstr "Spustit makro"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "nelze interpretovat adresáø: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "nelze interpretovat \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "øádek %<PRId64>: nelze interpretovat \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretuji \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "øádek %<PRId64>: interpretuji %s"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "dokonèena interpretace %s"
 
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "poèet novıch øádkù: 1"
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr "Chybnı argument"
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr "Chybnı argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr ""
+
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Varování: chybnı oddìlovaè øádkù. Moná chybí ^M."
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding pouito mimo interpretovanı soubor"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish pouito mimo interpretovanı soubor"
 
-msgid "No text to be printed"
-msgstr "ádnı text k vytištìní"
-
-msgid "Printing page %d (%d%%)"
-msgstr "Tisknu stranu %d (%d%%)"
-
-#, c-format
-msgid " Copy %d of %d"
-msgstr " Kopie %d z %d"
-
-#, c-format
-msgid "Printed: %s"
-msgstr "Vytištìno: %s"
-
-msgid "Printing aborted"
-msgstr "Tisk zrušen"
-
-msgid "E455: Error writing to PostScript output file"
-msgstr "E455: Nelze zapisovat do vıstupního PostScriptového souboru"
-
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: Nelze otevøít vıstupní PostScriptovı soubor"
-
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: Nelze otevøít soubor \"%s\""
-
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
-
-msgid "Sending to printer..."
-msgstr "Odesílám na tiskárnu..."
-
-msgid "E365: Failed to print PostScript file"
-msgstr "E365: Selhal tisk PostScriptového souboru"
-
-msgid "Print job sent."
-msgstr "Tisková úloha odeslána."
-
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Aktuální %sjazyk: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Nelze nastavit jazyk na \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Spouštím Ex mód. Napište \"visual\" pro návrat do normálního módu."
 
-#. must be at EOF
-msgid "At end-of-file"
+#: ../ex_docmd.c:428
+#, fuzzy
+msgid "E501: At end-of-file"
 msgstr "Konec souboru"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Pøíkaz je pøíliš rekurzivní"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Chybí :endwhile"
+#: ../ex_docmd.c:1006
+#, fuzzy, c-format
+msgid "E605: Exception not caught: %s"
+msgstr "E161: Bod pøerušení nenalezen: %s"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Chybí :endif"
-
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Konec interpretovaného souboru"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Konec funkce"
 
-msgid "Ambiguous use of user-defined command"
+#: ../ex_docmd.c:1628
+#, fuzzy
+msgid "E464: Ambiguous use of user-defined command"
 msgstr "Nejednoznaèné pouití uivatelsky definovaného pøíkazu"
 
-msgid "Not an editor command"
+#: ../ex_docmd.c:1638
+#, fuzzy
+msgid "E492: Not an editor command"
 msgstr "Není pøíkazem editoru"
 
-msgid "Don't panic!"
-msgstr "Nepanikaøte!"
-
-msgid "Backwards range given"
+#: ../ex_docmd.c:1729
+#, fuzzy
+msgid "E493: Backwards range given"
 msgstr "Zadán zpìtnı rozsah"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Zadán zpìtnı rozsah. Prohodit hranice"
 
-msgid "Use w or w>>"
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
+#, fuzzy
+msgid "E494: Use w or w>>"
 msgstr "Pouijte w èi w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Pøíkaz není této verzi bohuel implementován"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Pøípustnı je pouze jeden název souboru"
 
+#: ../ex_docmd.c:4238
+#, fuzzy
+msgid "1 more file to edit.  Quit anyway?"
+msgstr "Ještì zbıvají soubory k editaci (%d). Chcete pøesto ukonèit editor?"
+
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Ještì zbıvají soubory k editaci (%d). Chcete pøesto ukonèit editor?"
 
+#: ../ex_docmd.c:4248
+#, fuzzy
+msgid "E173: 1 more file to edit"
+msgstr "E173: Ještì zbıvají soubory k editaci (%<PRId64>)."
+
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Ještì zbıvají soubory k editaci (%<PRId64>)."
 
-msgid "E174: Command already exists: use ! to redefine"
+#: ../ex_docmd.c:4320
+#, fuzzy
+msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Pøíkaz ji existuje: pouijte ! pro pøedefinování"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -886,164 +1673,363 @@ msgstr ""
 "\n"
 "    Jméno       Args Rozsah Úplnost  Definice"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Nebyly nalezeny ádné uivatelsky definované pøíkazy"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nebyly zadány ádné atributy"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Chybnı poèet argumentù"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Opakování nemùe bıt zadáno dvakrát"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Chybná implicitní hodnota pro poèet"
 
-msgid "E179: argument required for complete"
+#: ../ex_docmd.c:4625
+#, fuzzy
+msgid "E179: argument required for -complete"
 msgstr "E179: chybná implicitní hodnota pro opakování"
 
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: Chybná hodnota doplnìní: %s"
-
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Chybnı atribut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Chybné jméno pøíkazu"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Uivatelsky definované pøíkazy musí zaèínat velikım písmenem."
 
+#: ../ex_docmd.c:4696
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr ""
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Uivatelsky definovanı pøíkaz %s neexistuje"
 
+#: ../ex_docmd.c:5219
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: Chybná hodnota doplnìní: %s"
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr ""
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr ""
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Nelze nalézt barevné schéma %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Blahopøeji, uivateli Vimu!"
 
-msgid "Edit File in new window"
-msgstr "Editovat soubor v novém oknì"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Poslední okno nelze uzavøít"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "Ji existuje pouze jedno okno"
+
+#: ../ex_docmd.c:6004
+#, c-format
+msgid "Tab page %d"
+msgstr ""
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "ádnı odkládací soubor"
 
-msgid "Append File"
-msgstr "Uloit soubor"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr "Nelze vytvoøit záloní soubor (pouijte ! pro vynucení)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: ádnı pøedchozí adresáø"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Neznámı"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Umístìní okna: X %d, Y %d"
+#: ../ex_docmd.c:6610
+msgid "E465: :winsize requires two number arguments"
+msgstr ""
 
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Na této platformì nelze umístìní okna zjistit"
 
-msgid "Save Redirection"
-msgstr "Uloit pøesmìrování"
+#: ../ex_docmd.c:6662
+#, fuzzy
+msgid "E466: :winpos requires two number arguments"
+msgstr "E176: Chybnı poèet argumentù"
 
-msgid "Save View"
-msgstr "Uloit pohled"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
+msgstr "nelze interpretovat adresáø: \"%s\""
 
-msgid "Save Session"
-msgstr "Uloit sezení"
-
-msgid "Save Setup"
-msgstr "Uloit nastavení"
-
-#, c-format
-msgid "E189: \"%s\" exists (use ! to override)"
+#: ../ex_docmd.c:7268
+#, fuzzy, c-format
+msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existuje (pouijte ! pro vynucení)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Nelze otevøít \"%s\" pro zápis"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumentem mùe bıt pouze písmeno nebo pravı èi levı apostrof"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Vnoøení :normal je pøíliš hluboké"
 
-msgid ":if nesting too deep"
-msgstr "vnoøení :if je pøíliš hluboké"
-
-msgid ":endif without :if"
-msgstr ":endif bez odpovídajícího :if"
-
-msgid ":else without :if"
-msgstr ":else bez odpovídajícího :if"
-
-msgid ":elseif without :if"
-msgstr ":elseif bez odpovídajícího :if"
-
-msgid ":while nesting too deep"
-msgstr "vnoøení :while je pøíliš hluboké"
-
-msgid ":continue without :while"
-msgstr ":continue bez odpovídajícího :while"
-
-msgid ":break without :while"
-msgstr ":break bez odpovídajícího :while"
-
-msgid ":endwhile without :while"
-msgstr ":endwhile bez odpovídajícího :while"
-
-msgid "E193: :endfunction not inside a function"
-msgstr "E193: :endfunction mimo funkci"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr ""
 "E194: ádnı alternativní název souboru, kterım by bylo moné nahradit '#'"
 
-msgid "no autocommand file name to substitute for \"<afile>\""
+#: ../ex_docmd.c:7841
+#, fuzzy
+msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "ádnı název souboru, kterım by bylo moné nahradit \"<afile>\""
 
-msgid "no autocommand buffer number to substitute for \"<abuf>\""
+#: ../ex_docmd.c:7850
+#, fuzzy
+msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "ádné èíslo bufferu, kterım by bylo moné nahradit \"<abuf>\""
 
-msgid "no autocommand match name to substitute for \"<amatch>\""
+#: ../ex_docmd.c:7861
+#, fuzzy
+msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "ádná shoda automatickıch pøíkazù, kterou by bylo moné nahradit \"<amatch>\""
 
-msgid "no :source file name to substitute for \"<sfile>\""
+#: ../ex_docmd.c:7870
+#, fuzzy
+msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "ádnı interpretovanı soubor, kterım by bylo moné nahradit \"<sfile>\""
 
-#, no-c-format
-msgid "Empty file name for '%' or '#', only works with \":p:h\""
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "ádnı interpretovanı soubor, kterım by bylo moné nahradit \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "Prázdnı název souboru pro '%' èi '#' funguje pouze s \":p:h\""
 
-msgid "Evaluates to an empty string"
+#: ../ex_docmd.c:7905
+#, fuzzy
+msgid "E500: Evaluates to an empty string"
 msgstr "Vısledkem vyhodnocení je prázdnı øetìzec"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Nelze otevøít pro ètení viminfo soubor"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: V této verzi nejsou spøeky podporovány"
+#: ../ex_eval.c:464
+msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
+msgstr ""
 
+#. always scroll up, don't overwrite
+#: ../ex_eval.c:496
+#, c-format
+msgid "Exception thrown: %s"
+msgstr ""
+
+#: ../ex_eval.c:545
+#, c-format
+msgid "Exception finished: %s"
+msgstr ""
+
+#: ../ex_eval.c:546
+#, c-format
+msgid "Exception discarded: %s"
+msgstr ""
+
+#: ../ex_eval.c:588 ../ex_eval.c:634
+#, fuzzy, c-format
+msgid "%s, line %<PRId64>"
+msgstr "øádek %<PRId64>"
+
+#. always scroll up, don't overwrite
+#: ../ex_eval.c:608
+#, c-format
+msgid "Exception caught: %s"
+msgstr ""
+
+#: ../ex_eval.c:676
+#, c-format
+msgid "%s made pending"
+msgstr ""
+
+#: ../ex_eval.c:679
+#, c-format
+msgid "%s resumed"
+msgstr ""
+
+#: ../ex_eval.c:683
+#, c-format
+msgid "%s discarded"
+msgstr ""
+
+#: ../ex_eval.c:708
+msgid "Exception"
+msgstr ""
+
+#: ../ex_eval.c:713
+#, fuzzy
+msgid "Error and interrupt"
+msgstr "pøerušení z klávesnice"
+
+#: ../ex_eval.c:715
+msgid "Error"
+msgstr "Chyba"
+
+#. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
+#, fuzzy
+msgid "Interrupt"
+msgstr "Pøerušení: "
+
+#: ../ex_eval.c:795
+#, fuzzy
+msgid "E579: :if nesting too deep"
+msgstr "vnoøení :if je pøíliš hluboké"
+
+#: ../ex_eval.c:830
+#, fuzzy
+msgid "E580: :endif without :if"
+msgstr ":endif bez odpovídajícího :if"
+
+#: ../ex_eval.c:873
+#, fuzzy
+msgid "E581: :else without :if"
+msgstr ":else bez odpovídajícího :if"
+
+#: ../ex_eval.c:876
+#, fuzzy
+msgid "E582: :elseif without :if"
+msgstr ":elseif bez odpovídajícího :if"
+
+#: ../ex_eval.c:880
+msgid "E583: multiple :else"
+msgstr ""
+
+#: ../ex_eval.c:883
+msgid "E584: :elseif after :else"
+msgstr ""
+
+#: ../ex_eval.c:941
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
+msgstr "vnoøení :while je pøíliš hluboké"
+
+#: ../ex_eval.c:1028
+#, fuzzy
+msgid "E586: :continue without :while or :for"
+msgstr ":continue bez odpovídajícího :while"
+
+#: ../ex_eval.c:1061
+#, fuzzy
+msgid "E587: :break without :while or :for"
+msgstr ":break bez odpovídajícího :while"
+
+#: ../ex_eval.c:1102
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: Chybí :endwhile"
+
+#: ../ex_eval.c:1104
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: Chybí :endwhile"
+
+#: ../ex_eval.c:1247
+#, fuzzy
+msgid "E601: :try nesting too deep"
+msgstr "vnoøení :if je pøíliš hluboké"
+
+#: ../ex_eval.c:1317
+msgid "E603: :catch without :try"
+msgstr ""
+
+#. Give up for a ":catch" after ":finally" and ignore it.
+#. * Just parse.
+#: ../ex_eval.c:1332
+msgid "E604: :catch after :finally"
+msgstr ""
+
+#: ../ex_eval.c:1451
+msgid "E606: :finally without :try"
+msgstr ""
+
+#. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
+msgid "E607: multiple :finally"
+msgstr ""
+
+#: ../ex_eval.c:1571
+#, fuzzy
+msgid "E602: :endtry without :try"
+msgstr ":endif bez odpovídajícího :if"
+
+#: ../ex_eval.c:2026
+msgid "E193: :endfunction not inside a function"
+msgstr "E193: :endfunction mimo funkci"
+
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: Není v bezpeènostní schránce povoleno"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: Vzoru %s nevyhovuje ádnı buffer"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "jméno tagu"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " typ soubor\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'volba 'history' je nastavena na nulu"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1052,184 +2038,315 @@ msgstr ""
 "\n"
 "# Historie %s (poèínaje nejnovìjší polokou):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "pøíkazové øádky"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "vyhledávanıch øetìzcù"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "vırazù"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "vstupní øádky"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar pøekraèuje délku pøíkazu"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Smazáno aktivní okno èi buffer"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Chybná cesta: '**[èíslo] musí bıt buï na konci cesty, nebo musí bıt\n"
+"následováno'%s. Viz :help path."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Adresáø \"%s\" nelze v cdpath nalézt"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Soubor \"%s\" nelze v path nalézt"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: ádnı další adresáø \"%s\" nebyl v cdpath nalezen"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: ádnı další soubor \"%s\" nebyl v cestì nalezen"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: Automatické pøíkazy *Filter* nesmí mìnit aktuální buffer"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "nepøípustnı název souboru"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "je adresáøem"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "není souborem"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[novı soubor]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[pøístup odmítnut]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre automatické pøíkazy uèinily soubor neèitelnım"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre automatické pøíkazy nesmí mìnit aktuální buffer"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Ètu ze standardního vstupu...\n"
 
-msgid "Reading from stdin..."
-msgstr "Ètu ze standardního vstupu..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Po konverzi je soubor neèitelnı!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[pojmenovaná roura/soket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[pojmenovaná roura]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[soket]"
 
-msgid "[RO]"
-msgstr "[RO]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 znak"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[chybí CR]"
 
-msgid "[NL found]"
-msgstr "[nalezeno NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[dlouhé øádky zalomeny]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[nezkonvertován]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[zkonvertován]"
 
-msgid "[crypted]"
-msgstr "[zašifrován]"
-
-msgid "[CONVERSION ERROR]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[CHYBA PØEVODU]"
 
+#: ../fileio.c:1835
+#, fuzzy, c-format
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "E320: Nelze nalézt øádek %<PRId64>"
+
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[CHYBY ÈTENÍ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nelze nalézt doèasnı soubor pro konverzi"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konverze s 'charconvert' se nezdaøila"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nelze èíst vıstup 'charconvert'"
 
+#: ../fileio.c:2437
+#, fuzzy
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr "ádné vyhovující automatické pøíkazy"
+
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Automatické pøíkazy smazaly èi deaktivovaly buffer, kterı mìl bıt "
 "uloen"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Automatickı pøíkaz neèekanım zpùsobem zmìnil poèet øádkù"
 
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "není souborem ani zaøízením na nì lze zapisovat"
 
-msgid "is read-only (use ! to override)"
+#: ../fileio.c:2601
+#, fuzzy
+msgid "is read-only (add ! to override)"
 msgstr "je pouze pro ètení (pouijte ! pro vynucení)"
 
-msgid "Can't write to backup file (use ! to override)"
+#: ../fileio.c:2886
+#, fuzzy
+msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "Nelze zapisovat do záloního souboru (pouijte ! pro vynucení)"
 
-msgid "Close error for backup file (use ! to override)"
+#: ../fileio.c:2898
+#, fuzzy
+msgid "E507: Close error for backup file (add ! to override)"
 msgstr "Chyba pøi uzavírání záloního souboru (pouijte ! pro vynucení)"
 
-msgid "Can't read file for backup (use ! to override)"
+#: ../fileio.c:2901
+#, fuzzy
+msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "Nelze naèíst soubor pro zálohu (pouijte ! pro vynucení)"
 
-msgid "Cannot create backup file (use ! to override)"
+#: ../fileio.c:2923
+#, fuzzy
+msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "Nelze vytvoøit záloní soubor (pouijte ! pro vynucení)"
 
-msgid "Can't make backup file (use ! to override)"
+#: ../fileio.c:3008
+#, fuzzy
+msgid "E510: Can't make backup file (add ! to override)"
 msgstr "Nelze vytvoøit záloní soubor (pouijte ! pro vynucení)"
 
-# resource fork ?!
-msgid "The resource fork will be lost (use ! to override)"
-msgstr "'Resource fork' bude ztracen (pouijte ! pro vynucení)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nelze najít doèasnı temp soubor pro zápis"
 
-msgid "E213: Cannot convert (use ! to write without conversion)"
+#: ../fileio.c:3134
+#, fuzzy
+msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nelze pøevést (pouijte ! pro zápis bez pøevodu)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Nelze otevøít pøipojenı soubor pro zápis"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Nelze otevøít soubor pro zápis"
 
-msgid "Close failed"
+#: ../fileio.c:3363
+msgid "E667: Fsync failed"
+msgstr ""
+
+#: ../fileio.c:3398
+#, fuzzy
+msgid "E512: Close failed"
 msgstr "Volání close selhalo"
 
-msgid "write error, conversion failed"
+#: ../fileio.c:3436
+#, fuzzy
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "chyba pøi zápisu, konverze se nezdaøila"
 
-msgid "write error (file system full?)"
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
+#, fuzzy
+msgid "E514: write error (file system full?)"
 msgstr "chyba pøi ukládání (je volné místo na disku?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " CHYBA PØEVODU"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "øádek %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[zaøízení]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Novı]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [p]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " pøipojen"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [u]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " uloen"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: nelze uloit pùvodní soubor"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nelze zapisovat do prázdného pùvodního souboru"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nelze smazat záloní soubor"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1237,75 +2354,96 @@ msgstr ""
 "\n"
 "VAROVÁNÍ: Obsah pùvodního souboru mùe bıt ztracen èi poškozen\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "neukonèujte editor døíve, ne bude soubor úspìšnì uloen!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos formát]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac formát]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix formát]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 øádek, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> øádkù, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znakù, "
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[ádnı eol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[neúplnı poslední øádek]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "VAROVÁNÍ: od jeho naètení byl obsah souboru zmìnìn!!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Chcete jej opravdu uloit"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Chyba pøi zápisu do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Chyb pøi uzavírání \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Chyba pøi ètení \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell autocommand zrušil buffer"
 
-#, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
+#: ../fileio.c:4894
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
 msgstr "E211: wa1: soubor \"%s\" ji není dostupnı"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1314,21 +2452,38 @@ msgstr ""
 "W12: Varování: soubor \"%s\" byl po poèátku editace zmìnìn a buffer ve Vim "
 "také"
 
+#: ../fileio.c:4907
+msgid "See \":help W12\" for more info."
+msgstr ""
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: wc2: soubor \"%s\" byl po poèátku editace zmìnìn"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr ""
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Varování: Mód souboru \"%s\" byl zmìnìn od zapoènutí editace"
 
+#: ../fileio.c:4915
+msgid "See \":help W16\" for more info."
+msgstr ""
+
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: wc4: po poèátku editace vytvoøen soubor \"%s\""
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Varování"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1336,27 +2491,48 @@ msgstr ""
 "&OK\n"
 "&Nahrát soubor"
 
+#: ../fileio.c:5065
+#, fuzzy, c-format
+msgid "E462: Could not prepare for reloading \"%s\""
+msgstr "E321: Nelze znovuotevøít \"%s\""
+
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Nelze znovuotevøít \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Vymazáno--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Skupina \"%s\" neexistuje"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Nepøípustnı znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Událost %s neexistuje"
 
+#: ../fileio.c:5907
+#, fuzzy, c-format
+msgid "E216: No such group or event: %s"
+msgstr "E216: Událost %s neexistuje"
+
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1364,741 +2540,930 @@ msgstr ""
 "\n"
 "--- Automatické pøíkazy ---"
 
+#: ../fileio.c:6293
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr "chybnı název bufferu"
+
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Automatické pøíkazy nelze spustit pro VŠECHNY události"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "ádné vyhovující automatické pøíkazy"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: vnoøení automatického pøíkazu pøíliš hluboká"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s automatické pøíkazy pro \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "spouštím %s"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "Automatickı pøíkaz %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Chybí {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Chybí }."
 
-msgid "No fold found"
+#: ../fold.c:93
+#, fuzzy
+msgid "E490: No fold found"
 msgstr "ádnı záhyb nebyl nalezen"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: pomocí aktuální 'foldmethod' nelze vytvoøit záhyb"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: pomocí aktuální 'foldmethod' nelze vytvoøit záhyb"
 
-msgid "E221: 'commentstring' is empty"
-msgstr "E221: volba 'commentstring' je prázdná"
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr "poèet øádkù v záhybu: %3ld"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Pøidat do bufferu pro ètení"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekurzivní mapování"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: pro %s ji globální zkratka ji existuje"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: pro %s ji globální mapování ji existuje"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: pro %s ji zkratka ji existuje"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: pro %s ji mapování ji existuje"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "ádná zkratka nebyl nalezena"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "ádné mapování nebylo nalezeno"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: nepøípustnı mód"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nelze spustit GUI"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Buffer neobsahuje ádnı øádek--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nelze èíst z \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+#, fuzzy
+msgid "E470: Command aborted"
+msgstr "Pøíkaz pøerušen"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: volba 'guifontwide' je chybnì nastavena"
+#: ../globals.h:997
+#, fuzzy
+msgid "E471: Argument required"
+msgstr "Je vyadován argument"
 
-msgid "Error"
-msgstr "Chyba"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ by mìl následovat /. ? nebo &"
 
-msgid "&Ok"
-msgstr "&Ok"
-
-msgid "<cannot open> "
-msgstr "<nelze otevøít> "
-
-#, c-format
-msgid "vim_SelFile: can't get font %s"
-msgstr "vim_SelFile: písmo %s není dostupné"
-
-msgid "vim_SelFile: can't return to current directory"
-msgstr "vim_SelFile: nelze se vrátit do aktuálního adresáøe"
-
-msgid "Pathname:"
-msgstr "Název cesty:"
-
-msgid "vim_SelFile: can't get current directory"
-msgstr "vim_SelFile: nelze zjistit aktuální adresáø"
-
-msgid "OK"
-msgstr "OK"
-
-#. 'Cancel' button
-msgid "Cancel"
-msgstr "Zrušit"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Pøípravek posunovací lišty: nelze zjistit geometrii obrázku"
-
-msgid "Vim dialog"
-msgstr "Vim dialog"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: BalloonEval nelze vytvoøit se zprávou a zároveò zpìtnım voláním"
-
-msgid "Vim dialog..."
-msgstr "Vim dialog.."
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Nalézt a nahradit..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Nalézt..."
-
-msgid "Find what:"
-msgstr "Vyhledat:"
-
-msgid "Replace with:"
-msgstr "Novı text:"
-
-#. exact match only button
-msgid "Match exact word only"
-msgstr "hledat pouze celá slova"
-
-msgid "Direction"
-msgstr "Smìr"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Nahoru"
-
-msgid "Down"
-msgstr "Dolù"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Najít další"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Nahradit"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Nahradit vše"
-
-msgid "E233: cannot open display"
-msgstr "E233: nelze otevøít display"
-
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Neznámá sada písem: %s"
-
-msgid "Font Selection"
-msgstr "Vıbìr písma"
-
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Neznámé písmo: %s"
-
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Písmo \"%s\" nemá pevnou šíøku"
-
-#, c-format
-msgid "E242: Color name not recognized: %s"
-msgstr "E242: Neznámé jméno barvy: %s"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Místo prádné schránky pouito CUT_BUFFER0"
-
-msgid "Filter"
-msgstr "Filtr"
-
-msgid "Directories"
-msgstr "Adresáøe"
-
-msgid "Help"
-msgstr "Nápovìda"
-
-msgid "Files"
-msgstr "Soubory"
-
-msgid "Selection"
-msgstr "Vıbìr"
-
-msgid "Undo"
-msgstr "Zpìt"
-
-#, c-format
-msgid "E235: Can't load Zap font '%s'"
-msgstr "E235: Nelze naèíst Zap font '%s'"
-
-#, c-format
-msgid "E235: Can't use font %s"
-msgstr "E235: Nelze pouít font %s"
-
-#, c-format
-msgid "E242: Missing color: %s"
-msgstr "E242: Chybí barva: %s"
-
-msgid ""
-"\n"
-"Sending message to terminate child process.\n"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"\n"
-"Posílám signál k ukonèení synovského procesu.\n"
+"E11: Chyba v oknì pøíkazové øádky; <CR> pro spuštšní, CTRL-C pro ukonèení"
 
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nepodporován: \"-%s\"; Pouijte OLE verzi."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Najít øetìzec (pouijte '\\\\' k nalezení '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Najít & Nahradit (pouijte '\\\\' k nalezení '\\')"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Vim E458: nelze alokovat poloku barevné mapy. Nìkteré barvy mohou bıt "
-"nesprávné"
+"E12: Pøíkaz není z exrc/vimrc v aktuálním adresáøi èi pøi hledání tagu "
+"povolen."
 
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: písma pro následující znakové sady chybí v sadì písem %s:"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Chybí :endif"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: název sady písem: %s"
+#: ../globals.h:1004
+#, fuzzy
+msgid "E600: Missing :endtry"
+msgstr "E171: Chybí :endif"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Písmo '%s' nemá pevnou šíøku"
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Chybí :endwhile"
 
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: název sady písem: %s\n"
+#: ../globals.h:1006
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: Chybí :endif"
 
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Písmo0: %s\n"
+#: ../globals.h:1007
+#, fuzzy
+msgid "E588: :endwhile without :while"
+msgstr ":endwhile bez odpovídajícího :while"
 
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Písmo1: %s\n"
+#: ../globals.h:1008
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr ":endif bez odpovídajícího :if"
 
-#, c-format
-msgid "Font%d width is not twice that of font0\n"
-msgstr "Šíøka písma%d není dvojnásoblem šíøky písma0\n"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Soubor existuje (pouijte ! pro vynucení)"
 
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Šíøka písma0: %<PRId64>\n"
+#: ../globals.h:1010
+#, fuzzy
+msgid "E472: Command failed"
+msgstr "Pøíkaz selhal"
 
+#: ../globals.h:1011
+#, fuzzy
+msgid "E473: Internal error"
+msgstr "Vnitøní chyba"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Pøerušeno"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Chybná adresa"
+
+#: ../globals.h:1014
+#, fuzzy
+msgid "E474: Invalid argument"
+msgstr "Chybnı argument"
+
+#: ../globals.h:1015
+#, fuzzy, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "Chybnı argument: %s"
+
+#: ../globals.h:1016
 #, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Chybnı vıraz: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Chybnı rozsah"
+
+#: ../globals.h:1018
+#, fuzzy
+msgid "E476: Invalid command"
+msgstr "Chybnı pøíkaz"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" je adresáøem"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Chybná hodnota volby 'scroll'"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Šíøka písma1: %<PRId64>\n"
-"\n"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: nelze alokovat barvu %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Volání knihovní funkce \"%s()\" selhalo"
+
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Znaèka má chybné èíslo øádku"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: není nastavena"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nelze mìnit, je nastavena volba 'modifiable'"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skript vnoøen pøíliš hluboko"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: ádnı alternativní soubor"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Taková zkratka neexistuje"
+
+#: ../globals.h:1033
+#, fuzzy
+msgid "E477: No ! allowed"
+msgstr "! není povoleno"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Nelze pouít GUI: nebylo zapnuto pøi pøekladu programu"
+
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Skupina zvıraznìní %s neexistuje"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Zatím není ádnı vloenı text"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: ádná pøedchozí pøíkazová øádka"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: ádné takové mapování"
+
+#: ../globals.h:1040
+#, fuzzy
+msgid "E479: No match"
+msgstr "ádná shoda"
+
+#: ../globals.h:1041
+#, fuzzy, c-format
+msgid "E480: No match: %s"
+msgstr "ádná shoda: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ádnı název souboru"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: ádnı pøedchozí regulární vıraz"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: ádnı pøedchozí pøíkaz"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: ádnı pøedchozí regulární vıraz"
+
+#: ../globals.h:1047
+#, fuzzy
+msgid "E481: No range allowed"
+msgstr "Rozsah není povolen"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Nedostatek místa"
+
+#: ../globals.h:1049
+#, fuzzy, c-format
+msgid "E482: Can't create file %s"
+msgstr "Nelze vytvoøit soubor %s"
+
+#: ../globals.h:1050
+#, fuzzy
+msgid "E483: Can't get temp file name"
+msgstr "Nelze získat název doèasného souboru"
+
+#: ../globals.h:1051
+#, fuzzy, c-format
+msgid "E484: Can't open file %s"
+msgstr "E456: Nelze otevøít soubor \"%s\""
+
+#: ../globals.h:1052
+#, fuzzy, c-format
+msgid "E485: Can't read file %s"
+msgstr "Nelze èíst soubor %s"
+
+#: ../globals.h:1054
+#, fuzzy
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Neuloené zmìny (pouijte ! pro vynucení)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Neuloené zmìny]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nulovı argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oèekáváno èíslo"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nelze otevøít chybovı soubor %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Nedostatek pamìti!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Vzor nenalezen"
+
+#: ../globals.h:1061
+#, fuzzy, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "Vzor nenalezen: %s"
+
+#: ../globals.h:1062
+#, fuzzy
+msgid "E487: Argument must be positive"
+msgstr "Argument musí bıt kladnı"
+
+#: ../globals.h:1064
+#, fuzzy
+msgid "E459: Cannot go back to previous directory"
+msgstr "E186: ádnı pøedchozí adresáø"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: ádné chyby"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr ""
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Poškozenı øetìzec pro vyhledávání"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: poškozenı regexp program"
+
+#: ../globals.h:1071
+#, fuzzy
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'nastavena volba 'readonly' (pouijte ! pro vynucení)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Chyba pøi ètení chybového souboru"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Není v bezpeènostní schránce povoleno"
+
+#: ../globals.h:1080
+#, fuzzy
+msgid "E523: Not allowed here"
+msgstr "Toto zde není povoleno"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Nastavování reimu obrazovky není podporováno"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Chybná hodnota volby 'scroll'"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: volba 'shell' je prázdná"
+
+#: ../globals.h:1085
 msgid "E255: Couldn't read in sign data!"
 msgstr "E255: Chyba -- nelze pøeèíst sign data!"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: CYBA Hangul automatu"
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Chyba pøi uzavírání odkládacího souboru"
 
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: seznam tagù je prázdnı"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Pøíkaz je pøíliš sloitı"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Název je pøíliš dlouhı"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: pøíliš mnoho ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Pøíliš mnoho názvù souborù"
+
+#: ../globals.h:1092
+#, fuzzy
+msgid "E488: Trailing characters"
+msgstr "Nadbyteèné znaky na konci"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Neznámá znaèka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nelze expandovat olíkové znaky"
+
+#: ../globals.h:1096
+#, fuzzy
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+"hodnota volby 'winheight' nesmí bıt menší ne hodnota volby 'winminheight'"
+
+#: ../globals.h:1098
+#, fuzzy
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+"hodnota volby 'winwidth' nesmí bıt menší ne hodnota volby 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Chyba pøi ukládání"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nulovı poèet"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Pouití <SID> mimo kontext skriptu"
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "Vnitøní chyba"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr ""
+
+#: ../globals.h:1105
+#, fuzzy
+msgid "E749: empty buffer"
+msgstr "E279: Není SNiFF+ buffer"
+
+#: ../globals.h:1108
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: Nepøípustnı hledanı øetìzec: %s"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Soubor je nahrán v jiném bufferu"
+
+#: ../globals.h:1110
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: Písmo \"%s\" nemá pevnou šíøku"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: '%s' není pøípustné jméno registru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "hledání dosáhlo zaèátku, pokraèování od konce"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "hledání dosáhlo konce, pokraèování od zaèátku"
+
+#: ../hardcopy.c:240
+#, fuzzy
+msgid "E550: Missing colon"
+msgstr "Chybí dvojteèka"
+
+#: ../hardcopy.c:252
+#, fuzzy
+msgid "E551: Illegal component"
+msgstr "nepøípustná souèást"
+
+#: ../hardcopy.c:259
+#, fuzzy
+msgid "E552: digit expected"
+msgstr "oèekávána èíslice"
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr ""
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr "ádnı text k vytištìní"
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "Tisknu stranu %d (%d%%)"
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr " Kopie %d z %d"
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr "Vytištìno: %s"
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr "Tisk zrušen"
+
+#: ../hardcopy.c:1365
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: Nelze zapisovat do vıstupního PostScriptového souboru"
+
+#: ../hardcopy.c:1747
+#, fuzzy, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E456: Nelze otevøít soubor \"%s\""
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
+
+#: ../hardcopy.c:1772
+#, fuzzy, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, fuzzy, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr ""
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: Nelze otevøít vıstupní PostScriptovı soubor"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: Nelze otevøít soubor \"%s\""
+
+#: ../hardcopy.c:2583
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
+
+#: ../hardcopy.c:2593
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, fuzzy, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E457: Nelze èíst zdrojovı PostScriptovı soubor \"%s\""
+
+#: ../hardcopy.c:2654
+#, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr ""
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr "Odesílám na tiskárnu..."
+
+#: ../hardcopy.c:2881
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: Selhal tisk PostScriptového souboru"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr "Tisková úloha odeslána."
+
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Pøidat novou databázi"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Hledání vzorku"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Zobrazit tuto zprávu"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Ukonèit spojení"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Znovu inicializovat všechna spojení"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Zobrazit spojení"
 
+#: ../if_cscope.c:101
+#, c-format
+msgid "E560: Usage: cs[cope] %s"
+msgstr ""
+
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Tento cscope pøíkaz nepodporuje rozdìlení okna.\n"
 
-msgid "Usage: cstag <ident>"
+#: ../if_cscope.c:266
+#, fuzzy
+msgid "E562: Usage: cstag <ident>"
 msgstr "Pouití: cstag <odsazení>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tag nenalezen"
 
-#, c-format
-msgid "stat(%s) error: %d"
+#: ../if_cscope.c:461
+#, fuzzy, c-format
+msgid "E563: stat(%s) error: %d"
 msgstr "stat(%s) chyba: %d"
 
+#: ../if_cscope.c:551
+#, fuzzy, c-format
+msgid "E564: %s is not a directory or a valid cscope database"
+msgstr "%s není ani adresáøem ani správnou cscope databází"
+
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Pøidána cscope databáze %s"
 
-#, c-format
-msgid "%s is not a directory or a valid cscope database"
-msgstr "%s není ani adresáøem ani správnou cscope databází"
+#: ../if_cscope.c:616
+#, fuzzy, c-format
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: pøi ètení cscope spojení %d"
 
-#, c-format
-msgid "error reading cscope connection %d"
-msgstr "chyba pøi ètení cscope spojení %d"
-
-msgid "unknown cscope search type"
+#: ../if_cscope.c:711
+#, fuzzy
+msgid "E561: unknown cscope search type"
 msgstr "neznámı typ cscope hledání"
 
-msgid "Could not create cscope pipes"
+#: ../if_cscope.c:752 ../if_cscope.c:789
+#, fuzzy
+msgid "E566: Could not create cscope pipes"
 msgstr "nelze vytvoøit cscope roury"
 
+#: ../if_cscope.c:767
+#, fuzzy
+msgid "E622: Could not fork for cscope"
+msgstr "E321: Nelze znovuotevøít \"%s\""
+
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "spuštìní cs_create_connection selhalo"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "spuštìní cs_create_connection selhalo"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: volání fdopen pro to_fp selhalo"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: volání fdopen pro fr_fp selhalo"
 
-msgid "no cscope connections"
+#: ../if_cscope.c:890
+#, fuzzy
+msgid "E623: Could not spawn cscope process"
+msgstr "nelze vytvoøit cscope roury"
+
+#: ../if_cscope.c:932
+#, fuzzy
+msgid "E567: no cscope connections"
 msgstr "ádná cscope spojení"
 
+#: ../if_cscope.c:1009
+#, c-format
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr ""
+
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: cscope hledání %s vzorku %s nenašlo ádnou shodu"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "pøíkazy cscope:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)\n"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Pouití: %s)\n"
 
-msgid "duplicate cscope database not added"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
+
+#: ../if_cscope.c:1226
+#, fuzzy
+msgid "E568: duplicate cscope database not added"
 msgstr "duplicitní cscope databáze nebyla pøidána"
 
-msgid "maximum number of cscope connections reached"
-msgstr "dosaen maximální poèet cscope spojení"
-
-msgid "E260: cscope connection not found"
-msgstr "E260: connection spojení nenalezeno"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: connection spojení %s nenalezeno"
 
-msgid "cscope connection closed"
-msgstr "closed spojení uzavøeno"
-
-#, c-format
-msgid "cscope connection %s closed\n"
+#: ../if_cscope.c:1364
+#, fuzzy, c-format
+msgid "cscope connection %s closed"
 msgstr "cscope spojení %s uzavøeno\n"
 
 #. should not reach here
-msgid "fatal error in cs_manage_matches"
+#: ../if_cscope.c:1486
+#, fuzzy
+msgid "E570: fatal error in cs_manage_matches"
 msgstr "osudová chyba v cs_manage_matches"
 
-#, c-format
-msgid "E262: error reading cscope connection %d"
-msgstr "E262: pøi ètení cscope spojení %d"
-
-msgid "couldn't malloc\n"
-msgstr "volání malloc selhalo\n"
-
-#, c-format
-msgid "Cscope tag: %s\n"
+#: ../if_cscope.c:1693
+#, fuzzy, c-format
+msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s\n"
 
-msgid "   #   line"
+#: ../if_cscope.c:1711
+#, fuzzy
+msgid ""
+"\n"
+"   #   line"
 msgstr "   #   øádek"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "název souboru/ kontext/ øádek\n"
 
+#: ../if_cscope.c:1809
+#, fuzzy, c-format
+msgid "E609: Cscope error: %s"
+msgstr "E40: Nelze otevøít chybovı soubor %s"
+
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Všechny cscope databáze resetovány"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "ádné cscope spojení\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    název databáze                      pøedpona cesty\n"
 
-#, c-format
-msgid "%2d %-5ld  %-34s  <none>\n"
-msgstr "%2d %-5ld  %-34s  <ádnı>\n"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Lituji, tento pøíkaz je deaktivován; knihovnu jazyka Python nelze "
-"nahrát."
-
-msgid "can't delete OutputObject attributes"
-msgstr "nelze smazat atributy OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "softspace musí bıt kladné celé èíslo"
-
-msgid "invalid attribute"
-msgstr "chybnı atribut"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() vyaduje seznam øetìzcù"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: chyba pøi inicializaci I/O objektù"
-
-msgid "invalid expression"
-msgstr "Chybnı vıraz"
-
-msgid "expressions disabled at compile time"
-msgstr "podpora vırazù byla vypnuta pøi pøekladu programu"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "pokus o odkaz na smazanı buffer"
-
-msgid "line number out of range"
-msgstr "èíslo øádku mimo rozsah"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<buffer objekt (smazán) na %8lX>"
-
-msgid "invalid mark name"
-msgstr "chybné jméno znaèky"
-
-msgid "no such buffer"
-msgstr "ádnı takovı buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "pokus o odkaz na smazané okno"
-
-msgid "readonly attribute"
-msgstr "atribut pouze_pro_ètení"
-
-msgid "cursor position outside buffer"
-msgstr "umístìní kurzoru mimo buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<objekt okna (smazán) na %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<objekt okna (neznámı) na %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<okno %d>"
-
-msgid "no such window"
-msgstr "ádné takové okno"
-
-msgid "cannot save undo information"
-msgstr "nelze uloit informace pro pøíkaz undo"
-
-msgid "cannot delete line"
-msgstr "nelze smazat øádek"
-
-msgid "cannot replace line"
-msgstr "nelze nahradit øádek"
-
-msgid "cannot insert line"
-msgstr "nelze vloit øádek"
-
-msgid "string cannot contain newlines"
-msgstr "øetìzec nesmí obsahovat znaky nového øádku"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Ruby nelze "
-"nahrát."
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: neznámı longjmp stav %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Prohození implementace/definice"
-
-msgid "Show base class of"
-msgstr "Zobrazení base class z"
-
-msgid "Show overridden member function"
-msgstr "Zobrazení overridden member funkce"
-
-msgid "Retrieve from file"
-msgstr "Znovuzískáno ze souboru"
-
-msgid "Retrieve from project"
-msgstr "Znovuzískáno z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Znovzískáno ze všech projektù"
-
-msgid "Retrieve"
-msgstr "Znovuzískáno"
-
-msgid "Show source of"
-msgstr "Zobrazení zdroje"
-
-msgid "Find symbol"
-msgstr "Najít symbol"
-
-msgid "Browse class"
-msgstr "Prohlíet class"
-
-msgid "Show class in hierarchy"
-msgstr "Zobrazení class v hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Zobrazení class v restricted hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odkazuje na"
-
-msgid "Xref referred by"
-msgstr "Xref odkazoval na"
-
-msgid "Xref has a"
-msgstr "Xref má"
-
-msgid "Xref used by"
-msgstr "Xref pouit"
-
-msgid "Show docu of"
-msgstr "Zobrazení documentace"
-
-msgid "Generate docu for"
-msgstr "Generována dokumentace pro"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Nelze se pøipojit k SNiFF+. Zkontrolujte promìnné (sniffemacs musí "
-"bıt)uvedena v $PATH.\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Chyba pøi ètení. Odpojeno"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ je právì "
-
-msgid "not "
-msgstr "ne "
-
-msgid "connected"
-msgstr "pøipojen"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Neznámı poadavek SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Chybné pøipojení k SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ nepøipojen"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Není SNiFF+ buffer"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Chyba pøi zápisu. Odpojeno."
-
-msgid "invalid buffer number"
-msgstr "chybnı název bufferu"
-
-msgid "not implemented yet"
-msgstr "není ještì podporováno"
-
-msgid "unknown option"
-msgstr "neznámá volba"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nelze nastavit øádky"
-
-msgid "mark not set"
-msgstr "znaèka není nastavena"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "øádek %d sloupec %d"
-
-msgid "cannot insert/append line"
-msgstr "nelze vloit/pøipojit øádek"
-
-msgid "unknown flag: "
-msgstr "neznámı pøíznak: "
-
-msgid "unknown vimOption"
-msgstr "neznámá vimOption"
-
-msgid "keyboard interrupt"
-msgstr "pøerušení z klávesnice"
-
-msgid "vim error"
-msgstr "chyba vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nelze vytvoøit pøíkaz bufferu/okna: objekt smazán"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nelze zaregistrovat pøíkaz zpìtného volání: buffer/okno ji bylo smazáno"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to "
-"vim-dev@vim.org"
-msgstr ""
-"E280: TCL FATAL ERROR: reflist poškozen!? Oznamte, prosím, tuto chybu na "
-"vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nelze zaregistrovat pøíkaz zpìtného volání: odkaz na buffer/okno nenalezen"
-
-msgid "Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Tcl nelze nahrát."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL CHYBA: návratovı kód není celé èíslo!? Oznamte, prosím, tuto chybu "
-"na vim-dev@vim.org"
-
-msgid "cannot get line"
-msgstr "nelze pøeèíst øádek"
-
-msgid "Unable to register a command server name"
-msgstr "Není moné zaznamenat jméno command serveru"
-
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Neexistuje registrovanı server jménem \"%s\""
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Selhalo zaslání pøíkazu urèenému programu"
-
-#, c-format
-msgid "Invalid server id used: %s"
-msgstr "Pouit chybnı id serveru: %s"
-
-msgid "E249: couldn't read VIM instance registry property"
-msgstr "E249: nelze èíst VIM instanci registry property"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: VIM instance registry property byla špatnì vytvoøenaa byla smazána!"
-
-msgid "Unknown option"
+#: ../main.c:144
+#, fuzzy
+msgid "Unknown option argument"
 msgstr "Neznámá volba"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Pøíliš mnoho edit argumentù"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Chybí argument po"
 
-msgid "Garbage after option"
+#: ../main.c:150
+#, fuzzy
+msgid "Garbage after option argument"
 msgstr "Chyby za volbou"
 
-msgid "Too many \"+command\" or \"-c command\" arguments"
+#: ../main.c:152
+#, fuzzy
+msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Pøíliš mnoho \"+pøíkaz\" èi \"-c pøíkaz\" argumentù"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Chybnı argument pro"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "VIM nebyl pøeloen s volbou +diff"
-
-msgid "Attempt to open script file again: \""
-msgstr "Pokus o opìtovné otevøení skriptu: \""
-
-msgid "\"\n"
-msgstr "\"\n"
-
-msgid "Cannot open for reading: \""
-msgstr "Nelze otevøít pro zápis: \""
-
-msgid "Cannot open for script output: \""
-msgstr "Nelze otevøít pro vıstup skriptu: \""
-
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "poèet souborù pro editaci: %d\n"
 
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr "Pokus o opìtovné otevøení skriptu: \""
+
+#: ../main.c:1350
+msgid "Cannot open for reading: \""
+msgstr "Nelze otevøít pro zápis: \""
+
+#: ../main.c:1393
+msgid "Cannot open for script output: \""
+msgstr "Nelze otevøít pro vıstup skriptu: \""
+
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Varování: vıstup nesmìøuje na terminál\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Varování: vstup nepochází z terminálu\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc pøíkazovı øádek"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nelze èíst z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2106,18 +3471,23 @@ msgstr ""
 "\n"
 "Podrobnìjší informace získáte pomocí \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[SOUBOR] ..          editovat SOUBOR(y)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                    èíst text ze standardního vstupu"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t TAG          editovat soubor na místì definice TAGU"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [chybovı soubor]  editovat soubor na místì vıskytu první chyby"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2127,9 +3497,11 @@ msgstr ""
 "\n"
 "pouití:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr "vim [pøepínaèe] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2137,6 +3509,7 @@ msgstr ""
 "\n"
 "   nebo"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2146,294 +3519,198 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tMohou následovat pouze názvy souborù"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tpøihlásit gvim na OLE"
+#: ../main.c:2199
+#, fuzzy
+msgid "--literal\t\tDon't expand wildcards"
+msgstr "E79: Nelze expandovat olíkové znaky"
 
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-register\t\todhlásit gvim z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tspustit v GUI reimu (stejné jako \"gvim\")"
-
-msgid "-f\t\t\tForeground: Don't fork when starting GUI"
-msgstr "-f\t\t\tPopøedí: pøi startu GUI se neoddìlí od shellu"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi mód (stejné jako \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-v\t\t\tEx mód (stejné jako \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tTichı (dávkovı) reim (pouze pro \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff reim (stejné jako \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-v\t\t\tSnadnı reim (stejné jako \"evim\", ádné módy )"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tReim pouze_pro_ètení (jako \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tOmezenı reim (stejné jako \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmìny (ukládání souborù) zakázány"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZmìny (ukládání souborù) zakázány"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinární reim"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp reim"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatabilní s Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tKompatibilita s Vi vypnuta: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tÚroveò vıpisu hlášek"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tLadící reim"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNebude vytváøet odkládací soubor, bude pouívat pouze pamì"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tVypíše seznam odkládacích souborù a skonèí"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r název souboru\tObnoví pøerušené sezení"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tStejné jako -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNebude pouívat newcli pro otevøení okna"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <zaøízení>\t\tPouít <zaøízení> pro I/O"
-
-msgid "-H\t\t\tstart in Hebrew mode"
-msgstr "-H\t\t\tnastartuje v hebrejském reimu"
-
-msgid "-F\t\t\tstart in Farsi mode"
+#: ../main.c:2221
+#, fuzzy
+msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-F\t\t\tnastartuje ve Farsi reimu"
 
+#: ../main.c:2222
+#, fuzzy
+msgid "-H\t\t\tStart in Hebrew mode"
+msgstr "-H\t\t\tnastartuje v hebrejském reimu"
+
+#: ../main.c:2223
+#, fuzzy
+msgid "-F\t\t\tStart in Farsi mode"
+msgstr "-F\t\t\tnastartuje ve Farsi reimu"
+
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminál>\tNastaví typ terminálu na <terminál>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tPouije <vimrc> místo jakéhokoliv .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tPouije <gvimrc> místo jakéhokoliv .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNenahraje 'plugin' skripty"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tOtevøe N oken (implicitnì jedno pro kadı soubor)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtevøe N oken (implicitnì jedno pro kadı soubor)"
 
-msgid "-O[N]\t\tlike -o but split vertically"
+#: ../main.c:2229
+#, fuzzy
+msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tJako -o but split vertically"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tNastaví kurzor na konec souboru"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<øádek>\t\tNastaví kurzor na <øádek>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <pøíkaz>\tPo nahrání prvního souboru vykoná <pøíkaz>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <pøíkaz>\t\tPo nahrání prvního souboru vykoná <pøíkaz>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sezení>\t\tPo nahrání prvního souboru vykoná pøíkazy v souboru <sezení>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skript>\t\tNaète pøíkazy normálního módu ze <skriptu>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <skript>\t\tPøipojí všechny napsané pøíkazy do souboru <skript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <skript>\t\tUloí všechny napsané pøíkazy do souboru <skript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEditace zašifrovanıch souborù"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tSpustí vim na danı X-server"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNepøipojí se k X serveru"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtevøe Vim uvnitø jiného GTK widgetu"
-
-msgid "--remote <files>\tEdit <files> in a Vim server and exit"
-msgstr "--remote <soubory>\tEdituje <soubory> na Vim serveru a skonèí"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <soubory> Jako --remote, ale èeká na soubory k editaci"
 
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <klávesy>\tPøedá <klávesy> Vim serveru a skonèí"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <vıraz>\tProvede <vıraz> na serveru a zobrazí vısledek"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVypíše seznam dostupnıch Vim serverù a skonèí"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr ""
-"--servername <jméno>\tZašle serveru <jméno>/stane se Vim serverem <jméno>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tPouije <viminfo> místo jakéhokoliv .viminfo"
 
-msgid "-h\t\t\tprint Help (this message) and exit"
+#: ../main.c:2243
+#, fuzzy
+msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h\t\t\tVypíše tuto nápovìdu a skonèí"
 
-msgid "--version\t\tprint version information and exit"
+#: ../main.c:2244
+#, fuzzy
+msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tvypíše informace o verzi a skonèí"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (Motif verzi):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (Athena verzi):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tSpustí vim na <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tSpustí vim minimalizované"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <název>\t\tPouije resource jako by vim mìl <název>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (není implementováno)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <barva>\tNastaví <barvu> pozadí (také -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <barva>\tNastaví <barvu> popøedí (také -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <písmo>\t\tNastaví <písmo> normálního textu (také -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <písmo>\tNastaví <písmo> pro zvıraznìnı text"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <písmo>\tNastaví <písmo> pro kurzívu"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geometrie>\tNastaví <geometrii> (také -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <šíøka>\tNastaví <šíøku> okrajù (také -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <šíøku> Nastaví <šíøku> posunovací lišty (také: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <vıška>\tNastaví <vıšku> nabídky (také -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tPouije reverzní barvy (také -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNepouije reverzní barvy (také +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tNastaví zadanı <resource>"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (RISC OS verzi):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <poèet>\t<poèet> sloupcù na okno"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <poèet>\t<poèet> øádkù na okno"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (GTK+ verzi):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tSpustí vim na <display> (také --display)"
-
-msgid "--help\t\tShow Gnome arguments"
-msgstr "--help\t\tVypíše Gnome pøepínaèe"
-
-#. Failed to send, abort.
-msgid ""
-"\n"
-"Send failed.\n"
-msgstr ""
-"\n"
-"Pøedání vırazu selhalo.\n"
-
-#. Let vim start normally.
-msgid ""
-"\n"
-"Send failed. Trying to execute locally\n"
-msgstr ""
-"\n"
-"Pøedání selhalo. Zkouším provést lokálnì\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d z %d editováno"
-
-msgid "Send expression failed.\n"
-msgstr "Pøedání vırazu selhalo.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Nejsou nastaveny ádné znaèky"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\" nevyhovují ádné znaèky"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2442,6 +3719,7 @@ msgstr ""
 "znaèka øádek  sloupec soubor/text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2449,6 +3727,17 @@ msgstr ""
 "\n"
 " skok øádek sloupec soubor/text"
 
+#. Highlight title
+#: ../mark.c:831
+#, fuzzy
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
+"\n"
+"znaèka øádek  sloupec soubor/text"
+
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2457,6 +3746,7 @@ msgstr ""
 "# Souborové znaèky:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -2464,6 +3754,7 @@ msgstr ""
 "\n"
 "# Seznam skokù (poèínaje nejnovìjší polokou):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -2471,96 +3762,87 @@ msgstr ""
 "\n"
 "# Historie znaèek v souborech (poèínaje nejnovìjší polokou):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Chybí '>'"
 
-msgid "Not a valid codepage"
-msgstr "Chybná kódová stránka"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nelze nastavit IC hodnoty"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nepodaøilo se vytvoøit vstupní kontext"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nepodaøilo se otevøít vstupní metodu"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Varování: likvidaèní zpìtné volání nelze nastavit na IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: vstupní metoda nepodporuje ádnı styl"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: vstupní metoda nepodporuje mùj 'preedit' typ"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: Nadbodovı styl vyaduje fontset"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Máte GTK+ verze starší ne 1.2.3. Stavová plocha vypnuta."
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Server vstupních metod nebìí"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nebyl zamknut"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Chyba posunu ukazovátka pøi ètení odkládacího souboru"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Chyba pøi ètení odkládacího souboru"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Chyba posunu ukazovátka pøi ukládání do odkládacího souboru"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr ""
 "E300: Odkládací soubor ji existuje! (Nìkdo hackujepøes nastraenı symlink?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nelze získat blok 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nelze získat blok 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: nelze získat blok 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Jéje, odkládací soubor byl ztracen!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nelze pøejmenovat odkládací soubor"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Nelze otevøít odkládací soubor pro \"%s\""
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_timestamp: nelze získat blok 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Odkládací soubor pro %s nebyl nalezen"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Zadejte èíslo odkládacího souboru, kterı se má pouít (0 pro ukonèení): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nelze otevøít %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nelze èíst blok 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -2568,22 +3850,28 @@ msgstr ""
 "\n"
 "Moná nedošlo k ádnım zmìnám, nebo Vim neaktualizoval odkládací soubor."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nelze pouít s touto verzí Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Pouijte Vim verze 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s se nezdá bıt odkládacím souborem Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nelze pouít na tomto poèítaèi.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Soubor byl vytvoøen "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -2591,60 +3879,85 @@ msgstr ""
 ",\n"
 "nebo byl soubor poškozen."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Pouívám odkládací soubor \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Pùvodní soubor \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Varování: Pùvodní soubor mohl bıt zmìnìn"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nelze èíst blok 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???CHYBÍ MNOHO ØÁDKÙ"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???CHYBNİ POÈET ØÁDKÙ"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PRÁZDNİ BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???CHYBÌJÍCÍ ØÁDKY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID bloku 1 je chybné (je %s odkládacím souborem?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???CHYBÍ BLOK"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "od ??? po ???END mohou bıt øádky pomíchané"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "od ??? po ???END mohou bıt vloené/smazané øádky"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Obnova pøerušena"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: V prùbìhu obnovy došlo k chybám; zkontrolujte øádky zaèínající na ???"
 
+#: ../memline.c:1245
+msgid "See \":help E312\" for more information."
+msgstr ""
+
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Obnova dokonèena. Zkontrolujte, zda je vše v poøádku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -2652,48 +3965,69 @@ msgstr ""
 "\n"
 "(Zvate uloení tohoto souboru pod jinım názvem\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "a kontrolu zmìn pomocí programu diff.)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr "Poté smate odkládací soubor.\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Nalezené odkládací soubory:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   V aktuálním adresáøi:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Se zadanım názvem:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   V adresáøi "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- ádné --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          vlastník: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   datum vytvoøení: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             datum vytvoøení: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [od Vim verze 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nevypadá jako odkládací soubor Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         název souboru: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -2701,12 +4035,15 @@ msgstr ""
 "\n"
 "          datum zmìny: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ANO"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ne"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -2714,9 +4051,11 @@ msgstr ""
 "\n"
 "         uivatelské jméno: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   název poèítaèe: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -2724,6 +4063,7 @@ msgstr ""
 "\n"
 "         název poèítaèe: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -2731,16 +4071,11 @@ msgstr ""
 "\n"
 "        ID procesu : "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (stále aktivní)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nepouitelné s touto verzí Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -2748,71 +4083,97 @@ msgstr ""
 "\n"
 "         [nepouitelné na tomto poèítaèi]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [nelze pøeèíst]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [nelze otevøít]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nelze zachovat - odkládací soubor neexistuje."
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Soubor zachován"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Uchování se nezdaøilo"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: chybné èíslo øádku: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nelze nalézt øádek %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné id ukazatele na blok 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx by mìlo mít hodnotu 3"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Aktualizováno pøíliš mnoho blokù?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: chybné id ukazatele na blok 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "smazán blok 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nelze nalézt øádek %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné id ukazatele na blok"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovou hodnotu"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: poèet øádkù mimo rozsah: %<PRId64> > celkovı poèet øádkù"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: chybnı poèet øádkù v bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Nárùst velikosti zásobníku"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: chybné id ukazatele na blok 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: POZOR"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -2820,38 +4181,44 @@ msgstr ""
 "\n"
 "Nalezen odkládací soubor se jménem \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Pøi otevírání souboru\""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOVÌJŠÍ ne odkládací soubor!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Soubor mùe bıt editován jinım programem.\n"
 "    Je-li tomu tak, pak si dejte pozor, aby jste po uloení zmìn\n"
 "    nemìli dvì rùzné verze tého souboru.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Ukonèete program, nebo opatrnì pokraèujte v editaci.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Editace tohoto souboru byla pøerušena neèekanım ukonèením programu.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Je-li tomu tak, pak pouijte \":recover\" èi \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -2859,9 +4226,11 @@ msgstr ""
 "\"\n"
 "    pro odstranìní zmìn (viz \":help recovery)\".\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Pokud jste tak ji uèinil, tak smate odkládací soubor \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -2869,35 +4238,45 @@ msgstr ""
 "\"\n"
 "    a tato zpráva se ji nebude objevovat.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Odkládací soubor \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ji existuje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - POZOR"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Odkládací soubor ji existuje!"
 
+#: ../memline.c:3464
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
-"&Quit"
+"&Quit\n"
+"&Abort"
 msgstr ""
 "&Otevøít pouze pro ètení\n"
 "&Pokraèovat v editaci\n"
 "O&bnovit soubor\n"
 "&Konec"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "&Otevøít pouze pro ètení\n"
 "&Pokraèovat v editaci\n"
@@ -2905,29 +4284,56 @@ msgstr ""
 "&Konec\n"
 "&Smazat"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Pøíliš mnoho odkládacích souborù"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %<PRIu64>)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Èásti cesty k pøedmìtu nabídky není podnabídkou"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Nabídka existuje pouze v jiném módu"
 
-msgid "E329: No menu of that name"
+#: ../menu.c:64
+#, fuzzy, c-format
+msgid "E329: No menu \"%s\""
 msgstr "E329: Nabídka tohoto jména neexistuje"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Cesta nabídkou nesmí vést do podnabídky"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Poloky nabídky nelze pøidávat pøímo na lištu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Oddìlovaè nesmí bıt èástí cesty nabídkou"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -2935,61 +4341,74 @@ msgstr ""
 "\n"
 "--- Nabídky ---"
 
-msgid "Tear off this menu"
-msgstr "Odtrhnout tuto nabídku"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Cesta nabídkou musí vést k poloce nabídky"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Vzor nenalezen: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: V %s módu není nabídka definována"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Cesta nabídkou musí vést do podnabídky"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Nabídka nenalezena - zkontrolujte názvy nabídek"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Chyba pøi zpracování %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "øádek %4ld:"
 
-msgid "[string too long]"
-msgstr "[pøíliš dlouhı øetìzec]"
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: '%s' není pøípustné jméno registru"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Správce zpráv: Bram Moolenaar <Bram@vim.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Pøerušení: "
 
-msgid "Hit ENTER to continue"
-msgstr "pokraèování stiskem ENTER"
-
-msgid "Hit ENTER or type command to continue"
+#: ../message.c:988
+#, fuzzy
+msgid "Press ENTER or type command to continue"
 msgstr "Pro pokraèování stisknìte ENTER nebo zadejte pøíkaz"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "øádek %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Pokraèování --"
 
-msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-msgstr " (RET/BS: øádek, MEZERNÍK/b: stránka, d/u: 0.5 stránky, q: konec)"
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
-msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-msgstr " (RET: øádek, MEZERNÍK: stránka, d: 0.5 stránky, q: konec)"
-
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Otázka"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -2997,6 +4416,7 @@ msgstr ""
 "&Ano\n"
 "&Ne"
 
+#: ../message.c:3033
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3006,6 +4426,7 @@ msgstr ""
 "&Ne\n"
 "&Zrušit"
 
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3019,195 +4440,181 @@ msgstr ""
 "Zahodit &vše\n"
 "&Zrušit"
 
-msgid "Save File dialog"
-msgstr "Dialog pro ukládání souborù"
+#: ../message.c:3058
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: Chybné argumenty pro funkci %s"
 
-msgid "Open File dialog"
-msgstr "Dialog pro otevírání souborù"
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
 
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Lituji, ale konzolová verze nepodporuje prohlíeè souborù"
+#: ../message.c:3873
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: Pøíliš mnoho argumentù pro funkci %s"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: wc1: mìním soubor pouze_pro_ètení"
 
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "poèet novıch øádkù: 1"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "poèet smazanıch øádkù: 1"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "poèet novıch øádkù: %<PRId64>"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "poèet smazanıch øádkù: %<PRId64>"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr "(Pøerušeno)"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachovávám soubory...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: ukonèen\n"
-
-msgid "ERROR: "
-msgstr "CHYBA: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
+#: ../misc1.c:2635
+msgid "Beep!"
 msgstr ""
-"\n"
-"[bajtù] celkem uvolnìno-alokováno %<PRIu64>-%<PRIu64>, vyuito %<PRIu64>, maximální vyuití "
-"%<PRIu64>\n"
 
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[volání] celkem re/malloc(): %<PRIu64>, celkem free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Øádek se stává pøíliš dlouhım"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %<PRIu64>)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Spouštím pøíkaz \"%s\" pomocí shellu"
 
-msgid "Missing colon"
-msgstr "Chybí dvojteèka"
-
-msgid "Illegal mode"
-msgstr "nepøípustnı mód"
-
-msgid "Illegal mouseshape"
-msgstr "Chybnı tvar myši"
-
-msgid "digit expected"
-msgstr "oèekávána èíslice"
-
-msgid "Illegal percentage"
-msgstr "nepøípustné procento"
-
-msgid "Enter encryption key: "
-msgstr "Zadejte šifrovací klíè: "
-
-msgid "Enter same key again: "
-msgstr "Zadejte ještì jednou tentı klíè:"
-
-msgid "Keys don't match!"
-msgstr "Klíèe se neshodují"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Chybná cesta: '**[èíslo] musí bıt buï na konci cesty, nebo musí bıt\n"
-"následováno'%s. Viz :help path."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Adresáø \"%s\" nelze v cdpath nalézt"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Soubor \"%s\" nelze v path nalézt"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: ádnı další adresáø \"%s\" nebyl v cdpath nalezen"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: ádnı další soubor \"%s\" nebyl v cestì nalezen"
-
-msgid "Illegal component"
-msgstr "nepøípustná souèást"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Varování: terminál nepodporuje zvırazòování"
-
-msgid "E348: No string under cursor"
-msgstr "E348: pod kurzorem není ádnı øetìzec"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: pod kurzorem není ádnı identifikátor"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E221: volba 'commentstring' je prázdná"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Varování: terminál nepodporuje zvırazòování"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: pod kurzorem není ádnı øetìzec"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: pomocí aktuální 'foldmethod' nelze mazat záhyby"
 
+#: ../normal.c:5897
+#, fuzzy
+msgid "E664: changelist is empty"
+msgstr "E91: volba 'shell' je prázdná"
+
+#: ../normal.c:5899
+msgid "E662: At start of changelist"
+msgstr ""
+
+#: ../normal.c:5901
+msgid "E663: At end of changelist"
+msgstr ""
+
+#: ../normal.c:7053
+#, fuzzy
+msgid "Type  :quit<Enter>  to exit Vim"
+msgstr "zadejte :q<Enter>             pro ukonèení programu"
+
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "poèet øádkù posunutıch jednou pomocí %s : 1"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Poèet øádkù posunutıch pomocí %s %d-krát : 1"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "Poèet øádkù: %<PRId64> (posunutıch jednou pomocí %s)"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "Poèet øádkù: %<PRId64> (posunutıch pomocí %s %d-krát)"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "poèet øádkù k odsazení: %<PRId64>"
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "poèet øádkù k odsazení: 1"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "poèet odsazenıch øádkù: %<PRId64>"
 
+#: ../ops.c:938
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: ádnı pøedchozí adresáø"
+
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nelze kopírovat; pøesto smazáno"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "poèet øádek se zmìnìnou velikostí písmen: 1"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "poèet øádek se zmìnìnou velikostí písmen: %<PRId64>"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "poèet uvolòovanıch øádkù: %<PRId64>"
+#: ../ops.c:2521
+#, fuzzy
+msgid "block of 1 line yanked"
+msgstr "poèet zkopírovanıch øádkù: 1"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "poèet zkopírovanıch øádkù: 1"
 
+#: ../ops.c:2525
+#, fuzzy, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr "poèet zkopírovanıch øádkù: %<PRId64>"
+
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "poèet zkopírovanıch øádkù: %<PRId64>"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Registr %s je prázdnı"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3215,9 +4622,11 @@ msgstr ""
 "\n"
 "--- Registry ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "nepøípustnı název registru"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3225,148 +4634,211 @@ msgstr ""
 "\n"
 "# Registry:\n"
 
-#, c-format
-msgid "Unknown register type %d"
+#: ../ops.c:4575
+#, fuzzy, c-format
+msgid "E574: Unknown register type %d"
 msgstr "%d není známım typem registru"
 
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: '%s' není pøípustné jméno registru"
-
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "øádkù: %<PRId64>;"
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> z %<PRId64> Bytù"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> "
+"z %<PRId64> Bytù"
 
+#: ../ops.c:5105
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> "
+"z %<PRId64> Bytù"
+
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Byte %<PRId64> z %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Byte %<PRId64> z %<PRId64>"
 
+#: ../ops.c:5133
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Byte %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> pro BOM)"
 
+#: ../option.c:1238
+msgid "%<%f%h%m%=Page %N"
+msgstr ""
+
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dìkuji za pouití Vim"
 
-msgid "Option not supported"
+#. found a mismatch: skip
+#: ../option.c:2698
+#, fuzzy
+msgid "E518: Unknown option"
+msgstr "Neznámá volba"
+
+#: ../option.c:2709
+#, fuzzy
+msgid "E519: Option not supported"
 msgstr "Volba není podporována"
 
-msgid "Not allowed in a modeline"
+#: ../option.c:2740
+#, fuzzy
+msgid "E520: Not allowed in a modeline"
 msgstr "Není v modeline povoleno"
 
-msgid ""
-"\n"
-"\tLast set from "
+#: ../option.c:2815
+msgid "E846: Key code not set"
 msgstr ""
-"\n"
-"\tNaposledy nastavena z "
 
-msgid "Number required after ="
+#: ../option.c:2924
+#, fuzzy
+msgid "E521: Number required after ="
 msgstr "Po = je vyadováno èíslo"
 
-msgid "Not found in termcap"
+#: ../option.c:3226 ../option.c:3864
+#, fuzzy
+msgid "E522: Not found in termcap"
 msgstr "Nenalezen v termcapu"
 
-#, c-format
-msgid "Illegal character <%s>"
+#: ../option.c:3335
+#, fuzzy, c-format
+msgid "E539: Illegal character <%s>"
 msgstr "Nepøípustnı znak <%s>"
 
-msgid "Not allowed here"
-msgstr "Toto zde není povoleno"
-
-msgid "Cannot set 'term' to empty string"
+#: ../option.c:3862
+#, fuzzy
+msgid "E529: Cannot set 'term' to empty string"
 msgstr "volba 'term' nemùe bıt prázdná"
 
-msgid "Cannot change term in GUI"
-msgstr "V GUI nelze mìnit term"
-
-msgid "Use \":gui\" to start the GUI"
-msgstr "Pouijte \"gui\" pro spuštìní GUI"
-
-msgid "'backupext' and 'patchmode' are equal"
+#: ../option.c:3885
+#, fuzzy
+msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "volby 'backupext' a 'patchmode' mají stejnou hodnotu"
 
-msgid "Zero length string"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
+
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
+#, fuzzy
+msgid "E524: Missing colon"
+msgstr "Chybí dvojteèka"
+
+#: ../option.c:4165
+#, fuzzy
+msgid "E525: Zero length string"
 msgstr "øetìzec o nulové délce"
 
-#, c-format
-msgid "Missing number after <%s>"
+#: ../option.c:4220
+#, fuzzy, c-format
+msgid "E526: Missing number after <%s>"
 msgstr "Po <%s> chybí èíslo"
 
-msgid "Missing comma"
+#: ../option.c:4232
+#, fuzzy
+msgid "E527: Missing comma"
 msgstr "Chybí èárka"
 
-msgid "Must specify a ' value"
+#: ../option.c:4239
+#, fuzzy
+msgid "E528: Must specify a ' value"
 msgstr "Je nutné zadat hodnotu '"
 
-msgid "contains unprintable character"
+#: ../option.c:4271
+#, fuzzy
+msgid "E595: contains unprintable or wide character"
 msgstr "obsahuje netisknutelné znaky"
 
-msgid "Invalid font(s)"
-msgstr "Chybná písma"
-
-msgid "can't select fontset"
-msgstr "nelze vybrat sadu písem"
-
-msgid "Invalid fontset"
-msgstr "chybná sada písem"
-
-msgid "can't select wide font"
-msgstr "nelze vybrat širokı font"
-
-msgid "Invalid wide font"
-msgstr "Chybné široké písmo"
-
-#, c-format
-msgid "Illegal character after <%c>"
+#: ../option.c:4469
+#, fuzzy, c-format
+msgid "E535: Illegal character after <%c>"
 msgstr "Nepøípustnı znak po <%c>"
 
-msgid "comma required"
+#: ../option.c:4534
+#, fuzzy
+msgid "E536: comma required"
 msgstr "je nutná èárka"
 
-#, c-format
-msgid "'commentstring' must be empty or contain %s"
+#: ../option.c:4543
+#, fuzzy, c-format
+msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "volba `commentstring` musí bıt buï prázdná nebo nastavená na %s"
 
-msgid "No mouse support"
-msgstr "Bez podpory myši"
-
-msgid "Unclosed expression sequence"
+#: ../option.c:4928
+#, fuzzy
+msgid "E540: Unclosed expression sequence"
 msgstr "neuzavøená sekvence vırazù"
 
-msgid "too many items"
+#: ../option.c:4932
+#, fuzzy
+msgid "E541: too many items"
 msgstr "pøíliš mnoho poloek"
 
-msgid "unbalanced groups"
+#: ../option.c:4934
+#, fuzzy
+msgid "E542: unbalanced groups"
 msgstr "nevyváené skupiny"
 
-msgid "A preview window already exists"
+#: ../option.c:5148
+#, fuzzy
+msgid "E590: A preview window already exists"
 msgstr "Okno náhledu ji existuje"
 
-msgid "'winheight' cannot be smaller than 'winminheight'"
+#: ../option.c:5311
+msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
-"hodnota volby 'winheight' nesmí bıt menší ne hodnota volby 'winminheight'"
 
-msgid "'winwidth' cannot be smaller than 'winminwidth'"
-msgstr ""
-"hodnota volby 'winwidth' nesmí bıt menší ne hodnota volby 'winminwidth'"
-
-#, c-format
-msgid "Need at least %d lines"
+#: ../option.c:5623
+#, fuzzy, c-format
+msgid "E593: Need at least %d lines"
 msgstr "minimální potøebnı poèet øádkù: %d"
 
-#, c-format
-msgid "Need at least %d columns"
+#: ../option.c:5631
+#, fuzzy, c-format
+msgid "E594: Need at least %d columns"
 msgstr "minimální potøebnı poèet sloupcù: %d"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Neznámá volba: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "Po = je vyadováno èíslo"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3374,6 +4846,7 @@ msgstr ""
 "\n"
 "--- Kódy terminálu ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3381,6 +4854,7 @@ msgstr ""
 "\n"
 "--- Nastavení globálních voleb ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3388,6 +4862,7 @@ msgstr ""
 "\n"
 "--- Nastavení lokálních voleb ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3395,134 +4870,21 @@ msgstr ""
 "\n"
 "--- Volby ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp CHYBA"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': pro %s chybí vyhovující znak"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': nadbyteèné znaky po støedníku: %s"
 
-msgid "cannot open "
-msgstr "nelze otevøít "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nelze otevøít nové okno!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Vyaduje Amigados verze 2.04 nebo vyšší\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Vyaduje %s verze %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nelze otevøít NIL:\n"
-
-msgid "Cannot create "
-msgstr " Nelze vytvoøit "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim bude ukonèen %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "Nelze zmìnit mód konzole ?!\n"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Nastavování reimu obrazovky není podporováno"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: neni konzole??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nelze spustit shell s parametrem -f"
-
-msgid "Cannot execute "
-msgstr "Nelze spustit "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " návratová hodnota shellu\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE je pøíliš malá."
-
-msgid "I/O ERROR"
-msgstr "I/O CHYBA"
-
-msgid "...(truncated)"
-msgstr "...(kráceno)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' není 80, nelze spustit externí pøíkaz"
-
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Volání knihovní funkce \"%s()\" selhalo"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Nelze zvolit tiskárnu"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "do %s v %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Chyba tisku: %s"
-
-msgid "Unknown"
-msgstr "Neznámı"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Vytištìno '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Nepøípustná jméno znakové sady \"%s\" ve fontu \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Nepøípustnı znak '%c' ve fontu \"%s\""
-
-msgid "E366: Invalid 'osfiletype' option - using Text"
-msgstr "E366: Neplatnı 'osfiletype' - pouit Text"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "VIm: dvojitı signál, konèím\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Zachycen smrtelnı signál %s\n"
-
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Zachycen smrtelnı signál\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Doba otevírání X displeje (v ms): %<PRId64>"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: chyba X11\n"
-
-msgid "Testing the X display failed"
-msgstr "Test X displeje se nezdaøil"
-
-msgid "Opening the X display timed out"
-msgstr "Vypršel èas pøi èekání na otevøení X displeje"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -3530,13 +4892,7 @@ msgstr ""
 "\n"
 "nelze spustit shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nelze spustit sh shell\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -3544,279 +4900,968 @@ msgstr ""
 "\n"
 " návratová hodnota shellu "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Nelze vytvoøit roury\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Volání fork selhalo\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Pøíkaz ukonèen\n"
-
-msgid "Opening the X display failed"
-msgstr "Otevøení X displeje se nezdaøilo"
-
-msgid "At line"
-msgstr "Na øádku"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nelze naèíst vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Chyba VIMu"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nelze nastavit ukazatele funkcí na DLL"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "shell returned %d"
-msgstr "návratová hodnota shellu %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Zachycen %s signál\n"
-
-msgid "close"
-msgstr "zavøít"
-
-msgid "logoff"
-msgstr "logoff"
-
-msgid "shutdown"
-msgstr "shutdown"
-
-msgid "E371: Command not found"
-msgstr "E371: Pøíkaz není k dispozici"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
+msgid "dlerror = \"%s\""
 msgstr ""
-"VIMRUN.EXE se nevyskytuje ve Vaší $PATH.\n"
-"Externí pøíkazy nebudou "
 
-msgid "Vim Warning"
-msgstr "Varování"
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Soubor \"%s\" nelze v path nalézt"
 
+#: ../quickfix.c:359
+#, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Pøíliš mnoho %%%c ve formátovacím øetìzci"
 
+#: ../quickfix.c:371
+#, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Neoèekávanı vıskyt %%%c ve formátovacím øetìzci"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Ve formátovacím øetìzci chybí ]"
 
+#: ../quickfix.c:431
+#, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c Nepodporovaná formátová specifikace ve formátovacím øetìzci"
 
+#: ../quickfix.c:448
+#, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Nepøípustné %%%c v prefixu formátovacího øetìzce"
 
+#: ../quickfix.c:454
+#, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Nepøípustné %%%c ve formátovacím øetìzci"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' neobsahuje ádnı vzorek"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Chybìjící nebo prázdnı název adresáøe"
 
-msgid "No more items"
+#: ../quickfix.c:1305
+#, fuzzy
+msgid "E553: No more items"
 msgstr "ádné další poloky"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d/%d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (øádek smazán)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Konec quickfix seznamu"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Zaèátek quickfix seznamu"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "seznam chyb %d z %d; poèet chyb: %d"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nelze uloit, je nastavena volba 'buftype'"
 
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "Nelze otevøít soubor %s"
+
+#: ../quickfix.c:3429
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "Poèet deaktivovanıch bufferù: 1"
+
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "oèekávána èíslice"
+
+#: ../regexp.c:359
+#, fuzzy, c-format
+msgid "E369: invalid item in %s%%[]"
+msgstr "E239: Neplatnı text volby: %s"
+
+#: ../regexp.c:374
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr ""
+
+#: ../regexp.c:376
+#, fuzzy, c-format
+msgid "E54: Unmatched %s("
+msgstr "ádná shoda: %s"
+
+#: ../regexp.c:377
+#, fuzzy, c-format
+msgid "E55: Unmatched %s)"
+msgstr "ádná shoda: %s"
+
+#: ../regexp.c:378
+#, fuzzy
+msgid "E66: \\z( not allowed here"
+msgstr "E407: %s zde není povoleno"
+
+#: ../regexp.c:379
+#, fuzzy
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E407: %s zde není povoleno"
+
+#: ../regexp.c:380
+#, fuzzy, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr ""
+
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Vzor je pøíliš dlouhı"
 
+#: ../regexp.c:1371
+#, fuzzy
+msgid "E50: Too many \\z("
+msgstr "E76: pøíliš mnoho ["
+
+#: ../regexp.c:1378
+#, fuzzy, c-format
+msgid "E51: Too many %s("
+msgstr "E76: pøíliš mnoho ["
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr ""
+
+#: ../regexp.c:1637
+#, fuzzy, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E215: Nepøípustnı znak po *: %s"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr ""
+
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: %s%c"
 
+#: ../regexp.c:1800
+#, fuzzy
+msgid "E63: invalid use of \\_"
+msgstr "E176: Chybnı poèet argumentù"
+
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c nic není"
 
-#, c-format
-msgid "Syntax error in %s{...}"
+#: ../regexp.c:1902
+#, fuzzy
+msgid "E65: Illegal back reference"
+msgstr "E125: Nepøípustnı argument: %s"
+
+#: ../regexp.c:1943
+#, fuzzy
+msgid "E68: Invalid character after \\z"
+msgstr "E215: Nepøípustnı znak po *: %s"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E215: Nepøípustnı znak po *: %s"
+
+#: ../regexp.c:2107
+#, fuzzy, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E215: Nepøípustnı znak po *: %s"
+
+#: ../regexp.c:3017
+#, fuzzy, c-format
+msgid "E554: Syntax error in %s{...}"
 msgstr "Chyba syntaxe v %s{...}"
 
-msgid "E361: Crash intercepted; regexp too complex?"
-msgstr "E361: Zachyceno pøeteèení zásobníku: pøíliš sloitı regulární vıraz?"
-
-msgid "E363: pattern caused out-of-stack error"
-msgstr "E363: vzorek zpùsobil pøeteèení zásobníku"
-
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Vnìjší podøazené shody:\n"
 
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "poèet øádkù v záhybu: %3ld"
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr ""
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Nelze najít doèasnı temp soubor pro zápis"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " VREPLACE"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " REPLACE"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " REVERSE"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERT"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (insert)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (replace)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (vreplace)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hebrejskı"
 
+#: ../screen.c:7454
+msgid " Arabic"
+msgstr ""
+
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lang)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (paste)"
 
-msgid " SELECT"
-msgstr " SHODY"
-
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VIZUÁLNÍ"
 
-msgid " BLOCK"
-msgstr " BLOK"
+#: ../screen.c:7470
+#, fuzzy
+msgid " VISUAL LINE"
+msgstr " VIZUÁLNÍ"
 
-msgid " LINE"
-msgstr " ØÁDEK"
+#: ../screen.c:7471
+#, fuzzy
+msgid " VISUAL BLOCK"
+msgstr " VIZUÁLNÍ"
 
+#: ../screen.c:7472
+msgid " SELECT"
+msgstr " SHODY"
+
+#: ../screen.c:7473
+#, fuzzy
+msgid " SELECT LINE"
+msgstr " SHODY"
+
+#: ../screen.c:7474
+#, fuzzy
+msgid " SELECT BLOCK"
+msgstr " SHODY"
+
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "nahrávám"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "hledání dosáhlo zaèátku, pokraèování od konce"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "hledání dosáhlo konce, pokraèování od zaèátku"
-
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Nepøípustnı hledanı øetìzec: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: hledanı dosáhlo zaèátku bez nalezení %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: hledanı dosáhlo konce bez nalezení %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Po ';' oèekávám '?' nebo '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (vèetnì ji vypsanıch shod)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Vloené soubory"
 
+#: ../search.c:4106
 msgid "not found "
 msgstr " nenalezeny"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "v cestì ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Ji vypsáno)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " NENALEZENY"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Prohledávám vloené soubory: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "Prohledávám vloené soubory: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Shoda je na aktuálním øádku"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Všechny vloené soubory byly nalezeny"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "ádné vloené soubory"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nelze nalézt definici"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nelze nalézt vzorek"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 nahrazení"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+#, fuzzy
+msgid "E759: Format error in spell file"
+msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:955
+#, fuzzy
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E431: Chyba formátu v souboru tagù \"%s\""
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "Pouívám odkládací soubor \"%s\""
+
+#: ../spell.c:2496
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s se nezdá bıt odkládacím souborem Vim"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
+
+#: ../spell.c:3762
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "Volba není podporována"
+
+#: ../spell.c:4550
+#, fuzzy, c-format
+msgid "Reading affix file %s ..."
+msgstr "Prohledávám soubor tagù %s"
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, fuzzy, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr "Pouit chybnı id serveru: %s"
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: Duplicitní tag \"%s\" v souboru %s"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "Pøíliš mnoho edit argumentù"
+
+#: ../spell.c:5238
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "Pøíliš mnoho edit argumentù"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, fuzzy, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "Prohledávám slovník %s"
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "Vzor nalezen na kadém øádku: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, fuzzy, c-format
+msgid "Reading word file %s ..."
+msgstr "Ètu ze standardního vstupu..."
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "Pouit chybnı id serveru: %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "Ukládám viminfo souboru \"%s\""
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr ""
+
+#: ../spell.c:7846
+#, fuzzy, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E15: Chybnı vıraz: %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, fuzzy, c-format
+msgid "Writing spell file %s ..."
+msgstr "Ukládám viminfo souboru \"%s\""
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, fuzzy, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr " na %<PRId64> øádcích"
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, fuzzy, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "Uloit zmìny do \"%.*s\"?"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: ádnı pøedchozí regulární vıraz"
+
+#: ../spell.c:8925
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: Vzor nenalezen: %s"
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s se nezdá bıt odkládacím souborem Vim"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Chyba pøi ètení chybového souboru"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Pro tento buffer nejsou definovány ádné pøedmìty syntaxe"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: nepøípustnı argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaktická sestava %s neexistuje"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Pro tento buffer nejsou definovány ádné pøedmìty syntaxe"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizuji komentáøe v C stylu"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "ádná synchronizace"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synchronizace zaèíná "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " øádkù pøed zaèátkem"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -3824,6 +5869,7 @@ msgstr ""
 "\n"
 "--- Poloky synchronizace syntaxe ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -3831,6 +5877,7 @@ msgstr ""
 "\n"
 "synchronizuji pøedmìty"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -3838,187 +5885,280 @@ msgstr ""
 "\n"
 "--- Pøedmìty syntaxe ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Syntaktická sestava %s neexistuje"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimální "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximální "
 
+#: ../syntax.c:3513
+#, fuzzy
+msgid "; match "
+msgstr "shoda %d"
+
+#: ../syntax.c:3515
+#, fuzzy
+msgid " line breaks"
+msgstr "poèet smazanıch øádkù: 1"
+
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: obsahuje argumenty, které zde nejsou povoleny"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E180: Chybná hodnota doplnìní: %s"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here nesmí bıt na tomto místì"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Pro %s chybí poloka regionu"
 
-msgid "E395: contains argument not accepted here"
-msgstr "E395: obsahuje argumenty, které zde nejsou povoleny"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: obsahuje argumenty, které zde nejsou povoleny"
-
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Vyadován název souboru"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Pøíliš mnoho názvù souborù"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: Chybí '=': %s"
+
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Chybí '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Pøíliš málo argumentù: oblast syntaxe %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaktická sestava %s neexistuje"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Nebyla zadána ádná sestava"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Oddìlovaè vzorku %s nenalezen"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Chyba za vzorkem %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: synchronizace syntaxe: vzorek pokraèování øádkù zadán dvakrát"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: nepøípustnı argument: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Chybí rovnítko: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Prázdnı argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s zde není povoleno"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musí bıt první v 'contains' seznamu"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Neznámá název skupiny: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: chybnı podøazenı pøíkaz :syntax : %s "
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: skupina zvıraznìní %s nebyla nalezena"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Pøíliš málo argumentù: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Pøíliš mnoho argumentù: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: skupina je nastavena, odkaz na zvırazòovací skupinu ignorován"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: neèekané rovnítko : %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: chybné rovnítko: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: chybí argument: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: nepøípustná hodnota: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: barva popøedí není známá"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: barva popøedí není známá"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: název èi èíslo barvy %s nebylo rozpoznáno"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminálovı kód %s je pøíliš dlouhı"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: nepøípustnı argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr ""
 "E424: Je pouíváno pøíliš velké mnoství odlišnıch zvırazòovacích atributù"
 
-msgid "at bottom of tag stack"
+#: ../syntax.c:7427
+msgid "E669: Unprintable character in group name"
+msgstr ""
+
+#: ../syntax.c:7434
+#, fuzzy
+msgid "W18: Invalid character in group name"
+msgstr "E182: Chybné jméno pøíkazu"
+
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
+#, fuzzy
+msgid "E555: at bottom of tag stack"
 msgstr "konec seznamu tagù"
 
-msgid "at top of tag stack"
+#: ../tag.c:105
+#, fuzzy
+msgid "E556: at top of tag stack"
 msgstr "zaèátek seznamu tagù"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Pøed první vyhovující tag nelze pøeskoèit"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tag %s nenalezen"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri typ tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "soubor\n"
 
-#.
-#. * Ask to select a tag from the list.
-#. * When using ":silent" assume that <CR> was entered.
-#.
-msgid "Enter nr of choice (<CR> to abort): "
-msgstr "Zadejte èíslo (<CR> pro ukonèení): "
-
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Vyhovuje pouze jeden tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Za poslední vyhovující tag nelze pøeskoèit"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Soubor \"%s\" neexistuje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d z celkového poètu %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " nebo více"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Pouívám tag s písmeny jiné velikosti!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: \"%s\" neexistuje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -4026,65 +6166,82 @@ msgstr ""
 "\n"
 "  # CÍL tag        START øádek  v souboru/textu"
 
-msgid "Linear tag search"
-msgstr "Lineární hledání tagu"
-
-msgid "Binary tag search"
-msgstr "Binární hledání tagu"
-
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Prohledávám soubor tagù %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Soubor tagù %s byl oøezán\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátu v souboru tagù \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Pøed bajtem %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Obsah soubor tagù %s není seøazen"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: ádnı soubor tagù"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nelze najít vzorek tagù"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Tag nelze nalézt, pouze hádám!"
 
+#: ../tag.c:2797
+#, c-format
+msgid "Duplicate field name: %s"
+msgstr ""
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' není znám. Dostupné vestavìné terminály:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "implicitní terminál '"
 
-msgid "Cannot open termcap file"
+#: ../term.c:1731
+#, fuzzy
+msgid "E557: Cannot open termcap file"
 msgstr "Nelze otevøít termcap"
 
-msgid "Terminal entry not found in terminfo"
+#: ../term.c:1735
+#, fuzzy
+msgid "E558: Terminal entry not found in terminfo"
 msgstr "Terminfo neobsahuje poloku pro tento terminál"
 
-msgid "Terminal entry not found in termcap"
+#: ../term.c:1737
+#, fuzzy
+msgid "E559: Terminal entry not found in termcap"
 msgstr "Termcap neobsahuje poloku pro tento terminál"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Termcap neobsahuje poloku pro \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminál musí mít schopnost \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -4092,109 +6249,176 @@ msgstr ""
 "\n"
 "--- Klávesy terminálu ---"
 
-msgid "new shell started\n"
-msgstr "spuštìn novı shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: chyba pøi ètení vstupu, konèím...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "odstranìní zmìn není moné; chcete pøesto pokraèovat"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Nelze otevøít soubor pro zápis"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Ukládám viminfo souboru \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Ètu viminfo soubor \"%s\"%s%s%s"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Nelze otevøít pro ètení viminfo soubor"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E150: %s není adresáøem"
+
+#: ../undo.c:1313
+#, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr ""
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "dokonèena interpretace %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> nenalezen"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: èísla øádkù jsou chybná"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "poèet novıch øádkù: 1"
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "poèet novıch øádkù: 1"
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "poèet smazanıch øádkù: 1"
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "poèet smazanıch øádkù: %<PRId64>"
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "poèet zmìn: 1"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "poèet zmìn: %<PRId64>"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "poèet zmìn: 1"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "Poèet øádkù: %<PRId64> (posunutıch pomocí %s %d-krát)"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "ádné mapování nebylo nalezeno"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "øádkù: %<PRId64>;"
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s zde není povoleno"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmìnách poškozen"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: chybí undo øádek"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32 bitová GUI verze pro MS Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitová GUI verze pro MS Windows"
-
-msgid " in Win32s mode"
-msgstr " ve Win32s reimu"
-
-msgid " with OLE support"
-msgstr " s OLE podporou"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitová verze pro MS Windows konzolu"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitová verze pro MS Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitová verze pro MS Windows"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitová MS-DOS verze"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) verze"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X verze"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS verze"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS verze"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -4202,6 +6426,19 @@ msgstr ""
 "\n"
 "Pouité záplaty: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Vnìjší podøazené shody:\n"
+
+#: ../version.c:639 ../version.c:864
+#, fuzzy
+msgid "Modified by "
+msgstr " [Zmìnìnı]"
+
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -4209,9 +6446,11 @@ msgstr ""
 "\n"
 "pøeloil "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -4219,446 +6458,1375 @@ msgstr ""
 "\n"
 "maximální verze"
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"velká verze "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"normální verze"
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"malá verze "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"minimální verze"
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez grafického rozhraní"
 
-msgid "with GTK-GNOME GUI."
-msgstr "s rozhraním GTK-GNOME"
-
-msgid "with GTK GUI."
-msgstr "s rozhraním GTK"
-
-msgid "with X11-Motif GUI."
-msgstr "s rozhraním X11-Motif"
-
-msgid "with X11-Athena GUI."
-msgstr "S rozhraním X11-Athena"
-
-msgid "with BeOS GUI."
-msgstr "s rozhraním BeOS"
-
-msgid "with Photon GUI."
-msgstr "s rozhraním Photon"
-
-msgid "with GUI."
-msgstr "s grafickım rozhraním"
-
-msgid "with Carbon GUI."
-msgstr "s grafickım rozhraním Carbon"
-
-msgid "with Cocoa GUI."
-msgstr "s grafickım rozhraním Cocoa"
-
-msgid "with (classic) GUI."
-msgstr "s (clasickım) grafickım rozhraním"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr " Vlastnosti zahrnuté (+) a nezahrnuté (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   systémovı vimrc soubor: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     uivatelskı vimrc soubor: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " druhı uivatelskı vimrc soubor: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " tøetí uivatelskı vimrc soubor: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      uivatelskı exrc soubor: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  druhı uivatelskı exrc soubor: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  systémovı gvimrc soubor: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    uivatelskı gvimrc soubor: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "druhı uivatelskı gvimrc soubor: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "tøetí uivatelskı gvimrc soubor: \""
-
-msgid "    system menu file: \""
-msgstr "    systémovı soubor s menu: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  implicitní hodnota $VIM:\""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "  implicitní hodnota $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Pøeklad: "
 
-msgid "Compiler: "
-msgstr "Pøekladaè: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Linkuji: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  PODPORA LADÌNÍ"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "verze "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Autor: Bram Moolenaar a další"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim je volnì šiøitelnı program s otevøenım zdrojovım kódem"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomozte chudım dìtem v Ugandì!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "podrobnìjší informace získáte pomocí :help iccf<Enter>"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "zadejte :q<Enter>             pro ukonèení programu"
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "zadejte :help<Enter>  èi <F1> pro nápovìdu"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "zadejte :help version7<Enter>  pro informace o verzi 6"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Bìím v reimu kompatibility s Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "zadejte :set nocp<Enter>     pro implicitní nastavení Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "podrobnìjší informace získáte pomocí :help cp-default<Enter>"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "VAROVÁNÍ: detekovány Windows 95/98/ME"
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr ""
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "zadejte :help windows95<Enter> pro podrobnìjší informace"
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr ""
 
-msgid "E441: There is no preview window"
-msgstr "E441: Není ádné preview okno není"
+#: ../version.c:831
+#, fuzzy
+msgid "type  :help sponsor<Enter>    for information "
+msgstr "podrobnìjší informace získáte pomocí :help iccf<Enter>"
 
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: Okno nelze rozdìlit zároveò topleft a botright"
+#: ../version.c:832
+#, fuzzy
+msgid "type  :help register<Enter>   for information "
+msgstr "podrobnìjší informace získáte pomocí :help iccf<Enter>"
 
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: Nelze rotovat, pokud je jiné okno rozdìleno"
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr ""
 
-msgid "E444: Cannot close last window"
-msgstr "E444: Poslední okno nelze uzavøít"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Ji existuje pouze jedno okno"
 
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: Není ádné preview okno není"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: Okno nelze rozdìlit zároveò topleft a botright"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: Nelze rotovat, pokud je jiné okno rozdìleno"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: Poslední okno nelze uzavøít"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Poslední okno nelze uzavøít"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Poslední okno nelze uzavøít"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Jiné okno obsahuje zmìny"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Pod kurzorem se nenachází název souboru"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Soubor \"%s\" nelze v path nalézt"
+#~ msgid "E86: Cannot go to buffer %<PRId64>"
+#~ msgstr "E86: Nelze pøeskoèit na buffer %<PRId64>"
 
-msgid "Edit with &multiple Vims"
-msgstr "Editace &multiple Vimy"
+#~ msgid "[Error List]"
+#~ msgstr "[seznam chyb]"
 
-msgid "Edit with single &Vim"
-msgstr "Editace jedním $Vim -em"
+#~ msgid "[No File]"
+#~ msgstr "[ádnı soubor]"
 
-msgid "Edit with &Vim"
-msgstr "Editace &Vim -em"
+#~ msgid "Patch file"
+#~ msgstr "Soubor se záplatou"
 
-msgid "Edit with existing Vim - &"
-msgstr "Editace existujícím Vimem - &"
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: Neznámá promìnná: \"%s\""
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Editace vybranıch souborù Vimem"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zrušit"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Chyba pøi spouštìní procesu: Zkontrolujte zdali je gvim v $PATH!"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Neexistuje pøipojení k Vim serveru"
 
-msgid "gvimext.dll error"
-msgstr "chyba gvimext.dll"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nelze èíst odpovìï serveru"
 
-msgid "Path length too long!"
-msgstr "Název (v path) je pøíliš dlouhı"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nelze pøedat do %s"
 
-msgid "--No lines in buffer--"
-msgstr "--Buffer neobsahuje ádnı øádek--"
+#~ msgid "function "
+#~ msgstr "funkce "
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "Command aborted"
-msgstr "Pøíkaz pøerušen"
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: Nedefinovaná funkce: %s"
 
-msgid "Argument required"
-msgstr "Je vyadován argument"
+#~ msgid "Save As"
+#~ msgstr "Uloit jako"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ by mìl následovat /. ? nebo &"
+#~ msgid "Edit File"
+#~ msgstr "Editovat soubor"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chyba v oknì pøíkazové øádky; <CR> pro spuštšní, CTRL-C pro ukonèení"
+#~ msgid "Run Macro"
+#~ msgstr "Spustit makro"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Pøíkaz není z exrc/vimrc v aktuálním adresáøi èi pøi hledání tagu "
-"povolen."
+#~ msgid "Edit File in new window"
+#~ msgstr "Editovat soubor v novém oknì"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Soubor existuje (pouijte ! pro vynucení)"
+#~ msgid "Append File"
+#~ msgstr "Uloit soubor"
 
-msgid "Command failed"
-msgstr "Pøíkaz selhal"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Umístìní okna: X %d, Y %d"
 
-msgid "Internal error"
-msgstr "Vnitøní chyba"
+#~ msgid "Save Redirection"
+#~ msgstr "Uloit pøesmìrování"
 
-msgid "Interrupted"
-msgstr "Pøerušeno"
+#~ msgid "Save View"
+#~ msgstr "Uloit pohled"
 
-msgid "E14: Invalid address"
-msgstr "E14: Chybná adresa"
+#~ msgid "Save Session"
+#~ msgstr "Uloit sezení"
 
-msgid "Invalid argument"
-msgstr "Chybnı argument"
+#~ msgid "Save Setup"
+#~ msgstr "Uloit nastavení"
 
-#, c-format
-msgid "Invalid argument: %s"
-msgstr "Chybnı argument: %s"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: V této verzi nejsou spøeky podporovány"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Chybnı vıraz: %s"
+#~ msgid "[NL found]"
+#~ msgstr "[nalezeno NL]"
 
-msgid "E16: Invalid range"
-msgstr "E16: Chybnı rozsah"
+#~ msgid "[crypted]"
+#~ msgstr "[zašifrován]"
 
-msgid "Invalid command"
-msgstr "Chybnı pøíkaz"
+# resource fork ?!
+#~ msgid "The resource fork will be lost (use ! to override)"
+#~ msgstr "'Resource fork' bude ztracen (pouijte ! pro vynucení)"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" je adresáøem"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nelze spustit GUI"
 
-msgid "E18: Unexpected characters before '='"
-msgstr "E18: Neoèekávané znaky pøed '='"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nelze èíst z \"%s\""
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Znaèka má chybné èíslo øádku"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: volba 'guifontwide' je chybnì nastavena"
 
-msgid "E20: Mark not set"
-msgstr "E20: není nastavena"
+#~ msgid "<cannot open> "
+#~ msgstr "<nelze otevøít> "
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nelze mìnit, je nastavena volba 'modifiable'"
+#~ msgid "vim_SelFile: can't get font %s"
+#~ msgstr "vim_SelFile: písmo %s není dostupné"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skript vnoøen pøíliš hluboko"
+#~ msgid "vim_SelFile: can't return to current directory"
+#~ msgstr "vim_SelFile: nelze se vrátit do aktuálního adresáøe"
 
-msgid "E23: No alternate file"
-msgstr "E23: ádnı alternativní soubor"
+#~ msgid "Pathname:"
+#~ msgstr "Název cesty:"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Taková zkratka neexistuje"
+#~ msgid "vim_SelFile: can't get current directory"
+#~ msgstr "vim_SelFile: nelze zjistit aktuální adresáø"
 
-msgid "No ! allowed"
-msgstr "! není povoleno"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Nelze pouít GUI: nebylo zapnuto pøi pøekladu programu"
+#~ msgid "Cancel"
+#~ msgstr "Zrušit"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E26: nelze pouít hebrejskı reim:  nebyl zapnut pøi pøekladu programu\n"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Pøípravek posunovací lišty: nelze zjistit geometrii obrázku"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Nelze pouít farsi reim:  nebyl zapnut pøi pøekladu programu\n"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim dialog"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Skupina zvıraznìní %s neexistuje"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: BalloonEval nelze vytvoøit se zprávou a zároveò zpìtnım voláním"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Zatím není ádnı vloenı text"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialog.."
 
-msgid "E30: No previous command line"
-msgstr "E30: ádná pøedchozí pøíkazová øádka"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Nalézt a nahradit..."
 
-msgid "E31: No such mapping"
-msgstr "E31: ádné takové mapování"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Nalézt..."
 
-msgid "No match"
-msgstr "ádná shoda"
+#~ msgid "Find what:"
+#~ msgstr "Vyhledat:"
 
-#, c-format
-msgid "No match: %s"
-msgstr "ádná shoda: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Novı text:"
 
-msgid "E32: No file name"
-msgstr "E32: ádnı název souboru"
+#~ msgid "Match exact word only"
+#~ msgstr "hledat pouze celá slova"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: ádnı pøedchozí regulární vıraz"
+#~ msgid "Direction"
+#~ msgstr "Smìr"
 
-msgid "E34: No previous command"
-msgstr "E34: ádnı pøedchozí pøíkaz"
+#~ msgid "Up"
+#~ msgstr "Nahoru"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: ádnı pøedchozí regulární vıraz"
+#~ msgid "Down"
+#~ msgstr "Dolù"
 
-msgid "No range allowed"
-msgstr "Rozsah není povolen"
+#~ msgid "Find Next"
+#~ msgstr "Najít další"
 
-msgid "E36: Not enough room"
-msgstr "E36: Nedostatek místa"
+#~ msgid "Replace"
+#~ msgstr "Nahradit"
 
-#, c-format
-msgid "Can't create file %s"
-msgstr "Nelze vytvoøit soubor %s"
+#~ msgid "Replace All"
+#~ msgstr "Nahradit vše"
 
-msgid "Can't get temp file name"
-msgstr "Nelze získat název doèasného souboru"
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nelze otevøít display"
 
-#, c-format
-msgid "Can't open file %s"
-msgstr "Nelze otevøít soubor %s"
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Neznámá sada písem: %s"
 
-#, c-format
-msgid "Can't read file %s"
-msgstr "Nelze èíst soubor %s"
+#~ msgid "Font Selection"
+#~ msgstr "Vıbìr písma"
 
-msgid "E37: No write since last change (use ! to override)"
-msgstr "E37: Neuloené zmìny (pouijte ! pro vynucení)"
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Neznámé písmo: %s"
 
-msgid "E38: Null argument"
-msgstr "E38: Nulovı argument"
+#~ msgid "E242: Color name not recognized: %s"
+#~ msgstr "E242: Neznámé jméno barvy: %s"
 
-msgid "E39: Number expected"
-msgstr "E39: Oèekáváno èíslo"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Místo prádné schránky pouito CUT_BUFFER0"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nelze otevøít chybovı soubor %s"
+#~ msgid "Filter"
+#~ msgstr "Filtr"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Nedostatek pamìti!"
+#~ msgid "Directories"
+#~ msgstr "Adresáøe"
 
-msgid "Pattern not found"
-msgstr "Vzor nenalezen"
+#~ msgid "Help"
+#~ msgstr "Nápovìda"
 
-#, c-format
-msgid "Pattern not found: %s"
-msgstr "Vzor nenalezen: %s"
+#~ msgid "Files"
+#~ msgstr "Soubory"
 
-msgid "Argument must be positive"
-msgstr "Argument musí bıt kladnı"
+#~ msgid "Selection"
+#~ msgstr "Vıbìr"
 
-msgid "E42: No Errors"
-msgstr "E42: ádné chyby"
+#~ msgid "Undo"
+#~ msgstr "Zpìt"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Poškozenı øetìzec pro vyhledávání"
+#~ msgid "E235: Can't load Zap font '%s'"
+#~ msgstr "E235: Nelze naèíst Zap font '%s'"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: poškozenı regexp program"
+#~ msgid ""
+#~ "\n"
+#~ "Sending message to terminate child process.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Posílám signál k ukonèení synovského procesu.\n"
 
-msgid "E45: 'readonly' option is set (use ! to override)"
-msgstr "E45: 'nastavena volba 'readonly' (pouijte ! pro vynucení)"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nepodporován: \"-%s\"; Pouijte OLE verzi."
 
-#, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Najít øetìzec (pouijte '\\\\' k nalezení '\\')"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Chyba pøi ètení chybového souboru"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Najít & Nahradit (pouijte '\\\\' k nalezení '\\')"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Není v bezpeènostní schránce povoleno"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: nelze alokovat poloku barevné mapy. Nìkteré barvy mohou bıt "
+#~ "nesprávné"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Chybná hodnota volby 'scroll'"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: písma pro následující znakové sady chybí v sadì písem %s:"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: volba 'shell' je prázdná"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: název sady písem: %s"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Chyba pøi uzavírání odkládacího souboru"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Písmo '%s' nemá pevnou šíøku"
 
-msgid "E73: tag stack empty"
-msgstr "E73: seznam tagù je prázdnı"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: název sady písem: %s\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: Pøíkaz je pøíliš sloitı"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Písmo0: %s\n"
 
-msgid "E75: Name too long"
-msgstr "E75: Název je pøíliš dlouhı"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Písmo1: %s\n"
 
-msgid "E76: Too many ["
-msgstr "E76: pøíliš mnoho ["
+#~ msgid "Font%d width is not twice that of font0\n"
+#~ msgstr "Šíøka písma%d není dvojnásoblem šíøky písma0\n"
 
-msgid "E77: Too many file names"
-msgstr "E77: Pøíliš mnoho názvù souborù"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Šíøka písma0: %<PRId64>\n"
 
-msgid "Trailing characters"
-msgstr "Nadbyteèné znaky na konci"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Šíøka písma1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Neznámá znaèka"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: nelze alokovat barvu %s"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nelze expandovat olíkové znaky"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: CYBA Hangul automatu"
 
-msgid "E80: Error while writing"
-msgstr "E80: Chyba pøi ukládání"
+#~ msgid "error reading cscope connection %d"
+#~ msgstr "chyba pøi ètení cscope spojení %d"
 
-msgid "Zero count"
-msgstr "Nulovı poèet"
+#~ msgid "maximum number of cscope connections reached"
+#~ msgstr "dosaen maximální poèet cscope spojení"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Pouití <SID> mimo kontext skriptu"
+#~ msgid "E260: cscope connection not found"
+#~ msgstr "E260: connection spojení nenalezeno"
+
+#~ msgid "cscope connection closed"
+#~ msgstr "closed spojení uzavøeno"
+
+#~ msgid "couldn't malloc\n"
+#~ msgstr "volání malloc selhalo\n"
+
+#~ msgid "%2d %-5ld  %-34s  <none>\n"
+#~ msgstr "%2d %-5ld  %-34s  <ádnı>\n"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Lituji, tento pøíkaz je deaktivován; knihovnu jazyka Python nelze "
+#~ "nahrát."
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nelze smazat atributy OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace musí bıt kladné celé èíslo"
+
+#~ msgid "invalid attribute"
+#~ msgstr "chybnı atribut"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() vyaduje seznam øetìzcù"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: chyba pøi inicializaci I/O objektù"
+
+#~ msgid "invalid expression"
+#~ msgstr "Chybnı vıraz"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "podpora vırazù byla vypnuta pøi pøekladu programu"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "pokus o odkaz na smazanı buffer"
+
+#~ msgid "line number out of range"
+#~ msgstr "èíslo øádku mimo rozsah"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffer objekt (smazán) na %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "chybné jméno znaèky"
+
+#~ msgid "no such buffer"
+#~ msgstr "ádnı takovı buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "pokus o odkaz na smazané okno"
+
+#~ msgid "readonly attribute"
+#~ msgstr "atribut pouze_pro_ètení"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "umístìní kurzoru mimo buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<objekt okna (smazán) na %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<objekt okna (neznámı) na %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<okno %d>"
+
+#~ msgid "no such window"
+#~ msgstr "ádné takové okno"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "nelze uloit informace pro pøíkaz undo"
+
+#~ msgid "cannot delete line"
+#~ msgstr "nelze smazat øádek"
+
+#~ msgid "cannot replace line"
+#~ msgstr "nelze nahradit øádek"
+
+#~ msgid "cannot insert line"
+#~ msgstr "nelze vloit øádek"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "øetìzec nesmí obsahovat znaky nového øádku"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Ruby nelze "
+#~ "nahrát."
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: neznámı longjmp stav %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Prohození implementace/definice"
+
+#~ msgid "Show base class of"
+#~ msgstr "Zobrazení base class z"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Zobrazení overridden member funkce"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Znovuzískáno ze souboru"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Znovuzískáno z projektu"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Znovzískáno ze všech projektù"
+
+#~ msgid "Retrieve"
+#~ msgstr "Znovuzískáno"
+
+#~ msgid "Show source of"
+#~ msgstr "Zobrazení zdroje"
+
+#~ msgid "Find symbol"
+#~ msgstr "Najít symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Prohlíet class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Zobrazení class v hierarchii"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Zobrazení class v restricted hierarchii"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odkazuje na"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref odkazoval na"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref má"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref pouit"
+
+#~ msgid "Show docu of"
+#~ msgstr "Zobrazení documentace"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generována dokumentace pro"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Nelze se pøipojit k SNiFF+. Zkontrolujte promìnné (sniffemacs musí "
+#~ "bıt)uvedena v $PATH.\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Chyba pøi ètení. Odpojeno"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ je právì "
+
+#~ msgid "not "
+#~ msgstr "ne "
+
+#~ msgid "connected"
+#~ msgstr "pøipojen"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Neznámı poadavek SNiFF+: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Chybné pøipojení k SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ nepøipojen"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Chyba pøi zápisu. Odpojeno."
+
+#~ msgid "not implemented yet"
+#~ msgstr "není ještì podporováno"
+
+#~ msgid "unknown option"
+#~ msgstr "neznámá volba"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "nelze nastavit øádky"
+
+#~ msgid "mark not set"
+#~ msgstr "znaèka není nastavena"
+
+#~ msgid "row %d column %d"
+#~ msgstr "øádek %d sloupec %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "nelze vloit/pøipojit øádek"
+
+#~ msgid "unknown flag: "
+#~ msgstr "neznámı pøíznak: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "neznámá vimOption"
+
+#~ msgid "vim error"
+#~ msgstr "chyba vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nelze vytvoøit pøíkaz bufferu/okna: objekt smazán"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nelze zaregistrovat pøíkaz zpìtného volání: buffer/okno ji bylo smazáno"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATAL ERROR: reflist poškozen!? Oznamte, prosím, tuto chybu na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nelze zaregistrovat pøíkaz zpìtného volání: odkaz na buffer/okno nenalezen"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Tcl library could not be loaded."
+#~ msgstr ""
+#~ "Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Tcl nelze nahrát."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL CHYBA: návratovı kód není celé èíslo!? Oznamte, prosím, tuto "
+#~ "chybu na vim-dev@vim.org"
+
+#~ msgid "cannot get line"
+#~ msgstr "nelze pøeèíst øádek"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Není moné zaznamenat jméno command serveru"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Neexistuje registrovanı server jménem \"%s\""
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Selhalo zaslání pøíkazu urèenému programu"
+
+#~ msgid "E249: couldn't read VIM instance registry property"
+#~ msgstr "E249: nelze èíst VIM instanci registry property"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: VIM instance registry property byla špatnì vytvoøenaa byla smazána!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "VIM nebyl pøeloen s volbou +diff"
+
+#~ msgid "\"\n"
+#~ msgstr "\"\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tpøihlásit gvim na OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-register\t\todhlásit gvim z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tspustit v GUI reimu (stejné jako \"gvim\")"
+
+#~ msgid "-f\t\t\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f\t\t\tPopøedí: pøi startu GUI se neoddìlí od shellu"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tÚroveò vıpisu hlášek"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNebude pouívat newcli pro otevøení okna"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <zaøízení>\t\tPouít <zaøízení> pro I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tPouije <gvimrc> místo jakéhokoliv .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEditace zašifrovanıch souborù"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tSpustí vim na danı X-server"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNepøipojí se k X serveru"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtevøe Vim uvnitø jiného GTK widgetu"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server and exit"
+#~ msgstr "--remote <soubory>\tEdituje <soubory> na Vim serveru a skonèí"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <soubory> Jako --remote, ale èeká na soubory k editaci"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <klávesy>\tPøedá <klávesy> Vim serveru a skonèí"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <vıraz>\tProvede <vıraz> na serveru a zobrazí vısledek"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVypíše seznam dostupnıch Vim serverù a skonèí"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr ""
+#~ "--servername <jméno>\tZašle serveru <jméno>/stane se Vim serverem <jméno>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (Motif verzi):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (Athena verzi):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tSpustí vim na <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tSpustí vim minimalizované"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <název>\t\tPouije resource jako by vim mìl <název>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (není implementováno)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <barva>\tNastaví <barvu> pozadí (také -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <barva>\tNastaví <barvu> popøedí (také -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <písmo>\t\tNastaví <písmo> normálního textu (také -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <písmo>\tNastaví <písmo> pro zvıraznìnı text"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <písmo>\tNastaví <písmo> pro kurzívu"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geometrie>\tNastaví <geometrii> (také -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <šíøka>\tNastaví <šíøku> okrajù (také -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <šíøku> Nastaví <šíøku> posunovací lišty (také: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <vıška>\tNastaví <vıšku> nabídky (také -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tPouije reverzní barvy (také -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNepouije reverzní barvy (také +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tNastaví zadanı <resource>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (RISC OS verzi):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <poèet>\t<poèet> sloupcù na okno"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <poèet>\t<poèet> øádkù na okno"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (GTK+ verzi):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tSpustí vim na <display> (také --display)"
+
+#~ msgid "--help\t\tShow Gnome arguments"
+#~ msgstr "--help\t\tVypíše Gnome pøepínaèe"
+
+#~ msgid ""
+#~ "\n"
+#~ "Send failed.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøedání vırazu selhalo.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Send failed. Trying to execute locally\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøedání selhalo. Zkouším provést lokálnì\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d z %d editováno"
+
+#~ msgid "Send expression failed.\n"
+#~ msgstr "Pøedání vırazu selhalo.\n"
+
+#~ msgid "Not a valid codepage"
+#~ msgstr "Chybná kódová stránka"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nepodaøilo se vytvoøit vstupní kontext"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nepodaøilo se otevøít vstupní metodu"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Varování: likvidaèní zpìtné volání nelze nastavit na IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: vstupní metoda nepodporuje ádnı styl"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: vstupní metoda nepodporuje mùj 'preedit' typ"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: Nadbodovı styl vyaduje fontset"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Máte GTK+ verze starší ne 1.2.3. Stavová plocha vypnuta."
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Server vstupních metod nebìí"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nepouitelné s touto verzí Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Odtrhnout tuto nabídku"
+
+#~ msgid "[string too long]"
+#~ msgstr "[pøíliš dlouhı øetìzec]"
+
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "pokraèování stiskem ENTER"
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: øádek, MEZERNÍK/b: stránka, d/u: 0.5 stránky, q: konec)"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: øádek, MEZERNÍK: stránka, d: 0.5 stránky, q: konec)"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialog pro ukládání souborù"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialog pro otevírání souborù"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Lituji, ale konzolová verze nepodporuje prohlíeè souborù"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachovávám soubory...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: ukonèen\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "CHYBA: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtù] celkem uvolnìno-alokováno %<PRIu64>-%<PRIu64>, vyuito %<PRIu64>, "
+#~ "maximální vyuití %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[volání] celkem re/malloc(): %<PRIu64>, celkem free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Øádek se stává pøíliš dlouhım"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
+
+#~ msgid "Illegal mouseshape"
+#~ msgstr "Chybnı tvar myši"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Zadejte šifrovací klíè: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Zadejte ještì jednou tentı klíè:"
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Klíèe se neshodují"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "poèet uvolòovanıch øádkù: %<PRId64>"
+
+#~ msgid "Cannot change term in GUI"
+#~ msgstr "V GUI nelze mìnit term"
+
+#~ msgid "Use \":gui\" to start the GUI"
+#~ msgstr "Pouijte \"gui\" pro spuštìní GUI"
+
+#~ msgid "Invalid font(s)"
+#~ msgstr "Chybná písma"
+
+#~ msgid "can't select fontset"
+#~ msgstr "nelze vybrat sadu písem"
+
+#~ msgid "Invalid fontset"
+#~ msgstr "chybná sada písem"
+
+#~ msgid "can't select wide font"
+#~ msgstr "nelze vybrat širokı font"
+
+#~ msgid "Invalid wide font"
+#~ msgstr "Chybné široké písmo"
+
+#~ msgid "No mouse support"
+#~ msgstr "Bez podpory myši"
+
+#~ msgid "cannot open "
+#~ msgstr "nelze otevøít "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nelze otevøít nové okno!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Vyaduje Amigados verze 2.04 nebo vyšší\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Vyaduje %s verze %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nelze otevøít NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr " Nelze vytvoøit "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim bude ukonèen %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "Nelze zmìnit mód konzole ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: neni konzole??\n"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nelze spustit "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " návratová hodnota shellu\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE je pøíliš malá."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O CHYBA"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(kráceno)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' není 80, nelze spustit externí pøíkaz"
+
+#~ msgid "to %s on %s"
+#~ msgstr "do %s v %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Chyba tisku: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Vytištìno '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Nepøípustná jméno znakové sady \"%s\" ve fontu \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Nepøípustnı znak '%c' ve fontu \"%s\""
+
+#~ msgid "E366: Invalid 'osfiletype' option - using Text"
+#~ msgstr "E366: Neplatnı 'osfiletype' - pouit Text"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "VIm: dvojitı signál, konèím\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Zachycen smrtelnı signál %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Zachycen smrtelnı signál\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Doba otevírání X displeje (v ms): %<PRId64>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: chyba X11\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test X displeje se nezdaøil"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Vypršel èas pøi èekání na otevøení X displeje"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nelze spustit sh shell\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nelze vytvoøit roury\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Volání fork selhalo\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøíkaz ukonèen\n"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otevøení X displeje se nezdaøilo"
+
+#~ msgid "At line"
+#~ msgstr "Na øádku"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nelze naèíst vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Chyba VIMu"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nelze nastavit ukazatele funkcí na DLL"
+
+#~ msgid "shell returned %d"
+#~ msgstr "návratová hodnota shellu %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Zachycen %s signál\n"
+
+#~ msgid "close"
+#~ msgstr "zavøít"
+
+#~ msgid "logoff"
+#~ msgstr "logoff"
+
+#~ msgid "shutdown"
+#~ msgstr "shutdown"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Pøíkaz není k dispozici"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE se nevyskytuje ve Vaší $PATH.\n"
+#~ "Externí pøíkazy nebudou "
+
+#~ msgid "Vim Warning"
+#~ msgstr "Varování"
+
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr ""
+#~ "E361: Zachyceno pøeteèení zásobníku: pøíliš sloitı regulární vıraz?"
+
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: vzorek zpùsobil pøeteèení zásobníku"
+
+#~ msgid " BLOCK"
+#~ msgstr " BLOK"
+
+#~ msgid " LINE"
+#~ msgstr " ØÁDEK"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: obsahuje argumenty, které zde nejsou povoleny"
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "Zadejte èíslo (<CR> pro ukonèení): "
+
+#~ msgid "Linear tag search"
+#~ msgstr "Lineární hledání tagu"
+
+#~ msgid "Binary tag search"
+#~ msgstr "Binární hledání tagu"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Soubor tagù %s byl oøezán\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "spuštìn novı shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "odstranìní zmìn není moné; chcete pøesto pokraèovat"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32 bitová GUI verze pro MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová GUI verze pro MS Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " ve Win32s reimu"
+
+#~ msgid " with OLE support"
+#~ msgstr " s OLE podporou"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verze pro MS Windows konzolu"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová verze pro MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verze pro MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová MS-DOS verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "velká verze "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "normální verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "malá verze "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "minimální verze"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "s rozhraním GTK-GNOME"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "s rozhraním GTK"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "s rozhraním X11-Motif"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "S rozhraním X11-Athena"
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "s rozhraním BeOS"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "s rozhraním Photon"
+
+#~ msgid "with GUI."
+#~ msgstr "s grafickım rozhraním"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "s grafickım rozhraním Carbon"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "s grafickım rozhraním Cocoa"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "s (clasickım) grafickım rozhraním"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  systémovı gvimrc soubor: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    uivatelskı gvimrc soubor: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "druhı uivatelskı gvimrc soubor: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "tøetí uivatelskı gvimrc soubor: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    systémovı soubor s menu: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Pøekladaè: "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "VAROVÁNÍ: detekovány Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "zadejte :help windows95<Enter> pro podrobnìjší informace"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Editace &multiple Vimy"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Editace jedním $Vim -em"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Editace &Vim -em"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "Editace existujícím Vimem - &"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Editace vybranıch souborù Vimem"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Chyba pøi spouštìní procesu: Zkontrolujte zdali je gvim v $PATH!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "chyba gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Název (v path) je pøíliš dlouhı"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: nelze pouít hebrejskı reim:  nebyl zapnut pøi pøekladu programu\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Nelze pouít farsi reim:  nebyl zapnut pøi pøekladu programu\n"

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -8,142 +8,219 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: vim-6.0\n"
-"POT-Creation-Date: 2001-10-08 08:27-0700\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2002-02-06 22:29+0100\n"
 "Last-Translator: Jiøí Pavlovský <jpavlovsky@mbox.vol.cz>\n"
 "Language-Team: Czech <cs@li.org>\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-2\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "E258: Nelze pøedat klientovi"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nelze alokovat ¾ádný buffer, konèím..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nelze alokovat buffer, pou¾iji jiný..."
 
-msgid "No buffers were unloaded"
+#: ../buffer.c:763
+#, fuzzy
+msgid "E515: No buffers were unloaded"
 msgstr "®ádný buffer nebyl deaktivován"
 
-msgid "No buffers were deleted"
+#: ../buffer.c:765
+#, fuzzy
+msgid "E516: No buffers were deleted"
 msgstr "®ádný buffer nebyl smazán"
 
-msgid "No buffers were wiped out"
+#: ../buffer.c:767
+#, fuzzy
+msgid "E517: No buffers were wiped out"
 msgstr "®ádný buffer nebyl zahozen"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Poèet deaktivovaných bufferù: 1"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Poèet deaktivovaných bufferù: %d"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Poèet smazaných bufferù: 1"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Poèet smazaných bufferù: %d"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Poèet zahozených bufferù: 1"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Poèet zahozených bufferù: %d"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Poslední buffer nelze deaktivovat"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nebyl nalezen ¾ádný zmìnìný buffer"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Seznam bufferù je prázdný"
 
-#, c-format
-msgid "E86: Cannot go to buffer %<PRId64>"
-msgstr "E86: Nelze pøeskoèit na buffer %<PRId64>"
+#: ../buffer.c:913
+#, fuzzy, c-format
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E92: Buffer %<PRId64> nenalezen"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za poslední buffer nelze pøeskoèit"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pøed první buffer nelze pøeskoèit"
 
-#, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (use ! to override)"
+#: ../buffer.c:945
+#, fuzzy, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Zmìny v bufferu %<PRId64> nebyly ulo¾eny (! pro vynucení)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Poslední buffer nelze deaktivovat"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varování: pøeteèení seznamu s názvy souborù"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Buffer %<PRId64> nenalezen"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Vzoru %s vyhovuje více bufferù"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje ¾ádný buffer"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "øádek %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer tohoto jména ji¾ existuje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmìnìný]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Needitovaný]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nový soubor]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Chyby pøi ètení]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[Pouze pro ètení]"
 
+#: ../buffer.c:2524
+#, c-format
 msgid "1 line --%d%%--"
 msgstr "øádkù: --%d%%--"
 
+#: ../buffer.c:2526
+#, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "øádkù: %<PRId64> --%d%%--"
 
+#: ../buffer.c:2530
+#, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "øádek %<PRId64>/%<PRId64> --%d%%-- sloupec"
 
-msgid "[No file]"
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+#, fuzzy
+msgid "[No Name]"
 msgstr "[®ádný soubor]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "nápovìda"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[nápovìda]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[náhled]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "V¹e"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Konec"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Zaèátek"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -151,12 +228,11 @@ msgstr ""
 "\n"
 "# Seznam bufferù:\n"
 
-msgid "[Error List]"
-msgstr "[seznam chyb]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[No File]"
-msgstr "[¾ádný soubor]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -164,115 +240,221 @@ msgstr ""
 "\n"
 "--- Znaky ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaky pro %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    øádek=%<PRId64> id=%d jméno=%s"
 
+#: ../cursor_shape.c:68
+#, fuzzy
+msgid "E545: Missing colon"
+msgstr "Chybí dvojteèka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+#, fuzzy
+msgid "E546: Illegal mode"
+msgstr "nepøípustný mód"
+
+#: ../cursor_shape.c:134
+#, fuzzy
+msgid "E548: digit expected"
+msgstr "oèekávána èíslice"
+
+#: ../cursor_shape.c:138
+#, fuzzy
+msgid "E549: Illegal percentage"
+msgstr "nepøípustné procento"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nelze pøekroèit maximální poèet %<PRId64> diff bufferù"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E164: Pøed první soubor nelze pøeskoèit"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nelze vytvoøit diffy"
 
-msgid "Patch file"
-msgstr "Soubor se záplatou"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Nelze èíst výstup programu diff"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nelze èíst výstup programu diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktuální buffer není v diff re¾imu"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: To byl poslední buffer v diff re¾imu"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: To byl poslední buffer v diff re¾imu"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
-msgstr "E101: V diff re¾imu jsou více ne¾ dva buffery. Nevím, který mám pou¾ít."
+msgstr ""
+"E101: V diff re¾imu jsou více ne¾ dva buffery. Nevím, který mám pou¾ít."
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nelze nalézt buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffer \"%s\" není v diff re¾imu"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: digraph nesmí obsahovat Escape"
 
-msgid "Keymap file not found"
+#: ../digraph.c:1760
+#, fuzzy
+msgid "E544: Keymap file not found"
 msgstr "Soubor s mapou klávesnice nebyl nalezen"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap mimo interpretovaný soubor"
 
-msgid " Keyword completion (^N/^P)"
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
+#, fuzzy
+msgid " Keyword completion (^N^P)"
 msgstr " Doplòování klíèových slov (^N/^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^E/^Y/^L/^]/^F/^I/^K/^D/^V/^N/^P)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X re¾im (^E/^Y/^L/^]/^F/^I/^K/^D/^V/^N/^P)"
 
-#. Scroll has it's own msgs, in it's place there is the msg for local
-#. * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-msgid " Keyword Local completion (^N/^P)"
-msgstr " Lokální doplòování klíèových slov (^N/^P)"
-
-msgid " Whole line completion (^L/^N/^P)"
+#: ../edit.c:85
+#, fuzzy
+msgid " Whole line completion (^L^N^P)"
 msgstr " Doplòování celých øádkù (^L/^N/^P)"
 
-msgid " File name completion (^F/^N/^P)"
+#: ../edit.c:86
+#, fuzzy
+msgid " File name completion (^F^N^P)"
 msgstr " Doplòování názvù souborù (^F/^N/^P)"
 
-msgid " Tag completion (^]/^N/^P)"
+#: ../edit.c:87
+#, fuzzy
+msgid " Tag completion (^]^N^P)"
 msgstr " Doplòování tagù (^I/^N/^P)"
 
-msgid " Path pattern completion (^N/^P)"
+#: ../edit.c:88
+#, fuzzy
+msgid " Path pattern completion (^N^P)"
 msgstr " Doplòování vzoru cest (^N/^P)"
 
-msgid " Definition completion (^D/^N/^P)"
+#: ../edit.c:89
+#, fuzzy
+msgid " Definition completion (^D^N^P)"
 msgstr " Doplòování definic (^D/^N/^P)"
 
-msgid " Dictionary completion (^K/^N/^P)"
+#: ../edit.c:91
+#, fuzzy
+msgid " Dictionary completion (^K^N^P)"
 msgstr " Doplòování podle slovníku (^K/^N/^P)"
 
-msgid " Thesaurus completion (^T/^N/^P)"
+#: ../edit.c:92
+#, fuzzy
+msgid " Thesaurus completion (^T^N^P)"
 msgstr " Doplòování podle tezauru (^T/^N/^P)"
 
-msgid " Command-line completion (^V/^N/^P)"
+#: ../edit.c:93
+#, fuzzy
+msgid " Command-line completion (^V^N^P)"
 msgstr " Doplòování pøíkazové øádky (^I/^N/^P)"
 
+#: ../edit.c:94
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " Doplòování celých øádkù (^L/^N/^P)"
+
+#: ../edit.c:95
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " Doplòování tagù (^I/^N/^P)"
+
+#: ../edit.c:96
+msgid " Spelling suggestion (s^N^P)"
+msgstr ""
+
+#: ../edit.c:97
+#, fuzzy
+msgid " Keyword Local completion (^N^P)"
+msgstr " Lokální doplòování klíèových slov (^N/^P)"
+
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Konec odstavce"
 
-msgid "'thesaurus' option is empty"
-msgstr "volba 'thesaurus' je prázdná"
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
 
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "volba 'dictionary' je prázdná"
 
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr "volba 'thesaurus' je prázdná"
+
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Prohledávám slovník %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (insert) Rolování (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (replace) Rolování (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Prohledávám %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Prohledávám tagy"
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr "Pøidávám"
 
@@ -280,179 +462,600 @@ msgstr "Pøidávám"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Hledám..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Výchozí podoba"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Slovo z jiného øádku"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jediná shoda"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "shoda %d/%d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "shoda %d"
 
-#, c-format
-msgid "E106: Unknown variable: \"%s\""
-msgstr "E106: Neznámá promìnná: \"%s\""
+#: ../eval.c:137
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: Neoèekávané znaky pøed '='"
 
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: Chybí závorky: %s"
+#: ../eval.c:138
+#, fuzzy, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E322: poèet øádkù mimo rozsah: %<PRId64> > celkový poèet øádkù"
 
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: Promìnná \"%s\" neexistuje"
-
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: Po '?' chybí ':'"
-
-msgid "E110: Missing ')'"
-msgstr "E110: Chybìjící ')'"
-
-msgid "E111: Missing ']'"
-msgstr "E111: Chybìjící ']'"
-
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: Chybí jméno volby: %s"
-
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: Neznámá volba: %s"
-
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: Chybí uvozovky: %s"
-
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: Chybí uvozovky: %s"
-
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: Chybné argumenty pro funkci %s"
-
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: Neznámá funkce: %s"
-
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: Pøíli¹ mnoho argumentù pro funkci %s"
-
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Pøíli¹ málo argumentù pro funkci %s"
-
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: Pou¾ití <SID> mimo kontext skriptu: %s"
-
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld øádkù:"
-
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zru¹it"
-
-msgid "E240: No connection to Vim server"
-msgstr "E240: Neexistuje pøipojení k Vim serveru"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nelze èíst odpovìï serveru"
-
-msgid "E258: Unable to send to client"
-msgstr "E258: Nelze pøedat klientovi"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nelze pøedat do %s"
-
-msgid "(Invalid)"
-msgstr "(Chybný)"
-
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nedefinovaná promìnná: %s"
 
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr "E111: Chybìjící ']'"
+
+#: ../eval.c:141
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "Argument musí být kladný"
+
+#: ../eval.c:143
 #, c-format
-msgid "E122: Function %s already exists, use ! to replace"
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: Nelze najít doèasný temp soubor pro zápis"
+
+#: ../eval.c:145
+#, fuzzy
+msgid "E714: List required"
+msgstr "E397: Vy¾adován název souboru"
+
+#: ../eval.c:146
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: Je vy¾adováno jméno funkce"
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Pøíli¹ mnoho argumentù pro funkci %s"
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
+#, fuzzy, c-format
+msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkce %s ji¾ existuje. Pou¾ijte ! pro její nahrazení."
 
+#: ../eval.c:151
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: Buffer tohoto jména ji¾ existuje"
+
+#: ../eval.c:152
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: Je vy¾adováno jméno funkce"
+
+#: ../eval.c:153
+#, fuzzy
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E360: Nelze spustit shell s parametrem -f"
+
+#: ../eval.c:154
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr ""
+
+#: ../eval.c:155
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: Neznámá funkce: %s"
+
+#: ../eval.c:156
+#, fuzzy, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E418: nepøípustná hodnota: %s"
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E235: Nelze pou¾ít font %s"
+
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: Chybí závorky: %s"
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: Promìnná \"%s\" neexistuje"
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+#, fuzzy
+msgid "E692: Invalid operation for Lists"
+msgstr "E15: Chybný výraz: %s"
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: Chybné argumenty pro funkci %s"
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: Chybné argumenty pro funkci %s"
+
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: Nelze spustit shell s parametrem -f"
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr "E110: Chybìjící ')'"
+
+#: ../eval.c:4609
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: Poslední buffer nelze deaktivovat"
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: Chybí jméno volby: %s"
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: Neznámá volba: %s"
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: Chybí uvozovky: %s"
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: Chybí uvozovky: %s"
+
+#: ../eval.c:5084
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: Chybí rovnítko: %s"
+
+#: ../eval.c:5091
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: Chybí '=': %s"
+
+#: ../eval.c:6475
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E242: Chybí barva: %s"
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E242: Chybí barva: %s"
+
+#: ../eval.c:6524
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: Chybí :endfunction"
+
+#: ../eval.c:6555
+#, fuzzy
+msgid "E724: variable nested too deep for displaying"
+msgstr "E22: Skript vnoøen pøíli¹ hluboko"
+
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Pøíli¹ mnoho argumentù pro funkci %s"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: Chybné argumenty pro funkci %s"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Neznámá funkce: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Pøíli¹ málo argumentù pro funkci %s"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: Pou¾ití <SID> mimo kontext skriptu: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+msgid "E808: Number or Float required"
+msgstr ""
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:7907
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "Pøíli¹ mnoho edit argumentù"
+
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: Nabídka existuje pouze v jiném módu"
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr "&Ok"
+
+#: ../eval.c:8676
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: pro %s ji¾ mapování ji¾ existuje"
+
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld øádkù:"
+
+#: ../eval.c:9291
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: Neznámá funkce: %s"
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr ""
+
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E407: %s zde není povoleno"
+
+#: ../eval.c:11140
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E178: Chybná implicitní hodnota pro poèet"
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:12466
+#, fuzzy
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E255: Nastaveno pøíli¹ mnoho voleb"
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "Chybný argument"
+
+#: ../eval.c:13776
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: Nelze zvolit tiskárnu"
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr "(Chybný)"
+
+#: ../eval.c:14590
+#, fuzzy
+msgid "E677: Error writing temp file"
+msgstr "E208: Chyba pøi zápisu do \"%s\""
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+#, fuzzy
+msgid "E730: using List as a String"
+msgstr "E374: Ve formátovacím øetìzci chybí ]"
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, fuzzy, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E93: Vzoru %s vyhovuje více bufferù"
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+
+#: ../eval.c:16724
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: Název funkce musí zaèínat velkým písmenem: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr "Neznámý"
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E284: Nelze nastavit IC hodnoty"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Nedefinovaná funkce: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Chybí '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Nelze nastavit IC hodnoty"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Nepøípustný argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: Duplicitní tag \"%s\" v souboru %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Chybí :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: Název funkce musí zaèínat velkým písmenem: %s"
+
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Nelze pøedefinovat funkci %s: je pou¾ívána"
 
-#, c-format
-msgid "E128: Function name must start with a capital: %s"
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
 msgstr "E128: Název funkce musí zaèínat velkým písmenem: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Je vy¾adováno jméno funkce"
 
-msgid "function "
-msgstr "funkce "
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr "E128: Název funkce musí zaèínat velkým písmenem: %s"
 
-#, c-format
-msgid "E130: Undefined function: %s"
-msgstr "E130: Nedefinovaná funkce: %s"
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Název funkce musí zaèínat velkým písmenem: %s"
 
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nelze smazat funkci %s: je ji¾ pou¾ívána"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zanoøení funkce je hlub¹í ne¾ 'maxfuncdepth'"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "volám %s"
 
-#. always scroll up, don't overwrite
-#, c-format
-msgid "continuing in %s"
-msgstr "pokraèuji v %s"
+#: ../eval.c:18651
+#, fuzzy, c-format
+msgid "%s aborted"
+msgstr "Pøíkaz pøeru¹en"
 
-msgid "E133: :return not inside a function"
-msgstr "E133: :return mimo funkci"
-
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "dokonèeno provádìní %s. Návratová hodnota #%<PRId64>"
 
-#, c-format
-msgid "%s returning \"%s\""
+#: ../eval.c:18670
+#, fuzzy, c-format
+msgid "%s returning %s"
 msgstr "dokonèeno provádìní %s. Návratová hodnota \"%s\""
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
+#, c-format
+msgid "continuing in %s"
+msgstr "pokraèuji v %s"
+
+#: ../eval.c:18795
+msgid "E133: :return not inside a function"
+msgstr "E133: :return mimo funkci"
+
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -460,66 +1063,114 @@ msgstr ""
 "\n"
 "# globální promìnné:\n"
 
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+"\n"
+"\tNaposledy nastavena z "
+
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "®ádné vlo¾ené soubory"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  ¹estnáctkovì %02x,  osmièkovì %03o"
 
+#: ../ex_cmds.c:145
+#, fuzzy, c-format
+msgid "> %d, Hex %04x, Octal %o"
+msgstr "<%s>%s%s  %d,  ¹estnáctkovì %02x,  osmièkovì %03o"
+
+#: ../ex_cmds.c:146
+#, fuzzy, c-format
+msgid "> %d, Hex %08x, Octal %o"
+msgstr "<%s>%s%s  %d,  ¹estnáctkovì %02x,  osmièkovì %03o"
+
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Nelze pøesunout øádky na pùvodní místo"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "poèet pøesunutých øádkù: 1"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Poèet pøesunutých øádkù: %<PRId64>"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Poèet filtrovaných øádkù: %<PRId64>"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické pøíkazy *Filter* nesmí mìnit aktuální buffer"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Neulo¾ené zmìny]\n"
 
-#, c-format
-msgid "viminfo: %s in line: "
+#: ../ex_cmds.c:1424
+#, fuzzy, c-format
+msgid "%sviminfo: %s in line: "
 msgstr "viminfo: %s na øádku: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: pøíli¹ mnoho chyb, pøeskakuji zbytek souboru"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Ètu viminfo soubor \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informace"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " znaèky"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "®ádné vlo¾ené soubory"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " se nezdaøilo"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: do viminfo souboru %s nelze zapisovat"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nelze ulo¾it viminfo soubor %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Ukládám viminfo souboru \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
+#, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tento viminfo soubor byl vytvoøen editorem Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -527,92 +1178,141 @@ msgstr ""
 "# Pokud budete opatrný, mù¾ete jej upravovat.\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Hodnota volby 'encoding' v dobì ulo¾ení tohoto souboru\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Nepøípustný poèáteèní znak"
 
-msgid "Save As"
-msgstr "Ulo¾it jako"
-
-#. Overwriting a file that is loaded in another buffer is not a
-#. * good idea.
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Soubor je nahrán v jiném bufferu"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Ulo¾it neúplný soubor?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Pou¾ijte ! pro ulo¾ení neúplného bufferu"
 
-#, c-format
-msgid "Overwrite existing file \"%.*s\"?"
+#: ../ex_cmds.c:2281
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
 msgstr "Pøepsat soubor \"%.*s\"?"
 
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: Soubor existuje (pou¾ijte ! pro vynucení)"
+
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: ®ádný název souboru pro buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Soubor nebyl ulo¾en: Ukládání je zakázáno volbou 'write'"
 
-#, c-format
+#: ../ex_cmds.c:2434
+#, fuzzy, c-format
 msgid ""
-"'readonly' option is set for \"%.*s\".\n"
+"'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "Pro \"%.*s\" je nastavena volba 'readonly'.\n"
 "Pøejete si ji potlaèit?"
 
-msgid "Edit File"
-msgstr "Editovat soubor"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "je pouze pro ètení (pou¾ijte ! pro vynucení)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Automatické pøíkazy neoèekávanì smazaly nový buffer %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselný argument pro :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim nepovoluje pou¾ití pøíkazù shellu"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulární výrazy nesmí být oddìleny písmeny"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "nahradit za %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Pøeru¹eno) "
 
+#: ../ex_cmds.c:4384
+#, fuzzy
+msgid "1 match"
+msgstr "®ádná shoda"
+
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 nahrazení"
 
+#: ../ex_cmds.c:4387
+#, fuzzy, c-format
+msgid "%<PRId64> matches"
+msgstr "poèet zmìn: %<PRId64>"
+
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> nahrazení"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " na jednom øádku"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " na %<PRId64> øádcích"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global nelze volat rekurzivnì"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: U pøíkazu 'global' chybí regulární výraz"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Vzor nalezen na ka¾dém øádku: %s"
 
+#: ../ex_cmds.c:4510
+#, c-format
+msgid "Pattern not found: %s"
+msgstr "Vzor nenalezen: %s"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -622,263 +1322,350 @@ msgstr ""
 "# Poslední nahrazující øetìzec:\n"
 "$"
 
+#: ../ex_cmds.c:4679
+#, fuzzy
+msgid "E478: Don't panic!"
+msgstr "Nepanikaøte!"
+
+#: ../ex_cmds.c:4717
+#, fuzzy, c-format
+msgid "E661: Sorry, no '%s' help for %s"
+msgstr "E149: Lituji, pro %s není ¾ádná nápovìda"
+
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Lituji, pro %s není ¾ádná nápovìda"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Lituji, soubor \"%s\" s nápovìdou nebyl nalezen"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s není adresáøem"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Nelze otevøít %s pro zápis"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Nelze otevøít %s pro zápis"
 
+#: ../ex_cmds.c:5500
 #, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s"
+msgid "E670: Mix of help file encodings within a language: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5565
+#, fuzzy, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplicitní tag \"%s\" v souboru %s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Neznámá volba pøíkazu: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Chybí jméno volby"
 
-msgid "E255: Too many signs defined"
+#: ../ex_cmds.c:5746
+#, fuzzy
+msgid "E612: Too many signs defined"
 msgstr "E255: Nastaveno pøíli¹ mnoho voleb"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Neplatný text volby: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Neznámá volba: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Chybí identifikátor volby"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: chybné jméno bufferu: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Chybné ID volby: %<PRId64>"
 
+#: ../ex_cmds.c:6066
+#, fuzzy
+msgid " (not supported)"
+msgstr "Volba není podporována"
+
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Vymazáno]"
 
-msgid "Entering Debug mode.  Type \"cont\" to leave."
+#: ../ex_cmds2.c:139
+#, fuzzy
+msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Spou¹tím ladící re¾im. Pro ukonèení napi¹te \"cont\"."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "øádek %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "pøíkaz: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Bod pøeru¹ení v \"%s%s\" na øádku %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Bod pøeru¹ení nenalezen: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Nebyly definovánu ¾ádné body pøeru¹ení"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  øádek %<PRId64>"
 
-#, c-format
-msgid "Save changes to \"%.*s\"?"
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
 msgstr "Ulo¾it zmìny do \"%.*s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Nepojmenováno"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Buffer \"%s\" obsahuje neulo¾ené zmìny"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Varování: Neèekaný vstup do jiného bufferu (zkontrolujte automatické pøíkazy)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Pro editaci byl zadán pouze jeden soubor"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Pøed první soubor nelze pøeskoèit"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Za poslední soubor nelze pøeskoèit"
 
+#: ../ex_cmds2.c:2175
+#, fuzzy, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E432: Obsah soubor tagù %s není seøazen"
+
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Hledám \"%s\" v \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Hledám \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "soubor \"%s\" nebyl nalezen v 'runtimepath'"
 
-msgid "Run Macro"
-msgstr "Spustit makro"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "nelze interpretovat adresáø: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "nelze interpretovat \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "øádek %<PRId64>: nelze interpretovat \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretuji \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "øádek %<PRId64>: interpretuji %s"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "dokonèena interpretace %s"
 
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "poèet nových øádkù: 1"
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr "Chybný argument"
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr "Chybný argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr ""
+
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Varování: chybný oddìlovaè øádkù. Mo¾ná chybí ^M."
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding pou¾ito mimo interpretovaný soubor"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish pou¾ito mimo interpretovaný soubor"
 
-msgid "No text to be printed"
-msgstr "®ádný text k vyti¹tìní"
-
-msgid "Printing page %d (%d%%)"
-msgstr "Tisknu stranu %d (%d%%)"
-
-#, c-format
-msgid " Copy %d of %d"
-msgstr " Kopie %d z %d"
-
-#, c-format
-msgid "Printed: %s"
-msgstr "Vyti¹tìno: %s"
-
-msgid "Printing aborted"
-msgstr "Tisk zru¹en"
-
-msgid "E455: Error writing to PostScript output file"
-msgstr "E455: Nelze zapisovat do výstupního PostScriptového souboru"
-
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: Nelze otevøít výstupní PostScriptový soubor"
-
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: Nelze otevøít soubor \"%s\""
-
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
-
-msgid "Sending to printer..."
-msgstr "Odesílám na tiskárnu..."
-
-msgid "E365: Failed to print PostScript file"
-msgstr "E365: Selhal tisk PostScriptového souboru"
-
-msgid "Print job sent."
-msgstr "Tisková úloha odeslána."
-
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Aktuální %sjazyk: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Nelze nastavit jazyk na \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Spou¹tím Ex mód. Napi¹te \"visual\" pro návrat do normálního módu."
 
-#. must be at EOF
-msgid "At end-of-file"
+#: ../ex_docmd.c:428
+#, fuzzy
+msgid "E501: At end-of-file"
 msgstr "Konec souboru"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Pøíkaz je pøíli¹ rekurzivní"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Chybí :endwhile"
+#: ../ex_docmd.c:1006
+#, fuzzy, c-format
+msgid "E605: Exception not caught: %s"
+msgstr "E161: Bod pøeru¹ení nenalezen: %s"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Chybí :endif"
-
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Konec interpretovaného souboru"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Konec funkce"
 
-msgid "Ambiguous use of user-defined command"
+#: ../ex_docmd.c:1628
+#, fuzzy
+msgid "E464: Ambiguous use of user-defined command"
 msgstr "Nejednoznaèné pou¾ití u¾ivatelsky definovaného pøíkazu"
 
-msgid "Not an editor command"
+#: ../ex_docmd.c:1638
+#, fuzzy
+msgid "E492: Not an editor command"
 msgstr "Není pøíkazem editoru"
 
-msgid "Don't panic!"
-msgstr "Nepanikaøte!"
-
-msgid "Backwards range given"
+#: ../ex_docmd.c:1729
+#, fuzzy
+msgid "E493: Backwards range given"
 msgstr "Zadán zpìtný rozsah"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Zadán zpìtný rozsah. Prohodit hranice"
 
-msgid "Use w or w>>"
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
+#, fuzzy
+msgid "E494: Use w or w>>"
 msgstr "Pou¾ijte w èi w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Pøíkaz není této verzi bohu¾el implementován"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Pøípustný je pouze jeden název souboru"
 
+#: ../ex_docmd.c:4238
+#, fuzzy
+msgid "1 more file to edit.  Quit anyway?"
+msgstr "Je¹tì zbývají soubory k editaci (%d). Chcete pøesto ukonèit editor?"
+
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Je¹tì zbývají soubory k editaci (%d). Chcete pøesto ukonèit editor?"
 
+#: ../ex_docmd.c:4248
+#, fuzzy
+msgid "E173: 1 more file to edit"
+msgstr "E173: Je¹tì zbývají soubory k editaci (%<PRId64>)."
+
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Je¹tì zbývají soubory k editaci (%<PRId64>)."
 
-msgid "E174: Command already exists: use ! to redefine"
+#: ../ex_docmd.c:4320
+#, fuzzy
+msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Pøíkaz ji¾ existuje: pou¾ijte ! pro pøedefinování"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -886,164 +1673,363 @@ msgstr ""
 "\n"
 "    Jméno       Args Rozsah Úplnost  Definice"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Nebyly nalezeny ¾ádné u¾ivatelsky definované pøíkazy"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nebyly zadány ¾ádné atributy"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Chybný poèet argumentù"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Opakování nemù¾e být zadáno dvakrát"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Chybná implicitní hodnota pro poèet"
 
-msgid "E179: argument required for complete"
+#: ../ex_docmd.c:4625
+#, fuzzy
+msgid "E179: argument required for -complete"
 msgstr "E179: chybná implicitní hodnota pro opakování"
 
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: Chybná hodnota doplnìní: %s"
-
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Chybný atribut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Chybné jméno pøíkazu"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: U¾ivatelsky definované pøíkazy musí zaèínat velikým písmenem."
 
+#: ../ex_docmd.c:4696
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr ""
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: U¾ivatelsky definovaný pøíkaz %s neexistuje"
 
+#: ../ex_docmd.c:5219
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: Chybná hodnota doplnìní: %s"
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr ""
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr ""
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Nelze nalézt barevné schéma %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Blahopøeji, u¾ivateli Vimu!"
 
-msgid "Edit File in new window"
-msgstr "Editovat soubor v novém oknì"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Poslední okno nelze uzavøít"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "Ji¾ existuje pouze jedno okno"
+
+#: ../ex_docmd.c:6004
+#, c-format
+msgid "Tab page %d"
+msgstr ""
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "®ádný odkládací soubor"
 
-msgid "Append File"
-msgstr "Ulo¾it soubor"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr "Nelze vytvoøit zálo¾ní soubor (pou¾ijte ! pro vynucení)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: ®ádný pøedchozí adresáø"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Neznámý"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Umístìní okna: X %d, Y %d"
+#: ../ex_docmd.c:6610
+msgid "E465: :winsize requires two number arguments"
+msgstr ""
 
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Na této platformì nelze umístìní okna zjistit"
 
-msgid "Save Redirection"
-msgstr "Ulo¾it pøesmìrování"
+#: ../ex_docmd.c:6662
+#, fuzzy
+msgid "E466: :winpos requires two number arguments"
+msgstr "E176: Chybný poèet argumentù"
 
-msgid "Save View"
-msgstr "Ulo¾it pohled"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
+msgstr "nelze interpretovat adresáø: \"%s\""
 
-msgid "Save Session"
-msgstr "Ulo¾it sezení"
-
-msgid "Save Setup"
-msgstr "Ulo¾it nastavení"
-
-#, c-format
-msgid "E189: \"%s\" exists (use ! to override)"
+#: ../ex_docmd.c:7268
+#, fuzzy, c-format
+msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existuje (pou¾ijte ! pro vynucení)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Nelze otevøít \"%s\" pro zápis"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumentem mù¾e být pouze písmeno nebo pravý èi levý apostrof"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Vnoøení :normal je pøíli¹ hluboké"
 
-msgid ":if nesting too deep"
-msgstr "vnoøení :if je pøíli¹ hluboké"
-
-msgid ":endif without :if"
-msgstr ":endif bez odpovídajícího :if"
-
-msgid ":else without :if"
-msgstr ":else bez odpovídajícího :if"
-
-msgid ":elseif without :if"
-msgstr ":elseif bez odpovídajícího :if"
-
-msgid ":while nesting too deep"
-msgstr "vnoøení :while je pøíli¹ hluboké"
-
-msgid ":continue without :while"
-msgstr ":continue bez odpovídajícího :while"
-
-msgid ":break without :while"
-msgstr ":break bez odpovídajícího :while"
-
-msgid ":endwhile without :while"
-msgstr ":endwhile bez odpovídajícího :while"
-
-msgid "E193: :endfunction not inside a function"
-msgstr "E193: :endfunction mimo funkci"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr ""
 "E194: ®ádný alternativní název souboru, kterým by bylo mo¾né nahradit '#'"
 
-msgid "no autocommand file name to substitute for \"<afile>\""
+#: ../ex_docmd.c:7841
+#, fuzzy
+msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "®ádný název souboru, kterým by bylo mo¾né nahradit \"<afile>\""
 
-msgid "no autocommand buffer number to substitute for \"<abuf>\""
+#: ../ex_docmd.c:7850
+#, fuzzy
+msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "®ádné èíslo bufferu, kterým by bylo mo¾né nahradit \"<abuf>\""
 
-msgid "no autocommand match name to substitute for \"<amatch>\""
+#: ../ex_docmd.c:7861
+#, fuzzy
+msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "®ádná shoda automatických pøíkazù, kterou by bylo mo¾né nahradit \"<amatch>\""
 
-msgid "no :source file name to substitute for \"<sfile>\""
+#: ../ex_docmd.c:7870
+#, fuzzy
+msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "®ádný interpretovaný soubor, kterým by bylo mo¾né nahradit \"<sfile>\""
 
-#, no-c-format
-msgid "Empty file name for '%' or '#', only works with \":p:h\""
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "®ádný interpretovaný soubor, kterým by bylo mo¾né nahradit \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "Prázdný název souboru pro '%' èi '#' funguje pouze s \":p:h\""
 
-msgid "Evaluates to an empty string"
+#: ../ex_docmd.c:7905
+#, fuzzy
+msgid "E500: Evaluates to an empty string"
 msgstr "Výsledkem vyhodnocení je prázdný øetìzec"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Nelze otevøít pro ètení viminfo soubor"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: V této verzi nejsou spøe¾ky podporovány"
+#: ../ex_eval.c:464
+msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
+msgstr ""
 
+#. always scroll up, don't overwrite
+#: ../ex_eval.c:496
+#, c-format
+msgid "Exception thrown: %s"
+msgstr ""
+
+#: ../ex_eval.c:545
+#, c-format
+msgid "Exception finished: %s"
+msgstr ""
+
+#: ../ex_eval.c:546
+#, c-format
+msgid "Exception discarded: %s"
+msgstr ""
+
+#: ../ex_eval.c:588 ../ex_eval.c:634
+#, fuzzy, c-format
+msgid "%s, line %<PRId64>"
+msgstr "øádek %<PRId64>"
+
+#. always scroll up, don't overwrite
+#: ../ex_eval.c:608
+#, c-format
+msgid "Exception caught: %s"
+msgstr ""
+
+#: ../ex_eval.c:676
+#, c-format
+msgid "%s made pending"
+msgstr ""
+
+#: ../ex_eval.c:679
+#, c-format
+msgid "%s resumed"
+msgstr ""
+
+#: ../ex_eval.c:683
+#, c-format
+msgid "%s discarded"
+msgstr ""
+
+#: ../ex_eval.c:708
+msgid "Exception"
+msgstr ""
+
+#: ../ex_eval.c:713
+#, fuzzy
+msgid "Error and interrupt"
+msgstr "pøeru¹ení z klávesnice"
+
+#: ../ex_eval.c:715
+msgid "Error"
+msgstr "Chyba"
+
+#. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
+#, fuzzy
+msgid "Interrupt"
+msgstr "Pøeru¹ení: "
+
+#: ../ex_eval.c:795
+#, fuzzy
+msgid "E579: :if nesting too deep"
+msgstr "vnoøení :if je pøíli¹ hluboké"
+
+#: ../ex_eval.c:830
+#, fuzzy
+msgid "E580: :endif without :if"
+msgstr ":endif bez odpovídajícího :if"
+
+#: ../ex_eval.c:873
+#, fuzzy
+msgid "E581: :else without :if"
+msgstr ":else bez odpovídajícího :if"
+
+#: ../ex_eval.c:876
+#, fuzzy
+msgid "E582: :elseif without :if"
+msgstr ":elseif bez odpovídajícího :if"
+
+#: ../ex_eval.c:880
+msgid "E583: multiple :else"
+msgstr ""
+
+#: ../ex_eval.c:883
+msgid "E584: :elseif after :else"
+msgstr ""
+
+#: ../ex_eval.c:941
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
+msgstr "vnoøení :while je pøíli¹ hluboké"
+
+#: ../ex_eval.c:1028
+#, fuzzy
+msgid "E586: :continue without :while or :for"
+msgstr ":continue bez odpovídajícího :while"
+
+#: ../ex_eval.c:1061
+#, fuzzy
+msgid "E587: :break without :while or :for"
+msgstr ":break bez odpovídajícího :while"
+
+#: ../ex_eval.c:1102
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: Chybí :endwhile"
+
+#: ../ex_eval.c:1104
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: Chybí :endwhile"
+
+#: ../ex_eval.c:1247
+#, fuzzy
+msgid "E601: :try nesting too deep"
+msgstr "vnoøení :if je pøíli¹ hluboké"
+
+#: ../ex_eval.c:1317
+msgid "E603: :catch without :try"
+msgstr ""
+
+#. Give up for a ":catch" after ":finally" and ignore it.
+#. * Just parse.
+#: ../ex_eval.c:1332
+msgid "E604: :catch after :finally"
+msgstr ""
+
+#: ../ex_eval.c:1451
+msgid "E606: :finally without :try"
+msgstr ""
+
+#. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
+msgid "E607: multiple :finally"
+msgstr ""
+
+#: ../ex_eval.c:1571
+#, fuzzy
+msgid "E602: :endtry without :try"
+msgstr ":endif bez odpovídajícího :if"
+
+#: ../ex_eval.c:2026
+msgid "E193: :endfunction not inside a function"
+msgstr "E193: :endfunction mimo funkci"
+
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: Není v bezpeènostní schránce povoleno"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: Vzoru %s nevyhovuje ¾ádný buffer"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "jméno tagu"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " typ soubor\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'volba 'history' je nastavena na nulu"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1052,184 +2038,315 @@ msgstr ""
 "\n"
 "# Historie %s (poèínaje nejnovìj¹í polo¾kou):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "pøíkazové øádky"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "vyhledávaných øetìzcù"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "výrazù"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "vstupní øádky"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar pøekraèuje délku pøíkazu"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Smazáno aktivní okno èi buffer"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Chybná cesta: '**[èíslo] musí být buï na konci cesty, nebo musí být\n"
+"následováno'%s. Viz :help path."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Adresáø \"%s\" nelze v cdpath nalézt"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Soubor \"%s\" nelze v path nalézt"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: ®ádný dal¹í adresáø \"%s\" nebyl v cdpath nalezen"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: ®ádný dal¹í soubor \"%s\" nebyl v cestì nalezen"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: Automatické pøíkazy *Filter* nesmí mìnit aktuální buffer"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "nepøípustný název souboru"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "je adresáøem"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "není souborem"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[nový soubor]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[pøístup odmítnut]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre automatické pøíkazy uèinily soubor neèitelným"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre automatické pøíkazy nesmí mìnit aktuální buffer"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Ètu ze standardního vstupu...\n"
 
-msgid "Reading from stdin..."
-msgstr "Ètu ze standardního vstupu..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Po konverzi je soubor neèitelný!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[pojmenovaná roura/soket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[pojmenovaná roura]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[soket]"
 
-msgid "[RO]"
-msgstr "[RO]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 znak"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[chybí CR]"
 
-msgid "[NL found]"
-msgstr "[nalezeno NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[dlouhé øádky zalomeny]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[nezkonvertován]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[zkonvertován]"
 
-msgid "[crypted]"
-msgstr "[za¹ifrován]"
-
-msgid "[CONVERSION ERROR]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[CHYBA PØEVODU]"
 
+#: ../fileio.c:1835
+#, fuzzy, c-format
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "E320: Nelze nalézt øádek %<PRId64>"
+
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[CHYBY ÈTENÍ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nelze nalézt doèasný soubor pro konverzi"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konverze s 'charconvert' se nezdaøila"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nelze èíst výstup 'charconvert'"
 
+#: ../fileio.c:2437
+#, fuzzy
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr "®ádné vyhovující automatické pøíkazy"
+
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Automatické pøíkazy smazaly èi deaktivovaly buffer, který mìl být "
 "ulo¾en"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Automatický pøíkaz neèekaným zpùsobem zmìnil poèet øádkù"
 
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "není souborem ani zaøízením na nì¾ lze zapisovat"
 
-msgid "is read-only (use ! to override)"
+#: ../fileio.c:2601
+#, fuzzy
+msgid "is read-only (add ! to override)"
 msgstr "je pouze pro ètení (pou¾ijte ! pro vynucení)"
 
-msgid "Can't write to backup file (use ! to override)"
+#: ../fileio.c:2886
+#, fuzzy
+msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "Nelze zapisovat do zálo¾ního souboru (pou¾ijte ! pro vynucení)"
 
-msgid "Close error for backup file (use ! to override)"
+#: ../fileio.c:2898
+#, fuzzy
+msgid "E507: Close error for backup file (add ! to override)"
 msgstr "Chyba pøi uzavírání zálo¾ního souboru (pou¾ijte ! pro vynucení)"
 
-msgid "Can't read file for backup (use ! to override)"
+#: ../fileio.c:2901
+#, fuzzy
+msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "Nelze naèíst soubor pro zálohu (pou¾ijte ! pro vynucení)"
 
-msgid "Cannot create backup file (use ! to override)"
+#: ../fileio.c:2923
+#, fuzzy
+msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "Nelze vytvoøit zálo¾ní soubor (pou¾ijte ! pro vynucení)"
 
-msgid "Can't make backup file (use ! to override)"
+#: ../fileio.c:3008
+#, fuzzy
+msgid "E510: Can't make backup file (add ! to override)"
 msgstr "Nelze vytvoøit zálo¾ní soubor (pou¾ijte ! pro vynucení)"
 
-# resource fork ?!
-msgid "The resource fork will be lost (use ! to override)"
-msgstr "'Resource fork' bude ztracen (pou¾ijte ! pro vynucení)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nelze najít doèasný temp soubor pro zápis"
 
-msgid "E213: Cannot convert (use ! to write without conversion)"
+#: ../fileio.c:3134
+#, fuzzy
+msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nelze pøevést (pou¾ijte ! pro zápis bez pøevodu)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Nelze otevøít pøipojený soubor pro zápis"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Nelze otevøít soubor pro zápis"
 
-msgid "Close failed"
+#: ../fileio.c:3363
+msgid "E667: Fsync failed"
+msgstr ""
+
+#: ../fileio.c:3398
+#, fuzzy
+msgid "E512: Close failed"
 msgstr "Volání close selhalo"
 
-msgid "write error, conversion failed"
+#: ../fileio.c:3436
+#, fuzzy
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "chyba pøi zápisu, konverze se nezdaøila"
 
-msgid "write error (file system full?)"
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
+#, fuzzy
+msgid "E514: write error (file system full?)"
 msgstr "chyba pøi ukládání (je volné místo na disku?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " CHYBA PØEVODU"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "øádek %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[zaøízení]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nový]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [p]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " pøipojen"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [u]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " ulo¾en"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: nelze ulo¾it pùvodní soubor"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nelze zapisovat do prázdného pùvodního souboru"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nelze smazat zálo¾ní soubor"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1237,75 +2354,96 @@ msgstr ""
 "\n"
 "VAROVÁNÍ: Obsah pùvodního souboru mù¾e být ztracen èi po¹kozen\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "neukonèujte editor døíve, ne¾ bude soubor úspì¹nì ulo¾en!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos formát]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac formát]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix formát]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 øádek, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> øádkù, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znakù, "
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[¾ádný eol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[neúplný poslední øádek]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "VAROVÁNÍ: od jeho naètení byl obsah souboru zmìnìn!!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Chcete jej opravdu ulo¾it"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Chyba pøi zápisu do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Chyb pøi uzavírání \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Chyba pøi ètení \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell autocommand zru¹il buffer"
 
-#, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
+#: ../fileio.c:4894
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
 msgstr "E211: wa1: soubor \"%s\" ji¾ není dostupný"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1314,21 +2452,38 @@ msgstr ""
 "W12: Varování: soubor \"%s\" byl po poèátku editace zmìnìn a buffer ve Vim "
 "také"
 
+#: ../fileio.c:4907
+msgid "See \":help W12\" for more info."
+msgstr ""
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: wc2: soubor \"%s\" byl po poèátku editace zmìnìn"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr ""
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Varování: Mód souboru \"%s\" byl zmìnìn od zapoènutí editace"
 
+#: ../fileio.c:4915
+msgid "See \":help W16\" for more info."
+msgstr ""
+
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: wc4: po poèátku editace vytvoøen soubor \"%s\""
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Varování"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1336,27 +2491,48 @@ msgstr ""
 "&OK\n"
 "&Nahrát soubor"
 
+#: ../fileio.c:5065
+#, fuzzy, c-format
+msgid "E462: Could not prepare for reloading \"%s\""
+msgstr "E321: Nelze znovuotevøít \"%s\""
+
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Nelze znovuotevøít \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Vymazáno--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Skupina \"%s\" neexistuje"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Nepøípustný znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Událost %s neexistuje"
 
+#: ../fileio.c:5907
+#, fuzzy, c-format
+msgid "E216: No such group or event: %s"
+msgstr "E216: Událost %s neexistuje"
+
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1364,741 +2540,930 @@ msgstr ""
 "\n"
 "--- Automatické pøíkazy ---"
 
+#: ../fileio.c:6293
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr "chybný název bufferu"
+
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Automatické pøíkazy nelze spustit pro V©ECHNY události"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "®ádné vyhovující automatické pøíkazy"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: vnoøení automatického pøíkazu pøíli¹ hluboká"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s automatické pøíkazy pro \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "spou¹tím %s"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "Automatický pøíkaz %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Chybí {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Chybí }."
 
-msgid "No fold found"
+#: ../fold.c:93
+#, fuzzy
+msgid "E490: No fold found"
 msgstr "®ádný záhyb nebyl nalezen"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: pomocí aktuální 'foldmethod' nelze vytvoøit záhyb"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: pomocí aktuální 'foldmethod' nelze vytvoøit záhyb"
 
-msgid "E221: 'commentstring' is empty"
-msgstr "E221: volba 'commentstring' je prázdná"
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr "poèet øádkù v záhybu: %3ld"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Pøidat do bufferu pro ètení"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekurzivní mapování"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: pro %s ji¾ globální zkratka ji¾ existuje"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: pro %s ji¾ globální mapování ji¾ existuje"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: pro %s ji¾ zkratka ji¾ existuje"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: pro %s ji¾ mapování ji¾ existuje"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "®ádná zkratka nebyl nalezena"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "®ádné mapování nebylo nalezeno"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: nepøípustný mód"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nelze spustit GUI"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Buffer neobsahuje ¾ádný øádek--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nelze èíst z \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+#, fuzzy
+msgid "E470: Command aborted"
+msgstr "Pøíkaz pøeru¹en"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: volba 'guifontwide' je chybnì nastavena"
+#: ../globals.h:997
+#, fuzzy
+msgid "E471: Argument required"
+msgstr "Je vy¾adován argument"
 
-msgid "Error"
-msgstr "Chyba"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ by mìl následovat /. ? nebo &"
 
-msgid "&Ok"
-msgstr "&Ok"
-
-msgid "<cannot open> "
-msgstr "<nelze otevøít> "
-
-#, c-format
-msgid "vim_SelFile: can't get font %s"
-msgstr "vim_SelFile: písmo %s není dostupné"
-
-msgid "vim_SelFile: can't return to current directory"
-msgstr "vim_SelFile: nelze se vrátit do aktuálního adresáøe"
-
-msgid "Pathname:"
-msgstr "Název cesty:"
-
-msgid "vim_SelFile: can't get current directory"
-msgstr "vim_SelFile: nelze zjistit aktuální adresáø"
-
-msgid "OK"
-msgstr "OK"
-
-#. 'Cancel' button
-msgid "Cancel"
-msgstr "Zru¹it"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Pøípravek posunovací li¹ty: nelze zjistit geometrii obrázku"
-
-msgid "Vim dialog"
-msgstr "Vim dialog"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: BalloonEval nelze vytvoøit se zprávou a zároveò zpìtným voláním"
-
-msgid "Vim dialog..."
-msgstr "Vim dialog.."
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Nalézt a nahradit..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Nalézt..."
-
-msgid "Find what:"
-msgstr "Vyhledat:"
-
-msgid "Replace with:"
-msgstr "Nový text:"
-
-#. exact match only button
-msgid "Match exact word only"
-msgstr "hledat pouze celá slova"
-
-msgid "Direction"
-msgstr "Smìr"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Nahoru"
-
-msgid "Down"
-msgstr "Dolù"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Najít dal¹í"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Nahradit"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Nahradit v¹e"
-
-msgid "E233: cannot open display"
-msgstr "E233: nelze otevøít display"
-
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Neznámá sada písem: %s"
-
-msgid "Font Selection"
-msgstr "Výbìr písma"
-
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Neznámé písmo: %s"
-
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Písmo \"%s\" nemá pevnou ¹íøku"
-
-#, c-format
-msgid "E242: Color name not recognized: %s"
-msgstr "E242: Neznámé jméno barvy: %s"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Místo prádné schránky pou¾ito CUT_BUFFER0"
-
-msgid "Filter"
-msgstr "Filtr"
-
-msgid "Directories"
-msgstr "Adresáøe"
-
-msgid "Help"
-msgstr "Nápovìda"
-
-msgid "Files"
-msgstr "Soubory"
-
-msgid "Selection"
-msgstr "Výbìr"
-
-msgid "Undo"
-msgstr "Zpìt"
-
-#, c-format
-msgid "E235: Can't load Zap font '%s'"
-msgstr "E235: Nelze naèíst Zap font '%s'"
-
-#, c-format
-msgid "E235: Can't use font %s"
-msgstr "E235: Nelze pou¾ít font %s"
-
-#, c-format
-msgid "E242: Missing color: %s"
-msgstr "E242: Chybí barva: %s"
-
-msgid ""
-"\n"
-"Sending message to terminate child process.\n"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"\n"
-"Posílám signál k ukonèení synovského procesu.\n"
+"E11: Chyba v oknì pøíkazové øádky; <CR> pro spu¹t¹ní, CTRL-C pro ukonèení"
 
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nepodporován: \"-%s\"; Pou¾ijte OLE verzi."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Najít øetìzec (pou¾ijte '\\\\' k nalezení '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Najít & Nahradit (pou¾ijte '\\\\' k nalezení '\\')"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Vim E458: nelze alokovat polo¾ku barevné mapy. Nìkteré barvy mohou být "
-"nesprávné"
+"E12: Pøíkaz není z exrc/vimrc v aktuálním adresáøi èi pøi hledání tagu "
+"povolen."
 
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: písma pro následující znakové sady chybí v sadì písem %s:"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Chybí :endif"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: název sady písem: %s"
+#: ../globals.h:1004
+#, fuzzy
+msgid "E600: Missing :endtry"
+msgstr "E171: Chybí :endif"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Písmo '%s' nemá pevnou ¹íøku"
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Chybí :endwhile"
 
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: název sady písem: %s\n"
+#: ../globals.h:1006
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: Chybí :endif"
 
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Písmo0: %s\n"
+#: ../globals.h:1007
+#, fuzzy
+msgid "E588: :endwhile without :while"
+msgstr ":endwhile bez odpovídajícího :while"
 
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Písmo1: %s\n"
+#: ../globals.h:1008
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr ":endif bez odpovídajícího :if"
 
-#, c-format
-msgid "Font%d width is not twice that of font0\n"
-msgstr "©íøka písma%d není dvojnásoblem ¹íøky písma0\n"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Soubor existuje (pou¾ijte ! pro vynucení)"
 
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "©íøka písma0: %<PRId64>\n"
+#: ../globals.h:1010
+#, fuzzy
+msgid "E472: Command failed"
+msgstr "Pøíkaz selhal"
 
+#: ../globals.h:1011
+#, fuzzy
+msgid "E473: Internal error"
+msgstr "Vnitøní chyba"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Pøeru¹eno"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Chybná adresa"
+
+#: ../globals.h:1014
+#, fuzzy
+msgid "E474: Invalid argument"
+msgstr "Chybný argument"
+
+#: ../globals.h:1015
+#, fuzzy, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "Chybný argument: %s"
+
+#: ../globals.h:1016
 #, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Chybný výraz: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Chybný rozsah"
+
+#: ../globals.h:1018
+#, fuzzy
+msgid "E476: Invalid command"
+msgstr "Chybný pøíkaz"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" je adresáøem"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Chybná hodnota volby 'scroll'"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"©íøka písma1: %<PRId64>\n"
-"\n"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: nelze alokovat barvu %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Volání knihovní funkce \"%s()\" selhalo"
+
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Znaèka má chybné èíslo øádku"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: není nastavena"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nelze mìnit, je nastavena volba 'modifiable'"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skript vnoøen pøíli¹ hluboko"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: ®ádný alternativní soubor"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Taková zkratka neexistuje"
+
+#: ../globals.h:1033
+#, fuzzy
+msgid "E477: No ! allowed"
+msgstr "! není povoleno"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Nelze pou¾ít GUI: nebylo zapnuto pøi pøekladu programu"
+
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Skupina zvýraznìní %s neexistuje"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Zatím není ¾ádný vlo¾ený text"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: ®ádná pøedchozí pøíkazová øádka"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: ®ádné takové mapování"
+
+#: ../globals.h:1040
+#, fuzzy
+msgid "E479: No match"
+msgstr "®ádná shoda"
+
+#: ../globals.h:1041
+#, fuzzy, c-format
+msgid "E480: No match: %s"
+msgstr "®ádná shoda: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ®ádný název souboru"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: ¾ádný pøedchozí regulární výraz"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: ®ádný pøedchozí pøíkaz"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: ¾ádný pøedchozí regulární výraz"
+
+#: ../globals.h:1047
+#, fuzzy
+msgid "E481: No range allowed"
+msgstr "Rozsah není povolen"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Nedostatek místa"
+
+#: ../globals.h:1049
+#, fuzzy, c-format
+msgid "E482: Can't create file %s"
+msgstr "Nelze vytvoøit soubor %s"
+
+#: ../globals.h:1050
+#, fuzzy
+msgid "E483: Can't get temp file name"
+msgstr "Nelze získat název doèasného souboru"
+
+#: ../globals.h:1051
+#, fuzzy, c-format
+msgid "E484: Can't open file %s"
+msgstr "E456: Nelze otevøít soubor \"%s\""
+
+#: ../globals.h:1052
+#, fuzzy, c-format
+msgid "E485: Can't read file %s"
+msgstr "Nelze èíst soubor %s"
+
+#: ../globals.h:1054
+#, fuzzy
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Neulo¾ené zmìny (pou¾ijte ! pro vynucení)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Neulo¾ené zmìny]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nulový argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oèekáváno èíslo"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nelze otevøít chybový soubor %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Nedostatek pamìti!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Vzor nenalezen"
+
+#: ../globals.h:1061
+#, fuzzy, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "Vzor nenalezen: %s"
+
+#: ../globals.h:1062
+#, fuzzy
+msgid "E487: Argument must be positive"
+msgstr "Argument musí být kladný"
+
+#: ../globals.h:1064
+#, fuzzy
+msgid "E459: Cannot go back to previous directory"
+msgstr "E186: ®ádný pøedchozí adresáø"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: ®ádné chyby"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr ""
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Po¹kozený øetìzec pro vyhledávání"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: po¹kozený regexp program"
+
+#: ../globals.h:1071
+#, fuzzy
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'nastavena volba 'readonly' (pou¾ijte ! pro vynucení)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Chyba pøi ètení chybového souboru"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Není v bezpeènostní schránce povoleno"
+
+#: ../globals.h:1080
+#, fuzzy
+msgid "E523: Not allowed here"
+msgstr "Toto zde není povoleno"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Nastavování re¾imu obrazovky není podporováno"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Chybná hodnota volby 'scroll'"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: volba 'shell' je prázdná"
+
+#: ../globals.h:1085
 msgid "E255: Couldn't read in sign data!"
 msgstr "E255: Chyba -- nelze pøeèíst sign data!"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: CYBA Hangul automatu"
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Chyba pøi uzavírání odkládacího souboru"
 
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: seznam tagù je prázdný"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Pøíkaz je pøíli¹ slo¾itý"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Název je pøíli¹ dlouhý"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: pøíli¹ mnoho ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Pøíli¹ mnoho názvù souborù"
+
+#: ../globals.h:1092
+#, fuzzy
+msgid "E488: Trailing characters"
+msgstr "Nadbyteèné znaky na konci"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Neznámá znaèka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nelze expandovat ¾olíkové znaky"
+
+#: ../globals.h:1096
+#, fuzzy
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+"hodnota volby 'winheight' nesmí být men¹í ne¾ hodnota volby 'winminheight'"
+
+#: ../globals.h:1098
+#, fuzzy
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+"hodnota volby 'winwidth' nesmí být men¹í ne¾ hodnota volby 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Chyba pøi ukládání"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nulový poèet"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Pou¾ití <SID> mimo kontext skriptu"
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "Vnitøní chyba"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr ""
+
+#: ../globals.h:1105
+#, fuzzy
+msgid "E749: empty buffer"
+msgstr "E279: Není SNiFF+ buffer"
+
+#: ../globals.h:1108
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: Nepøípustný hledaný øetìzec: %s"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Soubor je nahrán v jiném bufferu"
+
+#: ../globals.h:1110
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: Písmo \"%s\" nemá pevnou ¹íøku"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: '%s' není pøípustné jméno registru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "hledání dosáhlo zaèátku, pokraèování od konce"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "hledání dosáhlo konce, pokraèování od zaèátku"
+
+#: ../hardcopy.c:240
+#, fuzzy
+msgid "E550: Missing colon"
+msgstr "Chybí dvojteèka"
+
+#: ../hardcopy.c:252
+#, fuzzy
+msgid "E551: Illegal component"
+msgstr "nepøípustná souèást"
+
+#: ../hardcopy.c:259
+#, fuzzy
+msgid "E552: digit expected"
+msgstr "oèekávána èíslice"
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr ""
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr "®ádný text k vyti¹tìní"
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "Tisknu stranu %d (%d%%)"
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr " Kopie %d z %d"
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr "Vyti¹tìno: %s"
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr "Tisk zru¹en"
+
+#: ../hardcopy.c:1365
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: Nelze zapisovat do výstupního PostScriptového souboru"
+
+#: ../hardcopy.c:1747
+#, fuzzy, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E456: Nelze otevøít soubor \"%s\""
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
+
+#: ../hardcopy.c:1772
+#, fuzzy, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, fuzzy, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr ""
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: Nelze otevøít výstupní PostScriptový soubor"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: Nelze otevøít soubor \"%s\""
+
+#: ../hardcopy.c:2583
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
+
+#: ../hardcopy.c:2593
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, fuzzy, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E457: Nelze èíst zdrojový PostScriptový soubor \"%s\""
+
+#: ../hardcopy.c:2654
+#, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr ""
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr "Odesílám na tiskárnu..."
+
+#: ../hardcopy.c:2881
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: Selhal tisk PostScriptového souboru"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr "Tisková úloha odeslána."
+
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Pøidat novou databázi"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Hledání vzorku"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Zobrazit tuto zprávu"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Ukonèit spojení"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Znovu inicializovat v¹echna spojení"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Zobrazit spojení"
 
+#: ../if_cscope.c:101
+#, c-format
+msgid "E560: Usage: cs[cope] %s"
+msgstr ""
+
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Tento cscope pøíkaz nepodporuje rozdìlení okna.\n"
 
-msgid "Usage: cstag <ident>"
+#: ../if_cscope.c:266
+#, fuzzy
+msgid "E562: Usage: cstag <ident>"
 msgstr "Pou¾ití: cstag <odsazení>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tag nenalezen"
 
-#, c-format
-msgid "stat(%s) error: %d"
+#: ../if_cscope.c:461
+#, fuzzy, c-format
+msgid "E563: stat(%s) error: %d"
 msgstr "stat(%s) chyba: %d"
 
+#: ../if_cscope.c:551
+#, fuzzy, c-format
+msgid "E564: %s is not a directory or a valid cscope database"
+msgstr "%s není ani adresáøem ani správnou cscope databází"
+
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Pøidána cscope databáze %s"
 
-#, c-format
-msgid "%s is not a directory or a valid cscope database"
-msgstr "%s není ani adresáøem ani správnou cscope databází"
+#: ../if_cscope.c:616
+#, fuzzy, c-format
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: pøi ètení cscope spojení %d"
 
-#, c-format
-msgid "error reading cscope connection %d"
-msgstr "chyba pøi ètení cscope spojení %d"
-
-msgid "unknown cscope search type"
+#: ../if_cscope.c:711
+#, fuzzy
+msgid "E561: unknown cscope search type"
 msgstr "neznámý typ cscope hledání"
 
-msgid "Could not create cscope pipes"
+#: ../if_cscope.c:752 ../if_cscope.c:789
+#, fuzzy
+msgid "E566: Could not create cscope pipes"
 msgstr "nelze vytvoøit cscope roury"
 
+#: ../if_cscope.c:767
+#, fuzzy
+msgid "E622: Could not fork for cscope"
+msgstr "E321: Nelze znovuotevøít \"%s\""
+
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "spu¹tìní cs_create_connection selhalo"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "spu¹tìní cs_create_connection selhalo"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: volání fdopen pro to_fp selhalo"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: volání fdopen pro fr_fp selhalo"
 
-msgid "no cscope connections"
+#: ../if_cscope.c:890
+#, fuzzy
+msgid "E623: Could not spawn cscope process"
+msgstr "nelze vytvoøit cscope roury"
+
+#: ../if_cscope.c:932
+#, fuzzy
+msgid "E567: no cscope connections"
 msgstr "¾ádná cscope spojení"
 
+#: ../if_cscope.c:1009
+#, c-format
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr ""
+
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: cscope hledání %s vzorku %s nena¹lo ¾ádnou shodu"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "pøíkazy cscope:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)\n"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Pou¾ití: %s)\n"
 
-msgid "duplicate cscope database not added"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
+
+#: ../if_cscope.c:1226
+#, fuzzy
+msgid "E568: duplicate cscope database not added"
 msgstr "duplicitní cscope databáze nebyla pøidána"
 
-msgid "maximum number of cscope connections reached"
-msgstr "dosa¾en maximální poèet cscope spojení"
-
-msgid "E260: cscope connection not found"
-msgstr "E260: connection spojení nenalezeno"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: connection spojení %s nenalezeno"
 
-msgid "cscope connection closed"
-msgstr "closed spojení uzavøeno"
-
-#, c-format
-msgid "cscope connection %s closed\n"
+#: ../if_cscope.c:1364
+#, fuzzy, c-format
+msgid "cscope connection %s closed"
 msgstr "cscope spojení %s uzavøeno\n"
 
 #. should not reach here
-msgid "fatal error in cs_manage_matches"
+#: ../if_cscope.c:1486
+#, fuzzy
+msgid "E570: fatal error in cs_manage_matches"
 msgstr "osudová chyba v cs_manage_matches"
 
-#, c-format
-msgid "E262: error reading cscope connection %d"
-msgstr "E262: pøi ètení cscope spojení %d"
-
-msgid "couldn't malloc\n"
-msgstr "volání malloc selhalo\n"
-
-#, c-format
-msgid "Cscope tag: %s\n"
+#: ../if_cscope.c:1693
+#, fuzzy, c-format
+msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s\n"
 
-msgid "   #   line"
+#: ../if_cscope.c:1711
+#, fuzzy
+msgid ""
+"\n"
+"   #   line"
 msgstr "   #   øádek"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "název souboru/ kontext/ øádek\n"
 
+#: ../if_cscope.c:1809
+#, fuzzy, c-format
+msgid "E609: Cscope error: %s"
+msgstr "E40: Nelze otevøít chybový soubor %s"
+
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "V¹echny cscope databáze resetovány"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "¾ádné cscope spojení\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    název databáze                      pøedpona cesty\n"
 
-#, c-format
-msgid "%2d %-5ld  %-34s  <none>\n"
-msgstr "%2d %-5ld  %-34s  <¾ádný>\n"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Lituji, tento pøíkaz je deaktivován; knihovnu jazyka Python nelze "
-"nahrát."
-
-msgid "can't delete OutputObject attributes"
-msgstr "nelze smazat atributy OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "softspace musí být kladné celé èíslo"
-
-msgid "invalid attribute"
-msgstr "chybný atribut"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() vy¾aduje seznam øetìzcù"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: chyba pøi inicializaci I/O objektù"
-
-msgid "invalid expression"
-msgstr "Chybný výraz"
-
-msgid "expressions disabled at compile time"
-msgstr "podpora výrazù byla vypnuta pøi pøekladu programu"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "pokus o odkaz na smazaný buffer"
-
-msgid "line number out of range"
-msgstr "èíslo øádku mimo rozsah"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<buffer objekt (smazán) na %8lX>"
-
-msgid "invalid mark name"
-msgstr "chybné jméno znaèky"
-
-msgid "no such buffer"
-msgstr "¾ádný takový buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "pokus o odkaz na smazané okno"
-
-msgid "readonly attribute"
-msgstr "atribut pouze_pro_ètení"
-
-msgid "cursor position outside buffer"
-msgstr "umístìní kurzoru mimo buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<objekt okna (smazán) na %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<objekt okna (neznámý) na %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<okno %d>"
-
-msgid "no such window"
-msgstr "¾ádné takové okno"
-
-msgid "cannot save undo information"
-msgstr "nelze ulo¾it informace pro pøíkaz undo"
-
-msgid "cannot delete line"
-msgstr "nelze smazat øádek"
-
-msgid "cannot replace line"
-msgstr "nelze nahradit øádek"
-
-msgid "cannot insert line"
-msgstr "nelze vlo¾it øádek"
-
-msgid "string cannot contain newlines"
-msgstr "øetìzec nesmí obsahovat znaky nového øádku"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Ruby nelze "
-"nahrát."
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: neznámý longjmp stav %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Prohození implementace/definice"
-
-msgid "Show base class of"
-msgstr "Zobrazení base class z"
-
-msgid "Show overridden member function"
-msgstr "Zobrazení overridden member funkce"
-
-msgid "Retrieve from file"
-msgstr "Znovuzískáno ze souboru"
-
-msgid "Retrieve from project"
-msgstr "Znovuzískáno z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Znovzískáno ze v¹ech projektù"
-
-msgid "Retrieve"
-msgstr "Znovuzískáno"
-
-msgid "Show source of"
-msgstr "Zobrazení zdroje"
-
-msgid "Find symbol"
-msgstr "Najít symbol"
-
-msgid "Browse class"
-msgstr "Prohlí¾et class"
-
-msgid "Show class in hierarchy"
-msgstr "Zobrazení class v hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Zobrazení class v restricted hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odkazuje na"
-
-msgid "Xref referred by"
-msgstr "Xref odkazoval na"
-
-msgid "Xref has a"
-msgstr "Xref má"
-
-msgid "Xref used by"
-msgstr "Xref pou¾it"
-
-msgid "Show docu of"
-msgstr "Zobrazení documentace"
-
-msgid "Generate docu for"
-msgstr "Generována dokumentace pro"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Nelze se pøipojit k SNiFF+. Zkontrolujte promìnné (sniffemacs musí "
-"být)uvedena v $PATH.\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Chyba pøi ètení. Odpojeno"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ je právì "
-
-msgid "not "
-msgstr "ne "
-
-msgid "connected"
-msgstr "pøipojen"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Neznámý po¾adavek SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Chybné pøipojení k SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ nepøipojen"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Není SNiFF+ buffer"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Chyba pøi zápisu. Odpojeno."
-
-msgid "invalid buffer number"
-msgstr "chybný název bufferu"
-
-msgid "not implemented yet"
-msgstr "není je¹tì podporováno"
-
-msgid "unknown option"
-msgstr "neznámá volba"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nelze nastavit øádky"
-
-msgid "mark not set"
-msgstr "znaèka není nastavena"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "øádek %d sloupec %d"
-
-msgid "cannot insert/append line"
-msgstr "nelze vlo¾it/pøipojit øádek"
-
-msgid "unknown flag: "
-msgstr "neznámý pøíznak: "
-
-msgid "unknown vimOption"
-msgstr "neznámá vimOption"
-
-msgid "keyboard interrupt"
-msgstr "pøeru¹ení z klávesnice"
-
-msgid "vim error"
-msgstr "chyba vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nelze vytvoøit pøíkaz bufferu/okna: objekt smazán"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nelze zaregistrovat pøíkaz zpìtného volání: buffer/okno ji¾ bylo smazáno"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to "
-"vim-dev@vim.org"
-msgstr ""
-"E280: TCL FATAL ERROR: reflist po¹kozen!? Oznamte, prosím, tuto chybu na "
-"vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nelze zaregistrovat pøíkaz zpìtného volání: odkaz na buffer/okno nenalezen"
-
-msgid "Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Tcl nelze nahrát."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL CHYBA: návratový kód není celé èíslo!? Oznamte, prosím, tuto chybu "
-"na vim-dev@vim.org"
-
-msgid "cannot get line"
-msgstr "nelze pøeèíst øádek"
-
-msgid "Unable to register a command server name"
-msgstr "Není mo¾né zaznamenat jméno command serveru"
-
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Neexistuje registrovaný server jménem \"%s\""
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Selhalo zaslání pøíkazu urèenému programu"
-
-#, c-format
-msgid "Invalid server id used: %s"
-msgstr "Pou¾it chybný id serveru: %s"
-
-msgid "E249: couldn't read VIM instance registry property"
-msgstr "E249: nelze èíst VIM instanci registry property"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: VIM instance registry property byla ¹patnì vytvoøenaa byla smazána!"
-
-msgid "Unknown option"
+#: ../main.c:144
+#, fuzzy
+msgid "Unknown option argument"
 msgstr "Neznámá volba"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Pøíli¹ mnoho edit argumentù"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Chybí argument po"
 
-msgid "Garbage after option"
+#: ../main.c:150
+#, fuzzy
+msgid "Garbage after option argument"
 msgstr "Chyby za volbou"
 
-msgid "Too many \"+command\" or \"-c command\" arguments"
+#: ../main.c:152
+#, fuzzy
+msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Pøíli¹ mnoho \"+pøíkaz\" èi \"-c pøíkaz\" argumentù"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Chybný argument pro"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "VIM nebyl pøelo¾en s volbou +diff"
-
-msgid "Attempt to open script file again: \""
-msgstr "Pokus o opìtovné otevøení skriptu: \""
-
-msgid "\"\n"
-msgstr "\"\n"
-
-msgid "Cannot open for reading: \""
-msgstr "Nelze otevøít pro zápis: \""
-
-msgid "Cannot open for script output: \""
-msgstr "Nelze otevøít pro výstup skriptu: \""
-
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "poèet souborù pro editaci: %d\n"
 
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr "Pokus o opìtovné otevøení skriptu: \""
+
+#: ../main.c:1350
+msgid "Cannot open for reading: \""
+msgstr "Nelze otevøít pro zápis: \""
+
+#: ../main.c:1393
+msgid "Cannot open for script output: \""
+msgstr "Nelze otevøít pro výstup skriptu: \""
+
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Varování: výstup nesmìøuje na terminál\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Varování: vstup nepochází z terminálu\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc pøíkazový øádek"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nelze èíst z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2106,18 +3471,23 @@ msgstr ""
 "\n"
 "Podrobnìj¹í informace získáte pomocí \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[SOUBOR] ..          editovat SOUBOR(y)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                    èíst text ze standardního vstupu"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t TAG          editovat soubor na místì definice TAGU"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [chybový soubor]  editovat soubor na místì výskytu první chyby"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2127,9 +3497,11 @@ msgstr ""
 "\n"
 "pou¾ití:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr "vim [pøepínaèe] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2137,6 +3509,7 @@ msgstr ""
 "\n"
 "   nebo"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2146,294 +3519,198 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tMohou následovat pouze názvy souborù"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tpøihlásit gvim na OLE"
+#: ../main.c:2199
+#, fuzzy
+msgid "--literal\t\tDon't expand wildcards"
+msgstr "E79: Nelze expandovat ¾olíkové znaky"
 
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-register\t\todhlásit gvim z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tspustit v GUI re¾imu (stejné jako \"gvim\")"
-
-msgid "-f\t\t\tForeground: Don't fork when starting GUI"
-msgstr "-f\t\t\tPopøedí: pøi startu GUI se neoddìlí od shellu"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi mód (stejné jako \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-v\t\t\tEx mód (stejné jako \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tTichý (dávkový) re¾im (pouze pro \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff re¾im (stejné jako \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-v\t\t\tSnadný re¾im (stejné jako \"evim\", ¾ádné módy )"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tRe¾im pouze_pro_ètení (jako \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tOmezený re¾im (stejné jako \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmìny (ukládání souborù) zakázány"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZmìny (ukládání souborù) zakázány"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinární re¾im"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp re¾im"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatabilní s Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tKompatibilita s Vi vypnuta: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tÚroveò výpisu hlá¹ek"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tLadící re¾im"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNebude vytváøet odkládací soubor, bude pou¾ívat pouze pamì»"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tVypí¹e seznam odkládacích souborù a skonèí"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r název souboru\tObnoví pøeru¹ené sezení"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tStejné jako -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNebude pou¾ívat newcli pro otevøení okna"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <zaøízení>\t\tPou¾ít <zaøízení> pro I/O"
-
-msgid "-H\t\t\tstart in Hebrew mode"
-msgstr "-H\t\t\tnastartuje v hebrejském re¾imu"
-
-msgid "-F\t\t\tstart in Farsi mode"
+#: ../main.c:2221
+#, fuzzy
+msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-F\t\t\tnastartuje ve Farsi re¾imu"
 
+#: ../main.c:2222
+#, fuzzy
+msgid "-H\t\t\tStart in Hebrew mode"
+msgstr "-H\t\t\tnastartuje v hebrejském re¾imu"
+
+#: ../main.c:2223
+#, fuzzy
+msgid "-F\t\t\tStart in Farsi mode"
+msgstr "-F\t\t\tnastartuje ve Farsi re¾imu"
+
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminál>\tNastaví typ terminálu na <terminál>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tPou¾ije <vimrc> místo jakéhokoliv .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tPou¾ije <gvimrc> místo jakéhokoliv .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNenahraje 'plugin' skripty"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tOtevøe N oken (implicitnì jedno pro ka¾dý soubor)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtevøe N oken (implicitnì jedno pro ka¾dý soubor)"
 
-msgid "-O[N]\t\tlike -o but split vertically"
+#: ../main.c:2229
+#, fuzzy
+msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tJako -o but split vertically"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tNastaví kurzor na konec souboru"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<øádek>\t\tNastaví kurzor na <øádek>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <pøíkaz>\tPo nahrání prvního souboru vykoná <pøíkaz>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <pøíkaz>\t\tPo nahrání prvního souboru vykoná <pøíkaz>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sezení>\t\tPo nahrání prvního souboru vykoná pøíkazy v souboru <sezení>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skript>\t\tNaète pøíkazy normálního módu ze <skriptu>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <skript>\t\tPøipojí v¹echny napsané pøíkazy do souboru <skript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <skript>\t\tUlo¾í v¹echny napsané pøíkazy do souboru <skript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEditace za¹ifrovaných souborù"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tSpustí vim na daný X-server"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNepøipojí se k X serveru"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtevøe Vim uvnitø jiného GTK widgetu"
-
-msgid "--remote <files>\tEdit <files> in a Vim server and exit"
-msgstr "--remote <soubory>\tEdituje <soubory> na Vim serveru a skonèí"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <soubory> Jako --remote, ale èeká na soubory k editaci"
 
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <klávesy>\tPøedá <klávesy> Vim serveru a skonèí"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <výraz>\tProvede <výraz> na serveru a zobrazí výsledek"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVypí¹e seznam dostupných Vim serverù a skonèí"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr ""
-"--servername <jméno>\tZa¹le serveru <jméno>/stane se Vim serverem <jméno>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tPou¾ije <viminfo> místo jakéhokoliv .viminfo"
 
-msgid "-h\t\t\tprint Help (this message) and exit"
+#: ../main.c:2243
+#, fuzzy
+msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h\t\t\tVypí¹e tuto nápovìdu a skonèí"
 
-msgid "--version\t\tprint version information and exit"
+#: ../main.c:2244
+#, fuzzy
+msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tvypí¹e informace o verzi a skonèí"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (Motif verzi):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (Athena verzi):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tSpustí vim na <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tSpustí vim minimalizované"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <název>\t\tPou¾ije resource jako by vim mìl <název>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (není implementováno)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <barva>\tNastaví <barvu> pozadí (také -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <barva>\tNastaví <barvu> popøedí (také -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <písmo>\t\tNastaví <písmo> normálního textu (také -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <písmo>\tNastaví <písmo> pro zvýraznìný text"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <písmo>\tNastaví <písmo> pro kurzívu"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geometrie>\tNastaví <geometrii> (také -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <¹íøka>\tNastaví <¹íøku> okrajù (také -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <¹íøku> Nastaví <¹íøku> posunovací li¹ty (také: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <vý¹ka>\tNastaví <vý¹ku> nabídky (také -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tPou¾ije reverzní barvy (také -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNepou¾ije reverzní barvy (také +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tNastaví zadaný <resource>"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (RISC OS verzi):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <poèet>\t<poèet> sloupcù na okno"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <poèet>\t<poèet> øádkù na okno"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Pøepínaèe pro gvim (GTK+ verzi):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tSpustí vim na <display> (také --display)"
-
-msgid "--help\t\tShow Gnome arguments"
-msgstr "--help\t\tVypí¹e Gnome pøepínaèe"
-
-#. Failed to send, abort.
-msgid ""
-"\n"
-"Send failed.\n"
-msgstr ""
-"\n"
-"Pøedání výrazu selhalo.\n"
-
-#. Let vim start normally.
-msgid ""
-"\n"
-"Send failed. Trying to execute locally\n"
-msgstr ""
-"\n"
-"Pøedání selhalo. Zkou¹ím provést lokálnì\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d z %d editováno"
-
-msgid "Send expression failed.\n"
-msgstr "Pøedání výrazu selhalo.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Nejsou nastaveny ¾ádné znaèky"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\" nevyhovují ¾ádné znaèky"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2442,6 +3719,7 @@ msgstr ""
 "znaèka øádek  sloupec soubor/text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2449,6 +3727,17 @@ msgstr ""
 "\n"
 " skok øádek sloupec soubor/text"
 
+#. Highlight title
+#: ../mark.c:831
+#, fuzzy
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
+"\n"
+"znaèka øádek  sloupec soubor/text"
+
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2457,6 +3746,7 @@ msgstr ""
 "# Souborové znaèky:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -2464,6 +3754,7 @@ msgstr ""
 "\n"
 "# Seznam skokù (poèínaje nejnovìj¹í polo¾kou):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -2471,96 +3762,87 @@ msgstr ""
 "\n"
 "# Historie znaèek v souborech (poèínaje nejnovìj¹í polo¾kou):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Chybí '>'"
 
-msgid "Not a valid codepage"
-msgstr "Chybná kódová stránka"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nelze nastavit IC hodnoty"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nepodaøilo se vytvoøit vstupní kontext"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nepodaøilo se otevøít vstupní metodu"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Varování: likvidaèní zpìtné volání nelze nastavit na IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: vstupní metoda nepodporuje ¾ádný styl"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: vstupní metoda nepodporuje mùj 'preedit' typ"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: Nadbodový styl vy¾aduje fontset"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Máte GTK+ verze star¹í ne¾ 1.2.3. Stavová plocha vypnuta."
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Server vstupních metod nebì¾í"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nebyl zamknut"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Chyba posunu ukazovátka pøi ètení odkládacího souboru"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Chyba pøi ètení odkládacího souboru"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Chyba posunu ukazovátka pøi ukládání do odkládacího souboru"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr ""
 "E300: Odkládací soubor ji¾ existuje! (Nìkdo hackujepøes nastra¾ený symlink?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nelze získat blok 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nelze získat blok 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: nelze získat blok 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Jéje, odkládací soubor byl ztracen!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nelze pøejmenovat odkládací soubor"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Nelze otevøít odkládací soubor pro \"%s\""
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_timestamp: nelze získat blok 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Odkládací soubor pro %s nebyl nalezen"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Zadejte èíslo odkládacího souboru, který se má pou¾ít (0 pro ukonèení): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nelze otevøít %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nelze èíst blok 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -2568,22 +3850,28 @@ msgstr ""
 "\n"
 "Mo¾ná nedo¹lo k ¾ádným zmìnám, nebo Vim neaktualizoval odkládací soubor."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nelze pou¾ít s touto verzí Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Pou¾ijte Vim verze 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s se nezdá být odkládacím souborem Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nelze pou¾ít na tomto poèítaèi.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Soubor byl vytvoøen "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -2591,60 +3879,85 @@ msgstr ""
 ",\n"
 "nebo byl soubor po¹kozen."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Pou¾ívám odkládací soubor \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Pùvodní soubor \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Varování: Pùvodní soubor mohl být zmìnìn"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nelze èíst blok 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???CHYBÍ MNOHO ØÁDKÙ"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???CHYBNÝ POÈET ØÁDKÙ"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PRÁZDNÝ BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???CHYBÌJÍCÍ ØÁDKY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID bloku 1 je chybné (je %s odkládacím souborem?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???CHYBÍ BLOK"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "od ??? po ???END mohou být øádky pomíchané"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "od ??? po ???END mohou být vlo¾ené/smazané øádky"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Obnova pøeru¹ena"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: V prùbìhu obnovy do¹lo k chybám; zkontrolujte øádky zaèínající na ???"
 
+#: ../memline.c:1245
+msgid "See \":help E312\" for more information."
+msgstr ""
+
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Obnova dokonèena. Zkontrolujte, zda je v¹e v poøádku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -2652,48 +3965,69 @@ msgstr ""
 "\n"
 "(Zva¾te ulo¾ení tohoto souboru pod jiným názvem\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "a kontrolu zmìn pomocí programu diff.)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr "Poté sma¾te odkládací soubor.\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Nalezené odkládací soubory:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   V aktuálním adresáøi:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Se zadaným názvem:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   V adresáøi "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- ¾ádné --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          vlastník: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   datum vytvoøení: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             datum vytvoøení: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [od Vim verze 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nevypadá jako odkládací soubor Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         název souboru: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -2701,12 +4035,15 @@ msgstr ""
 "\n"
 "          datum zmìny: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ANO"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ne"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -2714,9 +4051,11 @@ msgstr ""
 "\n"
 "         u¾ivatelské jméno: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   název poèítaèe: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -2724,6 +4063,7 @@ msgstr ""
 "\n"
 "         název poèítaèe: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -2731,16 +4071,11 @@ msgstr ""
 "\n"
 "        ID procesu : "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (stále aktivní)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nepou¾itelné s touto verzí Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -2748,71 +4083,97 @@ msgstr ""
 "\n"
 "         [nepou¾itelné na tomto poèítaèi]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [nelze pøeèíst]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [nelze otevøít]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nelze zachovat - odkládací soubor neexistuje."
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Soubor zachován"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Uchování se nezdaøilo"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: chybné èíslo øádku: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nelze nalézt øádek %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné id ukazatele na blok 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx by mìlo mít hodnotu 3"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Aktualizováno pøíli¹ mnoho blokù?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: chybné id ukazatele na blok 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "smazán blok 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nelze nalézt øádek %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné id ukazatele na blok"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovou hodnotu"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: poèet øádkù mimo rozsah: %<PRId64> > celkový poèet øádkù"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: chybný poèet øádkù v bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Nárùst velikosti zásobníku"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: chybné id ukazatele na blok 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: POZOR"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -2820,38 +4181,44 @@ msgstr ""
 "\n"
 "Nalezen odkládací soubor se jménem \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Pøi otevírání souboru\""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOVÌJ©Í ne¾ odkládací soubor!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Soubor mù¾e být editován jiným programem.\n"
 "    Je-li tomu tak, pak si dejte pozor, aby jste po ulo¾ení zmìn\n"
 "    nemìli dvì rùzné verze tého¾ souboru.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Ukonèete program, nebo opatrnì pokraèujte v editaci.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Editace tohoto souboru byla pøeru¹ena neèekaným ukonèením programu.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Je-li tomu tak, pak pou¾ijte \":recover\" èi \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -2859,9 +4226,11 @@ msgstr ""
 "\"\n"
 "    pro odstranìní zmìn (viz \":help recovery)\".\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Pokud jste tak ji¾ uèinil, tak sma¾te odkládací soubor \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -2869,35 +4238,45 @@ msgstr ""
 "\"\n"
 "    a tato zpráva se ji¾ nebude objevovat.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Odkládací soubor \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ji¾ existuje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - POZOR"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Odkládací soubor ji¾ existuje!"
 
+#: ../memline.c:3464
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
-"&Quit"
+"&Quit\n"
+"&Abort"
 msgstr ""
 "&Otevøít pouze pro ètení\n"
 "&Pokraèovat v editaci\n"
 "O&bnovit soubor\n"
 "&Konec"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "&Otevøít pouze pro ètení\n"
 "&Pokraèovat v editaci\n"
@@ -2905,29 +4284,56 @@ msgstr ""
 "&Konec\n"
 "&Smazat"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Pøíli¹ mnoho odkládacích souborù"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %<PRIu64>)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Èásti cesty k pøedmìtu nabídky není podnabídkou"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Nabídka existuje pouze v jiném módu"
 
-msgid "E329: No menu of that name"
+#: ../menu.c:64
+#, fuzzy, c-format
+msgid "E329: No menu \"%s\""
 msgstr "E329: Nabídka tohoto jména neexistuje"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Cesta nabídkou nesmí vést do podnabídky"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Polo¾ky nabídky nelze pøidávat pøímo na li¹tu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Oddìlovaè nesmí být èástí cesty nabídkou"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -2935,61 +4341,74 @@ msgstr ""
 "\n"
 "--- Nabídky ---"
 
-msgid "Tear off this menu"
-msgstr "Odtrhnout tuto nabídku"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Cesta nabídkou musí vést k polo¾ce nabídky"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Vzor nenalezen: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: V %s módu není nabídka definována"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Cesta nabídkou musí vést do podnabídky"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Nabídka nenalezena - zkontrolujte názvy nabídek"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Chyba pøi zpracování %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "øádek %4ld:"
 
-msgid "[string too long]"
-msgstr "[pøíli¹ dlouhý øetìzec]"
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: '%s' není pøípustné jméno registru"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Správce zpráv: Bram Moolenaar <Bram@vim.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Pøeru¹ení: "
 
-msgid "Hit ENTER to continue"
-msgstr "pokraèování stiskem ENTER"
-
-msgid "Hit ENTER or type command to continue"
+#: ../message.c:988
+#, fuzzy
+msgid "Press ENTER or type command to continue"
 msgstr "Pro pokraèování stisknìte ENTER nebo zadejte pøíkaz"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "øádek %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Pokraèování --"
 
-msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-msgstr " (RET/BS: øádek, MEZERNÍK/b: stránka, d/u: 0.5 stránky, q: konec)"
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
-msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-msgstr " (RET: øádek, MEZERNÍK: stránka, d: 0.5 stránky, q: konec)"
-
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Otázka"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -2997,6 +4416,7 @@ msgstr ""
 "&Ano\n"
 "&Ne"
 
+#: ../message.c:3033
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3006,6 +4426,7 @@ msgstr ""
 "&Ne\n"
 "&Zru¹it"
 
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3019,195 +4440,181 @@ msgstr ""
 "Zahodit &v¹e\n"
 "&Zru¹it"
 
-msgid "Save File dialog"
-msgstr "Dialog pro ukládání souborù"
+#: ../message.c:3058
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: Chybné argumenty pro funkci %s"
 
-msgid "Open File dialog"
-msgstr "Dialog pro otevírání souborù"
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
 
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Lituji, ale konzolová verze nepodporuje prohlí¾eè souborù"
+#: ../message.c:3873
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: Pøíli¹ mnoho argumentù pro funkci %s"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: wc1: mìním soubor pouze_pro_ètení"
 
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "poèet nových øádkù: 1"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "poèet smazaných øádkù: 1"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "poèet nových øádkù: %<PRId64>"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "poèet smazaných øádkù: %<PRId64>"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr "(Pøeru¹eno)"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachovávám soubory...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: ukonèen\n"
-
-msgid "ERROR: "
-msgstr "CHYBA: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
+#: ../misc1.c:2635
+msgid "Beep!"
 msgstr ""
-"\n"
-"[bajtù] celkem uvolnìno-alokováno %<PRIu64>-%<PRIu64>, vyu¾ito %<PRIu64>, maximální vyu¾ití "
-"%<PRIu64>\n"
 
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[volání] celkem re/malloc(): %<PRIu64>, celkem free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Øádek se stává pøíli¹ dlouhým"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %<PRIu64>)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Spou¹tím pøíkaz \"%s\" pomocí shellu"
 
-msgid "Missing colon"
-msgstr "Chybí dvojteèka"
-
-msgid "Illegal mode"
-msgstr "nepøípustný mód"
-
-msgid "Illegal mouseshape"
-msgstr "Chybný tvar my¹i"
-
-msgid "digit expected"
-msgstr "oèekávána èíslice"
-
-msgid "Illegal percentage"
-msgstr "nepøípustné procento"
-
-msgid "Enter encryption key: "
-msgstr "Zadejte ¹ifrovací klíè: "
-
-msgid "Enter same key again: "
-msgstr "Zadejte je¹tì jednou tentý¾ klíè:"
-
-msgid "Keys don't match!"
-msgstr "Klíèe se neshodují"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Chybná cesta: '**[èíslo] musí být buï na konci cesty, nebo musí být\n"
-"následováno'%s. Viz :help path."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Adresáø \"%s\" nelze v cdpath nalézt"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Soubor \"%s\" nelze v path nalézt"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: ®ádný dal¹í adresáø \"%s\" nebyl v cdpath nalezen"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: ®ádný dal¹í soubor \"%s\" nebyl v cestì nalezen"
-
-msgid "Illegal component"
-msgstr "nepøípustná souèást"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Varování: terminál nepodporuje zvýrazòování"
-
-msgid "E348: No string under cursor"
-msgstr "E348: pod kurzorem není ¾ádný øetìzec"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: pod kurzorem není ¾ádný identifikátor"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E221: volba 'commentstring' je prázdná"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Varování: terminál nepodporuje zvýrazòování"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: pod kurzorem není ¾ádný øetìzec"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: pomocí aktuální 'foldmethod' nelze mazat záhyby"
 
+#: ../normal.c:5897
+#, fuzzy
+msgid "E664: changelist is empty"
+msgstr "E91: volba 'shell' je prázdná"
+
+#: ../normal.c:5899
+msgid "E662: At start of changelist"
+msgstr ""
+
+#: ../normal.c:5901
+msgid "E663: At end of changelist"
+msgstr ""
+
+#: ../normal.c:7053
+#, fuzzy
+msgid "Type  :quit<Enter>  to exit Vim"
+msgstr "zadejte :q<Enter>             pro ukonèení programu"
+
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "poèet øádkù posunutých jednou pomocí %s : 1"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Poèet øádkù posunutých pomocí %s %d-krát : 1"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "Poèet øádkù: %<PRId64> (posunutých jednou pomocí %s)"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "Poèet øádkù: %<PRId64> (posunutých pomocí %s %d-krát)"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "poèet øádkù k odsazení: %<PRId64>"
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "poèet øádkù k odsazení: 1"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "poèet odsazených øádkù: %<PRId64>"
 
+#: ../ops.c:938
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: ®ádný pøedchozí adresáø"
+
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nelze kopírovat; pøesto smazáno"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "poèet øádek se zmìnìnou velikostí písmen: 1"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "poèet øádek se zmìnìnou velikostí písmen: %<PRId64>"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "poèet uvolòovaných øádkù: %<PRId64>"
+#: ../ops.c:2521
+#, fuzzy
+msgid "block of 1 line yanked"
+msgstr "poèet zkopírovaných øádkù: 1"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "poèet zkopírovaných øádkù: 1"
 
+#: ../ops.c:2525
+#, fuzzy, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr "poèet zkopírovaných øádkù: %<PRId64>"
+
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "poèet zkopírovaných øádkù: %<PRId64>"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Registr %s je prázdný"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3215,9 +4622,11 @@ msgstr ""
 "\n"
 "--- Registry ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "nepøípustný název registru"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3225,148 +4634,211 @@ msgstr ""
 "\n"
 "# Registry:\n"
 
-#, c-format
-msgid "Unknown register type %d"
+#: ../ops.c:4575
+#, fuzzy, c-format
+msgid "E574: Unknown register type %d"
 msgstr "%d není známým typem registru"
 
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: '%s' není pøípustné jméno registru"
-
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "øádkù: %<PRId64>;"
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> z %<PRId64> Bytù"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> "
+"z %<PRId64> Bytù"
 
+#: ../ops.c:5105
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> "
+"z %<PRId64> Bytù"
+
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Byte %<PRId64> z %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Byte %<PRId64> z %<PRId64>"
 
+#: ../ops.c:5133
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Byte %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> pro BOM)"
 
+#: ../option.c:1238
+msgid "%<%f%h%m%=Page %N"
+msgstr ""
+
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dìkuji za pou¾ití Vim"
 
-msgid "Option not supported"
+#. found a mismatch: skip
+#: ../option.c:2698
+#, fuzzy
+msgid "E518: Unknown option"
+msgstr "Neznámá volba"
+
+#: ../option.c:2709
+#, fuzzy
+msgid "E519: Option not supported"
 msgstr "Volba není podporována"
 
-msgid "Not allowed in a modeline"
+#: ../option.c:2740
+#, fuzzy
+msgid "E520: Not allowed in a modeline"
 msgstr "Není v modeline povoleno"
 
-msgid ""
-"\n"
-"\tLast set from "
+#: ../option.c:2815
+msgid "E846: Key code not set"
 msgstr ""
-"\n"
-"\tNaposledy nastavena z "
 
-msgid "Number required after ="
+#: ../option.c:2924
+#, fuzzy
+msgid "E521: Number required after ="
 msgstr "Po = je vy¾adováno èíslo"
 
-msgid "Not found in termcap"
+#: ../option.c:3226 ../option.c:3864
+#, fuzzy
+msgid "E522: Not found in termcap"
 msgstr "Nenalezen v termcapu"
 
-#, c-format
-msgid "Illegal character <%s>"
+#: ../option.c:3335
+#, fuzzy, c-format
+msgid "E539: Illegal character <%s>"
 msgstr "Nepøípustný znak <%s>"
 
-msgid "Not allowed here"
-msgstr "Toto zde není povoleno"
-
-msgid "Cannot set 'term' to empty string"
+#: ../option.c:3862
+#, fuzzy
+msgid "E529: Cannot set 'term' to empty string"
 msgstr "volba 'term' nemù¾e být prázdná"
 
-msgid "Cannot change term in GUI"
-msgstr "V GUI nelze mìnit term"
-
-msgid "Use \":gui\" to start the GUI"
-msgstr "Pou¾ijte \"gui\" pro spu¹tìní GUI"
-
-msgid "'backupext' and 'patchmode' are equal"
+#: ../option.c:3885
+#, fuzzy
+msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "volby 'backupext' a 'patchmode' mají stejnou hodnotu"
 
-msgid "Zero length string"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
+
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
+#, fuzzy
+msgid "E524: Missing colon"
+msgstr "Chybí dvojteèka"
+
+#: ../option.c:4165
+#, fuzzy
+msgid "E525: Zero length string"
 msgstr "øetìzec o nulové délce"
 
-#, c-format
-msgid "Missing number after <%s>"
+#: ../option.c:4220
+#, fuzzy, c-format
+msgid "E526: Missing number after <%s>"
 msgstr "Po <%s> chybí èíslo"
 
-msgid "Missing comma"
+#: ../option.c:4232
+#, fuzzy
+msgid "E527: Missing comma"
 msgstr "Chybí èárka"
 
-msgid "Must specify a ' value"
+#: ../option.c:4239
+#, fuzzy
+msgid "E528: Must specify a ' value"
 msgstr "Je nutné zadat hodnotu '"
 
-msgid "contains unprintable character"
+#: ../option.c:4271
+#, fuzzy
+msgid "E595: contains unprintable or wide character"
 msgstr "obsahuje netisknutelné znaky"
 
-msgid "Invalid font(s)"
-msgstr "Chybná písma"
-
-msgid "can't select fontset"
-msgstr "nelze vybrat sadu písem"
-
-msgid "Invalid fontset"
-msgstr "chybná sada písem"
-
-msgid "can't select wide font"
-msgstr "nelze vybrat ¹iroký font"
-
-msgid "Invalid wide font"
-msgstr "Chybné ¹iroké písmo"
-
-#, c-format
-msgid "Illegal character after <%c>"
+#: ../option.c:4469
+#, fuzzy, c-format
+msgid "E535: Illegal character after <%c>"
 msgstr "Nepøípustný znak po <%c>"
 
-msgid "comma required"
+#: ../option.c:4534
+#, fuzzy
+msgid "E536: comma required"
 msgstr "je nutná èárka"
 
-#, c-format
-msgid "'commentstring' must be empty or contain %s"
+#: ../option.c:4543
+#, fuzzy, c-format
+msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "volba `commentstring` musí být buï prázdná nebo nastavená na %s"
 
-msgid "No mouse support"
-msgstr "Bez podpory my¹i"
-
-msgid "Unclosed expression sequence"
+#: ../option.c:4928
+#, fuzzy
+msgid "E540: Unclosed expression sequence"
 msgstr "neuzavøená sekvence výrazù"
 
-msgid "too many items"
+#: ../option.c:4932
+#, fuzzy
+msgid "E541: too many items"
 msgstr "pøíli¹ mnoho polo¾ek"
 
-msgid "unbalanced groups"
+#: ../option.c:4934
+#, fuzzy
+msgid "E542: unbalanced groups"
 msgstr "nevyvá¾ené skupiny"
 
-msgid "A preview window already exists"
+#: ../option.c:5148
+#, fuzzy
+msgid "E590: A preview window already exists"
 msgstr "Okno náhledu ji¾ existuje"
 
-msgid "'winheight' cannot be smaller than 'winminheight'"
+#: ../option.c:5311
+msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
-"hodnota volby 'winheight' nesmí být men¹í ne¾ hodnota volby 'winminheight'"
 
-msgid "'winwidth' cannot be smaller than 'winminwidth'"
-msgstr ""
-"hodnota volby 'winwidth' nesmí být men¹í ne¾ hodnota volby 'winminwidth'"
-
-#, c-format
-msgid "Need at least %d lines"
+#: ../option.c:5623
+#, fuzzy, c-format
+msgid "E593: Need at least %d lines"
 msgstr "minimální potøebný poèet øádkù: %d"
 
-#, c-format
-msgid "Need at least %d columns"
+#: ../option.c:5631
+#, fuzzy, c-format
+msgid "E594: Need at least %d columns"
 msgstr "minimální potøebný poèet sloupcù: %d"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Neznámá volba: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "Po = je vy¾adováno èíslo"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3374,6 +4846,7 @@ msgstr ""
 "\n"
 "--- Kódy terminálu ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3381,6 +4854,7 @@ msgstr ""
 "\n"
 "--- Nastavení globálních voleb ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3388,6 +4862,7 @@ msgstr ""
 "\n"
 "--- Nastavení lokálních voleb ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3395,134 +4870,21 @@ msgstr ""
 "\n"
 "--- Volby ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp CHYBA"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': pro %s chybí vyhovující znak"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': nadbyteèné znaky po støedníku: %s"
 
-msgid "cannot open "
-msgstr "nelze otevøít "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nelze otevøít nové okno!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Vy¾aduje Amigados verze 2.04 nebo vy¹¹í\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Vy¾aduje %s verze %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nelze otevøít NIL:\n"
-
-msgid "Cannot create "
-msgstr " Nelze vytvoøit "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim bude ukonèen %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "Nelze zmìnit mód konzole ?!\n"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Nastavování re¾imu obrazovky není podporováno"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: neni konzole??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nelze spustit shell s parametrem -f"
-
-msgid "Cannot execute "
-msgstr "Nelze spustit "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " návratová hodnota shellu\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE je pøíli¹ malá."
-
-msgid "I/O ERROR"
-msgstr "I/O CHYBA"
-
-msgid "...(truncated)"
-msgstr "...(kráceno)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' není 80, nelze spustit externí pøíkaz"
-
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Volání knihovní funkce \"%s()\" selhalo"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Nelze zvolit tiskárnu"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "do %s v %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Chyba tisku: %s"
-
-msgid "Unknown"
-msgstr "Neznámý"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Vyti¹tìno '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Nepøípustná jméno znakové sady \"%s\" ve fontu \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Nepøípustný znak '%c' ve fontu \"%s\""
-
-msgid "E366: Invalid 'osfiletype' option - using Text"
-msgstr "E366: Neplatný 'osfiletype' - pou¾it Text"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "VIm: dvojitý signál, konèím\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Zachycen smrtelný signál %s\n"
-
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Zachycen smrtelný signál\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Doba otevírání X displeje (v ms): %<PRId64>"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: chyba X11\n"
-
-msgid "Testing the X display failed"
-msgstr "Test X displeje se nezdaøil"
-
-msgid "Opening the X display timed out"
-msgstr "Vypr¹el èas pøi èekání na otevøení X displeje"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -3530,13 +4892,7 @@ msgstr ""
 "\n"
 "nelze spustit shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nelze spustit sh shell\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -3544,279 +4900,968 @@ msgstr ""
 "\n"
 " návratová hodnota shellu "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Nelze vytvoøit roury\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Volání fork selhalo\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Pøíkaz ukonèen\n"
-
-msgid "Opening the X display failed"
-msgstr "Otevøení X displeje se nezdaøilo"
-
-msgid "At line"
-msgstr "Na øádku"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nelze naèíst vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Chyba VIMu"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nelze nastavit ukazatele funkcí na DLL"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "shell returned %d"
-msgstr "návratová hodnota shellu %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Zachycen %s signál\n"
-
-msgid "close"
-msgstr "zavøít"
-
-msgid "logoff"
-msgstr "logoff"
-
-msgid "shutdown"
-msgstr "shutdown"
-
-msgid "E371: Command not found"
-msgstr "E371: Pøíkaz není k dispozici"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
+msgid "dlerror = \"%s\""
 msgstr ""
-"VIMRUN.EXE se nevyskytuje ve Va¹í $PATH.\n"
-"Externí pøíkazy nebudou "
 
-msgid "Vim Warning"
-msgstr "Varování"
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Soubor \"%s\" nelze v path nalézt"
 
+#: ../quickfix.c:359
+#, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Pøíli¹ mnoho %%%c ve formátovacím øetìzci"
 
+#: ../quickfix.c:371
+#, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Neoèekávaný výskyt %%%c ve formátovacím øetìzci"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Ve formátovacím øetìzci chybí ]"
 
+#: ../quickfix.c:431
+#, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c Nepodporovaná formátová specifikace ve formátovacím øetìzci"
 
+#: ../quickfix.c:448
+#, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Nepøípustné %%%c v prefixu formátovacího øetìzce"
 
+#: ../quickfix.c:454
+#, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Nepøípustné %%%c ve formátovacím øetìzci"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' neobsahuje ¾ádný vzorek"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Chybìjící nebo prázdný název adresáøe"
 
-msgid "No more items"
+#: ../quickfix.c:1305
+#, fuzzy
+msgid "E553: No more items"
 msgstr "®ádné dal¹í polo¾ky"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d/%d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (øádek smazán)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Konec quickfix seznamu"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Zaèátek quickfix seznamu"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "seznam chyb %d z %d; poèet chyb: %d"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nelze ulo¾it, je nastavena volba 'buftype'"
 
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "Nelze otevøít soubor %s"
+
+#: ../quickfix.c:3429
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "Poèet deaktivovaných bufferù: 1"
+
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "oèekávána èíslice"
+
+#: ../regexp.c:359
+#, fuzzy, c-format
+msgid "E369: invalid item in %s%%[]"
+msgstr "E239: Neplatný text volby: %s"
+
+#: ../regexp.c:374
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr ""
+
+#: ../regexp.c:376
+#, fuzzy, c-format
+msgid "E54: Unmatched %s("
+msgstr "®ádná shoda: %s"
+
+#: ../regexp.c:377
+#, fuzzy, c-format
+msgid "E55: Unmatched %s)"
+msgstr "®ádná shoda: %s"
+
+#: ../regexp.c:378
+#, fuzzy
+msgid "E66: \\z( not allowed here"
+msgstr "E407: %s zde není povoleno"
+
+#: ../regexp.c:379
+#, fuzzy
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E407: %s zde není povoleno"
+
+#: ../regexp.c:380
+#, fuzzy, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E109: Po '?' chybí ':'"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr ""
+
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Vzor je pøíli¹ dlouhý"
 
+#: ../regexp.c:1371
+#, fuzzy
+msgid "E50: Too many \\z("
+msgstr "E76: pøíli¹ mnoho ["
+
+#: ../regexp.c:1378
+#, fuzzy, c-format
+msgid "E51: Too many %s("
+msgstr "E76: pøíli¹ mnoho ["
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr ""
+
+#: ../regexp.c:1637
+#, fuzzy, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E215: Nepøípustný znak po *: %s"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr ""
+
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: %s%c"
 
+#: ../regexp.c:1800
+#, fuzzy
+msgid "E63: invalid use of \\_"
+msgstr "E176: Chybný poèet argumentù"
+
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c nic není"
 
-#, c-format
-msgid "Syntax error in %s{...}"
+#: ../regexp.c:1902
+#, fuzzy
+msgid "E65: Illegal back reference"
+msgstr "E125: Nepøípustný argument: %s"
+
+#: ../regexp.c:1943
+#, fuzzy
+msgid "E68: Invalid character after \\z"
+msgstr "E215: Nepøípustný znak po *: %s"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E215: Nepøípustný znak po *: %s"
+
+#: ../regexp.c:2107
+#, fuzzy, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E215: Nepøípustný znak po *: %s"
+
+#: ../regexp.c:3017
+#, fuzzy, c-format
+msgid "E554: Syntax error in %s{...}"
 msgstr "Chyba syntaxe v %s{...}"
 
-msgid "E361: Crash intercepted; regexp too complex?"
-msgstr "E361: Zachyceno pøeteèení zásobníku: pøíli¹ slo¾itý regulární výraz?"
-
-msgid "E363: pattern caused out-of-stack error"
-msgstr "E363: vzorek zpùsobil pøeteèení zásobníku"
-
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Vnìj¹í podøazené shody:\n"
 
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "poèet øádkù v záhybu: %3ld"
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr ""
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Nelze najít doèasný temp soubor pro zápis"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " VREPLACE"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " REPLACE"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " REVERSE"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERT"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (insert)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (replace)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (vreplace)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hebrejský"
 
+#: ../screen.c:7454
+msgid " Arabic"
+msgstr ""
+
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lang)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (paste)"
 
-msgid " SELECT"
-msgstr " SHODY"
-
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VIZUÁLNÍ"
 
-msgid " BLOCK"
-msgstr " BLOK"
+#: ../screen.c:7470
+#, fuzzy
+msgid " VISUAL LINE"
+msgstr " VIZUÁLNÍ"
 
-msgid " LINE"
-msgstr " ØÁDEK"
+#: ../screen.c:7471
+#, fuzzy
+msgid " VISUAL BLOCK"
+msgstr " VIZUÁLNÍ"
 
+#: ../screen.c:7472
+msgid " SELECT"
+msgstr " SHODY"
+
+#: ../screen.c:7473
+#, fuzzy
+msgid " SELECT LINE"
+msgstr " SHODY"
+
+#: ../screen.c:7474
+#, fuzzy
+msgid " SELECT BLOCK"
+msgstr " SHODY"
+
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "nahrávám"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "hledání dosáhlo zaèátku, pokraèování od konce"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "hledání dosáhlo konce, pokraèování od zaèátku"
-
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Nepøípustný hledaný øetìzec: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: hledaný dosáhlo zaèátku bez nalezení %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: hledaný dosáhlo konce bez nalezení %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Po ';' oèekávám '?' nebo '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (vèetnì ji¾ vypsaných shod)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Vlo¾ené soubory"
 
+#: ../search.c:4106
 msgid "not found "
 msgstr " nenalezeny"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "v cestì ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Ji¾ vypsáno)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " NENALEZENY"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Prohledávám vlo¾ené soubory: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "Prohledávám vlo¾ené soubory: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Shoda je na aktuálním øádku"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "V¹echny vlo¾ené soubory byly nalezeny"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "®ádné vlo¾ené soubory"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nelze nalézt definici"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nelze nalézt vzorek"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 nahrazení"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+#, fuzzy
+msgid "E759: Format error in spell file"
+msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:955
+#, fuzzy
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E431: Chyba formátu v souboru tagù \"%s\""
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "Pou¾ívám odkládací soubor \"%s\""
+
+#: ../spell.c:2496
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s se nezdá být odkládacím souborem Vim"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
+
+#: ../spell.c:3762
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "Volba není podporována"
+
+#: ../spell.c:4550
+#, fuzzy, c-format
+msgid "Reading affix file %s ..."
+msgstr "Prohledávám soubor tagù %s"
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, fuzzy, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr "Pou¾it chybný id serveru: %s"
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: Duplicitní tag \"%s\" v souboru %s"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "Pøíli¹ mnoho edit argumentù"
+
+#: ../spell.c:5238
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "Pøíli¹ mnoho edit argumentù"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, fuzzy, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "Prohledávám slovník %s"
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "Vzor nalezen na ka¾dém øádku: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, fuzzy, c-format
+msgid "Reading word file %s ..."
+msgstr "Ètu ze standardního vstupu..."
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "Pou¾it chybný id serveru: %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "Ukládám viminfo souboru \"%s\""
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr ""
+
+#: ../spell.c:7846
+#, fuzzy, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E15: Chybný výraz: %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, fuzzy, c-format
+msgid "Writing spell file %s ..."
+msgstr "Ukládám viminfo souboru \"%s\""
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, fuzzy, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr " na %<PRId64> øádcích"
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, fuzzy, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "Ulo¾it zmìny do \"%.*s\"?"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: ¾ádný pøedchozí regulární výraz"
+
+#: ../spell.c:8925
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: Vzor nenalezen: %s"
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s se nezdá být odkládacím souborem Vim"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Chyba pøi ètení chybového souboru"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Pro tento buffer nejsou definovány ¾ádné pøedmìty syntaxe"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: nepøípustný argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaktická sestava %s neexistuje"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Pro tento buffer nejsou definovány ¾ádné pøedmìty syntaxe"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizuji komentáøe v C stylu"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "¾ádná synchronizace"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synchronizace zaèíná "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " øádkù pøed zaèátkem"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -3824,6 +5869,7 @@ msgstr ""
 "\n"
 "--- Polo¾ky synchronizace syntaxe ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -3831,6 +5877,7 @@ msgstr ""
 "\n"
 "synchronizuji pøedmìty"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -3838,187 +5885,280 @@ msgstr ""
 "\n"
 "--- Pøedmìty syntaxe ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Syntaktická sestava %s neexistuje"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimální "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximální "
 
+#: ../syntax.c:3513
+#, fuzzy
+msgid "; match "
+msgstr "shoda %d"
+
+#: ../syntax.c:3515
+#, fuzzy
+msgid " line breaks"
+msgstr "poèet smazaných øádkù: 1"
+
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: obsahuje argumenty, které zde nejsou povoleny"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E180: Chybná hodnota doplnìní: %s"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here nesmí být na tomto místì"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Pro %s chybí polo¾ka regionu"
 
-msgid "E395: contains argument not accepted here"
-msgstr "E395: obsahuje argumenty, které zde nejsou povoleny"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: obsahuje argumenty, které zde nejsou povoleny"
-
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Vy¾adován název souboru"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Pøíli¹ mnoho názvù souborù"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: Chybí '=': %s"
+
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Chybí '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Pøíli¹ málo argumentù: oblast syntaxe %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaktická sestava %s neexistuje"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Nebyla zadána ¾ádná sestava"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Oddìlovaè vzorku %s nenalezen"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Chyba za vzorkem %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: synchronizace syntaxe: vzorek pokraèování øádkù zadán dvakrát"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: nepøípustný argument: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Chybí rovnítko: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Prázdný argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s zde není povoleno"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musí být první v 'contains' seznamu"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Neznámá název skupiny: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: chybný podøazený pøíkaz :syntax : %s "
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: skupina zvýraznìní %s nebyla nalezena"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Pøíli¹ málo argumentù: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Pøíli¹ mnoho argumentù: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: skupina je nastavena, odkaz na zvýrazòovací skupinu ignorován"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: neèekané rovnítko : %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: chybné rovnítko: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: chybí argument: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: nepøípustná hodnota: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: barva popøedí není známá"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: barva popøedí není známá"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: název èi èíslo barvy %s nebylo rozpoznáno"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminálový kód %s je pøíli¹ dlouhý"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: nepøípustný argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr ""
 "E424: Je pou¾íváno pøíli¹ velké mno¾ství odli¹ných zvýrazòovacích atributù"
 
-msgid "at bottom of tag stack"
+#: ../syntax.c:7427
+msgid "E669: Unprintable character in group name"
+msgstr ""
+
+#: ../syntax.c:7434
+#, fuzzy
+msgid "W18: Invalid character in group name"
+msgstr "E182: Chybné jméno pøíkazu"
+
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
+#, fuzzy
+msgid "E555: at bottom of tag stack"
 msgstr "konec seznamu tagù"
 
-msgid "at top of tag stack"
+#: ../tag.c:105
+#, fuzzy
+msgid "E556: at top of tag stack"
 msgstr "zaèátek seznamu tagù"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Pøed první vyhovující tag nelze pøeskoèit"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tag %s nenalezen"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri typ tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "soubor\n"
 
-#.
-#. * Ask to select a tag from the list.
-#. * When using ":silent" assume that <CR> was entered.
-#.
-msgid "Enter nr of choice (<CR> to abort): "
-msgstr "Zadejte èíslo (<CR> pro ukonèení): "
-
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Vyhovuje pouze jeden tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Za poslední vyhovující tag nelze pøeskoèit"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Soubor \"%s\" neexistuje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d z celkového poètu %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " nebo více"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Pou¾ívám tag s písmeny jiné velikosti!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: \"%s\" neexistuje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -4026,65 +6166,82 @@ msgstr ""
 "\n"
 "  # CÍL tag        START øádek  v souboru/textu"
 
-msgid "Linear tag search"
-msgstr "Lineární hledání tagu"
-
-msgid "Binary tag search"
-msgstr "Binární hledání tagu"
-
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Prohledávám soubor tagù %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Soubor tagù %s byl oøezán\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátu v souboru tagù \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Pøed bajtem %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Obsah soubor tagù %s není seøazen"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: ®ádný soubor tagù"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nelze najít vzorek tagù"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Tag nelze nalézt, pouze hádám!"
 
+#: ../tag.c:2797
+#, c-format
+msgid "Duplicate field name: %s"
+msgstr ""
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' není znám. Dostupné vestavìné terminály:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "implicitní terminál '"
 
-msgid "Cannot open termcap file"
+#: ../term.c:1731
+#, fuzzy
+msgid "E557: Cannot open termcap file"
 msgstr "Nelze otevøít termcap"
 
-msgid "Terminal entry not found in terminfo"
+#: ../term.c:1735
+#, fuzzy
+msgid "E558: Terminal entry not found in terminfo"
 msgstr "Terminfo neobsahuje polo¾ku pro tento terminál"
 
-msgid "Terminal entry not found in termcap"
+#: ../term.c:1737
+#, fuzzy
+msgid "E559: Terminal entry not found in termcap"
 msgstr "Termcap neobsahuje polo¾ku pro tento terminál"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Termcap neobsahuje polo¾ku pro \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminál musí mít schopnost \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -4092,109 +6249,176 @@ msgstr ""
 "\n"
 "--- Klávesy terminálu ---"
 
-msgid "new shell started\n"
-msgstr "spu¹tìn nový shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: chyba pøi ètení vstupu, konèím...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "odstranìní zmìn není mo¾né; chcete pøesto pokraèovat"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Nelze otevøít soubor pro zápis"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Ukládám viminfo souboru \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Chyba pøi ukládání do odkládacího souboru"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Ètu viminfo soubor \"%s\"%s%s%s"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Nelze otevøít pro ètení viminfo soubor"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E150: %s není adresáøem"
+
+#: ../undo.c:1313
+#, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr ""
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "dokonèena interpretace %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> nenalezen"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: èísla øádkù jsou chybná"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "poèet nových øádkù: 1"
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "poèet nových øádkù: 1"
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "poèet smazaných øádkù: 1"
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "poèet smazaných øádkù: %<PRId64>"
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "poèet zmìn: 1"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "poèet zmìn: %<PRId64>"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "poèet zmìn: 1"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "Poèet øádkù: %<PRId64> (posunutých pomocí %s %d-krát)"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "®ádné mapování nebylo nalezeno"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "øádkù: %<PRId64>;"
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s zde není povoleno"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmìnách po¹kozen"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: chybí undo øádek"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32 bitová GUI verze pro MS Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitová GUI verze pro MS Windows"
-
-msgid " in Win32s mode"
-msgstr " ve Win32s re¾imu"
-
-msgid " with OLE support"
-msgstr " s OLE podporou"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitová verze pro MS Windows konzolu"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitová verze pro MS Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitová verze pro MS Windows"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitová MS-DOS verze"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) verze"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X verze"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS verze"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS verze"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -4202,6 +6426,19 @@ msgstr ""
 "\n"
 "Pou¾ité záplaty: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Vnìj¹í podøazené shody:\n"
+
+#: ../version.c:639 ../version.c:864
+#, fuzzy
+msgid "Modified by "
+msgstr " [Zmìnìný]"
+
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -4209,9 +6446,11 @@ msgstr ""
 "\n"
 "pøelo¾il "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -4219,446 +6458,1375 @@ msgstr ""
 "\n"
 "maximální verze"
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"velká verze "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"normální verze"
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"malá verze "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"minimální verze"
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez grafického rozhraní"
 
-msgid "with GTK-GNOME GUI."
-msgstr "s rozhraním GTK-GNOME"
-
-msgid "with GTK GUI."
-msgstr "s rozhraním GTK"
-
-msgid "with X11-Motif GUI."
-msgstr "s rozhraním X11-Motif"
-
-msgid "with X11-Athena GUI."
-msgstr "S rozhraním X11-Athena"
-
-msgid "with BeOS GUI."
-msgstr "s rozhraním BeOS"
-
-msgid "with Photon GUI."
-msgstr "s rozhraním Photon"
-
-msgid "with GUI."
-msgstr "s grafickým rozhraním"
-
-msgid "with Carbon GUI."
-msgstr "s grafickým rozhraním Carbon"
-
-msgid "with Cocoa GUI."
-msgstr "s grafickým rozhraním Cocoa"
-
-msgid "with (classic) GUI."
-msgstr "s (clasickým) grafickým rozhraním"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr " Vlastnosti zahrnuté (+) a nezahrnuté (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   systémový vimrc soubor: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     u¾ivatelský vimrc soubor: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " druhý u¾ivatelský vimrc soubor: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " tøetí u¾ivatelský vimrc soubor: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      u¾ivatelský exrc soubor: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  druhý u¾ivatelský exrc soubor: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  systémový gvimrc soubor: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    u¾ivatelský gvimrc soubor: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "druhý u¾ivatelský gvimrc soubor: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "tøetí u¾ivatelský gvimrc soubor: \""
-
-msgid "    system menu file: \""
-msgstr "    systémový soubor s menu: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  implicitní hodnota $VIM:\""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "  implicitní hodnota $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Pøeklad: "
 
-msgid "Compiler: "
-msgstr "Pøekladaè: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Linkuji: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  PODPORA LADÌNÍ"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "verze "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Autor: Bram Moolenaar a dal¹í"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim je volnì ¹iøitelný program s otevøeným zdrojovým kódem"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomozte chudým dìtem v Ugandì!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "podrobnìj¹í informace získáte pomocí :help iccf<Enter>"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "zadejte :q<Enter>             pro ukonèení programu"
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "zadejte :help<Enter>  èi <F1> pro nápovìdu"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "zadejte :help version7<Enter>  pro informace o verzi 6"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Bì¾ím v re¾imu kompatibility s Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "zadejte :set nocp<Enter>     pro implicitní nastavení Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "podrobnìj¹í informace získáte pomocí :help cp-default<Enter>"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "VAROVÁNÍ: detekovány Windows 95/98/ME"
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr ""
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "zadejte :help windows95<Enter> pro podrobnìj¹í informace"
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr ""
 
-msgid "E441: There is no preview window"
-msgstr "E441: Není ¾ádné preview okno není"
+#: ../version.c:831
+#, fuzzy
+msgid "type  :help sponsor<Enter>    for information "
+msgstr "podrobnìj¹í informace získáte pomocí :help iccf<Enter>"
 
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: Okno nelze rozdìlit zároveò topleft a botright"
+#: ../version.c:832
+#, fuzzy
+msgid "type  :help register<Enter>   for information "
+msgstr "podrobnìj¹í informace získáte pomocí :help iccf<Enter>"
 
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: Nelze rotovat, pokud je jiné okno rozdìleno"
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr ""
 
-msgid "E444: Cannot close last window"
-msgstr "E444: Poslední okno nelze uzavøít"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Ji¾ existuje pouze jedno okno"
 
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: Není ¾ádné preview okno není"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: Okno nelze rozdìlit zároveò topleft a botright"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: Nelze rotovat, pokud je jiné okno rozdìleno"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: Poslední okno nelze uzavøít"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Poslední okno nelze uzavøít"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Poslední okno nelze uzavøít"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Jiné okno obsahuje zmìny"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Pod kurzorem se nenachází název souboru"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Soubor \"%s\" nelze v path nalézt"
+#~ msgid "E86: Cannot go to buffer %<PRId64>"
+#~ msgstr "E86: Nelze pøeskoèit na buffer %<PRId64>"
 
-msgid "Edit with &multiple Vims"
-msgstr "Editace &multiple Vimy"
+#~ msgid "[Error List]"
+#~ msgstr "[seznam chyb]"
 
-msgid "Edit with single &Vim"
-msgstr "Editace jedním $Vim -em"
+#~ msgid "[No File]"
+#~ msgstr "[¾ádný soubor]"
 
-msgid "Edit with &Vim"
-msgstr "Editace &Vim -em"
+#~ msgid "Patch file"
+#~ msgstr "Soubor se záplatou"
 
-msgid "Edit with existing Vim - &"
-msgstr "Editace existujícím Vimem - &"
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: Neznámá promìnná: \"%s\""
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Editace vybraných souborù Vimem"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zru¹it"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Chyba pøi spou¹tìní procesu: Zkontrolujte zdali je gvim v $PATH!"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Neexistuje pøipojení k Vim serveru"
 
-msgid "gvimext.dll error"
-msgstr "chyba gvimext.dll"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nelze èíst odpovìï serveru"
 
-msgid "Path length too long!"
-msgstr "Název (v path) je pøíli¹ dlouhý"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nelze pøedat do %s"
 
-msgid "--No lines in buffer--"
-msgstr "--Buffer neobsahuje ¾ádný øádek--"
+#~ msgid "function "
+#~ msgstr "funkce "
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "Command aborted"
-msgstr "Pøíkaz pøeru¹en"
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: Nedefinovaná funkce: %s"
 
-msgid "Argument required"
-msgstr "Je vy¾adován argument"
+#~ msgid "Save As"
+#~ msgstr "Ulo¾it jako"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ by mìl následovat /. ? nebo &"
+#~ msgid "Edit File"
+#~ msgstr "Editovat soubor"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chyba v oknì pøíkazové øádky; <CR> pro spu¹t¹ní, CTRL-C pro ukonèení"
+#~ msgid "Run Macro"
+#~ msgstr "Spustit makro"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Pøíkaz není z exrc/vimrc v aktuálním adresáøi èi pøi hledání tagu "
-"povolen."
+#~ msgid "Edit File in new window"
+#~ msgstr "Editovat soubor v novém oknì"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Soubor existuje (pou¾ijte ! pro vynucení)"
+#~ msgid "Append File"
+#~ msgstr "Ulo¾it soubor"
 
-msgid "Command failed"
-msgstr "Pøíkaz selhal"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Umístìní okna: X %d, Y %d"
 
-msgid "Internal error"
-msgstr "Vnitøní chyba"
+#~ msgid "Save Redirection"
+#~ msgstr "Ulo¾it pøesmìrování"
 
-msgid "Interrupted"
-msgstr "Pøeru¹eno"
+#~ msgid "Save View"
+#~ msgstr "Ulo¾it pohled"
 
-msgid "E14: Invalid address"
-msgstr "E14: Chybná adresa"
+#~ msgid "Save Session"
+#~ msgstr "Ulo¾it sezení"
 
-msgid "Invalid argument"
-msgstr "Chybný argument"
+#~ msgid "Save Setup"
+#~ msgstr "Ulo¾it nastavení"
 
-#, c-format
-msgid "Invalid argument: %s"
-msgstr "Chybný argument: %s"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: V této verzi nejsou spøe¾ky podporovány"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Chybný výraz: %s"
+#~ msgid "[NL found]"
+#~ msgstr "[nalezeno NL]"
 
-msgid "E16: Invalid range"
-msgstr "E16: Chybný rozsah"
+#~ msgid "[crypted]"
+#~ msgstr "[za¹ifrován]"
 
-msgid "Invalid command"
-msgstr "Chybný pøíkaz"
+# resource fork ?!
+#~ msgid "The resource fork will be lost (use ! to override)"
+#~ msgstr "'Resource fork' bude ztracen (pou¾ijte ! pro vynucení)"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" je adresáøem"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nelze spustit GUI"
 
-msgid "E18: Unexpected characters before '='"
-msgstr "E18: Neoèekávané znaky pøed '='"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nelze èíst z \"%s\""
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Znaèka má chybné èíslo øádku"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: volba 'guifontwide' je chybnì nastavena"
 
-msgid "E20: Mark not set"
-msgstr "E20: není nastavena"
+#~ msgid "<cannot open> "
+#~ msgstr "<nelze otevøít> "
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nelze mìnit, je nastavena volba 'modifiable'"
+#~ msgid "vim_SelFile: can't get font %s"
+#~ msgstr "vim_SelFile: písmo %s není dostupné"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skript vnoøen pøíli¹ hluboko"
+#~ msgid "vim_SelFile: can't return to current directory"
+#~ msgstr "vim_SelFile: nelze se vrátit do aktuálního adresáøe"
 
-msgid "E23: No alternate file"
-msgstr "E23: ®ádný alternativní soubor"
+#~ msgid "Pathname:"
+#~ msgstr "Název cesty:"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Taková zkratka neexistuje"
+#~ msgid "vim_SelFile: can't get current directory"
+#~ msgstr "vim_SelFile: nelze zjistit aktuální adresáø"
 
-msgid "No ! allowed"
-msgstr "! není povoleno"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Nelze pou¾ít GUI: nebylo zapnuto pøi pøekladu programu"
+#~ msgid "Cancel"
+#~ msgstr "Zru¹it"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E26: nelze pou¾ít hebrejský re¾im:  nebyl zapnut pøi pøekladu programu\n"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Pøípravek posunovací li¹ty: nelze zjistit geometrii obrázku"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Nelze pou¾ít farsi re¾im:  nebyl zapnut pøi pøekladu programu\n"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim dialog"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Skupina zvýraznìní %s neexistuje"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: BalloonEval nelze vytvoøit se zprávou a zároveò zpìtným voláním"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Zatím není ¾ádný vlo¾ený text"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialog.."
 
-msgid "E30: No previous command line"
-msgstr "E30: ®ádná pøedchozí pøíkazová øádka"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Nalézt a nahradit..."
 
-msgid "E31: No such mapping"
-msgstr "E31: ®ádné takové mapování"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Nalézt..."
 
-msgid "No match"
-msgstr "®ádná shoda"
+#~ msgid "Find what:"
+#~ msgstr "Vyhledat:"
 
-#, c-format
-msgid "No match: %s"
-msgstr "®ádná shoda: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Nový text:"
 
-msgid "E32: No file name"
-msgstr "E32: ®ádný název souboru"
+#~ msgid "Match exact word only"
+#~ msgstr "hledat pouze celá slova"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: ¾ádný pøedchozí regulární výraz"
+#~ msgid "Direction"
+#~ msgstr "Smìr"
 
-msgid "E34: No previous command"
-msgstr "E34: ®ádný pøedchozí pøíkaz"
+#~ msgid "Up"
+#~ msgstr "Nahoru"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: ¾ádný pøedchozí regulární výraz"
+#~ msgid "Down"
+#~ msgstr "Dolù"
 
-msgid "No range allowed"
-msgstr "Rozsah není povolen"
+#~ msgid "Find Next"
+#~ msgstr "Najít dal¹í"
 
-msgid "E36: Not enough room"
-msgstr "E36: Nedostatek místa"
+#~ msgid "Replace"
+#~ msgstr "Nahradit"
 
-#, c-format
-msgid "Can't create file %s"
-msgstr "Nelze vytvoøit soubor %s"
+#~ msgid "Replace All"
+#~ msgstr "Nahradit v¹e"
 
-msgid "Can't get temp file name"
-msgstr "Nelze získat název doèasného souboru"
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nelze otevøít display"
 
-#, c-format
-msgid "Can't open file %s"
-msgstr "Nelze otevøít soubor %s"
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Neznámá sada písem: %s"
 
-#, c-format
-msgid "Can't read file %s"
-msgstr "Nelze èíst soubor %s"
+#~ msgid "Font Selection"
+#~ msgstr "Výbìr písma"
 
-msgid "E37: No write since last change (use ! to override)"
-msgstr "E37: Neulo¾ené zmìny (pou¾ijte ! pro vynucení)"
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Neznámé písmo: %s"
 
-msgid "E38: Null argument"
-msgstr "E38: Nulový argument"
+#~ msgid "E242: Color name not recognized: %s"
+#~ msgstr "E242: Neznámé jméno barvy: %s"
 
-msgid "E39: Number expected"
-msgstr "E39: Oèekáváno èíslo"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Místo prádné schránky pou¾ito CUT_BUFFER0"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nelze otevøít chybový soubor %s"
+#~ msgid "Filter"
+#~ msgstr "Filtr"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Nedostatek pamìti!"
+#~ msgid "Directories"
+#~ msgstr "Adresáøe"
 
-msgid "Pattern not found"
-msgstr "Vzor nenalezen"
+#~ msgid "Help"
+#~ msgstr "Nápovìda"
 
-#, c-format
-msgid "Pattern not found: %s"
-msgstr "Vzor nenalezen: %s"
+#~ msgid "Files"
+#~ msgstr "Soubory"
 
-msgid "Argument must be positive"
-msgstr "Argument musí být kladný"
+#~ msgid "Selection"
+#~ msgstr "Výbìr"
 
-msgid "E42: No Errors"
-msgstr "E42: ®ádné chyby"
+#~ msgid "Undo"
+#~ msgstr "Zpìt"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Po¹kozený øetìzec pro vyhledávání"
+#~ msgid "E235: Can't load Zap font '%s'"
+#~ msgstr "E235: Nelze naèíst Zap font '%s'"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: po¹kozený regexp program"
+#~ msgid ""
+#~ "\n"
+#~ "Sending message to terminate child process.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Posílám signál k ukonèení synovského procesu.\n"
 
-msgid "E45: 'readonly' option is set (use ! to override)"
-msgstr "E45: 'nastavena volba 'readonly' (pou¾ijte ! pro vynucení)"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nepodporován: \"-%s\"; Pou¾ijte OLE verzi."
 
-#, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: Nelze nastavit pouze_pro_ètení promìnnou \"%s\""
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Najít øetìzec (pou¾ijte '\\\\' k nalezení '\\')"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Chyba pøi ètení chybového souboru"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Najít & Nahradit (pou¾ijte '\\\\' k nalezení '\\')"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Není v bezpeènostní schránce povoleno"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: nelze alokovat polo¾ku barevné mapy. Nìkteré barvy mohou být "
+#~ "nesprávné"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Chybná hodnota volby 'scroll'"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: písma pro následující znakové sady chybí v sadì písem %s:"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: volba 'shell' je prázdná"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: název sady písem: %s"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Chyba pøi uzavírání odkládacího souboru"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Písmo '%s' nemá pevnou ¹íøku"
 
-msgid "E73: tag stack empty"
-msgstr "E73: seznam tagù je prázdný"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: název sady písem: %s\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: Pøíkaz je pøíli¹ slo¾itý"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Písmo0: %s\n"
 
-msgid "E75: Name too long"
-msgstr "E75: Název je pøíli¹ dlouhý"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Písmo1: %s\n"
 
-msgid "E76: Too many ["
-msgstr "E76: pøíli¹ mnoho ["
+#~ msgid "Font%d width is not twice that of font0\n"
+#~ msgstr "©íøka písma%d není dvojnásoblem ¹íøky písma0\n"
 
-msgid "E77: Too many file names"
-msgstr "E77: Pøíli¹ mnoho názvù souborù"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "©íøka písma0: %<PRId64>\n"
 
-msgid "Trailing characters"
-msgstr "Nadbyteèné znaky na konci"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "©íøka písma1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Neznámá znaèka"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: nelze alokovat barvu %s"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nelze expandovat ¾olíkové znaky"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: CYBA Hangul automatu"
 
-msgid "E80: Error while writing"
-msgstr "E80: Chyba pøi ukládání"
+#~ msgid "error reading cscope connection %d"
+#~ msgstr "chyba pøi ètení cscope spojení %d"
 
-msgid "Zero count"
-msgstr "Nulový poèet"
+#~ msgid "maximum number of cscope connections reached"
+#~ msgstr "dosa¾en maximální poèet cscope spojení"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Pou¾ití <SID> mimo kontext skriptu"
+#~ msgid "E260: cscope connection not found"
+#~ msgstr "E260: connection spojení nenalezeno"
+
+#~ msgid "cscope connection closed"
+#~ msgstr "closed spojení uzavøeno"
+
+#~ msgid "couldn't malloc\n"
+#~ msgstr "volání malloc selhalo\n"
+
+#~ msgid "%2d %-5ld  %-34s  <none>\n"
+#~ msgstr "%2d %-5ld  %-34s  <¾ádný>\n"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Lituji, tento pøíkaz je deaktivován; knihovnu jazyka Python nelze "
+#~ "nahrát."
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nelze smazat atributy OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace musí být kladné celé èíslo"
+
+#~ msgid "invalid attribute"
+#~ msgstr "chybný atribut"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() vy¾aduje seznam øetìzcù"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: chyba pøi inicializaci I/O objektù"
+
+#~ msgid "invalid expression"
+#~ msgstr "Chybný výraz"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "podpora výrazù byla vypnuta pøi pøekladu programu"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "pokus o odkaz na smazaný buffer"
+
+#~ msgid "line number out of range"
+#~ msgstr "èíslo øádku mimo rozsah"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffer objekt (smazán) na %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "chybné jméno znaèky"
+
+#~ msgid "no such buffer"
+#~ msgstr "¾ádný takový buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "pokus o odkaz na smazané okno"
+
+#~ msgid "readonly attribute"
+#~ msgstr "atribut pouze_pro_ètení"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "umístìní kurzoru mimo buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<objekt okna (smazán) na %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<objekt okna (neznámý) na %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<okno %d>"
+
+#~ msgid "no such window"
+#~ msgstr "¾ádné takové okno"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "nelze ulo¾it informace pro pøíkaz undo"
+
+#~ msgid "cannot delete line"
+#~ msgstr "nelze smazat øádek"
+
+#~ msgid "cannot replace line"
+#~ msgstr "nelze nahradit øádek"
+
+#~ msgid "cannot insert line"
+#~ msgstr "nelze vlo¾it øádek"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "øetìzec nesmí obsahovat znaky nového øádku"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Ruby nelze "
+#~ "nahrát."
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: neznámý longjmp stav %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Prohození implementace/definice"
+
+#~ msgid "Show base class of"
+#~ msgstr "Zobrazení base class z"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Zobrazení overridden member funkce"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Znovuzískáno ze souboru"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Znovuzískáno z projektu"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Znovzískáno ze v¹ech projektù"
+
+#~ msgid "Retrieve"
+#~ msgstr "Znovuzískáno"
+
+#~ msgid "Show source of"
+#~ msgstr "Zobrazení zdroje"
+
+#~ msgid "Find symbol"
+#~ msgstr "Najít symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Prohlí¾et class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Zobrazení class v hierarchii"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Zobrazení class v restricted hierarchii"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odkazuje na"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref odkazoval na"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref má"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref pou¾it"
+
+#~ msgid "Show docu of"
+#~ msgstr "Zobrazení documentace"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generována dokumentace pro"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Nelze se pøipojit k SNiFF+. Zkontrolujte promìnné (sniffemacs musí "
+#~ "být)uvedena v $PATH.\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Chyba pøi ètení. Odpojeno"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ je právì "
+
+#~ msgid "not "
+#~ msgstr "ne "
+
+#~ msgid "connected"
+#~ msgstr "pøipojen"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Neznámý po¾adavek SNiFF+: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Chybné pøipojení k SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ nepøipojen"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Chyba pøi zápisu. Odpojeno."
+
+#~ msgid "not implemented yet"
+#~ msgstr "není je¹tì podporováno"
+
+#~ msgid "unknown option"
+#~ msgstr "neznámá volba"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "nelze nastavit øádky"
+
+#~ msgid "mark not set"
+#~ msgstr "znaèka není nastavena"
+
+#~ msgid "row %d column %d"
+#~ msgstr "øádek %d sloupec %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "nelze vlo¾it/pøipojit øádek"
+
+#~ msgid "unknown flag: "
+#~ msgstr "neznámý pøíznak: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "neznámá vimOption"
+
+#~ msgid "vim error"
+#~ msgstr "chyba vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nelze vytvoøit pøíkaz bufferu/okna: objekt smazán"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nelze zaregistrovat pøíkaz zpìtného volání: buffer/okno ji¾ bylo smazáno"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATAL ERROR: reflist po¹kozen!? Oznamte, prosím, tuto chybu na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nelze zaregistrovat pøíkaz zpìtného volání: odkaz na buffer/okno nenalezen"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Tcl library could not be loaded."
+#~ msgstr ""
+#~ "Lituji, ale tento pøíkaz je deaktivován; knihovnu jazyka Tcl nelze nahrát."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL CHYBA: návratový kód není celé èíslo!? Oznamte, prosím, tuto "
+#~ "chybu na vim-dev@vim.org"
+
+#~ msgid "cannot get line"
+#~ msgstr "nelze pøeèíst øádek"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Není mo¾né zaznamenat jméno command serveru"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Neexistuje registrovaný server jménem \"%s\""
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Selhalo zaslání pøíkazu urèenému programu"
+
+#~ msgid "E249: couldn't read VIM instance registry property"
+#~ msgstr "E249: nelze èíst VIM instanci registry property"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: VIM instance registry property byla ¹patnì vytvoøenaa byla smazána!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "VIM nebyl pøelo¾en s volbou +diff"
+
+#~ msgid "\"\n"
+#~ msgstr "\"\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tpøihlásit gvim na OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-register\t\todhlásit gvim z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tspustit v GUI re¾imu (stejné jako \"gvim\")"
+
+#~ msgid "-f\t\t\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f\t\t\tPopøedí: pøi startu GUI se neoddìlí od shellu"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tÚroveò výpisu hlá¹ek"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNebude pou¾ívat newcli pro otevøení okna"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <zaøízení>\t\tPou¾ít <zaøízení> pro I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tPou¾ije <gvimrc> místo jakéhokoliv .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEditace za¹ifrovaných souborù"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tSpustí vim na daný X-server"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNepøipojí se k X serveru"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtevøe Vim uvnitø jiného GTK widgetu"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server and exit"
+#~ msgstr "--remote <soubory>\tEdituje <soubory> na Vim serveru a skonèí"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <soubory> Jako --remote, ale èeká na soubory k editaci"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <klávesy>\tPøedá <klávesy> Vim serveru a skonèí"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <výraz>\tProvede <výraz> na serveru a zobrazí výsledek"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVypí¹e seznam dostupných Vim serverù a skonèí"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr ""
+#~ "--servername <jméno>\tZa¹le serveru <jméno>/stane se Vim serverem <jméno>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (Motif verzi):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (Athena verzi):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tSpustí vim na <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tSpustí vim minimalizované"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <název>\t\tPou¾ije resource jako by vim mìl <název>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (není implementováno)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <barva>\tNastaví <barvu> pozadí (také -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <barva>\tNastaví <barvu> popøedí (také -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <písmo>\t\tNastaví <písmo> normálního textu (také -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <písmo>\tNastaví <písmo> pro zvýraznìný text"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <písmo>\tNastaví <písmo> pro kurzívu"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geometrie>\tNastaví <geometrii> (také -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <¹íøka>\tNastaví <¹íøku> okrajù (také -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <¹íøku> Nastaví <¹íøku> posunovací li¹ty (také: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <vý¹ka>\tNastaví <vý¹ku> nabídky (také -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tPou¾ije reverzní barvy (také -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNepou¾ije reverzní barvy (také +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tNastaví zadaný <resource>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (RISC OS verzi):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <poèet>\t<poèet> sloupcù na okno"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <poèet>\t<poèet> øádkù na okno"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøepínaèe pro gvim (GTK+ verzi):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tSpustí vim na <display> (také --display)"
+
+#~ msgid "--help\t\tShow Gnome arguments"
+#~ msgstr "--help\t\tVypí¹e Gnome pøepínaèe"
+
+#~ msgid ""
+#~ "\n"
+#~ "Send failed.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøedání výrazu selhalo.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Send failed. Trying to execute locally\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøedání selhalo. Zkou¹ím provést lokálnì\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d z %d editováno"
+
+#~ msgid "Send expression failed.\n"
+#~ msgstr "Pøedání výrazu selhalo.\n"
+
+#~ msgid "Not a valid codepage"
+#~ msgstr "Chybná kódová stránka"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nepodaøilo se vytvoøit vstupní kontext"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nepodaøilo se otevøít vstupní metodu"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Varování: likvidaèní zpìtné volání nelze nastavit na IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: vstupní metoda nepodporuje ¾ádný styl"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: vstupní metoda nepodporuje mùj 'preedit' typ"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: Nadbodový styl vy¾aduje fontset"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Máte GTK+ verze star¹í ne¾ 1.2.3. Stavová plocha vypnuta."
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Server vstupních metod nebì¾í"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nepou¾itelné s touto verzí Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Odtrhnout tuto nabídku"
+
+#~ msgid "[string too long]"
+#~ msgstr "[pøíli¹ dlouhý øetìzec]"
+
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "pokraèování stiskem ENTER"
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: øádek, MEZERNÍK/b: stránka, d/u: 0.5 stránky, q: konec)"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: øádek, MEZERNÍK: stránka, d: 0.5 stránky, q: konec)"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialog pro ukládání souborù"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialog pro otevírání souborù"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Lituji, ale konzolová verze nepodporuje prohlí¾eè souborù"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachovávám soubory...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: ukonèen\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "CHYBA: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtù] celkem uvolnìno-alokováno %<PRIu64>-%<PRIu64>, vyu¾ito %<PRIu64>, "
+#~ "maximální vyu¾ití %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[volání] celkem re/malloc(): %<PRIu64>, celkem free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Øádek se stává pøíli¹ dlouhým"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
+
+#~ msgid "Illegal mouseshape"
+#~ msgstr "Chybný tvar my¹i"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Zadejte ¹ifrovací klíè: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Zadejte je¹tì jednou tentý¾ klíè:"
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Klíèe se neshodují"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "poèet uvolòovaných øádkù: %<PRId64>"
+
+#~ msgid "Cannot change term in GUI"
+#~ msgstr "V GUI nelze mìnit term"
+
+#~ msgid "Use \":gui\" to start the GUI"
+#~ msgstr "Pou¾ijte \"gui\" pro spu¹tìní GUI"
+
+#~ msgid "Invalid font(s)"
+#~ msgstr "Chybná písma"
+
+#~ msgid "can't select fontset"
+#~ msgstr "nelze vybrat sadu písem"
+
+#~ msgid "Invalid fontset"
+#~ msgstr "chybná sada písem"
+
+#~ msgid "can't select wide font"
+#~ msgstr "nelze vybrat ¹iroký font"
+
+#~ msgid "Invalid wide font"
+#~ msgstr "Chybné ¹iroké písmo"
+
+#~ msgid "No mouse support"
+#~ msgstr "Bez podpory my¹i"
+
+#~ msgid "cannot open "
+#~ msgstr "nelze otevøít "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nelze otevøít nové okno!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Vy¾aduje Amigados verze 2.04 nebo vy¹¹í\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Vy¾aduje %s verze %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nelze otevøít NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr " Nelze vytvoøit "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim bude ukonèen %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "Nelze zmìnit mód konzole ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: neni konzole??\n"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nelze spustit "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " návratová hodnota shellu\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE je pøíli¹ malá."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O CHYBA"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(kráceno)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' není 80, nelze spustit externí pøíkaz"
+
+#~ msgid "to %s on %s"
+#~ msgstr "do %s v %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Chyba tisku: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Vyti¹tìno '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Nepøípustná jméno znakové sady \"%s\" ve fontu \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Nepøípustný znak '%c' ve fontu \"%s\""
+
+#~ msgid "E366: Invalid 'osfiletype' option - using Text"
+#~ msgstr "E366: Neplatný 'osfiletype' - pou¾it Text"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "VIm: dvojitý signál, konèím\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Zachycen smrtelný signál %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Zachycen smrtelný signál\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Doba otevírání X displeje (v ms): %<PRId64>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: chyba X11\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test X displeje se nezdaøil"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Vypr¹el èas pøi èekání na otevøení X displeje"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nelze spustit sh shell\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nelze vytvoøit roury\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Volání fork selhalo\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pøíkaz ukonèen\n"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otevøení X displeje se nezdaøilo"
+
+#~ msgid "At line"
+#~ msgstr "Na øádku"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nelze naèíst vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Chyba VIMu"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nelze nastavit ukazatele funkcí na DLL"
+
+#~ msgid "shell returned %d"
+#~ msgstr "návratová hodnota shellu %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Zachycen %s signál\n"
+
+#~ msgid "close"
+#~ msgstr "zavøít"
+
+#~ msgid "logoff"
+#~ msgstr "logoff"
+
+#~ msgid "shutdown"
+#~ msgstr "shutdown"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Pøíkaz není k dispozici"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE se nevyskytuje ve Va¹í $PATH.\n"
+#~ "Externí pøíkazy nebudou "
+
+#~ msgid "Vim Warning"
+#~ msgstr "Varování"
+
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr ""
+#~ "E361: Zachyceno pøeteèení zásobníku: pøíli¹ slo¾itý regulární výraz?"
+
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: vzorek zpùsobil pøeteèení zásobníku"
+
+#~ msgid " BLOCK"
+#~ msgstr " BLOK"
+
+#~ msgid " LINE"
+#~ msgstr " ØÁDEK"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: obsahuje argumenty, které zde nejsou povoleny"
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "Zadejte èíslo (<CR> pro ukonèení): "
+
+#~ msgid "Linear tag search"
+#~ msgstr "Lineární hledání tagu"
+
+#~ msgid "Binary tag search"
+#~ msgstr "Binární hledání tagu"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Soubor tagù %s byl oøezán\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "spu¹tìn nový shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "odstranìní zmìn není mo¾né; chcete pøesto pokraèovat"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32 bitová GUI verze pro MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová GUI verze pro MS Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " ve Win32s re¾imu"
+
+#~ msgid " with OLE support"
+#~ msgstr " s OLE podporou"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verze pro MS Windows konzolu"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová verze pro MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verze pro MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová MS-DOS verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "velká verze "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "normální verze"
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "malá verze "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "minimální verze"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "s rozhraním GTK-GNOME"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "s rozhraním GTK"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "s rozhraním X11-Motif"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "S rozhraním X11-Athena"
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "s rozhraním BeOS"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "s rozhraním Photon"
+
+#~ msgid "with GUI."
+#~ msgstr "s grafickým rozhraním"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "s grafickým rozhraním Carbon"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "s grafickým rozhraním Cocoa"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "s (clasickým) grafickým rozhraním"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  systémový gvimrc soubor: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    u¾ivatelský gvimrc soubor: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "druhý u¾ivatelský gvimrc soubor: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "tøetí u¾ivatelský gvimrc soubor: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    systémový soubor s menu: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Pøekladaè: "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "VAROVÁNÍ: detekovány Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "zadejte :help windows95<Enter> pro podrobnìj¹í informace"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Editace &multiple Vimy"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Editace jedním $Vim -em"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Editace &Vim -em"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "Editace existujícím Vimem - &"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Editace vybraných souborù Vimem"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Chyba pøi spou¹tìní procesu: Zkontrolujte zdali je gvim v $PATH!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "chyba gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Název (v path) je pøíli¹ dlouhý"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: nelze pou¾ít hebrejský re¾im:  nebyl zapnut pøi pøekladu programu\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Nelze pou¾ít farsi re¾im:  nebyl zapnut pøi pøekladu programu\n"

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -6,150 +6,219 @@
 # Previous-Translator(s): 
 # Johannes Zellner <johannes@zellner.org>
 # Gerfried Fuchs <alfie@ist.org>
-
 msgid ""
 msgstr ""
 "Project-Id-Version: Vim(deutsch)\n"
-"POT-Creation-Date: 2006-04-02 11:30+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2008-05-24 17:26+0200\n"
 "Last-Translator: Georg Dahn <georg.dahn@gmail.com>\n"
 "Language-Team: German <de@li.org>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO_8859-1\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Schrott nach dem Optionsargument"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Positionsliste]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[QuickFix-Liste]"
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Kann keinen Puffer zuweisen; beenden..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Kann den Puffer nicht zuweisen; benutze einen anderen..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Keine Puffer wurden entladen"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Keine Puffer wurden vollständig gelöscht"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Keine Puffer wurden vollständig gelöscht"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "ein Puffer entladen"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d Puffer entladen"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "ein Puffer gelöscht"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d Puffer gelöscht"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "ein Puffer vollständig gelöscht"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d Puffer vollständig gelöscht"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Kann letzten Puffer nicht ausladen"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Kein veränderter Puffer gefunden"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Es gibt keine angezeigten Puffer"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Puffer %<PRId64> existiert nicht"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kann nicht über den letzten Puffer hinaus gehen"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kann nicht vor den ersten Puffer gehen"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
-msgstr "E89: Puffer %<PRId64> nicht gesichert seit der letzten Änderung (erzwinge mit !)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr ""
+"E89: Puffer %<PRId64> nicht gesichert seit der letzten Änderung (erzwinge "
+"mit !)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Kann letzten Puffer nicht ausladen"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Achtung: Überlauf der Liste der Dateinamen"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Kein Puffer %<PRId64> gefunden"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Mehr als ein Treffer für %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Kein übereinstimmender Puffer für %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "Zeile %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Ein Puffer mit diesem Namen existiert bereits"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Verändert]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Nicht editiert]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Neue Datei]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Lesefehler]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[Nur Lesen]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 Zeile --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> Zeilen --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "Zeile %<PRId64> von %<PRId64> --%d%%-- Spalte "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Unbenannt]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "Hilfe"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Hilfe]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Vorschau]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Alles"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Ende"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Anfang"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -157,12 +226,11 @@ msgstr ""
 "\n"
 "# Liste der Puffer:\n"
 
-msgid "[Location List]"
-msgstr "[Positionsliste]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[Quickfix List]"
-msgstr "[QuickFix-Liste]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -170,123 +238,202 @@ msgstr ""
 "\n"
 "--- Zeichen ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Zeichen für %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    Zeile=%<PRId64>  id=%d  Name=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Fehlender Doppelpunkt"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Unzulässiger Modus"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Ziffer erwartet"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Unzulässige Prozentangabe"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Keine Differenz für mehr als %<PRId64> Puffer"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Termcap-Datei kann nicht geöffnet werden"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kann keine Differenz erstellen"
 
-msgid "Patch file"
-msgstr "Patch-Datei"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Differenz-Ausgabe kann nicht gelesen werden"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Differenz-Ausgabe kann nicht gelesen werden"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktueller Puffer ist nicht im Differenz-Modus"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: Kein weiterer Puffer ist im Differenz-Modus"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Kein weiterer Puffer ist im Differenz-Modus"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Mehrdeutigkeit: Mehr als zwei Puffer im Differenz-Modus"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Kann Puffer \"%s\" nicht finden"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Puffer \"%s\" ist nicht im Differenz-Modus"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 'Escape' ist in einem Digraphen nicht erlaubt"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Datei für die Tastaturbelegung nicht gefunden"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap außerhalb einer eingelesenen Datei"
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Stichwort-Ergänzung (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X Modus (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Zeilen-Ergänzung (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Dateinamen-Ergänzung (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Tag-Ergänzung  (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Pfadmuster-Ergänzung (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Definitions-Ergänzung (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Wörterbuch-Ergänzung (^K^N^P) "
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus-Ergänzung (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Kommandozeilen-Ergänzung (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Benutzerdefinierte Ergänzung (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-Ergänzung (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Vorschlag der Rechtschreibprüfung (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokale Schlüsselwort-Ergänzung(^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Absatzende erreicht"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "Die Option 'dictionary' ist leer"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "Die Option 'thesaurus' ist leer"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Durchsuchen des Wörterbuchs: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (Einfügen) Scrollen (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (Ersetzen) Scrollen (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Durchsuche: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Durchsuchen von Tags."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Füge hinzu"
 
@@ -294,375 +441,593 @@ msgstr " Füge hinzu"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Suche..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Zurück am Ursprung"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Wort aus anderer Zeile"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Einziger Treffer"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "Treffer %d von %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "Treffer %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Unerwartete Zeichen in :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Index der Liste außerhalb des zulässigen Bereichs: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Undefinierte Variable: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Fehlende ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument von %s muss eine Liste sein"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument von %s muss eine Liste oder ein Wörterbuch"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Der Schlüssel für das Wörterbuch darf nicht leer sein"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Liste benötigt"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Wörterbuch benötigt"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Zu viele Argumente für Funktion: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Schlüssel nicht vorhanden im Wörterbuch: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funktion %s existiert bereits; zum Ersetzen ! hinzufügen"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Wörterbuch-Eintrag existiert bereits"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funktionsreferenz benötigt"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Falscher Typ der Variable für %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Unbekannte Funktion: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Unzulässiger Name der Variable: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: Liste als String verwendet"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Weniger Ziele als Einträge der Liste"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Mehr Ziele als Einträge der Liste"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Doppeltes ; in der Liste von Variablen"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Kann Variablen nicht auflisten: %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Kann nur Listen und Wörterbücher indizieren"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] muss am Schluss kommen"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] benötigt eine Liste als Wert"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Listenwert hat mehr Einträge als das Ziel"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Listenwert hat nicht genügend Einträge"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Fehlendes \"in\" nach :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Fehlende Klammern: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Keine solche Variable: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Variable ist zu tief verschachtelt für (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Fehlender ':' nach '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Kann nur eine Liste mit einer Liste vergleichen"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Unzulässige Operation für Listen"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Kann nur ein Wörterbuch mit einem Wörterbuch vergleichen"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Unzulässige Operation für ein Wörterbuch"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
-msgstr "E693: Kann nur eine Funktionsreferenz mit einer Funktionsreferenz vergleichen"
+msgstr ""
+"E693: Kann nur eine Funktionsreferenz mit einer Funktionsreferenz vergleichen"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Unzulässige Operation für Funktionsreferenzen"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Fehlende ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Kann keine Funktionsreferenz indizieren"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Bezeichnung der Option fehlt: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Unbekannte Option: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Fehlendes Anführungszeichen: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Fehlendes Anführungszeichen: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Fehlendes Komma in der Liste: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Fehlendes Ende der Liste ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Fehlender Doppelpunkt im Wörterbuch: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Doppelter Schlüssel im Wörterbuch: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Fehlendes Komma im Wörterbuch: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Fehlendes Ende des Wörterbuchs '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Variable ist zu tief verschachtelt für die Anzeige"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Zu viele Argumente für Funktion: %s"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: Ungültige Argumente für die Funktion %s"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Unbekannte Funktion: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Zu wenige Argumente für Funktion: %s"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> wurde nicht in einer Skript-Umgebung benutzt: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E725: Aufruf der 'dict' Funktion ohne Wörterbuch: %s"
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Zahl benötigt nach ="
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Zu viele Argumente"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() kann nur im Einfüge-Modus verwendet werden"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Schlüssel existiert bereits: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd Argument"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld Zeilen: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Unbekannte Funktion: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Abbrechen"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() wurde öfter als inputsave() aufgerufen"
 
-msgid "E745: Range not allowed"
-msgstr "E745: Bereich nicht erlaubt"
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c Argument"
 
+#: ../eval.c:10841
+msgid "E786: Range not allowed"
+msgstr "E786: Bereich nicht erlaubt"
+
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Unzulässiger Typ für len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Stride ist Null"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Start hinter dem Ende"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<leer>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Keine Verbindung zum Vim-Server"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd Argument"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Kann nicht zu %s senden"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Server-Antwort kann nicht gelesen werden"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Zu viele symbolische Links (zirkulär?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Kann nicht zum Client senden"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c Argument"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Ungültig)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Fehler beim Schreiben einer temporären Datei"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Liste als Zahl verwendet"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funktionsreferenz als Zahl verwendet"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Liste als Zahl verwendet"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Wörterbuch als Zahl verwendet"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funktionsreferenz als String verwendet"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Liste als String verwendet"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Wörterbuch als String verwendet"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funktionsreferenz-Variable muss mit einem Großbuchstaben beginnen: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Konflikt eines Variablennamens mit bestehender Funktion: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Typ der Variable falsch zugeordnet: %s"
 
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: Kann Variablen nicht auflisten: %s"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr ""
+"E704: Funktionsreferenz-Variable muss mit einem Großbuchstaben beginnen: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Konflikt eines Variablennamens mit bestehender Funktion: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Wert ist gesperrt: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Unbekannt"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Kann Wert nicht ändern: %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Variable ist zu tief verschachtelt für eine Kopie"
 
+#: ../eval.c:17249
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Unbekannte Funktion: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Fehlendes '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Kann die IC Werte nicht setzen"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Unzulässiges Argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: Doppelter Tag \"%s\" in der Datei %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Fehlendes :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr ""
+"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
+
+#: ../eval.c:17549
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
-msgstr "E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
+msgstr ""
+"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Funktionsname wird verlangt"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
-msgstr "E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen Doppelpunkt enthalten: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
+"Doppelpunkt enthalten: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
+"Doppelpunkt enthalten: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Funktionsaufrufstiefe überschreitet 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "rufe %s auf"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s abgebrochen"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s lieferte #%<PRId64> zurück"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s lieferte \"%s\" zurück"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "weiter in %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return außerhalb einer Funktion"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -670,6 +1035,7 @@ msgstr ""
 "\n"
 "# globale Variablen:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -677,76 +1043,106 @@ msgstr ""
 "\n"
 "\tZuletzt gesetzt von "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "Keine inkludierten Dateien"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Oktal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Verschiebe Zeilen in sich selbst"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 Zeile verschoben"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> Zeilen verschoben"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> Zeilen gefiltert"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-Autokommandos dürfen den aktuellen Puffer nicht ändern"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Kein Schreiben seit der letzten Änderung]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s in Zeile: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Zu viele Fehler; überspringe Rest der Datei"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Lesen der viminfo-Datei \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " Information"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " Markierungen"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "Keine inkludierten Dateien"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FEHLGESCHLAGEN"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo-Datei ist nicht schreibbar: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Schreiben der viminfo-Datei %s ist nicht möglich!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Schreiben der viminfo-Datei \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Diese viminfo-Datei wurde von Vim %s generiert.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -754,41 +1150,49 @@ msgstr ""
 "# Sie können sie verändern, wenn Sie vorsichtig vorgehen!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Wert von 'encoding', als diese Datei geschrieben wurde\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Unzulässiges Zeichen am Anfang"
 
-msgid "Save As"
-msgstr "Speichern als"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Partielle Datei schreiben?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Zum Schreiben von partiellen Puffern ! verwenden"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Überschreibe existierende Datei \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Auslagerungsdatei \"%s\" existiert bereits. Überschreiben?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Auslagerungsdatei existiert bereits: %s (mit :silent! erzwingen)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Kein Dateiname für Puffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
-msgstr "E142: Datei wurde nicht geschrieben: Schreiben ist durch die Option 'write' ausgeschaltet"
+msgstr ""
+"E142: Datei wurde nicht geschrieben: Schreiben ist durch die Option 'write' "
+"ausgeschaltet"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -797,61 +1201,91 @@ msgstr ""
 "'readonly'-Option ist für \"%s\" gesetzt.\n"
 "Möchten Sie trotzdem schreiben?"
 
-msgid "Edit File"
-msgstr "Öffne Datei"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "ist Schreibgeschützt (erzwinge mit !)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokommandos löschten unerwartet neuen Puffer %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Nicht-numerisches Argument für :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Shell-Befehle sind in rvim nicht erlaubt"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Reguläre Ausdrücke können nicht durch Buchstaben begrenzt werden"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "ersetze durch %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Unterbrochen) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "ein Treffer"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "eine Ersetzung"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> Treffer"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> Ersetzungen"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " auf einer Zeile"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " auf %<PRId64> Zeilen"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kann :global nicht rekursiv ausführen"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Regulärer Ausdruck fehlt in global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Muster in jeder Zeile gefunden: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Muster nicht gefunden"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -861,264 +1295,339 @@ msgstr ""
 "# Letzte ersetzte Zeichenkette:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Nur keine Panik!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Schade, keine '%s' Hilfe für %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Schade, keine Hilfe für %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Hilfe-Datei \"%s\" nicht gefunden"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Kein Verzeichnis: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: %s kann nicht zum Schreiben geöffnet werden"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: %s kann nicht zum Lesen geöffnet werden"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
-msgstr "E670: Mischung von Kodierungen einer Hilfedatei innerhalb einer Sprache: %s"
+msgstr ""
+"E670: Mischung von Kodierungen einer Hilfedatei innerhalb einer Sprache: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s"
-msgstr "E154: Doppelter Tag \"%s\" in der Datei %s"
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
+msgstr "E154: Doppelter Tag \"%s\" in der Datei %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Unbekannter \"sign\"-Befehl: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Name des Zeichens fehlt"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Zu viele Zeichen definiert"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Ungültiger Text für ein Zeichen: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Unbekanntes Zeichen: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Fehlende Zeichennummer"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: ungültige Puffernummer: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Ungültige Zeichen-ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NICHT GEFUNDEN)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (nicht unterstützt)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Gelöscht]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Debug-Modus. Geben Sie \"cont\" zum Fortsetzen ein."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "Zeile %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "Befehl: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Haltepunkt in \"%s%s\" Zeile %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Haltepunkt nicht gefunden: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Keine Haltepunkte definiert"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  Zeile %<PRId64>"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Erste Verwendung von :profile startet <fname>"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Änderungen in \"%s\" speichern?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Unbenannt"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Puffer \"%s\" wurde seit der letzten Änderung nicht geschrieben"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Achtung: Unerwarteter Eintritt in einen andren Puffer (überprüfen Sie die Autokommandos)"
+msgstr ""
+"Achtung: Unerwarteter Eintritt in einen andren Puffer (überprüfen Sie die "
+"Autokommandos)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Es gibt nur eine Datei zum Editieren"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Kann nicht über die erste Datei hinausgehen"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Kann nicht über die letzte Datei hinausgehen"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Compiler nicht unterstützt: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Suche nach \"%s\" in \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Suche nach \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "im 'runtimepath' nicht gefunden: \"%s\""
 
-msgid "Source Vim script"
-msgstr "Führe Vim-Skript aus"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Kann kein Verzeichnis einlesen: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\" konnte nicht gelesen werden"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "Zeile %<PRId64>: \"%s\" konnte nicht gelesen werden"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "lese \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "Zeile %<PRId64>: lese \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "Lesen von %s beendet"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modeline"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd Argument"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c Argument"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "Umgebungsvariable"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "Error-Handler"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Achtung: Falscher Zeilentrenner, vielleicht fehlt ein ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding außerhalb einer eingelesenen Datei"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish außerhalb einer eingelesenen Datei"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Momentane %sSprache: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Sprache kann nicht auf \"%s\" gesetzt werden"
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
-msgstr "Ex-Modus. Geben Sie \"visual\" ein, um zum Normal-Modus zurückzukehren."
+msgstr ""
+"Ex-Modus. Geben Sie \"visual\" ein, um zum Normal-Modus zurückzukehren."
 
-#. must be at EOF
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Am Dateiende"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Befehl zu rekursiv"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Ausnahme nicht aufgefangen: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Ende der eingelesenen Datei"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Ende der Funktion"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Mehrdeutige Verwendung eines benutzerdefinierten Befehls"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Kein Editorbefehl"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Bereichsgrenzen rückwärts"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Bereichsgrenzen rückwärts; vertauschen"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Verwenden Sie w oder w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Der Befehl ist in dieser Version nicht implementiert"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Nur ein Dateiname erlaubt"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Eine weitere Datei zum Editieren. Trotzdem beenden?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d weitere Dateien zum Editieren. Trotzdem beenden?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Eine weitere Datei zum Editieren"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> weitere Dateien zum Editieren"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Befehl existiert bereits: ! zum Ersetzen hinzufügen"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1126,267 +1635,346 @@ msgstr ""
 "\n"
 "   Name        Args Bereich Fertig  Definition"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Keine vom Benutzer definierten Befehle gefunden"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Kein Attribut angegeben"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Falsche Anzahl von Argumenten"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Zähler kann nicht zweimal angegeben werden"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Ungültige Voreinstellung für den Zähler"
 
-msgid "E179: argument required for complete"
-msgstr "E179: Argument wird zur Vervollständigung benötigt"
+#: ../ex_docmd.c:4625
+msgid "E179: argument required for -complete"
+msgstr "E179: Argument benötigt für -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Ungültiges Attribut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Ungültiger Befehls-Name"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Benutzerdefinierte Befehle müssen mit Großbuchstaben beginnen"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Mehrdeutige Verwendung eines benutzerdefinierten Befehls"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Unbekannter benutzerdefinierter Befehl: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Ungültiger Wert der Vervollständigung: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: Argument für Vervollständigung nur für eigene Vervollständigung erlaubt"
+msgstr ""
+"E468: Argument für Vervollständigung nur für eigene Vervollständigung erlaubt"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Eigene Vervollständigung benötigt eine Funktion als Argument"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Kann Farbschema %s nicht finden"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Herzliche Grüße, Vim Benutzer!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Kann letztes Tab nicht schließen"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Es existiert bereits nur ein Tab"
 
-msgid "Edit File in new window"
-msgstr "Öffne Datei in einem neuen Fenster"
+#: ../ex_docmd.c:6004
+#, c-format
+msgid "Tab page %d"
+msgstr "Tab %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Keine Auslagerungsdatei"
 
-msgid "Append File"
-msgstr "Füge Datei an"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr ""
+"E747: Kann das Verzeichnis nicht wechseln, da der Puffer verändert wurde "
+"(erzwinge mit !)"
 
-msgid "E747: Cannot change directory, buffer is modifed (add ! to override)"
-msgstr "E747: Kann das Verzeichnis nicht wechseln, da der Puffer verändert wurde (erzwinge mit !)"
-
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Kein vorheriges Verzeichnis"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Unbekannt"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize benötigt zwei numerische Argumente"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Fenster-Position: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
-msgstr "E188: Die Fensterposition kann für dieses Terminal nicht bestimmt werden"
+msgstr ""
+"E188: Die Fensterposition kann für dieses Terminal nicht bestimmt werden"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos benötigt zwei numerische Argumente"
 
-msgid "Save Redirection"
-msgstr "Umleitung Speichern"
-
-msgid "Save View"
-msgstr "Ansichten Speichern"
-
-msgid "Save Session"
-msgstr "Sitzung Speichern"
-
-msgid "Save Setup"
-msgstr "Einstellungen Speichern"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Kann Verzeichnis nicht erstellen: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existiert (erzwinge mit !)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" kann nicht zum Schreiben geöffnet werden"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
-msgstr "E191: Argument muss ein Buchstabe oder vorwärts/rückwärts-Anführungszeichen sein"
+msgstr ""
+"E191: Argument muss ein Buchstabe oder vorwärts/rückwärts-Anführungszeichen "
+"sein"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursive Verwendung von :normal zu tief"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Kein anderer Dateiname zur Ersetzung mit '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Kein Autokommando-Dateiname zur Ersetzung mit \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Keine Autokommando-Puffernummer zur Ersetzung mit \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
-msgstr "E497: Kein passender Name eines Autokommandos zur Ersetzung mit \"<amatch>\""
+msgstr ""
+"E497: Kein passender Name eines Autokommandos zur Ersetzung mit \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: kein :source Dateiname zur Ersetzung mit \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: kein :source Dateiname zur Ersetzung mit \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Leerer Dateiname für '%' oder '#', funktioniert nur mit \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Ergibt eine leere Zeichenkette"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: viminfo kann nicht zum Lesen geöffnet werden"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Keine Digraphen in dieser Version"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Kann nicht :throw Exceptions mit 'Vim' Präfix"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Ausnahme geworfen: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Ausnahme beendet: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Ausnahme verworfen: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, Zeile %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Ausnahme gefangen: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s schwebend gemacht"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s wieder aufgenommen"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s verworfen"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Ausnahme"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Fehler und Unterbrechung"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Fehler"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Unterbrechung"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if Schachtelung zu tief"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif ohne :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else ohne :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif ohne :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Mehrere :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif nach :else"
 
-msgid "E585: :while nesting too deep"
-msgstr "E585: :while Schachtelung zu tief"
+#: ../ex_eval.c:941
+msgid "E585: :while/:for nesting too deep"
+msgstr "E585: :while/:for Schachtelung zu tief"
 
-msgid "E586: :continue without :while"
-msgstr "E586: :continue ohne :while"
+#: ../ex_eval.c:1028
+msgid "E586: :continue without :while or :for"
+msgstr "E586: :continue ohne :while or :for"
 
-msgid "E587: :break without :while"
-msgstr "E587: :break ohne :while"
+#: ../ex_eval.c:1061
+msgid "E587: :break without :while or :for"
+msgstr "E587: :break ohne :while oder :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Benützung von :endfor mit :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Benützung von :endwhile mit :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try Schachtelung zu tief"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch ohne :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch nach :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally ohne :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Mehrere :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry ohne :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction außerhalb einer Funktion"
 
+#: ../ex_getln.c:1643
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "Tag-Name"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " verwandte Datei\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "Option 'history' ist Null"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1395,204 +1983,310 @@ msgstr ""
 "\n"
 "# %s Geschichte (neueste bis älteste):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Befehlszeile"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Suchausdruck"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Ausdruck"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Eingabe-Zeile"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar über die Länge des Befehls hinaus"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktives Fenster oder Puffer gelöscht"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Ungültiger Pfad: '**[Nummer]' muss am Ende des Pfads sein, oder von "
+"'%s' gefolgt werden. Siehe \":help path\"."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Kann Verzeichnis \"%s\" nicht im 'cdpath' finden"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Kann Datei \"%s\" nicht im Pfad finden"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Kein weiteres Verzeichnis \"%s\" im 'cdpath' gefunden"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Keine weitere Datei \"%s\" im Pfad gefunden"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter*-Autokommandos dürfen den aktuellen Puffer nicht ändern"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Unzulässiger Dateiname"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "ist ein Verzeichnis"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "ist keine Datei"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Neue Datei]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Neues VERZEICHNIS]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Datei zu groß]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Keine Erlaubnis]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre Autokommandos haben die Datei unlesbar gemacht"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
-msgstr "E201: *ReadPre Autokommandos dürfen nicht den aktuellen Puffer wechseln"
+msgstr ""
+"E201: *ReadPre Autokommandos dürfen nicht den aktuellen Puffer wechseln"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Lese von stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Lese von stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Datei wurde unlesbar durch Umwandlung"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[RO]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "ein Zeichen"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR fehlt]"
 
-msgid "[NL found]"
-msgstr "[NL gefunden]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[lange Zeilen geteilt]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NICHT konvertiert]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[konvertiert]"
 
-msgid "[crypted]"
-msgstr "[verschlüsselt]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "UMWANDLUNGSFEHLER in Zeile %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[UNZULÄSSIGES BYTE in Zeile %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LESE-FEHLER]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "temporäre Datei kann nicht zum Umwandeln geöffnet werden"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Fehler bei der Umwandlung mit 'charconvert'"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "Ausgabe von 'charconvert' kann nicht gelesen werden"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Keine übereinstimmenden Autokommandos für acwrite Puffer"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
-msgstr "E203: Autokommandos haben den zu schreibenden Puffer gelöscht oder entladen"
+msgstr ""
+"E203: Autokommandos haben den zu schreibenden Puffer gelöscht oder entladen"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
-msgstr "E204: Autokommandos haben die Anzahl der Zeilen in unerwarteter Weise verändert"
+msgstr ""
+"E204: Autokommandos haben die Anzahl der Zeilen in unerwarteter Weise "
+"verändert"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans verweigert das Schreiben von unveränderten Puffern"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Partielles Schreiben für NetBeans Puffer verweigert"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "ist keine Datei oder beschreibbares Device"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "ist Schreibgeschützt (erzwinge mit !)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Sicherungsdatei kann nicht geschrieben werden (erzwinge mit !)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Fehler beim Schließen der Sicherungsdatei (erzwinge mit !)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Sicherungsdatei kann nicht gelesen werden (erzwinge mit !)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Sicherungsdatei kann nicht angelegt werden (erzwinge mit !)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Sicherungsdatei kann nicht erstellt werden (erzwinge mit !)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Der Ressourcefork geht verloren (erzwinge mit !)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Temporäre Datei kann nicht zum Schreiben geöffnet werden"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Fehler bei der Umwandlung (schreibe ohne Umwandlung mit !)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Gelinkte Datei kann nicht zum Schreiben geöffnet werden"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Datei kann nicht zum Schreiben geöffnet werden"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync fehlgeschlagen"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Fehler beim Schließen"
 
-msgid "E513: write error, conversion failed"
-msgstr "E513: Schreibfehler, Umwandlung schlug fehl"
+#: ../fileio.c:3436
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
+msgstr ""
+"E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu "
+"erzwingen)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu "
+"erzwingen)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Schreibfehler (Dateisystem voll?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr "KONVERTIERUNGSFEHLER"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "Zeile %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Ausgabegerät]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Neu]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " angefügt"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " geschrieben"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: Original-Datei kann nicht gespeichert werden"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: leere Original-Datei kann nicht verändert werden"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Backup-Datei kann nicht gelöscht werden"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1600,75 +2294,96 @@ msgstr ""
 "\n"
 "ACHTUNG: Original-Datei kann verloren oder zerstört sein\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "beende nicht den Editor bis die Datei erfolgreich geschrieben wurde!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos Format]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac Format]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix Format]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "eine Zeile, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> Zeilen, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "ein Zeichen"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> Zeichen"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Unvollständige letzte Zeile]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ACHTUNG: Die Datei wurde seit dem letzten Lesen geändert!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Möchten Sie es wirklich schreiben"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Fehler während des Schreibens nach \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Fehler beim Schließen von \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Fehler beim Lesen von \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell-Autokommando löschte Puffer"
 
+#: ../fileio.c:4894
 #, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
-msgstr "E211: Achtung: Datei \"%s\" ist nicht länger vorhanden"
+msgid "E211: File \"%s\" no longer available"
+msgstr "E211: Datei \"%s\" ist nicht länger vorhanden"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1677,24 +2392,44 @@ msgstr ""
 "W12: Achtung: Datei \"%s\" wurde verändert und der Puffer wurde ebenfalls in "
 "Vim verändert"
 
+#: ../fileio.c:4907
+msgid "See \":help W12\" for more info."
+msgstr "Siehe \":help W12\" für mehr Information"
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
-msgstr "W11: Achtung: Datei \"%s\" wurde verändert, seit mit dem Editieren angefangen wurde"
+msgstr ""
+"W11: Achtung: Datei \"%s\" wurde verändert, seit mit dem Editieren "
+"angefangen wurde"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr "Siehe \":help W11\" für mehr Information"
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
-msgstr "W16: Achtung: Mode der Datei \"%s\" wurde verändert seit mit dem Editieren angefangen wurde"
+msgstr ""
+"W16: Achtung: Mode der Datei \"%s\" wurde verändert seit mit dem Editieren "
+"angefangen wurde"
 
-#, c-format
-msgid "W13: Warning: File \"%s\" has been created after editing started"
-msgstr "W13: Achtung: Datei \"%s\" wurde erstellt, nachdem mit dem Editieren begonnen wurde"
-
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Siehe \":help W16\" für mehr Information"
 
+#: ../fileio.c:4927
+#, c-format
+msgid "W13: Warning: File \"%s\" has been created after editing started"
+msgstr ""
+"W13: Achtung: Datei \"%s\" wurde erstellt, nachdem mit dem Editieren "
+"begonnen wurde"
+
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Warnung"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1702,35 +2437,48 @@ msgstr ""
 "&OK\n"
 "&Lies Datei"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Konnte das Neuladen von \"%s\" nicht vorbereiten"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\" konnte nicht neu geladen werden"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--gelöscht--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Keine solche Gruppe: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Unzulässiges Zeichen nach *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Kein derartiges Ereignis: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Keine solche Gruppe oder Ereignis: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1738,563 +2486,804 @@ msgstr ""
 "\n"
 "--- Autokommandos ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: Ungültige Puffer Nummer "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Autokommandos können nicht für ALL Ereignisse ausgeführt werden"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Keine passenden Autokommandos"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Autokommando-Schachtelung zu tief"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokommandos für \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Ausführung von %s"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "Autokommando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Es fehlt ein {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Es fehlt ein }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Keine Faltung gefunden"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
-msgstr "E350: Faltung kann mit der aktuellen Faltungsmethode nicht erzeugt werden"
+msgstr ""
+"E350: Faltung kann mit der aktuellen Faltungsmethode nicht erzeugt werden"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
-msgstr "E351: Faltung kann mit der aktuellen Faltungsmethode nicht gelöscht werden"
+msgstr ""
+"E351: Faltung kann mit der aktuellen Faltungsmethode nicht gelöscht werden"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld Zeilen gefaltet "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Zum Lesepuffer hinzufügen"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursive Zuordnung"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Globale Abkürzung für %s existiert bereits"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Globale Zuordnung für %s existiert bereits"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Abkürzung für %s existiert bereits"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Zuordnung für %s existiert bereits"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Keine Abkürzung gefunden"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Keine Zuordnung gefunden"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Unzulässiger Modus"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUI kann nicht gestartet werden"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Keine Zeilen im Puffer--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Kann nicht von \"%s\" lesen"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Befehl abgebrochen"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: GUI kann nicht gestartet werden, keine gültige Schrift gefunden"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argument benötigt"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' ungültig"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ sollte von /, ? or & gefolgt werden"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Wert von 'imactivatekey' ist ungültig"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Ungültig im Kommandozeilenfenster; <CR> führt aus, CTRL-C beendet"
 
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Kann die Farbe %s nicht zuweisen"
-
-msgid "<cannot open> "
-msgstr "<kann nicht öffnen> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: kann Schriftart %s nicht erhalten"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: kann nicht zum laufenden Verzeichnis zurückkehren"
-
-msgid "Pathname:"
-msgstr "Pfad:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: aktuelles Verzeichnis kann nicht ermittelt werden"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Abbrechen"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Geometrie des Bildchens kann nicht ermittelt werden"
-
-msgid "Vim dialog"
-msgstr "Vim-Dialog"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: BalloonEval kann nicht mit sowohl \"message\" und \"callback\" erzeugt werden"
-
-msgid "Vim dialog..."
-msgstr "Vim-Dialog..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Ja\n"
-"&Nein\n"
-"&Abbrechen"
+"E12: Befehl nicht zulässig vom exrc/vimrc in der momentanen Verzeichnis- "
+"oder Tag-Suche"
 
-msgid "Input _Methods"
-msgstr "Eingabe _Methoden"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Fehlendes :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Suchen und Ersetzen..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Fehlendes :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Suchen..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: fehlendes :endwhile"
 
-msgid "Find what:"
-msgstr "Wonach suchen:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Fehlendes :endfor"
 
-msgid "Replace with:"
-msgstr "Ersetzen mit:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile ohne :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Nur ganzes Wort suchen"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor ohne :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Groß-/Kleinschreibung"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Datei existiert bereits (erzwinge mit !)"
 
-msgid "Direction"
-msgstr "Richtung"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Befehl fehlgeschlagen"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Aufwärts"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Interner Fehler"
 
-msgid "Down"
-msgstr "Abwärts"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Unterbrochen"
 
-msgid "Find Next"
-msgstr "Suche Nächstes"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Ungültige Adresse"
 
-msgid "Replace"
-msgstr "Ersetzen"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Ungültiges Argument"
 
-msgid "Replace All"
-msgstr "Alle ersetzen"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: \"die\"-Request von Session-Manager erhalten\n"
-
-msgid "Close"
-msgstr "Schließe"
-
-msgid "New tab"
-msgstr "Neues Tab"
-
-msgid "Open Tab..."
-msgstr "Öffne in Tab..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Hauptfenster unerwartet gelöscht\n"
-
-msgid "Font Selection"
-msgstr "Auswahl der Schriftart"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "CUT_BUFFER0 anstatt der leeren Auswahl benutzt"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Abbrechen"
-
-msgid "Directories"
-msgstr "Verzeichnisse"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Hilfe"
-
-msgid "Files"
-msgstr "Dateien"
-
-msgid "&OK"
-msgstr "&Ok"
-
-msgid "Selection"
-msgstr "Auswahl"
-
-msgid "Find &Next"
-msgstr "&Nächste"
-
-msgid "&Replace"
-msgstr "&Ersetze"
-
-msgid "Replace &All"
-msgstr "Ersetze &alles"
-
-msgid "&Undo"
-msgstr "&Rückgängig"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Kann Fenstertitel \"%s\" nicht finden"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Ungültiges Argument: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument wird nicht unterstützt: \"-%s\"; verwende die OLE Version."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: ungültiger Ausdruck: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Kann Fenster nicht innerhalb einer MDI Anwendung öffnen"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Ungültiger Bereich"
 
-msgid "Close tab"
-msgstr "Tab schließen"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Ungültiger Befehl"
 
-msgid "Open tab..."
-msgstr "Öffne in Tab..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Suche (benütze '\\\\' um ein '\\' zu finden)"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Suche & Ersetze (benütze '\\\\' um ein '\\' zu finden)"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Nicht verwendet"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Verzeichnis\t*.nichts\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: \"Colormap\"-Eintrag kann nicht zugewiesen werden, einige Farben können falsch sein"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Schriftarten für die folgenden Zeichensätze fehlen im Fontset %s:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" ist ein Verzeichnis"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Fontset Name: %s"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Ungültige Scroll-Größe"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Schriftart '%s' hat keine feste Breite"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Fontset Name: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Schriftart 0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Schriftart 1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Die Breite der Schriftart %<PRId64> ist nicht doppelt so groß wie die der Schriftart 0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Schriftart 0 Breite: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Schriftart 1 Breite: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Ungültige Spezifikation der Schriftart"
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
-msgid "&Dismiss"
-msgstr "&Aufheben"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Bibliotheksaufruf für \"%s()\" schlug fehl"
 
-msgid "no specific match"
-msgstr "keine spezifische Übereinstimmung"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Marke hat ungültige Zeilennummer"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Auswahl der Schriftart"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Marke nicht gesetzt"
 
-msgid "Name:"
-msgstr "Name:"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Kann keine Änderungen machen, 'modifiable' ist aus"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Zeige Größe in Punkten"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skript ist zu tief verschachtelt"
 
-msgid "Encoding:"
-msgstr "Zeichensatz:"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Keine alternative Datei"
 
-msgid "Font:"
-msgstr "Schriftart:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Keine Abkürzung gefunden"
 
-msgid "Style:"
-msgstr "Stil:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Kein ! erlaubt"
 
-msgid "Size:"
-msgstr "Größe:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr ""
+"E25: GUI kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens "
+"nicht eingeschaltet."
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul-Automat Fehler"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Hervorhebungsgruppe existiert nicht: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Noch kein eingefügter Text"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Keine vorherige Befehlszeile"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Keine Zuordnung gefunden"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Kein Treffer"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Kein Treffer: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Kein Dateiname"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Kein vorheriger regulärer Ersetzungsausdruck"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Kein vorheriger Befehl"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Keine vorheriger regulärer Ausdruck"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Kein Bereich erlaubt"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Zu wenig Platz"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Kann Datei %s nicht erzeugen"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Kann den Namen der temporären Datei nicht ermitteln"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Kann die Datei %s nicht öffnen"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Kann Datei %s nicht lesen"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Kein Schreibvorgang seit der letzten Änderung (erzwinge mit !)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Kein Schreiben seit der letzten Änderung]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Null-Argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nummer erwartet"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Fehlerdatei %s kann nicht geöffnet werden"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Speicher erschöpft!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Muster nicht gefunden"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Muster nicht gefunden: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument muss positiv sein"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Kann nicht ins vorhergehende Verzeichnis wechseln"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Kein Fehler"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Keine Positionsliste"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Beschädigter Suchausdruck"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: schadhaftes regexp Programm"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Die Option 'readonly' ist gesetzt (erzwinge mit !)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Variable \"%s\" kann nur gelesen werden"
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Variable \"%s\" kann in der Sandbox nur gelesen werden"
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Fehler während des Lesens der Fehlerdatei"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: In einer Sandbox nicht erlaubt"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Hier nicht erlaubt"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Bildschirm-Modus wird nicht unterstützt"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Ungültige Scroll-Größe"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Die Option 'shell' ist leer"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Fehler -- Daten für Debuggersymbol konnten nicht gelesen werden"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Fehler beim Schließen der Auslagerungsdatei"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tag Stapel leer."
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Befehl zu kompliziert"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Name zu lang"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Zu viele ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Zu viele Dateinamen"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Überschüssige Zeichen"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Unbekannte Mark"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Kann die Platzhalter nicht erweitern"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' darf nicht kleiner sein als 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' darf nicht kleiner sein als 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Fehler während des Schreibens"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Null-Zähler"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> wurde nicht in einer Skript-Umgebung benutzt"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Interner Fehler: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Muster benötigt mehr Speicher als 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Leerer Puffer"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Ungültiges Suchmuster oder Trennzeichen"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Datei ist in einem anderen Puffer geladen"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Option '%s' ist nicht gesetzt"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Ungültiger Register Name: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Suche erreichte den ANFANG und wurde am ENDE fortgesetzt"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Suche erreichte das ENDE und wurde am ANFANG fortgesetzt"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Fehlender Doppelpunkt"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Unzulässige Komponente"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: Ziffer erwartet"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Seite %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Kein Text zum Drucken"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Drucke Seite %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopiere %d von %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Gedruckt: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Ausdruck abgebrochen"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Fehler beim Schreiben der PostScript-Ausgabedatei"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Datei \"%s\" kann nicht geöffnet werden"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: PostScript Ressource-Datei \"%s\" kann nicht gelesen werden"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Datei \"%s\" ist keine PostScript Ressource-Datei"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Datei \"%s\" ist keine unterstützte PostScript Ressource-Datei"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" Ressource-Datei hat die falsche Version"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Unzulässiger Multi-Byte Zeichensatz"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset darf nicht leer sein mit Multi-Byte Zeichensatz."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Keine Standardschriftart angegeben für Multi-Byte Ausdruck."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript Ausgabe-Datei kann nicht geöffnet werden"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Datei \"%s\" kann nicht geöffnet werden"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: PostScript Ressource-Datei \"prolog.ps\" nicht gefunden"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: PostScript Ressource-Datei \"cidfont.ps\" nicht gefunden"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: PostScript Ressource-Datei \"%s\" nicht gefunden"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
-msgstr "E620: Umwandlung nach dem Zeichensatz für den Ausdruck \"%s\" fehlgeschlagen"
+msgstr ""
+"E620: Umwandlung nach dem Zeichensatz für den Ausdruck \"%s\" fehlgeschlagen"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Schicke zum Drucker..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Druck der PostScript-Datei schlug fehl"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Druckauftrag abgeschickt"
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Eine neue Datenbank hinzufügen"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Muster suchen"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "diese Nachricht anzeigen"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Verbindung abbrechen"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Verbindungen reinitialisieren"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Verbindungen anzeigen"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Verwendung: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Dieser cscope-Befehl unterstützt nicht Teilen des Fensters.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Verwendung: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: Tag nicht gefunden"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) Fehler: %d"
 
-msgid "E563: stat error"
-msgstr "E563: 'stat' Fehler"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s ist kein Verzeichnis oder eine gültige cscope Datenbank"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "csope Datenbank %s hinzugefügt"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Fehler beim Lesen aus der cscope Verbindung %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Unbekannter cscope Suchtyp"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscope Pipes konnten nicht angelegt werden"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Konnte nicht für cscope verzweigen"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection exec misslang"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection exec misslang"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Konnte cscope Prozess nicht hervorbringen"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen von to_fp misslang"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen von fr_fp misslang"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Konnte cscope Prozess nicht hervorbringen"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: Keine cscope Verbindungen"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: keine Übereinstimmungen gefunden für cscope Abfrage %s aus %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Unzulässiges cscopequickfix Flag %c für %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: keine Übereinstimmungen gefunden für cscope Abfrage %s aus %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope Befehle:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Verwendung: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Kann cscope Datenbank nicht öffnen: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Kann cscope Datenbank-Informationen nicht bekommen"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: cscope Datenbank nicht doppelt hinzugefügt"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: Maximale Anzahl von cscope Verbindungen erreicht"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope Verbindung %s nicht gefunden"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope Verbindung %s geschlossen"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Fataler Fehler in cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope Tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2302,371 +3291,87 @@ msgstr ""
 "\n"
 "   #   Zeile"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "Dateiname / Kontext / Zeile\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope Fehler: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "alle cscope Datenbanken zurückgesetzt"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "keine cscope-Verbindungen\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid   Datenbank Name\t                    führender Pfad\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr ""
-"???: Dieser Befehl ist nicht verfügbar, die MzScheme Bibliothek konnte nicht "
-"geladen werden"
-
-msgid "invalid expression"
-msgstr "ungültiger Ausdruck"
-
-msgid "expressions disabled at compile time"
-msgstr "Ausdrücke wurden zur Zeit des Übersetzens nicht zugelassen"
-
-msgid "hidden option"
-msgstr "versteckte Option"
-
-msgid "unknown option"
-msgstr "unbekannte Option"
-
-msgid "window index is out of range"
-msgstr "Fensterindex außerhalb des zulässigen Bereichs"
-
-msgid "couldn't open buffer"
-msgstr "konnte Puffer nicht öffnen"
-
-msgid "cannot save undo information"
-msgstr "kann Information für die Wiederherstellung nicht speichern"
-
-msgid "cannot delete line"
-msgstr "Zeile kann nicht gelöscht werden"
-
-msgid "cannot replace line"
-msgstr "Zeile kann nicht ersetzt werden"
-
-msgid "cannot insert line"
-msgstr "Zeile kann nicht eingefügt werden"
-
-msgid "string cannot contain newlines"
-msgstr "Zeichenfolge kann keine Zeilenwechsel enthalten"
-
-msgid "Vim error: ~a"
-msgstr "Vim Fehler: ~a"
-
-msgid "Vim error"
-msgstr "Vim Fehler"
-
-msgid "buffer is invalid"
-msgstr "ungültiger Puffer"
-
-msgid "window is invalid"
-msgstr "ungültiges Fenster"
-
-msgid "linenr out of range"
-msgstr "'linenr' außerhalb des zulässigen Bereichs"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "in der Vim-Sandbox nicht erlaubt"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Dieser Befehl ist nicht verfügbar, die Python-Bibliothek konnte nicht "
-"geladen werden"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Kann Python nicht rekursiv ausführen"
-
-msgid "can't delete OutputObject attributes"
-msgstr "OutputObject-Attribute können nicht gelöscht werden"
-
-msgid "softspace must be an integer"
-msgstr "\"softspace\" muss eine ganze Zahl sein"
-
-msgid "invalid attribute"
-msgstr "unzulässiges Attribut"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() verlangt eine Liste von Zeichenfolgen"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Fehler bei der Initialisierung von I/O Objekten"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "Versuch, Bezug auf einen gelöschten Puffer zu nehmen"
-
-msgid "line number out of range"
-msgstr "Zeilennummer außerhalb des zulässigen Bereichs"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<Pufferobjekt (gelöscht) bei %8lX>"
-
-msgid "invalid mark name"
-msgstr "ungültiger Name einer Markierung"
-
-msgid "no such buffer"
-msgstr "kein solcher Puffer vorhanden"
-
-msgid "attempt to refer to deleted window"
-msgstr "Versuch, Bezug auf eine gelöschtes Fenster zu nehmen"
-
-msgid "readonly attribute"
-msgstr "nur-Lesen Attribut"
-
-msgid "cursor position outside buffer"
-msgstr "Cursor Position außerhalb des Puffers"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<Fensterobjekt (gelöscht) bei %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<Fensterobjekt (unbekannt) bei %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<Fenster %d>"
-
-msgid "no such window"
-msgstr "ungültiges Fenster"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Dieser Befehl ist nicht verfügbar, die Ruby Bibliothek konnte nicht geladen werden"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Unbekannter longjmp Status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Umschaltung zwischen Implementierung/Definition"
-
-msgid "Show base class of"
-msgstr "Zeige Basis-Klasse von"
-
-msgid "Show overridden member function"
-msgstr "Zeige überschriebene Methode"
-
-msgid "Retrieve from file"
-msgstr "Beziehe aus Datei"
-
-msgid "Retrieve from project"
-msgstr "Beziehe aus Projekt"
-
-msgid "Retrieve from all projects"
-msgstr "Beziehe aus allen Projekten"
-
-msgid "Retrieve"
-msgstr "Beziehe"
-
-msgid "Show source of"
-msgstr "Zeige die Quelle von"
-
-msgid "Find symbol"
-msgstr "Finde Symbol"
-
-msgid "Browse class"
-msgstr "Durchsehe Klassen"
-
-msgid "Show class in hierarchy"
-msgstr "Zeige Klasse in Hierarchie"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Zeige Klasse in eingeschränkter Hierarchie"
-
-msgid "Xref refers to"
-msgstr "Xref bezieht sich auf"
-
-msgid "Xref referred by"
-msgstr "Xref hat Bezüge zu"
-
-msgid "Xref has a"
-msgstr "Xref hat ein"
-
-msgid "Xref used by"
-msgstr "Xref wird verwendet von"
-
-msgid "Show docu of"
-msgstr "Zeige Docu aus"
-
-msgid "Generate docu for"
-msgstr "Generiere Docu für"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Kann keine verbindung zu SNiFF+ aufnehmen. Prüfe die Umgebung (sniffemacs "
-"muss in $PATH) zu finden sein.\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Fehler beim Lesen. Verbindung abgebrochen"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ ist zur Zeit"
-
-msgid "not "
-msgstr "nicht"
-
-msgid "connected"
-msgstr "verbunden"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Unbekannte SNiFF+ Anfrage: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Fehler beim Herstellen der Verbindung mit SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ ist nicht verbunden"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ist kein SNiFF+ Puffer"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Fehler beim Schreiben. Verbindung abgebrochen"
-
-msgid "invalid buffer number"
-msgstr "ungültige Puffernummer"
-
-msgid "not implemented yet"
-msgstr "nicht implementiert"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "kann keine Zeile/Zeilen setzen"
-
-msgid "mark not set"
-msgstr "Marke nicht gesetzt"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "Zeile %d Spalte %d"
-
-msgid "cannot insert/append line"
-msgstr "kann Zeile nicht ein-/anfügen"
-
-msgid "unknown flag: "
-msgstr "unbekanntes Flag: "
-
-msgid "unknown vimOption"
-msgstr "unbekannte vimOption"
-
-msgid "keyboard interrupt"
-msgstr "Tastatur-Unterbrechung"
-
-msgid "vim error"
-msgstr "vim Fehler"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "Puffer/Fenster-Befehl kann nicht ausgeführt werden: das Objekt wird gelöscht"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"kann keinen Callback-Befehl registrieren: Puffer/Fenster ist bereits gelöscht"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATALER FEHLER: reflist kaputt!? Bitte vim-dev@vim.org"
-"benachrichtigen."
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "kann keinen Callback-Befehl registrieren: Puffer/Fenster-Referenz nicht gefunden"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Dieser Befehl ist nicht verfügbar: die Tcl Bibliothek konnte nicht geladen werden"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL FEHLER: Exit-Code ist nicht int!? Bitte vim-dev@vim.org benachrichtigen."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Ekit-Code %d"
-
-msgid "cannot get line"
-msgstr "kann Zeile nicht erhalten"
-
-msgid "Unable to register a command server name"
-msgstr "Befehls-Server Name kann nicht registriert werden"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Schicken des Befehls zum Ziel-Programm schlug fehl"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Ungültige Server ID verwendet: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Registry-Eigenschaft der VIM Instanz ist fehlerhaft. Gelöscht!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Unbekanntes Optionsargument"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Zu viele Editor-Argumente"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argument fehlt nach"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Schrott nach dem Optionsargument"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Zu viele \"+command\", \"-c command\" oder \"--cmd command\" Argumente"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Ungültiges Argument für"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Vim wurde nicht mit der \"diff\"-Eigenschaft übersetzt"
+#: ../main.c:294
+#, c-format
+msgid "%d files to edit\n"
+msgstr "%d Dateien zum Editieren\n"
 
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Versuche, die Skript-Datei erneut zu öffnen: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "kann nicht zum Lesen geöffnet werden: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "kann nicht zur Skript-Ausgabe geöffnet werden: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Fehler: Konnte gvim nicht von NetBeans aus starten\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Warnung: Die Ausgabe erfolgt nicht auf einem Terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Warnung: Die Eingabe kommt nicht von einem Terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc Befehls-Zeile"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kann nicht von \"%s\" lesen"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2674,18 +3379,23 @@ msgstr ""
 "\n"
 "Weitere Informationen mit: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[Datei ..]      editiere die angegebenen Datei(-en)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               lese Text von stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          öffne Datei in der der Tag definiert wurde"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [Fehler-Datei]  öffne Datei mit erstem Fehler"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2695,9 +3405,11 @@ msgstr ""
 "\n"
 "Verwendung:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [Argumente] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2705,6 +3417,7 @@ msgstr ""
 "\n"
 "   oder:"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2714,314 +3427,190 @@ msgstr ""
 "\n"
 "Argumente:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tHiernach nur Dateinamen"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tPlatzhalter werden nicht ausgewertet"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistriere diesen gvim in OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tDeregistriere gvim aus OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tStart als GUI (wie \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f\t\t\tVordergrund: Kein \"fork\" beim Start der GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi Modus (wie \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx Modus (wie \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tLeiser (batch) Modus (nur für \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff Modus (wie \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tLeichter Modus (wie \"evim\", ohne Modi)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModus ohne Schreibrechte (wie \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tEingeschränkter Modus (wie \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifikationen (beim Schreiben von Dateien) sind nicht erlaubt"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModifikationen im Text nicht erlaubt"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinärmodus"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp Modus"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatibel zu Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNicht ganz kompatibel zu Vi: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tVerbose Stufe"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tDebug-Modus"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tKeine Auslagerungsdatei, verwende nur Speicher"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tListe nur Auslagerungsdateien auf"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (mit Dateiname)\tStelle abgestürzte Session wieder her"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tGenauso wie z -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tVerwende nicht newcli zum Öffnen eines neuen Fensters"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tVerwende <device> for I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tStart im Arabischen Modus"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tStart im Hebräischen Modus"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tStart im Farsi Modus"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tSetze Terminaltyp auf <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tBenutze <vimrc> anstatt jeglicher .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tBenutze <gvimrc> anstatt jeglicher .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tlade keine \"plugin\"-Skripte"
 
+#: ../main.c:2227
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-p[N]\t\tÖffne N Tabs (Vorgabe: einzeln für jede Datei)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tÖffne N Fenster (Vorgabe: einzeln für jede Datei)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tWie -o, aber teile vertikal"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tStarte am Ende der Datei"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tStart in Zeile <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <Befehl>\tFühre <Befehl> vor dem Laden jeglicher vimrc-Datei aus"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <Befehl>\t\tFühre <Befehl> nach dem Laden der ersten Datei aus"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\tLese Datei <session> nach dem Laden der ersten Datei"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
-msgstr "-s <scriptin>\tLese Normal-Modus Befehle aus der Skript-Datei <scriptin>"
+msgstr ""
+"-s <scriptin>\tLese Normal-Modus Befehle aus der Skript-Datei <scriptin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\tBefehle am Ende der Skript-Datei <scriptout> anfügen"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\tSchreibe Befehle in die Skript-Datei <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEditiere kodierte Dateien"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tStarte vim <display>"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tStelle keine Verbindung zum X-server her"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <Dateien>\tEditiere <Dateien> in einem Vim-Server falls möglich"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <Dateien>  Dasselbe ohne Warnung, wenn kein Server vorhanden ist"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <Dateien>  Wie --remote, aber warte, bis die <Dateien> editiert wurden"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <files>  Dasselbe ohne Warnung, wenn kein Server vorhanden ist"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\tSchicke <keys> zu einem Vim Server und beende"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <Ausdruck>\tFühre <Ausdruck> in einem Vim-Server aus und drucke das Ergebnis"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tDrucke verfügbare Vim-Server-Namen und beende"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <Name>\tBenutze den Vim-Server <Name>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tBenutze <viminfo> statt .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  or  --help\tAnzeigen der Hilfe (diesen Text) und beenden"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tVersionsinformation anzeigen und beenden"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumente für die gvim (Motif Version):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumente für die gvim (neXtaw Version):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumente für die gvim (Athena Version):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tStarte vim auf <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tStarte vim als Icon"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\tBenutze so als ob vim <name> hieße"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Nicht implementiert)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <Farbe>\tBenutze <Farbe> für den Hintergrund (auch mit: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <Farbe>\tBenutze <Farbe> für den Text Vordergrund (auch mit: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <Schriftart>\tBenutze <Schriftart> für normalen Text (auch mit: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <Schriftart>\tBenutze <Schriftart> für Fettschrift"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <Schriftart>\tBenutze <Schriftart> für geneigten Text"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\tbenutze <geom> für die Anfangs Abmessungen (auch mit: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <Breite>\tBenutze einen Rahmen der Breite <Breite> (auch mit: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <Breite>  Benutze eine Scrollbar der Breite <Breite> (auch mit: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <Höhe>\tBenutze einen Menü-Balken der Höhe <Höhe> (auch mit: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tBenutze invertierte Farben (auch mit: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tBenutze keine invertierten Farben (auch mit: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tSetze die gegebene Ressource"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argumente für die gvim RISC-OS Version:\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <Nummer>\tAnfangsbreite des Fensters in Spalten"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <Nummer>\tAnfangshöhe des Fensters in Zeilen"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumente für die gvim GTK+ Version:\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tStarte vim auf <display> (auch mit: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tSetze eine eindeutige Rolle, um das Hauptfenster zu identifizieren"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tÖffne Vim in einem anderen GTK widget"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\tÖffne Vim innerhalb der Vater-Applikation"
-
-msgid "No display"
-msgstr "Keine Anzeige"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Versendung fehlgeschlagen.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Versendung fehlgeschlagen. Versuche lokale Ausführung\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d von %d bearbeitet"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Keine Anzeige: Versenden des Ausdrucks fehlgeschlagen.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Versenden des Ausdrucks fehlgeschlagen.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Keine Markierungen gesetzt"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Keine Markierungen passen zu \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3030,6 +3619,7 @@ msgstr ""
 "Mark Zeile Sp  Datei/Text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3038,6 +3628,7 @@ msgstr ""
 " Sprung Zeile Sp Datei/Text"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3045,6 +3636,7 @@ msgstr ""
 "\n"
 "Änder. Zeile Sp  Text"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3053,6 +3645,7 @@ msgstr ""
 "# Datei-Marken:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3060,6 +3653,7 @@ msgstr ""
 "\n"
 "# Geschichte (neueste zuerst):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3067,117 +3661,118 @@ msgstr ""
 "\n"
 "# Geschichte der Markierungen innerhalb von Dateien (neueste zuerst):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>' fehlt"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Keine zulässige Codepage"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Kann die IC Werte nicht setzen"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Eingabe-Kontext konnte nicht erzeugt werden"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Eingabemethode konnte geöffnet werden"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Achtung: Destroy Callabck konnte nicht auf IM gesetzt werden"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Eingabemethode unterstützt keinen einzigen Stil"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: Eingabemethode unterstützt nicht meinen Voreditier-Typen"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: der Über-dem-Punkt Stil benötigt fontset"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Ihr GTK+ ist älter als 1.2.3. Der Status-Bereich wird abgeschaltet"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Server der Eingabemethode läuft nicht"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Block war nicht gesperrt"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Positionierungsfehler beim Lesen der Auslagerungsdatei"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Lesefehler in der Auslagerungsdatei"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Positionierungsfehler beim Schreiben in die Auslagerungsdatei"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Auslagerungsdatei ist bereits vorhanden (symlink Attacke?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Block Nr. 0 nicht erhalten?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Block Nr. 1 nicht erhalten?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Block Nr. 2 nicht erhalten?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ups, Verlust der Auslagerungsdatei!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Auslagerungsdatei konnte nicht umbenannt werden"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
-msgstr "E303: Auslagerungsdatei für \"%s\" konnte nicht geöffnet werden, Wiederherstellung unmöglich"
+msgstr ""
+"E303: Auslagerungsdatei für \"%s\" konnte nicht geöffnet werden, "
+"Wiederherstellung unmöglich"
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
-msgstr "E304: ml_timestamp: Block Nr. 0 nicht erhalten?"
+#: ../memline.c:666
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
+msgstr "E304: ml_upd_block0(): Block Nr. 0 nicht erhalten?"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Keine Auslagerungsdatei für %s gefunden"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
-msgstr "Geben Sie die Nummer der Auslagerungsdatei ein die verwendet werden soll (0 um abzubrechen): "
+msgstr ""
+"Geben Sie die Nummer der Auslagerungsdatei ein die verwendet werden soll (0 "
+"um abzubrechen): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s kann nicht geöffnet werden"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Block 0 kann nicht gelesen werden aus "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
 msgstr ""
 "\n"
-"Vielleicht wurden keine Änderungen vorgenommen oder Vim hatte die Auslagerungsdatei nicht aktualisiert."
+"Vielleicht wurden keine Änderungen vorgenommen oder Vim hatte die "
+"Auslagerungsdatei nicht aktualisiert."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " kann nicht zusammen mit dieser Vim Version verwendet werden.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Benutze Vim Version 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s sieht nicht wie eine Vim Auslagerungsdatei aus"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " kann auf diesem Rechner nicht verwendet werden.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Die Datei wurde erstellt um "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3185,63 +3780,86 @@ msgstr ""
 ",\n"
 "oder die Datei wurde zerstört."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Verwende Auslagerungsdatei \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Original-Datei \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Warnung: Die Originaldatei könnte verändert worden sein"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Block 1 kann nicht nicht von %s gelesen werden"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???VIELE ZEILEN FEHLEN"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???ZEILEN ZÄHLER FALSCH"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???LEERER BLOCK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???ZEILEN FEHLEN"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Block 1 ID falsch (ist %s keine .swp-Datei?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOCK FEHLT"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? von hier bis ???ENDE könnten die Zeilen falsch sein"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? von hier bis ???ENDE könnten Zeilen eingefügt oder gelöscht sein"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???ENDE"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Wiederherstellung unterbrochen"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
-"E312: Fehler wurden festgestellt während der Wiederherstellung: suche nach Zeilen die mit ??? beginnen"
+"E312: Fehler wurden festgestellt während der Wiederherstellung: suche nach "
+"Zeilen die mit ??? beginnen"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Lesen Sie \":help E312\" für weitere Informationen."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Wiederherstellung beendet. Prüfen Sie, ob alles alles OK ist."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3249,50 +3867,71 @@ msgstr ""
 "\n"
 "(Wollen Sie vielleicht diese Datei unter einem neuen Namen speichern\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "und \"diff\" zur Original-Datei machen, um Änderungen zu prüfen)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Löschen Sie die .swp-Datei danach.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Auslagerungsdateien gefunden:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   Im laufenden Verzeichnis:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Benutze gegebenen Namen:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   Im Verzeichnis "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- Nichts --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "      Eigentum von: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "     vom: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "               vom: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [von Vim Version 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [sieht nicht wie eine Vim Auslagerungsdatei aus]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         Dateiname: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3300,12 +3939,15 @@ msgstr ""
 "\n"
 "         verändert: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nein"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3313,9 +3955,11 @@ msgstr ""
 "\n"
 "     Benutzer-Name: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   Host-Name: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3323,6 +3967,7 @@ msgstr ""
 "\n"
 "         Host-Name: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3330,16 +3975,11 @@ msgstr ""
 "\n"
 "        Process-ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (läuft noch)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nicht verwendbar zusammen mit dieser Vim-Version]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3347,71 +3987,98 @@ msgstr ""
 "\n"
 "         [nicht verwendbar auf diesem Rechner]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [kann nicht gelesen werden]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [kann nicht geöffnet werden]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Kann nicht absichern, es gibt keine Auslagerungsdatei"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Datei gesichert"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Absicherung fehlgeschlagen"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: unzulässige lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: kann Zeile %<PRId64> nicht finden"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Zeiger Block id falsch 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx sollte 0 sein"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Zu viele Blocks aktualisiert?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Zeiger Block id falsch 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "Block 1 gelöscht?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Kann Zeile %<PRId64> nicht finden"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Zeiger Block id ist falsch"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count ist Null"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
-msgstr "E322: Zeilennummer nicht im zulässigen Bereich: %<PRId64> nach dem Ende"
+msgstr ""
+"E322: Zeilennummer nicht im zulässigen Bereich: %<PRId64> nach dem Ende"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Zeilen Zähler falsch in Block %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Stapel Größe wächst"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Zeiger Block id falsch 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr "E773: Symlink Schleife für \"%s\""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ACHTUNG"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3419,38 +4086,45 @@ msgstr ""
 "\n"
 "Auslagerungsdatei mit folgendem Namen gefunden: \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Beim Öffnen der Datei \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      neuer als Auslagerungsdatei!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Ein anderes Programm editiert möglicherweise diese Datei.\n"
 "    Wenn dies der Fall ist, sollten Sie vorsichtig sein, damit\n"
 "    es nicht zu Überschneidungen kommt.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Ende, oder Fortsetzung mit Vorsicht.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Eine Editiersitzung für diese Datei ist abgestürzt.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Wenn dies der Fall ist, so verwenden Sie \":recover\" oder \"vim -r "
+msgstr ""
+"    Wenn dies der Fall ist, so verwenden Sie \":recover\" oder \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3458,9 +4132,12 @@ msgstr ""
 "\"\n"
 "    um die Änderungen wiederherzustellen (siehe \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
-msgstr "    Wenn dies bereits geschehen ist, löschen Sie die Auslagerungsdatei \""
+msgstr ""
+"    Wenn dies bereits geschehen ist, löschen Sie die Auslagerungsdatei \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3468,18 +4145,23 @@ msgstr ""
 "\"\n"
 "    um diese Nachricht zu vermeiden.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Auslagerungsdatei \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ist bereits vorhanden!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ACHTUNG"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Auslagerungsdatei ist bereits vorhanden!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3493,6 +4175,7 @@ msgstr ""
 "&Beenden\n"
 "&Abbrechen"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3508,30 +4191,57 @@ msgstr ""
 "&Beenden\n"
 "&Abbrechen"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Zu viele Auslagerungsdateien gefunden"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Kein Speicherplatz mehr vorhanden (%<PRIu64> Bytes reserviert)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Teil des Menüpunkt-Pfades muss zum Untermenü führen"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menü existiert nur in anderen Modus"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Kein Menü \"%s\""
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+#, fuzzy
+msgid "E792: Empty menu name"
+msgstr "E749: Leerer Puffer"
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Menü-Pfad darf nicht zum Untermenü führen"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Menüpunkt können nicht direkt zum Menü-Balken hinzugefügt werden"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Trenner kann nicht Teil des Menü-Pfades sein"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3539,60 +4249,75 @@ msgstr ""
 "\n"
 "--- Menüs ---"
 
-msgid "Tear off this menu"
-msgstr "Reiße dieses Menü ab"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Menü-Pfad muss zu einem Menüpunkt führen"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Menü nicht gefunden: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menü ist für %s Modus nicht definiert"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Menü-Pfad muss zum Untermenü führen"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Menü nicht gefunden - überprüfe Menü-Namen"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Fehler beim Ausführen von \"%s\":"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "Zeile %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ungültiger Register Name: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Übersetzt von Georg Dahn <gorgyd@yahoo.co.uk>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Unterbrechung: "
 
-msgid "Hit ENTER or type command to continue"
-msgstr "Drücken Sie die EINGABETASTE oder geben Sie einen Befehl ein"
+#: ../message.c:988
+msgid "Press ENTER or type command to continue"
+msgstr "Betätigen Sie die EINGABETASTE oder geben Sie einen Befehl ein"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s Zeile %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Mehr --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
-msgstr " LEERZEICHEN/d/j: Seite/halbe Seite/Zeile vorwärts, b/u/k: rückwärts, q: Ende "
+msgstr ""
+" LEERZEICHEN/d/j: Seite/halbe Seite/Zeile vorwärts, b/u/k: rückwärts, q: "
+"Ende "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Frage"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3600,6 +4325,17 @@ msgstr ""
 "&Ja\n"
 "&Nein"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ja\n"
+"&Nein\n"
+"&Abbrechen"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3613,256 +4349,181 @@ msgstr ""
 "Alle &Verwerfen\n"
 "&Abbrechen"
 
-msgid "Save File dialog"
-msgstr "Datei Speichern Dialog"
-
-msgid "Open File dialog"
-msgstr "Datei Öffnen Dialog"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Kein Datei-Dialog im Konsole-Modus"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Zu wenige Argumente für printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Zu wenige Argumente für printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Zu viele Argumente für printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Warnung: Ändern einer schreibgeschützten Datei"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
-msgstr "Bitte Nummer eingeben oder mit der Maus auswählen (abbrechen mit <Enter>)"
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+"Bitte Nummer eingeben oder mit der Maus auswählen (abbrechen mit <Enter>)"
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Gewünschte Nummer (abbrechen mit <Enter>)"
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "eine Zeile mehr"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "eine Zeile weniger"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> Zeilen mehr"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> Zeilen weniger"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Unterbrochen)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Beep!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: Sichern der Dateien...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Beendet.\n"
-
-msgid "ERROR: "
-msgstr "FEHLER: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[Bytes] gesamt alloc-frei %<PRIu64>-%<PRIu64>, in Verwendung %<PRIu64>, maximale Verwendung %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[Aufrufe] gesamt re/malloc()s %<PRIu64>, gesamt free()s %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Zeile wird zu lang"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Interner Fehler: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Kein Speicherplatz mehr vorhanden (%<PRIu64> Bytes reserviert)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Rufe Shell auf, um \"%s\" auszuführen"
 
-msgid "E545: Missing colon"
-msgstr "E545: Fehlender Doppelpunkt"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Unzulässiger Modus"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Unzulässiger Mauszeiger"
-
-msgid "E548: digit expected"
-msgstr "E548: Ziffer erwartet"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Unzulässige Prozentangabe"
-
-msgid "Enter encryption key: "
-msgstr "Geben Sie bitte den Schlüssel ein: "
-
-msgid "Enter same key again: "
-msgstr "Geben Sie den gleichen Schlüssel nochmals ein:"
-
-msgid "Keys don't match!"
-msgstr "Die Schlüssel stimmen nicht überein!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Ungültiger Pfad: '**[Nummer]' muss am Ende des Pfads sein, oder von "
-"'%s' gefolgt werden. Siehe \":help path\"."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Kann Verzeichnis \"%s\" nicht im 'cdpath' finden"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Kann Datei \"%s\" nicht im Pfad finden"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Kein weiteres Verzeichnis \"%s\" im 'cdpath' gefunden"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Keine weitere Datei \"%s\" im Pfad gefunden"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Keine Verbindung zu NetBeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Keine Verbindung zu NetBeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Falscher Zugriffsmodus auf die NetBeans Zugriff-Informationsdatei: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "gelesen vom NetBeans Socket"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Verbindung zu NetBeans für Puffer %<PRId64> verloren"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' is empty"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: Evaluierungsfunktion nicht verfügbar"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Achtung: Terminal unterstützt keine Hervorhebung"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Keine Zeichenkette unter dem Cursor"
-
 # Identifizierungszeichen/merkmal, Bezeichner
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Kein Merkmal unter dem Cursor"
 
-msgid "E352: Cannot erase folds with current 'foldmethod'"
-msgstr "E352: Faltung kann mit der eingestellten Faltungsmethode nicht gelöscht werden"
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' is empty"
 
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Achtung: Terminal unterstützt keine Hervorhebung"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Keine Zeichenkette unter dem Cursor"
+
+#: ../normal.c:3937
+msgid "E352: Cannot erase folds with current 'foldmethod'"
+msgstr ""
+"E352: Faltung kann mit der eingestellten Faltungsmethode nicht gelöscht "
+"werden"
+
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Liste der Änderungen ist leer"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Am Anfang der Liste der Änderungen"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Am Ende der Liste der Änderungen"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Bitte  :quit<Enter>  eingeben um Vim zu verlassen"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "eine Zeile ein Mal %s"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "eine Zeile %s %d Mal"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> Zeilen %s ein Mal"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> Zeilen %s %d Mal"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> Zeilen zum Einrücken... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "eine Zeile eingerückt... "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> Zeilen eingerückt... "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Kein bereits verwendetes Register"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "kann nicht kopieren; lösche trotzdem"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "eine Zeile geändert"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> Zeilen geändert"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "gebe %<PRId64> Zeilen frei"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "Block von einer Zeile kopiert"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "eine Zeile kopiert"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "Block von %<PRId64> Zeilen kopiert"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> Zeilen kopiert"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Register %s ist leer"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3870,9 +4531,11 @@ msgstr ""
 "\n"
 "--- Register ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Unzulässiger Register Name"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3880,157 +4543,194 @@ msgstr ""
 "\n"
 "# Register:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Unbekannter Register Typ %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Spalten; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> von %<PRId64> Bytes"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> von %<PRId64> Zeichen; %<PRId64> von %<PRId64> "
-"Bytes"
+"%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> "
+"von %<PRId64> Bytes"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; Byte %<PRId64> von %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; Zeichen %<PRId64> von %<PRId64>; Byte %<PRId64> von "
-"%<PRId64>"
+"%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> "
+"von %<PRId64> Zeichen; %<PRId64> von %<PRId64> Bytes"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; "
+"Byte %<PRId64> von %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; "
+"Zeichen %<PRId64> von %<PRId64>; Byte %<PRId64> von %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> für BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Seite %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Danke für die Benutzung von Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Unbekannte Option"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Option nicht unterstützt"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Nicht erlaubt in einer Modeline"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Zahl benötigt nach ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nicht gefunden in 'termcap'"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Unzulässiges Zeichen <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' darf keine leere Zeichenkette sein"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Kann Terminal in der GUI nicht verändern"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Verwende \":gui\", um die GUI-Version zu starten"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' und 'patchmode' sind gleich"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Kann in der GTK+ 2 GUI nicht verändert werden"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Fehlender Doppelpunkt"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Zeichenkette der Länge Null"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Fehlende Zahl nach <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Fehlendes Komma"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Ein ' Wert muss angegeben werden"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Enthält nicht-druckbare oder Multi-Byte Zeichen"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Ungültige Schriftart(en)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Kann \"Fontset\" nicht auswählen"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Ungültiges \"Fontset\""
-
-msgid "E533: can't select wide font"
-msgstr "E533: Kann Breitschrift nicht auswählen"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Ungültige Breitschrift"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ungültiges Zeichen nach <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Komma benötigt"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' muss leer sein oder %s enthalten"
 
-msgid "E538: No mouse support"
-msgstr "E538: Keine Maus-Unterstützung"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Nicht-geschlossene Ausdrucksfolge"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Zu viele Elemente"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Unausgewogene Gruppen"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Ein Voransichtsfenster existiert bereits"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabisch benötigt UTF-8, bitte ':set encoding=utf-8' ausführen"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Mindestens %d Zeilen werden benötigt"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Mindestens %d Spalten werden benötigt"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Unbekannte Option: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Zahl benötigt nach ="
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4038,6 +4738,7 @@ msgstr ""
 "\n"
 "--- Terminal Codes ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4045,6 +4746,7 @@ msgstr ""
 "\n"
 "--- Werte globaler Optionen ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4052,6 +4754,7 @@ msgstr ""
 "\n"
 "--- Werte lokaler Optionen ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4059,128 +4762,21 @@ msgstr ""
 "\n"
 "--- Optionen ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp FEHLER"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Passendes Zeichen fehlt für %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Überschüssige Zeichen nach dem Semikolon: %s"
 
-msgid "cannot open "
-msgstr "kann nicht öffnen"
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Fenster kann nicht geöffnet werden!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Brauche Amigados Version 2.04 oder neuere\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Benötige %s Version %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Kann NIL nicht öffnen:\n"
-
-msgid "Cannot create "
-msgstr "Kann nicht anlegen "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim steigt aus mit %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "kann Konsolenmodus nicht wechseln ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_winsize: keine Konsole??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Kann Shell nicht mit der -f Option ausführen"
-
-msgid "Cannot execute "
-msgstr "Kann nicht ausführen "
-
-msgid "shell "
-msgstr "Shell "
-
-msgid " returned\n"
-msgstr " zurückgegeben\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE zu klein."
-
-msgid "I/O ERROR"
-msgstr "I/O FEHLER"
-
-msgid "...(truncated)"
-msgstr "...(abgeschnitten)"
-
-msgid "Message"
-msgstr "Nachricht"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' beträgt nicht 80, kann externe Befehle nicht ausführen"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Drucker-Auswahl fehlgeschlagen"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "nach %s auf %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Unbekannte Druckerschriftart: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Fehler beim Drucken: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Drucke '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Unzulässiger Zeichensatz-Name \"%s\" im Schriftart-Namen \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Unzulässiges Zeichen '%c' in der Schriftart \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Doppel-Signal, beenden\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Erhielt tödliches Signal %s\n"
-
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Erhielt tödliches Signal\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Öffnen des X-Displays dauerte %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: ein X11 Fehler trat auf\n"
-
-msgid "Testing the X display failed"
-msgstr "Test des X-Displays schlug fehl"
-
-msgid "Opening the X display timed out"
-msgstr "Zeitüberschreitung während des Öffnens des X-Displays"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4188,13 +4784,7 @@ msgstr ""
 "\n"
 "Shell kann nicht ausführt werden "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Shell sh kann nicht ausführt werden\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4202,1891 +4792,468 @@ msgstr ""
 "\n"
 "Shell beendet "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Pipes können nicht angelegt werden\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"'fork' schlug fehl\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Befehl beendet\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP verlor ICE Verbindung"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Öffnen des X-Displays schlug fehl"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP verarbeitet 'save-yourself request'"
-
-msgid "XSMP opening connection"
-msgstr "XSMP öffnet Verbindung"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE Verbindungsüberwachung fehlgeschlagen"
-
-#, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection fehlgeschlagen: %s"
-
-msgid "At line"
-msgstr "In Zeile"
-
-msgid "Could not load vim32.dll!"
-msgstr "Konnte vim32.dll nicht laden!"
-
-msgid "VIM Error"
-msgstr "VIM Fehler"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Konnte Funktions-Zeiger in der DLL nicht korrigieren!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "Shell gab %d zurück"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Fing Ereignis %s ein\n"
-
-msgid "close"
-msgstr "schließe"
-
-msgid "logoff"
-msgstr "ausloggen"
-
-msgid "shutdown"
-msgstr "beenden"
-
-msgid "E371: Command not found"
-msgstr "E371: Befehl nicht gefunden"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE wurde im Pfad $PATH nicht gefunden.\n"
-"Externe Befehle werden nach Ausführung nicht anhalten.\n"
-"Siehe  :help win32-vimrun  für weitere Informationen."
-
-msgid "Vim Warning"
-msgstr "Vim Warnung"
-
-#, c-format
-msgid "E372: Too many %%%c in format string"
-msgstr "E372: Zu viele %%%c im Format"
-
-#, c-format
-msgid "E373: Unexpected %%%c in format string"
-msgstr "E373: Unerwartetes %%%c im Format"
-
-msgid "E374: Missing ] in format string"
-msgstr "E374: Fehlende ] im Format"
-
-#, c-format
-msgid "E375: Unsupported %%%c in format string"
-msgstr "E375: %%%c wird im Format nicht unterstützt"
-
-#, c-format
-msgid "E376: Invalid %%%c in format string prefix"
-msgstr "E376: Unzulässiges %%%c im Prefix des Formats"
-
-#, c-format
-msgid "E377: Invalid %%%c in format string"
-msgstr "E377: Unzulässiges %%%c im Format"
-
-msgid "E378: 'errorformat' contains no pattern"
-msgstr "E378: 'errorformat' enthält kein Muster"
-
-msgid "E379: Missing or empty directory name"
-msgstr "E379: Fehlender oder leerer Verzeichnisname"
-
-msgid "E553: No more items"
-msgstr "E553: Keine weiteren Einträge"
-
-#, c-format
-msgid "(%d of %d)%s%s: "
-msgstr "(%d aus %d)%s%s: "
-
-msgid " (line deleted)"
-msgstr " (Zeile gelöscht)"
-
-msgid "E380: At bottom of quickfix stack"
-msgstr "E380: Am Anfang der quickfix Liste"
-
-msgid "E381: At top of quickfix stack"
-msgstr "E381: An Ende der quickfix Liste"
-
-#, c-format
-msgid "error list %d of %d; %d errors"
-msgstr "Fehlerliste %d aus %d; %d Fehler"
-
-msgid "E382: Cannot write, 'buftype' option is set"
-msgstr "E382: Kann nicht schreiben, 'buftype'-Option ist gesetzt"
-
-msgid "E683: File name missing or invalid pattern"
-msgstr "E683: Dateiname fehlt oder ungültiges Muster"
-
-#, c-format
-msgid "Cannot open file \"%s\""
-msgstr "Kann Datei \"%s\" nicht öffnen"
-
-msgid "E681: Buffer is not loaded"
-msgstr "E681: Buffer ist nicht geladen"
-
-msgid "E777: String or List expected"
-msgstr "E777: Zeichenkette oder Liste erwartet"
-
-#, c-format
-msgid "E369: invalid item in %s%%[]"
-msgstr "E369: Ungültiges Element in %s%%[]"
-
-msgid "E339: Pattern too long"
-msgstr "E339: Muster zu lang"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Zu viele \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Zu viele %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: \\z( ohne Gegenstück"
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: %s%%( ohne Gegenstück"
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: %s( ohne Gegenstück"
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: %s) ohne Gegenstück"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Ungültiges Zeichen nach %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Zu viele komplexe %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Verschachteltes %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Verschachteltes %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: Ungültige Verwendung von \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c nach Nichts"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Ungültige Rückreferenz"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( ist hier nicht erlaubt"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 usw. ist hier nicht erlaubt"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Ungültiges Zeichen nach \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Fehlende ] nach %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: %s%%[] ist leer"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Ungültiges Zeichen nach %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Ungültiges Zeichen nach %s%%"
-
-#, c-format
-msgid "E769: Missing ] after %s["
-msgstr "E769: Fehlende ] nach %s["
-
-#, c-format
-msgid "E554: Syntax error in %s{...}"
-msgstr "E554: Syntaxfehler in %s{...}"
-
-msgid "External submatches:\n"
-msgstr "Externe 'submatches':\n"
-
-msgid " VREPLACE"
-msgstr " V-ERSETZEN"
-
-msgid " REPLACE"
-msgstr " ERSETZEN"
-
-msgid " REVERSE"
-msgstr " INVERTIERT"
-
-msgid " INSERT"
-msgstr " EINFÜGEN"
-
-msgid " (insert)"
-msgstr " (einfügen)"
-
-msgid " (replace)"
-msgstr " (ersetzen)"
-
-msgid " (vreplace)"
-msgstr " (v-ersetzen)"
-
-msgid " Hebrew"
-msgstr " Hebräisch"
-
-msgid " Arabic"
-msgstr " Arabisch"
-
-msgid " (lang)"
-msgstr " (Sprache)"
-
-msgid " (paste)"
-msgstr " (paste)"
-
-msgid " VISUAL"
-msgstr " VISUELL"
-
-msgid " VISUAL LINE"
-msgstr " VISUELL ZEILE"
-
-msgid " VISUAL BLOCK"
-msgstr " VISUELL BLOCK"
-
-msgid " SELECT"
-msgstr " AUSWAHL"
-
-msgid " SELECT LINE"
-msgstr " AUSWAHL ZEILE"
-
-msgid " SELECT BLOCK"
-msgstr " AUSWAHL BLOCK"
-
-msgid "recording"
-msgstr "aufzeichnen"
-
-#, c-format
-msgid "E383: Invalid search string: %s"
-msgstr "E383: Unzulässiges Suchmuster: %s"
-
-#, c-format
-msgid "E384: search hit TOP without match for: %s"
-msgstr "E384: Suche erreichte den ANFANG ohne Treffer für: %s"
-
-#, c-format
-msgid "E385: search hit BOTTOM without match for: %s"
-msgstr "E385: Suche erreichte das ENDE ohne Treffer für: %s"
-
-msgid "E386: Expected '?' or '/'  after ';'"
-msgstr "E386: Erwarte '?' oder '/'  nach ';'"
-
-msgid " (includes previously listed match)"
-msgstr " (enthält bereits vorher aufgezählte Treffer)"
-
-#. cursor at status line
-msgid "--- Included files "
-msgstr "--- Eingefügte Dateien "
-
-msgid "not found "
-msgstr "nicht gefunden "
-
-msgid "in path ---\n"
-msgstr "im Pfad ---\n"
-
-msgid "  (Already listed)"
-msgstr "  (Bereits aufgelistet)"
-
-msgid "  NOT FOUND"
-msgstr "  NICHT GEFUNDEN"
-
-#, c-format
-msgid "Scanning included file: %s"
-msgstr "Durchsuche inkludierte Datei: %s"
-
-#, c-format
-msgid "Searching included file %s"
-msgstr "Suche inkludierte Datei %s"
-
-msgid "E387: Match is on current line"
-msgstr "E387: Treffer ist auf der momentanen Zeile"
-
-msgid "All included files were found"
-msgstr "Alle inkludierten Dateien wurden gefunden"
-
-msgid "No included files"
-msgstr "Keine inkludierten Dateien"
-
-msgid "E388: Couldn't find definition"
-msgstr "E388: Konnte Definition nicht finden"
-
-msgid "E389: Couldn't find pattern"
-msgstr "E389: Konnte Muster nicht finden"
-
-msgid "E759: Format error in spell file"
-msgstr "E759: Format-Fehler im Rechtschreibwörterbuch"
-
-msgid "E758: Truncated spell file"
-msgstr "E758: Abgeschnittenes Rechtschreibwörterbuch"
-
-#, c-format
-msgid "Trailing text in %s line %d: %s"
-msgstr "Angehängter Text in %s Zeile %d: %s"
-
-#, c-format
-msgid "Affix name too long in %s line %d: %s"
-msgstr "Affix Name zu lang in %s Zeile %d: %s"
-
-msgid "E761: Format error in affix file FOL, LOW or UPP"
-msgstr "E761: Format-Fehler in Affix-Datei FOL, LOW oder UPP"
-
-msgid "E762: Character in FOL, LOW or UPP is out of range"
-msgstr "E762: Zeichen in FOL, LOW oder UPP außerhalb des zulässigen Bereichs"
-
-msgid "Compressing word tree..."
-msgstr "Komprimiere Wörter-Baum..."
-
-msgid "E756: Spell checking is not enabled"
-msgstr "E756: Rechtschreibprüfung ist nicht aktiviert"
-
-#, c-format
-msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr "Achtung: Kann Wortliste \"%s.%s.spl\" oder \"%s.ascii.spl\" nicht finden"
-
-#, c-format
-msgid "Reading spell file \"%s\""
-msgstr "Lese Rechtschreibwörterbuch \"%s\" ein"
-
-msgid "E757: This does not look like a spell file"
-msgstr "E757: Das sieht nicht nach einem Rechtschreibwörterbuch aus"
-
-msgid "E771: Old spell file, needs to be updated"
-msgstr "E771: Altes Rechtschreibwörterbuch, benötigt Aktualisierung"
-
-msgid "E772: Spell file is for newer version of Vim"
-msgstr "E772: Rechtschreibwörterbuch ist für eine neuere Version von Vim"
-
-msgid "E770: Unsupported section in spell file"
-msgstr "E770: Nicht unterstützter Abschnitt im Rechtschreibwörterbuch"
-
-#, c-format
-msgid "Warning: region %s not supported"
-msgstr "Achtung: Region %s nicht unterstützt"
-
-#, c-format
-msgid "Reading affix file %s ..."
-msgstr "Lese Affix-Datei %s ..."
-
-#, c-format
-msgid "Conversion failure for word in %s line %d: %s"
-msgstr "Umwandlungsfehler beim Wort in %s Zeile %d: %s"
-
-#, c-format
-msgid "Conversion in %s not supported: from %s to %s"
-msgstr "Umwandlung in %s nicht unterstützt: von %s nach %s"
-
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Umwandlung in %s nicht unterstützt"
-
-#, c-format
-msgid "Invalid value for FLAG in %s line %d: %s"
-msgstr "Ungültiger Wert von FLAG in %s Zeile %d: %s"
-
-#, c-format
-msgid "FLAG after using flags in %s line %d: %s"
-msgstr "FLAG nach dem Gebrauch von Flags in %s Zeile %d: %s"
-
-#, c-format
-msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
-msgstr "Falscher COMPOUNDWORDMAX-Wert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
-msgstr "Falscher COMPOUNDMIN-Wert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
-msgstr "Falscher COMPOUNDSYLMAX-Wert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
-msgstr "Falscher CHECKCOMPOUNDPATTERN-Wert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr "Unterschiedliches verknüpfendes Flag im fortgesetzten Affix-Block in %s Zeile %d: %s"
-
-#, c-format
-msgid "Duplicate affix in %s line %d: %s"
-msgstr "Doppeltes Affix in %s Zeile %d: %s"
-
-#, c-format
-msgid ""
-"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
-"line %d: %s"
-msgstr ""
-"Affix wird auch für BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST verwendet in %s "
-"Zeile %d: %s"
-
-#, c-format
-msgid "Expected Y or N in %s line %d: %s"
-msgstr "Y oder N erwartet in %s Zeile %d: %s"
-
-#, c-format
-msgid "Broken condition in %s line %d: %s"
-msgstr "Bedingung verletzt in %s Zeile %d: %s"
-
-#, c-format
-msgid "Affix flags ignored when PFXPOSTPONE used in %s line %d: %s"
-msgstr "Affix Flags ignoriert, wenn PFXPOSTPONE verwendet wird in %s Zeile %d: %s"
-
-#, c-format
-msgid "Expected REP(SAL) count in %s line %d"
-msgstr "Erwartetes REP(SAL) gezählt in %s Zeile %d"
-
-#, c-format
-msgid "Expected MAP count in %s line %d"
-msgstr "Erwartetes MAP gezählt in %s Zeile %d"
-
-#, c-format
-msgid "Duplicate character in MAP in %s line %d"
-msgstr "Doppeltes Zeichen in MAP in %s Zeile %d"
-
-#, c-format
-msgid "Unrecognized or duplicate item in %s line %d: %s"
-msgstr "Nicht erkanntes oder doppeltes Element in %s Zeile %d: %s"
-
-#, c-format
-msgid "Missing FOL/LOW/UPP line in %s"
-msgstr "Fehlende FOL/LOW/UPP Zeile in %s"
-
-msgid "COMPOUNDSYLMAX used without SYLLABLE"
-msgstr "COMPOUNDSYLMAX ohne SYLLABLE verwendet"
-
-msgid "Too many postponed prefixes"
-msgstr "Zu viele zurück gestellte Präfixe"
-
-msgid "Too many compound flags"
-msgstr "Zu viele zusammengesetzte Flags"
-
-msgid "Too many postponed prefixes and/or compound flags"
-msgstr "Zu viele zurück gestellte Präfixe und/oder zusammengesetzte Flags"
-
-#, c-format
-msgid "Missing SOFO%s line in %s"
-msgstr "Fehlende SOFO%s Zeile in %s"
-
-#, c-format
-msgid "Both SAL and SOFO lines in %s"
-msgstr "Sowohl SAL als auch SOFO Zeilen in %s"
-
-#, c-format
-msgid "Flag is not a number in %s line %d: %s"
-msgstr "Flag ist keine Zahl in %s Zeile %d: %s"
-
-#, c-format
-msgid "Illegal flag in %s line %d: %s"
-msgstr "Unerlaubtes Flag in %s Zeile %d: %s"
-
-#, c-format
-msgid "%s value differs from what is used in another .aff file"
-msgstr "%s Wert unterscheidet sich von dem, was in einer anderen .aff Datei verwendet wird"
-
-#, c-format
-msgid "Reading dictionary file %s ..."
-msgstr "Lese Wörterbuch-Datei %s ..."
-
-#, c-format
-msgid "E760: No word count in %s"
-msgstr "E760: Keine Wörter gezählt in %s"
-
-#, c-format
-msgid "line %6d, word %6d - %s"
-msgstr "Zeile %6d, Wort %6d - %s"
-
-#, c-format
-msgid "Duplicate word in %s line %d: %s"
-msgstr "Doppeltes Wort in %s Zeile %d: %s"
-
-#, c-format
-msgid "First duplicate word in %s line %d: %s"
-msgstr "Erstes doppeltes Wort in %s Zeile %d: %s"
-
-#, c-format
-msgid "%d duplicate word(s) in %s"
-msgstr "%d doppelte(s) Wort(e) in %s"
-
-#, c-format
-msgid "Ignored %d word(s) with non-ASCII characters in %s"
-msgstr "%d Wort(e) mit nicht-ASCII Zeichen ignoriert in %s"
-
-#, c-format
-msgid "Reading word file %s ..."
-msgstr "Lese Wort-Datei %s ..."
-
-#, c-format
-msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-msgstr "Doppelte /encoding= Zeile ignoriert in %s Zeile %d: %s"
-
-#, c-format
-msgid "/encoding= line after word ignored in %s line %d: %s"
-msgstr "/encoding= Zeile nach Wort ignoriert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Duplicate /regions= line ignored in %s line %d: %s"
-msgstr "Doppelte /regions= Zeile ignoriert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Too many regions in %s line %d: %s"
-msgstr "Zu viele Regionen in %s Zeile %d: %s"
-
-#, c-format
-msgid "/ line ignored in %s line %d: %s"
-msgstr "/ Zeile ignoriert in %s Zeile %d: %s"
-
-#, c-format
-msgid "Invalid region nr in %s line %d: %s"
-msgstr "Ungültige Regionsnummer in %s Zeile %d: %s"
-
-#, c-format
-msgid "Unrecognized flags in %s line %d: %s"
-msgstr "Nicht erkanntes Flag in %s Zeile %d: %s"
-
-#, c-format
-msgid "Ignored %d words with non-ASCII characters"
-msgstr "%d Wörter mit nicht-ASCII Zeichen ignoriert"
-
-#, c-format
-msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
-msgstr "%d von %d Knoten komprimiert; %d (%d%%) übrig"
-
-msgid "Reading back spell file..."
-msgstr "Lese Rechtschreibwörterbuch zurück..."
-
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
-msgid "Performing soundfolding..."
-msgstr "Führe 'Soundfolding' durch..."
-
-#, c-format
-msgid "Number of words after soundfolding: %<PRId64>"
-msgstr "Anzahl der Wörter nach 'Soundfolding': %<PRId64>"
-
-#, c-format
-msgid "Total number of words: %d"
-msgstr "Gesamte Anzahl von Wörtern: %d"
-
-#, c-format
-msgid "Writing suggestion file %s ..."
-msgstr "Schreibe Datei %s für Vorschläge ..."
-
-#, c-format
-msgid "Estimated runtime memory use: %d bytes"
-msgstr "Geschätzter Speicher zur Laufzeit: %d Bytes"
-
-msgid "E751: Output file name must not have region name"
-msgstr "E751: Ausgabedatei darf keinen Regionsnamen haben"
-
-msgid "E754: Only up to 8 regions supported"
-msgstr "E754: Maximal 8 Regionen unterstützt"
-
-#, c-format
-msgid "E755: Invalid region in %s"
-msgstr "E755: Ungültige Region in %s"
-
-msgid "Warning: both compounding and NOBREAK specified"
-msgstr "Achtung: Sowohl zusammengesetzte Wörter als auch NOBREAK angegeben"
-
-#, c-format
-msgid "Writing spell file %s ..."
-msgstr "Schreibe Rechtschreibwörterbuch %s ..."
-
-msgid "Done!"
-msgstr "Fertig!"
-
-#, c-format
-msgid "E765: 'spellfile' does not have %<PRId64> entries"
-msgstr "E765: 'spellfile' hat nicht %<PRId64> Einträge"
-
-#, c-format
-msgid "Word removed from %s"
-msgstr "Wort entfernt von %s"
-
-#, c-format
-msgid "Word added to %s"
-msgstr "Wort zu %s hinzugefügt"
-
-msgid "E763: Word characters differ between spell files"
-msgstr "E763: 'Word Characters' unterscheiden sich zwischen Rechtschreibwörterbüchern"
-
-msgid "Sorry, no suggestions"
-msgstr "Leider keine Vorschläge"
-
-#, c-format
-msgid "Sorry, only %<PRId64> suggestions"
-msgstr "Leider nur %<PRId64> Vorschläge"
-
-#. avoid more prompt
-#, c-format
-msgid "Change \"%.*s\" to:"
-msgstr "Ändere \"%.*s\" nach:"
-
-#, c-format
-msgid " < \"%.*s\""
-msgstr " < \"%.*s\""
-
-msgid "E752: No previous spell replacement"
-msgstr "E752: Keine vorhergehende Ersetzung"
-
-#, c-format
-msgid "E753: Not found: %s"
-msgstr "E753: Nicht gefunden: %s"
-
-#, c-format
-msgid "E778: This does not look like a .sug file: %s"
-msgstr "E778: Das sieht nicht nach einer .sug Datei aus: %s"
-
-#, c-format
-msgid "E779: Old .sug file, needs to be updated: %s"
-msgstr "E779: Veraltete .sug Datei; Aktualisierung erforderlich: %s"
-
-#, c-format
-msgid "E780: .sug file is for newer version of Vim: %s"
-msgstr "E780: .sug Datei ist für eine neuere Version von Vim: %s"
-
-#, c-format
-msgid "E781: .sug file doesn't match .spl file: %s"
-msgstr "E781: .sug Datei passt nicht zur .spl Datei: %s"
-
-#, c-format
-msgid "E782: error while reading .sug file: %s"
-msgstr "E782: Fehler beim Lesen der .sug Datei: %s"
-
-#. This should have been checked when generating the .spl
-#. * file.
-msgid "E783: duplicate char in MAP entry"
-msgstr "E783: Doppeltes Zeichen im MAP Eintrag"
-
-#, c-format
-msgid "E390: Illegal argument: %s"
-msgstr "E390: Unerlaubtes Argument: %s"
-
-#, c-format
-msgid "E391: No such syntax cluster: %s"
-msgstr "E391: Kein solcher Syntax Cluster: %s"
-
-msgid "No Syntax items defined for this buffer"
-msgstr "Keine Syntax-Elemente für diesen Puffer definiert"
-
-msgid "syncing on C-style comments"
-msgstr "Synchronisation an C-Stil Kommentaren"
-
-msgid "no syncing"
-msgstr "keine Synchronisation"
-
-msgid "syncing starts "
-msgstr "Synchronisation beginnt "
-
-msgid " lines before top line"
-msgstr " Zeilen vor der obersten Zeile"
-
-msgid ""
-"\n"
-"--- Syntax sync items ---"
-msgstr ""
-"\n"
-"--- Syntax Synchronisations-Elemente ---"
-
-msgid ""
-"\n"
-"syncing on items"
-msgstr ""
-"\n"
-"Synchronisation an Elementen"
-
-msgid ""
-"\n"
-"--- Syntax items ---"
-msgstr ""
-"\n"
-"--- Syntax-Elemente ---"
-
-#, c-format
-msgid "E392: No such syntax cluster: %s"
-msgstr "E392: Kein solcher Syntax-Cluster: %s"
-
-msgid "minimal "
-msgstr "minimal "
-
-msgid "maximal "
-msgstr "maximal "
-
-msgid "; match "
-msgstr "; Treffer "
-
-msgid " line breaks"
-msgstr " Zeilenumbrüche"
-
-msgid "E393: group[t]here not accepted here"
-msgstr "E393: \"group[t]here\" ist an dieser Stelle ungültig"
-
-#, c-format
-msgid "E394: Didn't find region item for %s"
-msgstr "E394: Konnte kein \"region\"-Element für \"%s\" finden"
-
-msgid "E395: contains argument not accepted here"
-msgstr "E395: \"contains\"-Argument ist an dieser Stelle ungültig"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: \"containedin\"-Argument ist an dieser Stelle ungültig"
-
-msgid "E397: Filename required"
-msgstr "E397: Dateiname wird benötigt"
-
-#, c-format
-msgid "E789: Missing ']': %s"
-msgstr "E789: Fehlende ']': %s"
-
-#, c-format
-msgid "E398: Missing '=': %s"
-msgstr "E398: Fehlendes '=': %s"
-
-#, c-format
-msgid "E399: Not enough arguments: syntax region %s"
-msgstr "E399: Nicht ausreichend viele Argumente: syntax region %s"
-
-msgid "E400: No cluster specified"
-msgstr "E400: Kein Cluster angegeben"
-
-#, c-format
-msgid "E401: Pattern delimiter not found: %s"
-msgstr "E401: Muster-Abgrenzer nicht gefunden: %s"
-
-#, c-format
-msgid "E402: Garbage after pattern: %s"
-msgstr "E402: Schrott nach Muster: %s"
-
-msgid "E403: syntax sync: line continuations pattern specified twice"
-msgstr "E403: Syntax sync: Zeilen-Fortsetzungsmuster zweifach angegeben"
-
-#, c-format
-msgid "E404: Illegal arguments: %s"
-msgstr "E404: Unzulässige Argumente; %s"
-
-#, c-format
-msgid "E405: Missing equal sign: %s"
-msgstr "E405: Gleichheitszeichen fehlt: %s"
-
-#, c-format
-msgid "E406: Empty argument: %s"
-msgstr "E406: Leeres Argument: %s"
-
-#, c-format
-msgid "E407: %s not allowed here"
-msgstr "E407: %s ist hier nicht erlaubt"
-
-#, c-format
-msgid "E408: %s must be first in contains list"
-msgstr "E408: %s muss als Erstes in der Liste der enthaltenen Elemente auftreten"
-
-#, c-format
-msgid "E409: Unknown group name: %s"
-msgstr "E409: Unbekannter Gruppenname: %s"
-
-#, c-format
-msgid "E410: Invalid :syntax subcommand: %s"
-msgstr "E410: Ungültiger :syntax Befehl: %s"
-
-msgid "E679: recursive loop loading syncolor.vim"
-msgstr "E679: Rekursive Schleife beim Laden von syncolor.vim"
-
-#, c-format
-msgid "E411: highlight group not found: %s"
-msgstr "E411: Hervorhebungsgruppe nicht gefunden: %s"
-
-#, c-format
-msgid "E412: Not enough arguments: \":highlight link %s\""
-msgstr "E412: Nicht ausreichend viele Argumente: \":highlight link %s\""
-
-#, c-format
-msgid "E413: Too many arguments: \":highlight link %s\""
-msgstr "E413: Zu viele Argumente: \":highlight link %s\""
-
-msgid "E414: group has settings, highlight link ignored"
-msgstr "E414: Gruppe hat Einstellungen, highlight link ignorieren"
-
-#, c-format
-msgid "E415: unexpected equal sign: %s"
-msgstr "E415: Unerwartetes Gleichheitszeichen: %s"
-
-#, c-format
-msgid "E416: missing equal sign: %s"
-msgstr "E416: fehlendes Gleichheitszeichen: %s"
-
-#, c-format
-msgid "E417: missing argument: %s"
-msgstr "E417: Fehlendes Argument: %s"
-
-#, c-format
-msgid "E418: Illegal value: %s"
-msgstr "E418: Unzulässiger Wert: %s"
-
-msgid "E419: FG color unknown"
-msgstr "E419: FG Farbe unbekannt"
-
-msgid "E420: BG color unknown"
-msgstr "E420: BG Farbe unbekannt"
-
-#, c-format
-msgid "E421: Color name or number not recognized: %s"
-msgstr "E421: Unbekannte Farbbezeichnung oder -Nummer: %s"
-
-#, c-format
-msgid "E422: terminal code too long: %s"
-msgstr "E422: Terminal-Code zu lang: %s"
-
-#, c-format
-msgid "E423: Illegal argument: %s"
-msgstr "E423: Unzulässiges Argument: %s"
-
-msgid "E424: Too many different highlighting attributes in use"
-msgstr "E424: Zu viele verschieden Hervorhebungsattribute in Gebrauch"
-
-msgid "E669: Unprintable character in group name"
-msgstr "E669: Nicht druckbare Zeichen im Namen der Gruppe"
-
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ungültiges Zeichen im Namen der Gruppe"
-
-msgid "E555: at bottom of tag stack"
-msgstr "E555: Am Ende des Tag-Stacks"
-
-msgid "E556: at top of tag stack"
-msgstr "E556: Am Anfang des Tag-Stacks"
-
-msgid "E425: Cannot go before first matching tag"
-msgstr "E425: Kann nicht vor den ersten passenden Tag hinausgehen"
-
-#, c-format
-msgid "E426: tag not found: %s"
-msgstr "E426: Konnte Tag \"%s\" nicht finden"
-
-msgid "  # pri kind tag"
-msgstr "   # pri verw. tag"
-
-msgid "file\n"
-msgstr "Datei\n"
-
-msgid "E427: There is only one matching tag"
-msgstr "E427: Es gibt nur einen passenden Tag"
-
-msgid "E428: Cannot go beyond last matching tag"
-msgstr "E428: Kann nicht über den letzten passenden Tag hinausgehen"
-
-#, c-format
-msgid "File \"%s\" does not exist"
-msgstr "Die Datei \"%s\" existiert nicht"
-
-#. Give an indication of the number of matching tags
-#, c-format
-msgid "tag %d of %d%s"
-msgstr "Tag %d aus %d%s"
-
-msgid " or more"
-msgstr " oder mehr"
-
-msgid "  Using tag with different case!"
-msgstr "  Verwendung eines Tags mit abgewandelter Groß-/Klein-Schreibung"
-
-#, c-format
-msgid "E429: File \"%s\" does not exist"
-msgstr "E429: Die Datei \"%s\" existiert nicht"
-
-#. Highlight title
-msgid ""
-"\n"
-"  # TO tag         FROM line  in file/text"
-msgstr ""
-"\n"
-"  # NACH TAG       VON Zeile  in Datei/Text"
-
-#, c-format
-msgid "Searching tags file %s"
-msgstr "tags file %s wird durchsucht"
-
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tag-Dateipfad wurde abgeschnitten für %s\n"
-
-#, c-format
-msgid "E431: Format error in tags file \"%s\""
-msgstr "E431: Format Fehler in Tag-Datei \"%s\""
-
-#, c-format
-msgid "Before byte %<PRId64>"
-msgstr "Vor byte %<PRId64>"
-
-#, c-format
-msgid "E432: Tags file not sorted: %s"
-msgstr "E432: Tag-Datei ist nicht sortiert: %s"
-
-#. never opened any tags file
-msgid "E433: No tags file"
-msgstr "E433: Keine Tag-Datei"
-
-msgid "E434: Can't find tag pattern"
-msgstr "E434: Kann Tag-Muster nicht finden"
-
-msgid "E435: Couldn't find tag, just guessing!"
-msgstr "E435: Konnte Tag möglicherweise nicht finden!"
-
-msgid "' not known. Available builtin terminals are:"
-msgstr "' nicht bekannt. Die folgenden eingebauten Terminals stehen zur Verfügung:"
-
-msgid "defaulting to '"
-msgstr "Voreinstellung '"
-
-msgid "E557: Cannot open termcap file"
-msgstr "E557: Termcap-Datei kann nicht geöffnet werden"
-
-msgid "E558: Terminal entry not found in terminfo"
-msgstr "E558: Kein Terminal-Eintrag in der Terminfo-Datenbank gefunden"
-
-msgid "E559: Terminal entry not found in termcap"
-msgstr "E559: Kein Terminal-Eintrag in der Termcap-Datei gefunden"
-
-#, c-format
-msgid "E436: No \"%s\" entry in termcap"
-msgstr "E436: Kein \"%s\" Eintrag in der Termcap-Datei"
-
-msgid "E437: terminal capability \"cm\" required"
-msgstr "E437: Terminalfähigkeit \"cm\" wird benötigt"
-
-#. Highlight title
-msgid ""
-"\n"
-"--- Terminal keys ---"
-msgstr ""
-"\n"
-"--- Terminal Tasten ---"
-
-msgid "new shell started\n"
-msgstr "neue Shell gestartet\n"
-
-msgid "Vim: Error reading input, exiting...\n"
-msgstr "Vim: Fehler beim Lesen der Eingabe, Abbruch...\n"
-
-msgid "No undo possible; continue anyway"
-msgstr "Wiederherstellung nicht möglich; setze trotzdem fort"
-
-msgid "Already at oldest change"
-msgstr "Bereits bei der ältesten Änderung"
-
-msgid "Already at newest change"
-msgstr "Bereits bei der jüngsten Änderung"
-
-#, c-format
-msgid "Undo number %<PRId64> not found"
-msgstr "Nummer %<PRId64> zur Wiederherstellung nicht gefunden"
-
-msgid "E438: u_undo: line numbers wrong"
-msgstr "E438: u_undo: Zeilennummer falsch"
-
-msgid "more line"
-msgstr "Zeile mehr"
-
-msgid "more lines"
-msgstr "Zeilen mehr"
-
-msgid "line less"
-msgstr "Zeile weniger"
-
-msgid "fewer lines"
-msgstr "Zeilen weniger"
-
-msgid "change"
-msgstr "Änderung"
-
-msgid "changes"
-msgstr "Änderungen"
-
-#, c-format
-msgid "%<PRId64> %s; %s #%<PRId64>  %s"
-msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
-
-msgid "before"
-msgstr "vor"
-
-msgid "after"
-msgstr "nach"
-
-msgid "Nothing to undo"
-msgstr "Nichts wiederherzustellen"
-
-msgid "number changes  time"
-msgstr "Nummer Änd.     Zeit"
-
-msgid "E439: undo list corrupt"
-msgstr "E439: Liste der Wiederherstellungen fehlerhaft"
-
-msgid "E440: undo line missing"
-msgstr "E440: Wiederherstellungszeile fehlt"
-
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 Bit GUI Version"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit GUI Version"
-
-msgid " in Win32s mode"
-msgstr " in Win32s Modus"
-
-msgid " with OLE support"
-msgstr " mit OLE-Unterstützung"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit Konsolen-Version"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 Bit Version"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 Bit MS-DOS Version"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 Bit MS-DOS Version"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) Version"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X Version"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS Version"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS Version"
-
-msgid ""
-"\n"
-"Included patches: "
-msgstr ""
-"\n"
-"Inklusive der Korrekturen: "
-
-msgid "Modified by "
-msgstr "Verändert von "
-
-msgid ""
-"\n"
-"Compiled "
-msgstr ""
-"\n"
-"Übersetzt "
-
-msgid "by "
-msgstr "von "
-
-msgid ""
-"\n"
-"Huge version "
-msgstr ""
-"\n"
-"Riesige Version "
-
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Große Version "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normale Version "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Kleine Version "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Winzige Version "
-
-msgid "without GUI."
-msgstr "ohne GUI."
-
-msgid "with GTK2-GNOME GUI."
-msgstr "mit GTK2-GNOME GUI."
-
-msgid "with GTK-GNOME GUI."
-msgstr "mit GTK-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "mit GTK2 GUI."
-
-msgid "with GTK GUI."
-msgstr "mit GTK GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "mit X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "mit X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "mit X11-Athena GUI."
-
-msgid "with BeOS GUI."
-msgstr "mit BeOS GUI."
-
-msgid "with Photon GUI."
-msgstr "mit Photon GUI."
-
-msgid "with GUI."
-msgstr "mit GUI."
-
-msgid "with Carbon GUI."
-msgstr "mit Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "mit Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "mit (klassischem) GUI."
-
-msgid "  Features included (+) or not (-):\n"
-msgstr " Ein- (+) oder ausschließlich (-) der Eigenschaften:\n"
-
-msgid "   system vimrc file: \""
-msgstr "          System-vimrc-Datei: \""
-
-msgid "     user vimrc file: \""
-msgstr "        Benutzer-vimrc-Datei: \""
-
-msgid " 2nd user vimrc file: \""
-msgstr " zweite Benutzer-vimrc-Datei: \""
-
-msgid " 3rd user vimrc file: \""
-msgstr " dritte Benutzer-vimrc-Datei: \""
-
-msgid "      user exrc file: \""
-msgstr "         Benutzer-exrc-Datei: \""
-
-msgid "  2nd user exrc file: \""
-msgstr " zweite Benutzer-exrc-Datei: \""
-
-msgid "  system gvimrc file: \""
-msgstr "         System-gvimrc-Datei: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       Benutzer-gvimrc-Datei: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "zweite Benutzer-gvimrc-Datei: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "dritte Benutzer-gvimrc-Datei: \""
-
-msgid "    system menu file: \""
-msgstr "           System-Menü-Datei: \""
-
-msgid "  fall-back for $VIM: \""
-msgstr "     Voreinstellung für $VIM: \""
-
-msgid " f-b for $VIMRUNTIME: \""
-msgstr "         und für $VIMRUNTIME: \""
-
-msgid "Compilation: "
-msgstr "Übersetzt: "
-
-msgid "Compiler: "
-msgstr "Compiler: "
-
-msgid "Linking: "
-msgstr "Linken: "
-
-msgid "  DEBUG BUILD"
-msgstr "  DEBUG-VERSION"
-
-msgid "VIM - Vi IMproved"
-msgstr "VIM - verbesserter Vi"
-
-msgid "version "
-msgstr "Version "
-
-msgid "by Bram Moolenaar et al."
-msgstr "von Bram Moolenaar und Anderen"
-
-msgid "Vim is open source and freely distributable"
-msgstr "Vim ist Open Source und kann frei weitergegeben werden"
-
-msgid "Help poor children in Uganda!"
-msgstr "Helfen Sie armen Kindern in Uganda!"
-
-msgid "type  :help iccf<Enter>       for information "
-msgstr "Tippe  :help iccf<Enter>        für Informationen darüber "
-
-msgid "type  :q<Enter>               to exit         "
-msgstr "Tippe  :q<Enter>                zum Beenden               "
-
-msgid "type  :help<Enter>  or  <F1>  for on-line help"
-msgstr "Tippe  :help<Enter>  oder <F1>  für Online Hilfe          "
-
-msgid "type  :help version7<Enter>   for version info"
-msgstr "Tippe  :help version7<Enter>    für Versions-Informationen"
-
-msgid "Running in Vi compatible mode"
-msgstr "Vi kompatible Einstellung"
-
-msgid "type  :set nocp<Enter>        for Vim defaults"
-msgstr "Tippe  :set nocp<Enter>         für Vim-Voreinstellungen  "
-
-msgid "type  :help cp-default<Enter> for info on this"
-msgstr "Tippe  :help cp-default<Enter>  für Informationen darüber "
-
-msgid "menu  Help->Orphans           for information    "
-msgstr "Menü   Hilfe->Waisen            für Informationen darüber "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Mode-freier Betrieb, getippter Text wird eingefügt"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "Menü  Editieren->Globale Einstellung->Einfüge-Modus ein- und ausschalten  "
-
-msgid "                              for two modes      "
-msgstr "                              für zwei Modi       "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "Menü  Editieren->Globale Einstellung->Vi-Kompatibilität ein- und ausschalten"
-
-msgid "                              for Vim defaults   "
-msgstr "                              für Vim Voreinstellungen   "
-
-msgid "Sponsor Vim development!"
-msgstr "Unterstützen Sie die Entwicklung von Vim"
-
-msgid "Become a registered Vim user!"
-msgstr "Werden Sie ein registrierter Benutzer von Vim!"
-
-msgid "type  :help sponsor<Enter>    for information "
-msgstr "Tippe  :help sponsor<Enter>     für mehr Informationen    "
-
-msgid "type  :help register<Enter>   for information "
-msgstr "Tippe  :help register<Enter>    für mehr Informationen    "
-
-msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "Menü   Hilfe->Sponsor/Register  für mehr Informationen    "
-
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ACHTUNG: Windows 95/98/ME wurde erkannt"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "Tippe  :help windows95<Enter>   für Informationen darüber "
-
-msgid "E441: There is no preview window"
-msgstr "E441: Es gibt kein Fenster zur Voransicht"
-
-# should read: topleft / botright
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: topleft und botright können nicht gleichzeitig verwendet werden"
-
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: Rotieren nicht möglich wenn ein anderes Fenster geteilt ist"
-
-msgid "E444: Cannot close last window"
-msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
-
-msgid "Already only one window"
-msgstr "Bereits nur ein Fenster"
-
-msgid "E445: Other window contains changes"
-msgstr "E445: Anderes Fenster enthält Änderungen"
-
-# Cursor: Schreibmarke Positionsmarke
-msgid "E446: No file name under cursor"
-msgstr "E446: Kein Dateiname unter dem Cursor"
-
+#: ../path.c:1449
 #, c-format
 msgid "E447: Can't find file \"%s\" in path"
 msgstr "E447: Kann Datei \"%s\" nicht im Pfad finden"
 
+#: ../quickfix.c:359
 #, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Konnte Bibliothek %s nicht laden"
+msgid "E372: Too many %%%c in format string"
+msgstr "E372: Zu viele %%%c im Format"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Dieser Befehl ist nicht verfügbar, da die Perl-Bibliothek nicht geladen werden konnte"
-
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Perl-Evaluierung in der Sandbox ohne dem 'Safe' Modul"
-
-msgid "--No lines in buffer--"
-msgstr "--Keine Zeilen im Puffer--"
-
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Befehl abgebrochen"
-
-msgid "E471: Argument required"
-msgstr "E471: Argument benötigt"
-
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ sollte von /, ? or & gefolgt werden"
-
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ungültig im Kommandozeilenfenster; <CR> führt aus, CTRL-C beendet"
-
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: Befehl nicht zulässig vom exrc/vimrc in der momentanen Verzeichnis- oder Tag-Suche"
-
-msgid "E171: Missing :endif"
-msgstr "E171: Fehlendes :endif"
-
-msgid "E600: Missing :endtry"
-msgstr "E600: Fehlendes :endtry"
-
-msgid "E170: Missing :endwhile"
-msgstr "E170: fehlendes :endwhile"
-
-msgid "E170: Missing :endfor"
-msgstr "E170: Fehlendes :endfor"
-
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile ohne :while"
-
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor ohne :for"
-
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Datei existiert bereits (erzwinge mit !)"
-
-
-msgid "E472: Command failed"
-msgstr "E472: Befehl fehlgeschlagen"
-
+#: ../quickfix.c:371
 #, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Unbekannter Fontset: %s"
+msgid "E373: Unexpected %%%c in format string"
+msgstr "E373: Unerwartetes %%%c im Format"
 
+#: ../quickfix.c:420
+msgid "E374: Missing ] in format string"
+msgstr "E374: Fehlende ] im Format"
+
+#: ../quickfix.c:431
 #, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Unbekannte Schriftart: %s"
+msgid "E375: Unsupported %%%c in format string"
+msgstr "E375: %%%c wird im Format nicht unterstützt"
 
+#: ../quickfix.c:448
 #, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Schriftart \"%s\" hat keine feste Breite"
+msgid "E376: Invalid %%%c in format string prefix"
+msgstr "E376: Unzulässiges %%%c im Prefix des Formats"
 
-msgid "E473: Internal error"
-msgstr "E473: Interner Fehler"
-
-msgid "Interrupted"
-msgstr "Unterbrochen"
-
-msgid "E14: Invalid address"
-msgstr "E14: Ungültige Adresse"
-
-msgid "E474: Invalid argument"
-msgstr "E474: Ungültiges Argument"
-
+#: ../quickfix.c:454
 #, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Ungültiges Argument: %s"
+msgid "E377: Invalid %%%c in format string"
+msgstr "E377: Unzulässiges %%%c im Format"
 
+#. nothing found
+#: ../quickfix.c:477
+msgid "E378: 'errorformat' contains no pattern"
+msgstr "E378: 'errorformat' enthält kein Muster"
+
+#: ../quickfix.c:695
+msgid "E379: Missing or empty directory name"
+msgstr "E379: Fehlender oder leerer Verzeichnisname"
+
+#: ../quickfix.c:1305
+msgid "E553: No more items"
+msgstr "E553: Keine weiteren Einträge"
+
+#: ../quickfix.c:1674
 #, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: ungültiger Ausdruck: %s"
+msgid "(%d of %d)%s%s: "
+msgstr "(%d aus %d)%s%s: "
 
-msgid "E16: Invalid range"
-msgstr "E16: Ungültiger Bereich"
+#: ../quickfix.c:1676
+msgid " (line deleted)"
+msgstr " (Zeile gelöscht)"
 
-msgid "E476: Invalid command"
-msgstr "E476: Ungültiger Befehl"
+#: ../quickfix.c:1863
+msgid "E380: At bottom of quickfix stack"
+msgstr "E380: Am Anfang der quickfix Liste"
 
+#: ../quickfix.c:1869
+msgid "E381: At top of quickfix stack"
+msgstr "E381: An Ende der quickfix Liste"
+
+#: ../quickfix.c:1880
 #, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" ist ein Verzeichnis"
+msgid "error list %d of %d; %d errors"
+msgstr "Fehlerliste %d aus %d; %d Fehler"
 
+#: ../quickfix.c:2427
+msgid "E382: Cannot write, 'buftype' option is set"
+msgstr "E382: Kann nicht schreiben, 'buftype'-Option ist gesetzt"
+
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr "E683: Dateiname fehlt oder ungültiges Muster"
+
+#: ../quickfix.c:2911
 #, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Bibliotheksaufruf für \"%s()\" schlug fehl"
+msgid "Cannot open file \"%s\""
+msgstr "Kann Datei \"%s\" nicht öffnen"
 
+#: ../quickfix.c:3429
+msgid "E681: Buffer is not loaded"
+msgstr "E681: Buffer ist nicht geladen"
+
+#: ../quickfix.c:3487
+msgid "E777: String or List expected"
+msgstr "E777: Zeichenkette oder Liste erwartet"
+
+#: ../regexp.c:359
 #, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Bibliotheksfunktion %s konnte nicht geladen werden"
+msgid "E369: invalid item in %s%%[]"
+msgstr "E369: Ungültiges Element in %s%%[]"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Marke hat ungültige Zeilennummer"
-
-msgid "E20: Mark not set"
-msgstr "E20: Marke nicht gesetzt"
-
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Kann keine Änderungen machen, 'modifiable' ist aus"
-
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skript ist zu tief verschachtelt"
-
-msgid "E23: No alternate file"
-msgstr "E23: Keine alternative Datei"
-
-msgid "E24: No such abbreviation"
-msgstr "E24: Keine Abkürzung gefunden"
-
-msgid "E477: No ! allowed"
-msgstr "E477: Kein ! erlaubt"
-
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens nicht eingeschaltet."
-
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebräisch kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens nicht eingeschaltet.\n"
-
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens nicht eingeschaltet.\n"
-
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabisch kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens nicht eingeschaltet.\n"
-
+#: ../regexp.c:374
 #, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Hervorhebungsgruppe existiert nicht: %s"
+msgid "E769: Missing ] after %s["
+msgstr "E769: Fehlende ] nach %s["
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Noch kein eingefügter Text"
-
-msgid "E30: No previous command line"
-msgstr "E30: Keine vorherige Befehlszeile"
-
-msgid "E31: No such mapping"
-msgstr "E31: Keine Zuordnung gefunden"
-
-msgid "E479: No match"
-msgstr "E479: Kein Treffer"
-
+#: ../regexp.c:375
 #, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Kein Treffer: %s"
+msgid "E53: Unmatched %s%%("
+msgstr "E53: %s%%( ohne Gegenstück"
 
-msgid "E32: No file name"
-msgstr "E32: Kein Dateiname"
-
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Kein vorheriger regulärer Ersetzungsausdruck"
-
-msgid "E34: No previous command"
-msgstr "E34: Kein vorheriger Befehl"
-
-msgid "E35: No previous regular expression"
-msgstr "E35: Keine vorheriger regulärer Ausdruck"
-
-msgid "E481: No range allowed"
-msgstr "E481: Kein Bereich erlaubt"
-
-msgid "E36: Not enough room"
-msgstr "E36: Zu wenig Platz"
-
+#: ../regexp.c:376
 #, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Kein registrierter Servername \"%s\""
+msgid "E54: Unmatched %s("
+msgstr "E54: %s( ohne Gegenstück"
 
+#: ../regexp.c:377
 #, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Kann Datei %s nicht erzeugen"
+msgid "E55: Unmatched %s)"
+msgstr "E55: %s) ohne Gegenstück"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Kann den Namen der temporären Datei nicht ermitteln"
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( ist hier nicht erlaubt"
 
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 usw. ist hier nicht erlaubt"
+
+#: ../regexp.c:380
 #, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Kann die Datei %s nicht öffnen"
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Fehlende ] nach %s%%["
 
+#: ../regexp.c:381
 #, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Kann Datei %s nicht lesen"
+msgid "E70: Empty %s%%[]"
+msgstr "E70: %s%%[] ist leer"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Kein Schreibvorgang seit der letzten Änderung (erzwinge mit !)"
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Muster zu lang"
 
-msgid "E38: Null argument"
-msgstr "E38: Null-Argument"
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Zu viele \\z("
 
-msgid "E39: Number expected"
-msgstr "E39: Nummer erwartet"
-
+#: ../regexp.c:1378
 #, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Fehlerdatei %s kann nicht geöffnet werden"
+msgid "E51: Too many %s("
+msgstr "E51: Zu viele %s("
 
-msgid "E233: cannot open display"
-msgstr "E233: Display kann nicht geöffnet werden"
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: \\z( ohne Gegenstück"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Speicher erschöpft!"
-
-msgid "Pattern not found"
-msgstr "Muster nicht gefunden"
-
+#: ../regexp.c:1637
 #, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Muster nicht gefunden: %s"
+msgid "E59: invalid character after %s@"
+msgstr "E59: Ungültiges Zeichen nach %s@"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument muss positiv sein"
-
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Kann nicht ins vorhergehende Verzeichnis wechseln"
-
-msgid "E42: No Errors"
-msgstr "E42: Kein Fehler"
-
-msgid "E776: No location list"
-msgstr "E776: Keine Positionsliste"
-
-msgid "E43: Damaged match string"
-msgstr "E43: Beschädigter Suchausdruck"
-
-msgid "E44: Corrupted regexp program"
-msgstr "E44: schadhaftes regexp Programm"
-
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Die Option 'readonly' ist gesetzt (erzwinge mit !)"
-
+#: ../regexp.c:1672
 #, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: Variable \"%s\" kann nur gelesen werden"
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Zu viele komplexe %s{...}s"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Fehler während des Lesens der Fehlerdatei"
-
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: In einer Sandbox nicht erlaubt"
-
-msgid "E523: Not allowed here"
-msgstr "E523: Hier nicht erlaubt"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Bildschirm-Modus wird nicht unterstützt"
-
-msgid "E49: Invalid scroll size"
-msgstr "E49: Ungültige Scroll-Größe"
-
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Die Option 'shell' ist leer"
-
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Fehler -- Daten für Debuggersymbol konnten nicht gelesen werden"
-
-msgid "E72: Close error on swap file"
-msgstr "E72: Fehler beim Schließen der Auslagerungsdatei"
-
-msgid "E73: tag stack empty"
-msgstr "E73: tag Stapel leer."
-
-msgid "E74: Command too complex"
-msgstr "E74: Befehl zu kompliziert"
-
-msgid "E75: Name too long"
-msgstr "E75: Name zu lang"
-
-msgid "E76: Too many ["
-msgstr "E76: Zu viele ["
-
-msgid "E77: Too many file names"
-msgstr "E77: Zu viele Dateinamen"
-
-msgid "E488: Trailing characters"
-msgstr "E488: Überschüssige Zeichen"
-
-msgid "E78: Unknown mark"
-msgstr "E78: Unbekannte Mark"
-
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Kann die Platzhalter nicht erweitern"
-
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' darf nicht kleiner sein als 'winminheight'"
-
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' darf nicht kleiner sein als 'winminwidth'"
-
-msgid "E80: Error while writing"
-msgstr "E80: Fehler während des Schreibens"
-
-msgid "Zero count"
-msgstr "Null-Zähler"
-
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> wurde nicht in einer Skript-Umgebung benutzt"
-
-msgid "E449: Invalid expression received"
-msgstr "E449: Ungültiger Ausdruck"
-
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Region ist geschützt; keine Änderung möglich"
-
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans erlaubt keine Änderungen in schreibgeschützten Dateien"
-
+#: ../regexp.c:1687
 #, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Interner Fehler: %s"
+msgid "E61: Nested %s*"
+msgstr "E61: Verschachteltes %s*"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Muster benötigt mehr Speicher als 'maxmempattern'"
-
-msgid "E749: empty buffer"
-msgstr "E749: Leerer Puffer"
-
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Ungültiges Suchmuster oder Trennzeichen"
-
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Datei ist in einem anderen Puffer geladen"
-
+#: ../regexp.c:1690
 #, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Option '%s' ist nicht gesetzt"
+msgid "E62: Nested %s%c"
+msgstr "E62: Verschachteltes %s%c"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Suche erreichte den ANFANG und wurde am ENDE fortgesetzt"
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Ungültige Verwendung von \\_"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Suche erreichte das ENDE und wurde am ANFANG fortgesetzt"
-
-msgid "Edit with &multiple Vims"
-msgstr "Editiere mit &mehreren Vims"
-
-msgid "Edit with single &Vim"
-msgstr "Editiere mit einem &Vim"
-
-msgid "Diff with Vim"
-msgstr "Differenz mit Vim"
-
-msgid "Edit with &Vim"
-msgstr "Editiere mit &Vim"
-
-msgid "Edit with existing Vim - "
-msgstr "Editiere mit vorhandenem Vim - "
-
-msgid "Press ENTER or type command to continue"
-msgstr "Betätigen Sie die EINGABETASTE oder geben Sie einen Befehl ein"
-
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Fehler beim Erzeugen des Prozesses: Überprüfen Sie, ob gvim in Ihrem Pfad ist!"
-
-msgid "gvimext.dll error"
-msgstr "gvimext.dll Fehler"
-
-msgid "Path length too long!"
-msgstr "Die Länge des Pfads ist zu groß!"
-
-msgid "Edits the selected file(s) with Vim"
-msgstr "Editiert die ausgewählte(n) Datei(en) mit Vim"
-
-msgid "%<PRId64> seconds ago"
-msgstr "vor %<PRId64> Sekunden"
-
-msgid "E790: undojoin is not allowed after undo"
-msgstr "E790: 'undojoin' ist nicht erlaubt nach 'undo'"
-
+#: ../regexp.c:1850
 #, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: Unbekannte Funktion: %s"
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c nach Nichts"
 
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Ungültige Rückreferenz"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Ungültiges Zeichen nach \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Zu wenige Argumente für Funktion: %s"
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Ungültiges Zeichen nach %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: <SID> wurde nicht in einer Skript-Umgebung benutzt: %s"
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Ungültiges Zeichen nach %s%%"
 
+#: ../regexp.c:3017
 #, c-format
-msgid "E725: Calling dict function without Dictionary: %s"
-msgstr "E725: Aufruf der 'dict' Funktion ohne Wörterbuch: %s"
+msgid "E554: Syntax error in %s{...}"
+msgstr "E554: Syntaxfehler in %s{...}"
 
-msgid "E786: Range not allowed"
-msgstr "E786: Bereich nicht erlaubt"
+#: ../regexp.c:3805
+msgid "External submatches:\n"
+msgstr "Externe 'submatches':\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
 #, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s/%s"
-msgstr "E154: Doppelter Tag \"%s\" in der Datei %s/%s"
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
 
-msgid "E179: argument required for -complete"
-msgstr "E179: Argument benötigt für -complete"
-
+#: ../regexp_nfa.c:242
 #, c-format
-msgid "Tab page %d"
-msgstr "Tab %d"
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
-msgid "E585: :while/:for nesting too deep"
-msgstr "E585: :while/:for Schachtelung zu tief"
-
-msgid "E586: :continue without :while or :for"
-msgstr "E586: :continue ohne :while or :for"
-
-msgid "E587: :break without :while or :for"
-msgstr "E587: :break ohne :while oder :for"
-
-msgid "E788: Not allowed to edit another buffer now"
-msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
-
-msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu erzwingen)"
-
+#: ../regexp_nfa.c:1261
 #, c-format
-msgid "E211: File \"%s\" no longer available"
-msgstr "E211: Datei \"%s\" ist nicht länger vorhanden"
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
 
-msgid "See \":help W12\" for more info."
-msgstr "Siehe \":help W12\" für mehr Information"
-
-msgid "See \":help W11\" for more info."
-msgstr "Siehe \":help W11\" für mehr Information"
-
+#: ../regexp_nfa.c:1387
 #, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Variable \"%s\" kann nur gelesen werden"
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
 
+#: ../regexp_nfa.c:1802
 #, c-format
-msgid "E46: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: Variable \"%s\" kann in der Sandbox nur gelesen werden"
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
 
-msgid "E267: unexpected return"
-msgstr "E267: Unerwartetes 'return'"
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
 
-msgid "E268: unexpected next"
-msgstr "E268: Unerwartetes 'next'"
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
 
-msgid "E269: unexpected break"
-msgstr "E269: Unerwartetes 'break'"
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
 
-msgid "E270: unexpected redo"
-msgstr "E270: Unerwartetes 'redo'"
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Zu viele \\z("
 
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: 'retry' außerhalb der 'rescue clause'"
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
 
-msgid "E272: unhandled exception"
-msgstr "E272: Unbehandelte Ausnahme"
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
 
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
 #, c-format
-msgid "%d files to edit\n"
-msgstr "%d Dateien zum Editieren\n"
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
 
-msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
-msgstr "-p[N]\t\tÖffne N Tabs (Vorgabe: einzeln für jede Datei)"
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Temporäre Datei kann nicht zum Schreiben geöffnet werden"
 
-msgid "--remote-tab <files>  As --remote but open tab page for each file"
-msgstr "--remote-tab <Dateien>  Wie --remote, aber öffne ein Tab für jede Datei"
+#: ../screen.c:7435
+msgid " VREPLACE"
+msgstr " V-ERSETZEN"
 
-msgid "E304: ml_upd_block0(): Didn't get block 0??"
-msgstr "E304: ml_upd_block0(): Block Nr. 0 nicht erhalten?"
+#: ../screen.c:7437
+msgid " REPLACE"
+msgstr " ERSETZEN"
 
-msgid "Select Directory dialog"
-msgstr "Verzeichnis Auswahl Dialog"
+#: ../screen.c:7440
+msgid " REVERSE"
+msgstr " INVERTIERT"
 
-msgid "No match at cursor, finding next"
-msgstr "Kein Treffer beim Cursur, finde den nächsten"
+#: ../screen.c:7441
+msgid " INSERT"
+msgstr " EINFÜGEN"
 
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ muss eine Instanz einer Zeichenkette sein"
+#: ../screen.c:7443
+msgid " (insert)"
+msgstr " (einfügen)"
 
-msgid "E773: Symlink loop for \"%s\""
-msgstr "E773: Symlink Schleife für \"%s\""
+#: ../screen.c:7445
+msgid " (replace)"
+msgstr " (ersetzen)"
 
+#: ../screen.c:7447
+msgid " (vreplace)"
+msgstr " (v-ersetzen)"
+
+#: ../screen.c:7449
+msgid " Hebrew"
+msgstr " Hebräisch"
+
+#: ../screen.c:7454
+msgid " Arabic"
+msgstr " Arabisch"
+
+#: ../screen.c:7456
+msgid " (lang)"
+msgstr " (Sprache)"
+
+#: ../screen.c:7459
+msgid " (paste)"
+msgstr " (paste)"
+
+#: ../screen.c:7469
+msgid " VISUAL"
+msgstr " VISUELL"
+
+#: ../screen.c:7470
+msgid " VISUAL LINE"
+msgstr " VISUELL ZEILE"
+
+#: ../screen.c:7471
+msgid " VISUAL BLOCK"
+msgstr " VISUELL BLOCK"
+
+#: ../screen.c:7472
+msgid " SELECT"
+msgstr " AUSWAHL"
+
+#: ../screen.c:7473
+msgid " SELECT LINE"
+msgstr " AUSWAHL ZEILE"
+
+#: ../screen.c:7474
+msgid " SELECT BLOCK"
+msgstr " AUSWAHL BLOCK"
+
+#: ../screen.c:7486 ../screen.c:7541
+msgid "recording"
+msgstr "aufzeichnen"
+
+#: ../search.c:487
+#, c-format
+msgid "E383: Invalid search string: %s"
+msgstr "E383: Unzulässiges Suchmuster: %s"
+
+#: ../search.c:832
+#, c-format
+msgid "E384: search hit TOP without match for: %s"
+msgstr "E384: Suche erreichte den ANFANG ohne Treffer für: %s"
+
+#: ../search.c:835
+#, c-format
+msgid "E385: search hit BOTTOM without match for: %s"
+msgstr "E385: Suche erreichte das ENDE ohne Treffer für: %s"
+
+#: ../search.c:1200
+msgid "E386: Expected '?' or '/'  after ';'"
+msgstr "E386: Erwarte '?' oder '/'  nach ';'"
+
+#: ../search.c:4085
+msgid " (includes previously listed match)"
+msgstr " (enthält bereits vorher aufgezählte Treffer)"
+
+#. cursor at status line
+#: ../search.c:4104
+msgid "--- Included files "
+msgstr "--- Eingefügte Dateien "
+
+#: ../search.c:4106
+msgid "not found "
+msgstr "nicht gefunden "
+
+#: ../search.c:4107
+msgid "in path ---\n"
+msgstr "im Pfad ---\n"
+
+#: ../search.c:4168
+msgid "  (Already listed)"
+msgstr "  (Bereits aufgelistet)"
+
+#: ../search.c:4170
+msgid "  NOT FOUND"
+msgstr "  NICHT GEFUNDEN"
+
+#: ../search.c:4211
+#, c-format
+msgid "Scanning included file: %s"
+msgstr "Durchsuche inkludierte Datei: %s"
+
+#: ../search.c:4216
+#, c-format
+msgid "Searching included file %s"
+msgstr "Suche inkludierte Datei %s"
+
+#: ../search.c:4405
+msgid "E387: Match is on current line"
+msgstr "E387: Treffer ist auf der momentanen Zeile"
+
+#: ../search.c:4517
+msgid "All included files were found"
+msgstr "Alle inkludierten Dateien wurden gefunden"
+
+#: ../search.c:4519
+msgid "No included files"
+msgstr "Keine inkludierten Dateien"
+
+#: ../search.c:4527
+msgid "E388: Couldn't find definition"
+msgstr "E388: Konnte Definition nicht finden"
+
+#: ../search.c:4529
+msgid "E389: Couldn't find pattern"
+msgstr "E389: Konnte Muster nicht finden"
+
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "eine Ersetzung"
+
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -6097,21 +5264,2769 @@ msgstr ""
 "# Letztes %sSuchmuster:\n"
 "~"
 
+#: ../spell.c:951
+msgid "E759: Format error in spell file"
+msgstr "E759: Format-Fehler im Rechtschreibwörterbuch"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr "E758: Abgeschnittenes Rechtschreibwörterbuch"
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr "Angehängter Text in %s Zeile %d: %s"
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr "Affix Name zu lang in %s Zeile %d: %s"
+
+#: ../spell.c:955
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E761: Format-Fehler in Affix-Datei FOL, LOW oder UPP"
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr "E762: Zeichen in FOL, LOW oder UPP außerhalb des zulässigen Bereichs"
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr "Komprimiere Wörter-Baum..."
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr "E756: Rechtschreibprüfung ist nicht aktiviert"
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+"Achtung: Kann Wortliste \"%s.%s.spl\" oder \"%s.ascii.spl\" nicht finden"
+
+#: ../spell.c:2473
+#, c-format
+msgid "Reading spell file \"%s\""
+msgstr "Lese Rechtschreibwörterbuch \"%s\" ein"
+
+#: ../spell.c:2496
+msgid "E757: This does not look like a spell file"
+msgstr "E757: Das sieht nicht nach einem Rechtschreibwörterbuch aus"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr "E771: Altes Rechtschreibwörterbuch, benötigt Aktualisierung"
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr "E772: Rechtschreibwörterbuch ist für eine neuere Version von Vim"
+
+#: ../spell.c:2602
+msgid "E770: Unsupported section in spell file"
+msgstr "E770: Nicht unterstützter Abschnitt im Rechtschreibwörterbuch"
+
+#: ../spell.c:3762
+#, c-format
+msgid "Warning: region %s not supported"
+msgstr "Achtung: Region %s nicht unterstützt"
+
+#: ../spell.c:4550
+#, c-format
+msgid "Reading affix file %s ..."
+msgstr "Lese Affix-Datei %s ..."
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr "Umwandlungsfehler beim Wort in %s Zeile %d: %s"
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr "Umwandlung in %s nicht unterstützt: von %s nach %s"
+
+#: ../spell.c:4642
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr "Ungültiger Wert von FLAG in %s Zeile %d: %s"
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr "FLAG nach dem Gebrauch von Flags in %s Zeile %d: %s"
+
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
 "%d"
 msgstr ""
-"Die Definition von COMPOUNDFORBIDFLAG nach dem PFX Element kann falsches Ergebnis in Zeile %s ergeben "
-"%d"
+"Die Definition von COMPOUNDFORBIDFLAG nach dem PFX Element kann falsches "
+"Ergebnis in Zeile %s ergeben %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
 "%d"
 msgstr ""
-"Die Definition von COMPOUNDPERMITFLAG nach dem PFX Element kann falsches Ergebnis in Zeile %s ergeben "
-"%d"
+"Die Definition von COMPOUNDPERMITFLAG nach dem PFX Element kann falsches "
+"Ergebnis in Zeile %s ergeben %d"
 
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: Ungültige Argumente für die Funktion %s"
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "Falscher COMPOUNDMIN-Wert in %s Zeile %d: %s"
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr "Falscher COMPOUNDWORDMAX-Wert in %s Zeile %d: %s"
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr "Falscher COMPOUNDMIN-Wert in %s Zeile %d: %s"
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr "Falscher COMPOUNDSYLMAX-Wert in %s Zeile %d: %s"
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr "Falscher CHECKCOMPOUNDPATTERN-Wert in %s Zeile %d: %s"
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+"Unterschiedliches verknüpfendes Flag im fortgesetzten Affix-Block in %s "
+"Zeile %d: %s"
+
+#: ../spell.c:4850
+#, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "Doppeltes Affix in %s Zeile %d: %s"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+"Affix wird auch für BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
+"verwendet in %s Zeile %d: %s"
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr "Y oder N erwartet in %s Zeile %d: %s"
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr "Bedingung verletzt in %s Zeile %d: %s"
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr "Erwartetes REP(SAL) gezählt in %s Zeile %d"
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr "Erwartetes MAP gezählt in %s Zeile %d"
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr "Doppeltes Zeichen in MAP in %s Zeile %d"
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr "Nicht erkanntes oder doppeltes Element in %s Zeile %d: %s"
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr "Fehlende FOL/LOW/UPP Zeile in %s"
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr "COMPOUNDSYLMAX ohne SYLLABLE verwendet"
+
+#: ../spell.c:5236
+msgid "Too many postponed prefixes"
+msgstr "Zu viele zurück gestellte Präfixe"
+
+#: ../spell.c:5238
+msgid "Too many compound flags"
+msgstr "Zu viele zusammengesetzte Flags"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr "Zu viele zurück gestellte Präfixe und/oder zusammengesetzte Flags"
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr "Fehlende SOFO%s Zeile in %s"
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr "Sowohl SAL als auch SOFO Zeilen in %s"
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr "Flag ist keine Zahl in %s Zeile %d: %s"
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr "Unerlaubtes Flag in %s Zeile %d: %s"
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+"%s Wert unterscheidet sich von dem, was in einer anderen .aff Datei "
+"verwendet wird"
+
+#: ../spell.c:5602
+#, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "Lese Wörterbuch-Datei %s ..."
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr "E760: Keine Wörter gezählt in %s"
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr "Zeile %6d, Wort %6d - %s"
+
+#: ../spell.c:5691
+#, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "Doppeltes Wort in %s Zeile %d: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr "Erstes doppeltes Wort in %s Zeile %d: %s"
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr "%d doppelte(s) Wort(e) in %s"
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr "%d Wort(e) mit nicht-ASCII Zeichen ignoriert in %s"
+
+#: ../spell.c:6115
+#, c-format
+msgid "Reading word file %s ..."
+msgstr "Lese Wort-Datei %s ..."
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr "Doppelte /encoding= Zeile ignoriert in %s Zeile %d: %s"
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr "/encoding= Zeile nach Wort ignoriert in %s Zeile %d: %s"
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr "Doppelte /regions= Zeile ignoriert in %s Zeile %d: %s"
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr "Zu viele Regionen in %s Zeile %d: %s"
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr "/ Zeile ignoriert in %s Zeile %d: %s"
+
+#: ../spell.c:6224
+#, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "Ungültige Regionsnummer in %s Zeile %d: %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr "Nicht erkanntes Flag in %s Zeile %d: %s"
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr "%d Wörter mit nicht-ASCII Zeichen ignoriert"
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr "%d von %d Knoten komprimiert; %d (%d%%) übrig"
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr "Lese Rechtschreibwörterbuch zurück..."
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr "Führe 'Soundfolding' durch..."
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Anzahl der Wörter nach 'Soundfolding': %<PRId64>"
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr "Gesamte Anzahl von Wörtern: %d"
+
+#: ../spell.c:7655
+#, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "Schreibe Datei %s für Vorschläge ..."
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr "Geschätzter Speicher zur Laufzeit: %d Bytes"
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr "E751: Ausgabedatei darf keinen Regionsnamen haben"
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr "E754: Maximal 8 Regionen unterstützt"
+
+#: ../spell.c:7846
+#, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E755: Ungültige Region in %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr "Achtung: Sowohl zusammengesetzte Wörter als auch NOBREAK angegeben"
+
+#: ../spell.c:7920
+#, c-format
+msgid "Writing spell file %s ..."
+msgstr "Schreibe Rechtschreibwörterbuch %s ..."
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr "Fertig!"
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' hat nicht %<PRId64> Einträge"
+
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr "Wort entfernt von %s"
+
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
+msgstr "Wort zu %s hinzugefügt"
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+"E763: 'Word Characters' unterscheiden sich zwischen Rechtschreibwörterbüchern"
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr "Leider keine Vorschläge"
+
+#: ../spell.c:8687
+#, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Leider nur %<PRId64> Vorschläge"
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "Ändere \"%.*s\" nach:"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr " < \"%.*s\""
+
+#: ../spell.c:8882
+msgid "E752: No previous spell replacement"
+msgstr "E752: Keine vorhergehende Ersetzung"
+
+#: ../spell.c:8925
+#, c-format
+msgid "E753: Not found: %s"
+msgstr "E753: Nicht gefunden: %s"
+
+#: ../spell.c:9276
+#, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E778: Das sieht nicht nach einer .sug Datei aus: %s"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr "E779: Veraltete .sug Datei; Aktualisierung erforderlich: %s"
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr "E780: .sug Datei ist für eine neuere Version von Vim: %s"
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr "E781: .sug Datei passt nicht zur .spl Datei: %s"
+
+#: ../spell.c:9305
+#, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E782: Fehler beim Lesen der .sug Datei: %s"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr "E783: Doppeltes Zeichen im MAP Eintrag"
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Keine Syntax-Elemente für diesen Puffer definiert"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
+#, c-format
+msgid "E390: Illegal argument: %s"
+msgstr "E390: Unerlaubtes Argument: %s"
+
+#: ../syntax.c:3299
+#, c-format
+msgid "E391: No such syntax cluster: %s"
+msgstr "E391: Kein solcher Syntax Cluster: %s"
+
+#: ../syntax.c:3433
+msgid "syncing on C-style comments"
+msgstr "Synchronisation an C-Stil Kommentaren"
+
+#: ../syntax.c:3439
+msgid "no syncing"
+msgstr "keine Synchronisation"
+
+#: ../syntax.c:3441
+msgid "syncing starts "
+msgstr "Synchronisation beginnt "
+
+#: ../syntax.c:3443 ../syntax.c:3506
+msgid " lines before top line"
+msgstr " Zeilen vor der obersten Zeile"
+
+#: ../syntax.c:3448
+msgid ""
+"\n"
+"--- Syntax sync items ---"
+msgstr ""
+"\n"
+"--- Syntax Synchronisations-Elemente ---"
+
+#: ../syntax.c:3452
+msgid ""
+"\n"
+"syncing on items"
+msgstr ""
+"\n"
+"Synchronisation an Elementen"
+
+#: ../syntax.c:3457
+msgid ""
+"\n"
+"--- Syntax items ---"
+msgstr ""
+"\n"
+"--- Syntax-Elemente ---"
+
+#: ../syntax.c:3475
+#, c-format
+msgid "E392: No such syntax cluster: %s"
+msgstr "E392: Kein solcher Syntax-Cluster: %s"
+
+#: ../syntax.c:3497
+msgid "minimal "
+msgstr "minimal "
+
+#: ../syntax.c:3503
+msgid "maximal "
+msgstr "maximal "
+
+#: ../syntax.c:3513
+msgid "; match "
+msgstr "; Treffer "
+
+#: ../syntax.c:3515
+msgid " line breaks"
+msgstr " Zeilenumbrüche"
+
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: \"contains\"-Argument ist an dieser Stelle ungültig"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Ungültiges Argument"
+
+#: ../syntax.c:4107
+msgid "E393: group[t]here not accepted here"
+msgstr "E393: \"group[t]here\" ist an dieser Stelle ungültig"
+
+#: ../syntax.c:4126
+#, c-format
+msgid "E394: Didn't find region item for %s"
+msgstr "E394: Konnte kein \"region\"-Element für \"%s\" finden"
+
+#: ../syntax.c:4188
+msgid "E397: Filename required"
+msgstr "E397: Dateiname wird benötigt"
+
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Zu viele Dateinamen"
+
+#: ../syntax.c:4303
+#, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E789: Fehlende ']': %s"
+
+#: ../syntax.c:4531
+#, c-format
+msgid "E398: Missing '=': %s"
+msgstr "E398: Fehlendes '=': %s"
+
+#: ../syntax.c:4666
+#, c-format
+msgid "E399: Not enough arguments: syntax region %s"
+msgstr "E399: Nicht ausreichend viele Argumente: syntax region %s"
+
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Kein solcher Syntax Cluster: %s"
+
+#: ../syntax.c:4954
+msgid "E400: No cluster specified"
+msgstr "E400: Kein Cluster angegeben"
+
+#. end delimiter not found
+#: ../syntax.c:4986
+#, c-format
+msgid "E401: Pattern delimiter not found: %s"
+msgstr "E401: Muster-Abgrenzer nicht gefunden: %s"
+
+#: ../syntax.c:5049
+#, c-format
+msgid "E402: Garbage after pattern: %s"
+msgstr "E402: Schrott nach Muster: %s"
+
+#: ../syntax.c:5120
+msgid "E403: syntax sync: line continuations pattern specified twice"
+msgstr "E403: Syntax sync: Zeilen-Fortsetzungsmuster zweifach angegeben"
+
+#: ../syntax.c:5169
+#, c-format
+msgid "E404: Illegal arguments: %s"
+msgstr "E404: Unzulässige Argumente; %s"
+
+#: ../syntax.c:5217
+#, c-format
+msgid "E405: Missing equal sign: %s"
+msgstr "E405: Gleichheitszeichen fehlt: %s"
+
+#: ../syntax.c:5222
+#, c-format
+msgid "E406: Empty argument: %s"
+msgstr "E406: Leeres Argument: %s"
+
+#: ../syntax.c:5240
+#, c-format
+msgid "E407: %s not allowed here"
+msgstr "E407: %s ist hier nicht erlaubt"
+
+#: ../syntax.c:5246
+#, c-format
+msgid "E408: %s must be first in contains list"
+msgstr ""
+"E408: %s muss als Erstes in der Liste der enthaltenen Elemente auftreten"
+
+#: ../syntax.c:5304
+#, c-format
+msgid "E409: Unknown group name: %s"
+msgstr "E409: Unbekannter Gruppenname: %s"
+
+#: ../syntax.c:5512
+#, c-format
+msgid "E410: Invalid :syntax subcommand: %s"
+msgstr "E410: Ungültiger :syntax Befehl: %s"
+
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr "E679: Rekursive Schleife beim Laden von syncolor.vim"
+
+#: ../syntax.c:6256
+#, c-format
+msgid "E411: highlight group not found: %s"
+msgstr "E411: Hervorhebungsgruppe nicht gefunden: %s"
+
+#: ../syntax.c:6278
+#, c-format
+msgid "E412: Not enough arguments: \":highlight link %s\""
+msgstr "E412: Nicht ausreichend viele Argumente: \":highlight link %s\""
+
+#: ../syntax.c:6284
+#, c-format
+msgid "E413: Too many arguments: \":highlight link %s\""
+msgstr "E413: Zu viele Argumente: \":highlight link %s\""
+
+#: ../syntax.c:6302
+msgid "E414: group has settings, highlight link ignored"
+msgstr "E414: Gruppe hat Einstellungen, highlight link ignorieren"
+
+#: ../syntax.c:6367
+#, c-format
+msgid "E415: unexpected equal sign: %s"
+msgstr "E415: Unerwartetes Gleichheitszeichen: %s"
+
+#: ../syntax.c:6395
+#, c-format
+msgid "E416: missing equal sign: %s"
+msgstr "E416: fehlendes Gleichheitszeichen: %s"
+
+#: ../syntax.c:6418
+#, c-format
+msgid "E417: missing argument: %s"
+msgstr "E417: Fehlendes Argument: %s"
+
+#: ../syntax.c:6446
+#, c-format
+msgid "E418: Illegal value: %s"
+msgstr "E418: Unzulässiger Wert: %s"
+
+#: ../syntax.c:6496
+msgid "E419: FG color unknown"
+msgstr "E419: FG Farbe unbekannt"
+
+#: ../syntax.c:6504
+msgid "E420: BG color unknown"
+msgstr "E420: BG Farbe unbekannt"
+
+#: ../syntax.c:6564
+#, c-format
+msgid "E421: Color name or number not recognized: %s"
+msgstr "E421: Unbekannte Farbbezeichnung oder -Nummer: %s"
+
+#: ../syntax.c:6714
+#, c-format
+msgid "E422: terminal code too long: %s"
+msgstr "E422: Terminal-Code zu lang: %s"
+
+#: ../syntax.c:6753
+#, c-format
+msgid "E423: Illegal argument: %s"
+msgstr "E423: Unzulässiges Argument: %s"
+
+#: ../syntax.c:6925
+msgid "E424: Too many different highlighting attributes in use"
+msgstr "E424: Zu viele verschieden Hervorhebungsattribute in Gebrauch"
+
+#: ../syntax.c:7427
+msgid "E669: Unprintable character in group name"
+msgstr "E669: Nicht druckbare Zeichen im Namen der Gruppe"
+
+#: ../syntax.c:7434
+msgid "W18: Invalid character in group name"
+msgstr "W18: Ungültiges Zeichen im Namen der Gruppe"
+
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
+msgid "E555: at bottom of tag stack"
+msgstr "E555: Am Ende des Tag-Stacks"
+
+#: ../tag.c:105
+msgid "E556: at top of tag stack"
+msgstr "E556: Am Anfang des Tag-Stacks"
+
+#: ../tag.c:380
+msgid "E425: Cannot go before first matching tag"
+msgstr "E425: Kann nicht vor den ersten passenden Tag hinausgehen"
+
+#: ../tag.c:504
+#, c-format
+msgid "E426: tag not found: %s"
+msgstr "E426: Konnte Tag \"%s\" nicht finden"
+
+#: ../tag.c:528
+msgid "  # pri kind tag"
+msgstr "   # pri verw. tag"
+
+#: ../tag.c:531
+msgid "file\n"
+msgstr "Datei\n"
+
+#: ../tag.c:829
+msgid "E427: There is only one matching tag"
+msgstr "E427: Es gibt nur einen passenden Tag"
+
+#: ../tag.c:831
+msgid "E428: Cannot go beyond last matching tag"
+msgstr "E428: Kann nicht über den letzten passenden Tag hinausgehen"
+
+#: ../tag.c:850
+#, c-format
+msgid "File \"%s\" does not exist"
+msgstr "Die Datei \"%s\" existiert nicht"
+
+#. Give an indication of the number of matching tags
+#: ../tag.c:859
+#, c-format
+msgid "tag %d of %d%s"
+msgstr "Tag %d aus %d%s"
+
+#: ../tag.c:862
+msgid " or more"
+msgstr " oder mehr"
+
+#: ../tag.c:864
+msgid "  Using tag with different case!"
+msgstr "  Verwendung eines Tags mit abgewandelter Groß-/Klein-Schreibung"
+
+#: ../tag.c:909
+#, c-format
+msgid "E429: File \"%s\" does not exist"
+msgstr "E429: Die Datei \"%s\" existiert nicht"
+
+#. Highlight title
+#: ../tag.c:960
+msgid ""
+"\n"
+"  # TO tag         FROM line  in file/text"
+msgstr ""
+"\n"
+"  # NACH TAG       VON Zeile  in Datei/Text"
+
+#: ../tag.c:1303
+#, c-format
+msgid "Searching tags file %s"
+msgstr "tags file %s wird durchsucht"
+
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
+
+#: ../tag.c:1915
+#, c-format
+msgid "E431: Format error in tags file \"%s\""
+msgstr "E431: Format Fehler in Tag-Datei \"%s\""
+
+#: ../tag.c:1917
+#, c-format
+msgid "Before byte %<PRId64>"
+msgstr "Vor byte %<PRId64>"
+
+#: ../tag.c:1929
+#, c-format
+msgid "E432: Tags file not sorted: %s"
+msgstr "E432: Tag-Datei ist nicht sortiert: %s"
+
+#. never opened any tags file
+#: ../tag.c:1960
+msgid "E433: No tags file"
+msgstr "E433: Keine Tag-Datei"
+
+#: ../tag.c:2536
+msgid "E434: Can't find tag pattern"
+msgstr "E434: Kann Tag-Muster nicht finden"
+
+#: ../tag.c:2544
+msgid "E435: Couldn't find tag, just guessing!"
+msgstr "E435: Konnte Tag möglicherweise nicht finden!"
+
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Doppeltes Affix in %s Zeile %d: %s"
+
+#: ../term.c:1442
+msgid "' not known. Available builtin terminals are:"
+msgstr ""
+"' nicht bekannt. Die folgenden eingebauten Terminals stehen zur Verfügung:"
+
+#: ../term.c:1463
+msgid "defaulting to '"
+msgstr "Voreinstellung '"
+
+#: ../term.c:1731
+msgid "E557: Cannot open termcap file"
+msgstr "E557: Termcap-Datei kann nicht geöffnet werden"
+
+#: ../term.c:1735
+msgid "E558: Terminal entry not found in terminfo"
+msgstr "E558: Kein Terminal-Eintrag in der Terminfo-Datenbank gefunden"
+
+#: ../term.c:1737
+msgid "E559: Terminal entry not found in termcap"
+msgstr "E559: Kein Terminal-Eintrag in der Termcap-Datei gefunden"
+
+#: ../term.c:1878
+#, c-format
+msgid "E436: No \"%s\" entry in termcap"
+msgstr "E436: Kein \"%s\" Eintrag in der Termcap-Datei"
+
+#: ../term.c:2249
+msgid "E437: terminal capability \"cm\" required"
+msgstr "E437: Terminalfähigkeit \"cm\" wird benötigt"
+
+#. Highlight title
+#: ../term.c:4376
+msgid ""
+"\n"
+"--- Terminal keys ---"
+msgstr ""
+"\n"
+"--- Terminal Tasten ---"
+
+#: ../ui.c:481
+msgid "Vim: Error reading input, exiting...\n"
+msgstr "Vim: Fehler beim Lesen der Eingabe, Abbruch...\n"
+
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
+
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Datei kann nicht zum Schreiben geöffnet werden"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Schreiben der viminfo-Datei \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Lese Wort-Datei %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: viminfo kann nicht zum Lesen geöffnet werden"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Nicht gefunden: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Kann die Datei %s nicht öffnen"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "Lesen von %s beendet"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr "Bereits bei der ältesten Änderung"
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr "Bereits bei der jüngsten Änderung"
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "Nummer %<PRId64> zur Wiederherstellung nicht gefunden"
+
+#: ../undo.c:1979
+msgid "E438: u_undo: line numbers wrong"
+msgstr "E438: u_undo: Zeilennummer falsch"
+
+#: ../undo.c:2183
+msgid "more line"
+msgstr "Zeile mehr"
+
+#: ../undo.c:2185
+msgid "more lines"
+msgstr "Zeilen mehr"
+
+#: ../undo.c:2187
+msgid "line less"
+msgstr "Zeile weniger"
+
+#: ../undo.c:2189
+msgid "fewer lines"
+msgstr "Zeilen weniger"
+
+#: ../undo.c:2193
+msgid "change"
+msgstr "Änderung"
+
+#: ../undo.c:2195
+msgid "changes"
+msgstr "Änderungen"
+
+#: ../undo.c:2225
+#, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr "vor"
+
+#: ../undo.c:2228
+msgid "after"
+msgstr "nach"
+
+#: ../undo.c:2325
+msgid "Nothing to undo"
+msgstr "Nichts wiederherzustellen"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "vor %<PRId64> Sekunden"
+
+#: ../undo.c:2372
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E790: 'undojoin' ist nicht erlaubt nach 'undo'"
+
+#: ../undo.c:2466
+msgid "E439: undo list corrupt"
+msgstr "E439: Liste der Wiederherstellungen fehlerhaft"
+
+#: ../undo.c:2495
+msgid "E440: undo line missing"
+msgstr "E440: Wiederherstellungszeile fehlt"
+
+#: ../version.c:600
+msgid ""
+"\n"
+"Included patches: "
+msgstr ""
+"\n"
+"Inklusive der Korrekturen: "
+
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Externe 'submatches':\n"
+
+#: ../version.c:639 ../version.c:864
+msgid "Modified by "
+msgstr "Verändert von "
+
+#: ../version.c:646
+msgid ""
+"\n"
+"Compiled "
+msgstr ""
+"\n"
+"Übersetzt "
+
+#: ../version.c:649
+msgid "by "
+msgstr "von "
+
+#: ../version.c:660
+msgid ""
+"\n"
+"Huge version "
+msgstr ""
+"\n"
+"Riesige Version "
+
+#: ../version.c:661
+msgid "without GUI."
+msgstr "ohne GUI."
+
+#: ../version.c:662
+msgid "  Features included (+) or not (-):\n"
+msgstr " Ein- (+) oder ausschließlich (-) der Eigenschaften:\n"
+
+#: ../version.c:667
+msgid "   system vimrc file: \""
+msgstr "          System-vimrc-Datei: \""
+
+#: ../version.c:672
+msgid "     user vimrc file: \""
+msgstr "        Benutzer-vimrc-Datei: \""
+
+#: ../version.c:677
+msgid " 2nd user vimrc file: \""
+msgstr " zweite Benutzer-vimrc-Datei: \""
+
+#: ../version.c:682
+msgid " 3rd user vimrc file: \""
+msgstr " dritte Benutzer-vimrc-Datei: \""
+
+#: ../version.c:687
+msgid "      user exrc file: \""
+msgstr "         Benutzer-exrc-Datei: \""
+
+#: ../version.c:692
+msgid "  2nd user exrc file: \""
+msgstr " zweite Benutzer-exrc-Datei: \""
+
+#: ../version.c:699
+msgid "  fall-back for $VIM: \""
+msgstr "     Voreinstellung für $VIM: \""
+
+#: ../version.c:705
+msgid " f-b for $VIMRUNTIME: \""
+msgstr "         und für $VIMRUNTIME: \""
+
+#: ../version.c:709
+msgid "Compilation: "
+msgstr "Übersetzt: "
+
+#: ../version.c:712
+msgid "Linking: "
+msgstr "Linken: "
+
+#: ../version.c:717
+msgid "  DEBUG BUILD"
+msgstr "  DEBUG-VERSION"
+
+#: ../version.c:767
+msgid "VIM - Vi IMproved"
+msgstr "VIM - verbesserter Vi"
+
+#: ../version.c:769
+msgid "version "
+msgstr "Version "
+
+#: ../version.c:770
+msgid "by Bram Moolenaar et al."
+msgstr "von Bram Moolenaar und Anderen"
+
+#: ../version.c:774
+msgid "Vim is open source and freely distributable"
+msgstr "Vim ist Open Source und kann frei weitergegeben werden"
+
+#: ../version.c:776
+msgid "Help poor children in Uganda!"
+msgstr "Helfen Sie armen Kindern in Uganda!"
+
+#: ../version.c:777
+msgid "type  :help iccf<Enter>       for information "
+msgstr "Tippe  :help iccf<Enter>        für Informationen darüber "
+
+#: ../version.c:779
+msgid "type  :q<Enter>               to exit         "
+msgstr "Tippe  :q<Enter>                zum Beenden               "
+
+#: ../version.c:780
+msgid "type  :help<Enter>  or  <F1>  for on-line help"
+msgstr "Tippe  :help<Enter>  oder <F1>  für Online Hilfe          "
+
+#: ../version.c:781
+msgid "type  :help version7<Enter>   for version info"
+msgstr "Tippe  :help version7<Enter>    für Versions-Informationen"
+
+#: ../version.c:784
+msgid "Running in Vi compatible mode"
+msgstr "Vi kompatible Einstellung"
+
+#: ../version.c:785
+msgid "type  :set nocp<Enter>        for Vim defaults"
+msgstr "Tippe  :set nocp<Enter>         für Vim-Voreinstellungen  "
+
+#: ../version.c:786
+msgid "type  :help cp-default<Enter> for info on this"
+msgstr "Tippe  :help cp-default<Enter>  für Informationen darüber "
+
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr "Unterstützen Sie die Entwicklung von Vim"
+
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr "Werden Sie ein registrierter Benutzer von Vim!"
+
+#: ../version.c:831
+msgid "type  :help sponsor<Enter>    for information "
+msgstr "Tippe  :help sponsor<Enter>     für mehr Informationen    "
+
+#: ../version.c:832
+msgid "type  :help register<Enter>   for information "
+msgstr "Tippe  :help register<Enter>    für mehr Informationen    "
+
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr "Menü   Hilfe->Sponsor/Register  für mehr Informationen    "
+
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "Bereits nur ein Fenster"
+
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: Es gibt kein Fenster zur Voransicht"
+
+# should read: topleft / botright
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: topleft und botright können nicht gleichzeitig verwendet werden"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: Rotieren nicht möglich wenn ein anderes Fenster geteilt ist"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
+
+#: ../window.c:2717
+msgid "E445: Other window contains changes"
+msgstr "E445: Anderes Fenster enthält Änderungen"
+
+# Cursor: Schreibmarke Positionsmarke
+#: ../window.c:4805
+msgid "E446: No file name under cursor"
+msgstr "E446: Kein Dateiname unter dem Cursor"
+
+#~ msgid "Patch file"
+#~ msgstr "Patch-Datei"
+
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Abbrechen"
+
+#~ msgid "E745: Range not allowed"
+#~ msgstr "E745: Bereich nicht erlaubt"
+
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Keine Verbindung zum Vim-Server"
+
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Kann nicht zu %s senden"
+
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Server-Antwort kann nicht gelesen werden"
+
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Kann nicht zum Client senden"
+
+#~ msgid "Save As"
+#~ msgstr "Speichern als"
+
+#~ msgid "Edit File"
+#~ msgstr "Öffne Datei"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NICHT GEFUNDEN)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "Führe Vim-Skript aus"
+
+#~ msgid "E179: argument required for complete"
+#~ msgstr "E179: Argument wird zur Vervollständigung benötigt"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "Öffne Datei in einem neuen Fenster"
+
+#~ msgid "Append File"
+#~ msgstr "Füge Datei an"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Fenster-Position: X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "Umleitung Speichern"
+
+#~ msgid "Save View"
+#~ msgstr "Ansichten Speichern"
+
+#~ msgid "Save Session"
+#~ msgstr "Sitzung Speichern"
+
+#~ msgid "Save Setup"
+#~ msgstr "Einstellungen Speichern"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Keine Digraphen in dieser Version"
+
+#~ msgid "E585: :while nesting too deep"
+#~ msgstr "E585: :while Schachtelung zu tief"
+
+#~ msgid "E586: :continue without :while"
+#~ msgstr "E586: :continue ohne :while"
+
+#~ msgid "E587: :break without :while"
+#~ msgstr "E587: :break ohne :while"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "Lese von stdin..."
+
+#~ msgid "[NL found]"
+#~ msgstr "[NL gefunden]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[verschlüsselt]"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans verweigert das Schreiben von unveränderten Puffern"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Partielles Schreiben für NetBeans Puffer verweigert"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Der Ressourcefork geht verloren (erzwinge mit !)"
+
+#~ msgid "E513: write error, conversion failed"
+#~ msgstr "E513: Schreibfehler, Umwandlung schlug fehl"
+
+#~ msgid "E211: Warning: File \"%s\" no longer available"
+#~ msgstr "E211: Achtung: Datei \"%s\" ist nicht länger vorhanden"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUI kann nicht gestartet werden"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Kann nicht von \"%s\" lesen"
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: GUI kann nicht gestartet werden, keine gültige Schrift gefunden"
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' ungültig"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Wert von 'imactivatekey' ist ungültig"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Kann die Farbe %s nicht zuweisen"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<kann nicht öffnen> "
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: kann Schriftart %s nicht erhalten"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr ""
+#~ "E614: vim_SelFile: kann nicht zum laufenden Verzeichnis zurückkehren"
+
+#~ msgid "Pathname:"
+#~ msgstr "Pfad:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr ""
+#~ "E615: vim_SelFile: aktuelles Verzeichnis kann nicht ermittelt werden"
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "Cancel"
+#~ msgstr "Abbrechen"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Scrollbar Widget: Geometrie des Bildchens kann nicht ermittelt werden"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Vim-Dialog"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: BalloonEval kann nicht mit sowohl \"message\" und \"callback\" "
+#~ "erzeugt werden"
+
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim-Dialog..."
+
+#~ msgid "Input _Methods"
+#~ msgstr "Eingabe _Methoden"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Suchen und Ersetzen..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Suchen..."
+
+#~ msgid "Find what:"
+#~ msgstr "Wonach suchen:"
+
+#~ msgid "Replace with:"
+#~ msgstr "Ersetzen mit:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "Nur ganzes Wort suchen"
+
+#~ msgid "Match case"
+#~ msgstr "Groß-/Kleinschreibung"
+
+#~ msgid "Direction"
+#~ msgstr "Richtung"
+
+#~ msgid "Up"
+#~ msgstr "Aufwärts"
+
+#~ msgid "Down"
+#~ msgstr "Abwärts"
+
+#~ msgid "Find Next"
+#~ msgstr "Suche Nächstes"
+
+#~ msgid "Replace"
+#~ msgstr "Ersetzen"
+
+#~ msgid "Replace All"
+#~ msgstr "Alle ersetzen"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: \"die\"-Request von Session-Manager erhalten\n"
+
+#~ msgid "Close"
+#~ msgstr "Schließe"
+
+#~ msgid "New tab"
+#~ msgstr "Neues Tab"
+
+#~ msgid "Open Tab..."
+#~ msgstr "Öffne in Tab..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Hauptfenster unerwartet gelöscht\n"
+
+#~ msgid "Font Selection"
+#~ msgstr "Auswahl der Schriftart"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "CUT_BUFFER0 anstatt der leeren Auswahl benutzt"
+
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
+
+#~ msgid "&Cancel"
+#~ msgstr "&Abbrechen"
+
+#~ msgid "Directories"
+#~ msgstr "Verzeichnisse"
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "&Help"
+#~ msgstr "&Hilfe"
+
+#~ msgid "Files"
+#~ msgstr "Dateien"
+
+#~ msgid "&OK"
+#~ msgstr "&Ok"
+
+#~ msgid "Selection"
+#~ msgstr "Auswahl"
+
+#~ msgid "Find &Next"
+#~ msgstr "&Nächste"
+
+#~ msgid "&Replace"
+#~ msgstr "&Ersetze"
+
+#~ msgid "Replace &All"
+#~ msgstr "Ersetze &alles"
+
+#~ msgid "&Undo"
+#~ msgstr "&Rückgängig"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Kann Fenstertitel \"%s\" nicht finden"
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr ""
+#~ "E243: Argument wird nicht unterstützt: \"-%s\"; verwende die OLE Version."
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Kann Fenster nicht innerhalb einer MDI Anwendung öffnen"
+
+#~ msgid "Close tab"
+#~ msgstr "Tab schließen"
+
+#~ msgid "Open tab..."
+#~ msgstr "Öffne in Tab..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Suche (benütze '\\\\' um ein '\\' zu finden)"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Suche & Ersetze (benütze '\\\\' um ein '\\' zu finden)"
+
+#~ msgid "Not Used"
+#~ msgstr "Nicht verwendet"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Verzeichnis\t*.nichts\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: \"Colormap\"-Eintrag kann nicht zugewiesen werden, einige "
+#~ "Farben können falsch sein"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Schriftarten für die folgenden Zeichensätze fehlen im Fontset %s:"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Fontset Name: %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Schriftart '%s' hat keine feste Breite"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Fontset Name: %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "Schriftart 0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "Schriftart 1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr ""
+#~ "Die Breite der Schriftart %<PRId64> ist nicht doppelt so groß wie die der "
+#~ "Schriftart 0\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Schriftart 0 Breite: %<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Schriftart 1 Breite: %<PRId64>\n"
+#~ "\n"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "Ungültige Spezifikation der Schriftart"
+
+#~ msgid "&Dismiss"
+#~ msgstr "&Aufheben"
+
+#~ msgid "no specific match"
+#~ msgstr "keine spezifische Übereinstimmung"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Auswahl der Schriftart"
+
+#~ msgid "Name:"
+#~ msgstr "Name:"
+
+#~ msgid "Show size in Points"
+#~ msgstr "Zeige Größe in Punkten"
+
+#~ msgid "Encoding:"
+#~ msgstr "Zeichensatz:"
+
+#~ msgid "Font:"
+#~ msgstr "Schriftart:"
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Size:"
+#~ msgstr "Größe:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul-Automat Fehler"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: 'stat' Fehler"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Kann cscope Datenbank nicht öffnen: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Kann cscope Datenbank-Informationen nicht bekommen"
+
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: Maximale Anzahl von cscope Verbindungen erreicht"
+
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Dieser Befehl ist nicht verfügbar, die MzScheme Bibliothek konnte "
+#~ "nicht geladen werden"
+
+#~ msgid "invalid expression"
+#~ msgstr "ungültiger Ausdruck"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "Ausdrücke wurden zur Zeit des Übersetzens nicht zugelassen"
+
+#~ msgid "hidden option"
+#~ msgstr "versteckte Option"
+
+#~ msgid "unknown option"
+#~ msgstr "unbekannte Option"
+
+#~ msgid "window index is out of range"
+#~ msgstr "Fensterindex außerhalb des zulässigen Bereichs"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "konnte Puffer nicht öffnen"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "kann Information für die Wiederherstellung nicht speichern"
+
+#~ msgid "cannot delete line"
+#~ msgstr "Zeile kann nicht gelöscht werden"
+
+#~ msgid "cannot replace line"
+#~ msgstr "Zeile kann nicht ersetzt werden"
+
+#~ msgid "cannot insert line"
+#~ msgstr "Zeile kann nicht eingefügt werden"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "Zeichenfolge kann keine Zeilenwechsel enthalten"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim Fehler: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim Fehler"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "ungültiger Puffer"
+
+#~ msgid "window is invalid"
+#~ msgstr "ungültiges Fenster"
+
+#~ msgid "linenr out of range"
+#~ msgstr "'linenr' außerhalb des zulässigen Bereichs"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "in der Vim-Sandbox nicht erlaubt"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Dieser Befehl ist nicht verfügbar, die Python-Bibliothek konnte "
+#~ "nicht geladen werden"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Kann Python nicht rekursiv ausführen"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "OutputObject-Attribute können nicht gelöscht werden"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "\"softspace\" muss eine ganze Zahl sein"
+
+#~ msgid "invalid attribute"
+#~ msgstr "unzulässiges Attribut"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() verlangt eine Liste von Zeichenfolgen"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Fehler bei der Initialisierung von I/O Objekten"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "Versuch, Bezug auf einen gelöschten Puffer zu nehmen"
+
+#~ msgid "line number out of range"
+#~ msgstr "Zeilennummer außerhalb des zulässigen Bereichs"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<Pufferobjekt (gelöscht) bei %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "ungültiger Name einer Markierung"
+
+#~ msgid "no such buffer"
+#~ msgstr "kein solcher Puffer vorhanden"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "Versuch, Bezug auf eine gelöschtes Fenster zu nehmen"
+
+#~ msgid "readonly attribute"
+#~ msgstr "nur-Lesen Attribut"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "Cursor Position außerhalb des Puffers"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<Fensterobjekt (gelöscht) bei %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<Fensterobjekt (unbekannt) bei %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<Fenster %d>"
+
+#~ msgid "no such window"
+#~ msgstr "ungültiges Fenster"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Dieser Befehl ist nicht verfügbar, die Ruby Bibliothek konnte nicht "
+#~ "geladen werden"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Unbekannter longjmp Status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Umschaltung zwischen Implementierung/Definition"
+
+#~ msgid "Show base class of"
+#~ msgstr "Zeige Basis-Klasse von"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Zeige überschriebene Methode"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Beziehe aus Datei"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Beziehe aus Projekt"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Beziehe aus allen Projekten"
+
+#~ msgid "Retrieve"
+#~ msgstr "Beziehe"
+
+#~ msgid "Show source of"
+#~ msgstr "Zeige die Quelle von"
+
+#~ msgid "Find symbol"
+#~ msgstr "Finde Symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Durchsehe Klassen"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Zeige Klasse in Hierarchie"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Zeige Klasse in eingeschränkter Hierarchie"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref bezieht sich auf"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref hat Bezüge zu"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref hat ein"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref wird verwendet von"
+
+#~ msgid "Show docu of"
+#~ msgstr "Zeige Docu aus"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generiere Docu für"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Kann keine verbindung zu SNiFF+ aufnehmen. Prüfe die Umgebung (sniffemacs "
+#~ "muss in $PATH) zu finden sein.\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Fehler beim Lesen. Verbindung abgebrochen"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ ist zur Zeit"
+
+#~ msgid "not "
+#~ msgstr "nicht"
+
+#~ msgid "connected"
+#~ msgstr "verbunden"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Unbekannte SNiFF+ Anfrage: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Fehler beim Herstellen der Verbindung mit SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ ist nicht verbunden"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ist kein SNiFF+ Puffer"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Fehler beim Schreiben. Verbindung abgebrochen"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "ungültige Puffernummer"
+
+#~ msgid "not implemented yet"
+#~ msgstr "nicht implementiert"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "kann keine Zeile/Zeilen setzen"
+
+#~ msgid "mark not set"
+#~ msgstr "Marke nicht gesetzt"
+
+#~ msgid "row %d column %d"
+#~ msgstr "Zeile %d Spalte %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "kann Zeile nicht ein-/anfügen"
+
+#~ msgid "unknown flag: "
+#~ msgstr "unbekanntes Flag: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "unbekannte vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "Tastatur-Unterbrechung"
+
+#~ msgid "vim error"
+#~ msgstr "vim Fehler"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "Puffer/Fenster-Befehl kann nicht ausgeführt werden: das Objekt wird "
+#~ "gelöscht"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "kann keinen Callback-Befehl registrieren: Puffer/Fenster ist bereits "
+#~ "gelöscht"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATALER FEHLER: reflist kaputt!? Bitte vim-dev@vim."
+#~ "orgbenachrichtigen."
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "kann keinen Callback-Befehl registrieren: Puffer/Fenster-Referenz nicht "
+#~ "gefunden"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Dieser Befehl ist nicht verfügbar: die Tcl Bibliothek konnte nicht "
+#~ "geladen werden"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL FEHLER: Exit-Code ist nicht int!? Bitte vim-dev@vim.org "
+#~ "benachrichtigen."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Ekit-Code %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "kann Zeile nicht erhalten"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Befehls-Server Name kann nicht registriert werden"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Schicken des Befehls zum Ziel-Programm schlug fehl"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Ungültige Server ID verwendet: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Registry-Eigenschaft der VIM Instanz ist fehlerhaft. Gelöscht!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Vim wurde nicht mit der \"diff\"-Eigenschaft übersetzt"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Fehler: Konnte gvim nicht von NetBeans aus starten\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistriere diesen gvim in OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tDeregistriere gvim aus OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tStart als GUI (wie \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f\t\t\tVordergrund: Kein \"fork\" beim Start der GUI"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose Stufe"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tVerwende nicht newcli zum Öffnen eines neuen Fensters"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tVerwende <device> for I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tBenutze <gvimrc> anstatt jeglicher .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEditiere kodierte Dateien"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tStarte vim <display>"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tStelle keine Verbindung zum X-server her"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <Dateien>\tEditiere <Dateien> in einem Vim-Server falls möglich"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <Dateien>  Dasselbe ohne Warnung, wenn kein Server "
+#~ "vorhanden ist"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <Dateien>  Wie --remote, aber warte, bis die <Dateien> "
+#~ "editiert wurden"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  Dasselbe ohne Warnung, wenn kein Server "
+#~ "vorhanden ist"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\tSchicke <keys> zu einem Vim Server und beende"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <Ausdruck>\tFühre <Ausdruck> in einem Vim-Server aus und "
+#~ "drucke das Ergebnis"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tDrucke verfügbare Vim-Server-Namen und beende"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <Name>\tBenutze den Vim-Server <Name>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumente für die gvim (Motif Version):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumente für die gvim (neXtaw Version):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumente für die gvim (Athena Version):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tStarte vim auf <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tStarte vim als Icon"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\tBenutze so als ob vim <name> hieße"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Nicht implementiert)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr ""
+#~ "-background <Farbe>\tBenutze <Farbe> für den Hintergrund (auch mit: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <Farbe>\tBenutze <Farbe> für den Text Vordergrund (auch mit: -"
+#~ "fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <Schriftart>\tBenutze <Schriftart> für normalen Text (auch mit: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <Schriftart>\tBenutze <Schriftart> für Fettschrift"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <Schriftart>\tBenutze <Schriftart> für geneigten Text"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tbenutze <geom> für die Anfangs Abmessungen (auch mit: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <Breite>\tBenutze einen Rahmen der Breite <Breite> (auch "
+#~ "mit: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <Breite>  Benutze eine Scrollbar der Breite <Breite> "
+#~ "(auch mit: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <Höhe>\tBenutze einen Menü-Balken der Höhe <Höhe> (auch mit: -"
+#~ "mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tBenutze invertierte Farben (auch mit: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tBenutze keine invertierten Farben (auch mit: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tSetze die gegebene Ressource"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumente für die gvim RISC-OS Version:\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <Nummer>\tAnfangsbreite des Fensters in Spalten"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <Nummer>\tAnfangshöhe des Fensters in Zeilen"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumente für die gvim GTK+ Version:\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tStarte vim auf <display> (auch mit: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <role>\tSetze eine eindeutige Rolle, um das Hauptfenster zu "
+#~ "identifizieren"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tÖffne Vim in einem anderen GTK widget"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\tÖffne Vim innerhalb der Vater-Applikation"
+
+#~ msgid "No display"
+#~ msgstr "Keine Anzeige"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Versendung fehlgeschlagen.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Versendung fehlgeschlagen. Versuche lokale Ausführung\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d von %d bearbeitet"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Keine Anzeige: Versenden des Ausdrucks fehlgeschlagen.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Versenden des Ausdrucks fehlgeschlagen.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Keine zulässige Codepage"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Eingabe-Kontext konnte nicht erzeugt werden"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Eingabemethode konnte geöffnet werden"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Achtung: Destroy Callabck konnte nicht auf IM gesetzt werden"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Eingabemethode unterstützt keinen einzigen Stil"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: Eingabemethode unterstützt nicht meinen Voreditier-Typen"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: der Über-dem-Punkt Stil benötigt fontset"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr ""
+#~ "E291: Ihr GTK+ ist älter als 1.2.3. Der Status-Bereich wird abgeschaltet"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Server der Eingabemethode läuft nicht"
+
+#~ msgid "E304: ml_timestamp: Didn't get block 0??"
+#~ msgstr "E304: ml_timestamp: Block Nr. 0 nicht erhalten?"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nicht verwendbar zusammen mit dieser Vim-Version]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Reiße dieses Menü ab"
+
+#~ msgid "Hit ENTER or type command to continue"
+#~ msgstr "Drücken Sie die EINGABETASTE oder geben Sie einen Befehl ein"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Datei Speichern Dialog"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Datei Öffnen Dialog"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Kein Datei-Dialog im Konsole-Modus"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: Sichern der Dateien...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Beendet.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "FEHLER: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[Bytes] gesamt alloc-frei %<PRIu64>-%<PRIu64>, in Verwendung %<PRIu64>, "
+#~ "maximale Verwendung %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[Aufrufe] gesamt re/malloc()s %<PRIu64>, gesamt free()s %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Zeile wird zu lang"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Interner Fehler: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Unzulässiger Mauszeiger"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Geben Sie bitte den Schlüssel ein: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Geben Sie den gleichen Schlüssel nochmals ein:"
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Die Schlüssel stimmen nicht überein!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Keine Verbindung zu NetBeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Keine Verbindung zu NetBeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Falscher Zugriffsmodus auf die NetBeans Zugriff-Informationsdatei: "
+#~ "\"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "gelesen vom NetBeans Socket"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Verbindung zu NetBeans für Puffer %<PRId64> verloren"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Evaluierungsfunktion nicht verfügbar"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "gebe %<PRId64> Zeilen frei"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Kann Terminal in der GUI nicht verändern"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Verwende \":gui\", um die GUI-Version zu starten"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Kann in der GTK+ 2 GUI nicht verändert werden"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Ungültige Schriftart(en)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Kann \"Fontset\" nicht auswählen"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Ungültiges \"Fontset\""
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Kann Breitschrift nicht auswählen"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Ungültige Breitschrift"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Keine Maus-Unterstützung"
+
+#~ msgid "cannot open "
+#~ msgstr "kann nicht öffnen"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Fenster kann nicht geöffnet werden!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Brauche Amigados Version 2.04 oder neuere\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Benötige %s Version %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Kann NIL nicht öffnen:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Kann nicht anlegen "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim steigt aus mit %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "kann Konsolenmodus nicht wechseln ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_winsize: keine Konsole??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Kann Shell nicht mit der -f Option ausführen"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Kann nicht ausführen "
+
+#~ msgid "shell "
+#~ msgstr "Shell "
+
+#~ msgid " returned\n"
+#~ msgstr " zurückgegeben\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE zu klein."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O FEHLER"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(abgeschnitten)"
+
+#~ msgid "Message"
+#~ msgstr "Nachricht"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' beträgt nicht 80, kann externe Befehle nicht ausführen"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Drucker-Auswahl fehlgeschlagen"
+
+#~ msgid "to %s on %s"
+#~ msgstr "nach %s auf %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Unbekannte Druckerschriftart: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Fehler beim Drucken: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Drucke '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: Unzulässiger Zeichensatz-Name \"%s\" im Schriftart-Namen \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Unzulässiges Zeichen '%c' in der Schriftart \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Doppel-Signal, beenden\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Erhielt tödliches Signal %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Erhielt tödliches Signal\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Öffnen des X-Displays dauerte %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: ein X11 Fehler trat auf\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test des X-Displays schlug fehl"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Zeitüberschreitung während des Öffnens des X-Displays"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Shell sh kann nicht ausführt werden\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pipes können nicht angelegt werden\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "'fork' schlug fehl\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Befehl beendet\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP verlor ICE Verbindung"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Öffnen des X-Displays schlug fehl"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP verarbeitet 'save-yourself request'"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP öffnet Verbindung"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE Verbindungsüberwachung fehlgeschlagen"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection fehlgeschlagen: %s"
+
+#~ msgid "At line"
+#~ msgstr "In Zeile"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Konnte vim32.dll nicht laden!"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM Fehler"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Konnte Funktions-Zeiger in der DLL nicht korrigieren!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "Shell gab %d zurück"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Fing Ereignis %s ein\n"
+
+#~ msgid "close"
+#~ msgstr "schließe"
+
+#~ msgid "logoff"
+#~ msgstr "ausloggen"
+
+#~ msgid "shutdown"
+#~ msgstr "beenden"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Befehl nicht gefunden"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE wurde im Pfad $PATH nicht gefunden.\n"
+#~ "Externe Befehle werden nach Ausführung nicht anhalten.\n"
+#~ "Siehe  :help win32-vimrun  für weitere Informationen."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Warnung"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Umwandlung in %s nicht unterstützt"
+
+#~ msgid "Affix flags ignored when PFXPOSTPONE used in %s line %d: %s"
+#~ msgstr ""
+#~ "Affix Flags ignoriert, wenn PFXPOSTPONE verwendet wird in %s Zeile %d: %s"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: \"containedin\"-Argument ist an dieser Stelle ungültig"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag-Dateipfad wurde abgeschnitten für %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "neue Shell gestartet\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Wiederherstellung nicht möglich; setze trotzdem fort"
+
+#~ msgid "number changes  time"
+#~ msgstr "Nummer Änd.     Zeit"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 Bit GUI Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit GUI Version"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " in Win32s Modus"
+
+#~ msgid " with OLE support"
+#~ msgstr " mit OLE-Unterstützung"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit Konsolen-Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 Bit Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 Bit MS-DOS Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 Bit MS-DOS Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS Version"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Große Version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normale Version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Kleine Version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Winzige Version "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "mit GTK2-GNOME GUI."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "mit GTK-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "mit GTK2 GUI."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "mit GTK GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "mit X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "mit X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "mit X11-Athena GUI."
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "mit BeOS GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "mit Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "mit GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "mit Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "mit Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "mit (klassischem) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "         System-gvimrc-Datei: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       Benutzer-gvimrc-Datei: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "zweite Benutzer-gvimrc-Datei: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "dritte Benutzer-gvimrc-Datei: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "           System-Menü-Datei: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Compiler: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "Menü   Hilfe->Waisen            für Informationen darüber "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Mode-freier Betrieb, getippter Text wird eingefügt"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr ""
+#~ "Menü  Editieren->Globale Einstellung->Einfüge-Modus ein- und ausschalten  "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              für zwei Modi       "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr ""
+#~ "Menü  Editieren->Globale Einstellung->Vi-Kompatibilität ein- und "
+#~ "ausschalten"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              für Vim Voreinstellungen   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ACHTUNG: Windows 95/98/ME wurde erkannt"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "Tippe  :help windows95<Enter>   für Informationen darüber "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Konnte Bibliothek %s nicht laden"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Dieser Befehl ist nicht verfügbar, da die Perl-Bibliothek nicht geladen "
+#~ "werden konnte"
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: Perl-Evaluierung in der Sandbox ohne dem 'Safe' Modul"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Unbekannter Fontset: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Unbekannte Schriftart: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Schriftart \"%s\" hat keine feste Breite"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Bibliotheksfunktion %s konnte nicht geladen werden"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Hebräisch kann nicht benutzt werden: wurde zum Zeitpunkt des "
+#~ "Übersetzens nicht eingeschaltet.\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Farsi kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens "
+#~ "nicht eingeschaltet.\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Arabisch kann nicht benutzt werden: wurde zum Zeitpunkt des "
+#~ "Übersetzens nicht eingeschaltet.\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Kein registrierter Servername \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Display kann nicht geöffnet werden"
+
+#~ msgid "E46: Cannot set read-only variable \"%s\""
+#~ msgstr "E46: Variable \"%s\" kann nur gelesen werden"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Ungültiger Ausdruck"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Region ist geschützt; keine Änderung möglich"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr ""
+#~ "E744: NetBeans erlaubt keine Änderungen in schreibgeschützten Dateien"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Editiere mit &mehreren Vims"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Editiere mit einem &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Differenz mit Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Editiere mit &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Editiere mit vorhandenem Vim - "
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr ""
+#~ "Fehler beim Erzeugen des Prozesses: Überprüfen Sie, ob gvim in Ihrem Pfad "
+#~ "ist!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll Fehler"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Die Länge des Pfads ist zu groß!"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Editiert die ausgewählte(n) Datei(en) mit Vim"
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: Unerwartetes 'return'"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: Unerwartetes 'next'"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: Unerwartetes 'break'"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: Unerwartetes 'redo'"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: 'retry' außerhalb der 'rescue clause'"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Unbehandelte Ausnahme"
+
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr ""
+#~ "--remote-tab <Dateien>  Wie --remote, aber öffne ein Tab für jede Datei"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Verzeichnis Auswahl Dialog"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Kein Treffer beim Cursur, finde den nächsten"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ muss eine Instanz einer Zeichenkette sein"

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -17,33 +17,1107 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(UK English)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2008-07-19 18:03+0100\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2003-02-25 11:05+0000\n"
 "Last-Translator: Mike Williams <mrw@eandem.co.uk>\n"
 "Language-Team: Mike Williams <mrw@eandem.co.uk>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO_8859-1\n"
 "Content-Transfer-Encoding: 7bit\n"
 
+#: ../api/private/helpers.c:201
+msgid "Unable to get option value"
+msgstr ""
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
+#, fuzzy
+msgid "E82: Cannot allocate any buffer, exiting..."
+msgstr "E254: Cannot allocate colour %s"
+
+#: ../buffer.c:138
+msgid "E83: Cannot allocate buffer, using other one..."
+msgstr ""
+
+#: ../buffer.c:763
+msgid "E515: No buffers were unloaded"
+msgstr ""
+
+#: ../buffer.c:765
+msgid "E516: No buffers were deleted"
+msgstr ""
+
+#: ../buffer.c:767
+msgid "E517: No buffers were wiped out"
+msgstr ""
+
+#: ../buffer.c:772
+msgid "1 buffer unloaded"
+msgstr ""
+
+#: ../buffer.c:774
+#, c-format
+msgid "%d buffers unloaded"
+msgstr ""
+
+#: ../buffer.c:777
+msgid "1 buffer deleted"
+msgstr ""
+
+#: ../buffer.c:779
+#, c-format
+msgid "%d buffers deleted"
+msgstr ""
+
+#: ../buffer.c:782
+msgid "1 buffer wiped out"
+msgstr ""
+
+#: ../buffer.c:784
+#, c-format
+msgid "%d buffers wiped out"
+msgstr ""
+
+#: ../buffer.c:806
+#, fuzzy
+msgid "E90: Cannot unload last buffer"
+msgstr "E102: Cannot find buffer \"%s\""
+
+#: ../buffer.c:874
+msgid "E84: No modified buffer found"
+msgstr ""
+
+#. back where we started, didn't find anything.
+#: ../buffer.c:903
+msgid "E85: There is no listed buffer"
+msgstr ""
+
+#: ../buffer.c:913
+#, c-format
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr ""
+
+#: ../buffer.c:915
+msgid "E87: Cannot go beyond last buffer"
+msgstr ""
+
+#: ../buffer.c:917
+msgid "E88: Cannot go before first buffer"
+msgstr ""
+
+#: ../buffer.c:945
+#, fuzzy, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E508: Cannot read file for backup (add ! to override)"
+
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
+msgid "W14: Warning: List of file names overflow"
+msgstr ""
+
+#: ../buffer.c:1555 ../quickfix.c:3361
+#, c-format
+msgid "E92: Buffer %<PRId64> not found"
+msgstr ""
+
+#: ../buffer.c:1798
+#, c-format
+msgid "E93: More than one match for %s"
+msgstr ""
+
+#: ../buffer.c:1800
+#, c-format
+msgid "E94: No matching buffer for %s"
+msgstr ""
+
+#: ../buffer.c:2161
+#, c-format
+msgid "line %<PRId64>"
+msgstr ""
+
+#: ../buffer.c:2233
+msgid "E95: Buffer with this name already exists"
+msgstr ""
+
+#: ../buffer.c:2498
+msgid " [Modified]"
+msgstr ""
+
+#: ../buffer.c:2501
+msgid "[Not edited]"
+msgstr ""
+
+#: ../buffer.c:2504
+msgid "[New file]"
+msgstr ""
+
+#: ../buffer.c:2505
+msgid "[Read errors]"
+msgstr ""
+
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr ""
+
+#: ../buffer.c:2507 ../fileio.c:1807
+msgid "[readonly]"
+msgstr ""
+
+#: ../buffer.c:2524
+#, c-format
+msgid "1 line --%d%%--"
+msgstr ""
+
+#: ../buffer.c:2526
+#, c-format
+msgid "%<PRId64> lines --%d%%--"
+msgstr ""
+
+#: ../buffer.c:2530
+#, c-format
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr ""
+
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+msgid "[No Name]"
+msgstr ""
+
+#. must be a help buffer
+#: ../buffer.c:2667
+msgid "help"
+msgstr ""
+
+#: ../buffer.c:3225 ../screen.c:4883
+msgid "[Help]"
+msgstr ""
+
+#: ../buffer.c:3254 ../screen.c:4887
+msgid "[Preview]"
+msgstr ""
+
+#: ../buffer.c:3528
+msgid "All"
+msgstr ""
+
+#: ../buffer.c:3528
+msgid "Bot"
+msgstr ""
+
+#: ../buffer.c:3531
+msgid "Top"
+msgstr ""
+
+#: ../buffer.c:4244
+msgid ""
+"\n"
+"# Buffer list:\n"
+msgstr ""
+
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
+
+#: ../buffer.c:4529
+msgid ""
+"\n"
+"--- Signs ---"
+msgstr ""
+
+#: ../buffer.c:4538
+#, c-format
+msgid "Signs for %s:"
+msgstr ""
+
+#: ../buffer.c:4543
+#, c-format
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr ""
+
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr ""
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr ""
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr ""
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr ""
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Cannot diff more than %<PRId64> buffers"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E482: Cannot create file %s"
+
+#: ../diff.c:755
+#, fuzzy
+msgid "E97: Cannot create diffs"
+msgstr "E482: Cannot create file %s"
+
+#: ../diff.c:966
+msgid "E816: Cannot read patch output"
+msgstr ""
+
+#: ../diff.c:1220
+#, fuzzy
+msgid "E98: Cannot read diff output"
+msgstr "E485: Cannot read file %s"
+
+#: ../diff.c:2081
+msgid "E99: Current buffer is not in diff mode"
+msgstr ""
+
+#: ../diff.c:2100
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr ""
+
+#: ../diff.c:2102
+msgid "E100: No other buffer in diff mode"
+msgstr ""
+
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: More than two buffers in diff mode, do not know which one to use"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Cannot find buffer \"%s\""
 
+#: ../diff.c:2152
+#, c-format
+msgid "E103: Buffer \"%s\" is not in diff mode"
+msgstr ""
+
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
+msgid "E104: Escape not allowed in digraph"
+msgstr ""
+
+#: ../digraph.c:1760
+msgid "E544: Keymap file not found"
+msgstr ""
+
+#: ../digraph.c:1785
+msgid "E105: Using :loadkeymap not in a sourced file"
+msgstr ""
+
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
+msgid " Keyword completion (^N^P)"
+msgstr ""
+
+#. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
+msgstr ""
+
+#: ../edit.c:85
+msgid " Whole line completion (^L^N^P)"
+msgstr ""
+
+#: ../edit.c:86
+msgid " File name completion (^F^N^P)"
+msgstr ""
+
+#: ../edit.c:87
+msgid " Tag completion (^]^N^P)"
+msgstr ""
+
+#: ../edit.c:88
+msgid " Path pattern completion (^N^P)"
+msgstr ""
+
+#: ../edit.c:89
+msgid " Definition completion (^D^N^P)"
+msgstr ""
+
+#: ../edit.c:91
+msgid " Dictionary completion (^K^N^P)"
+msgstr ""
+
+#: ../edit.c:92
+msgid " Thesaurus completion (^T^N^P)"
+msgstr ""
+
+#: ../edit.c:93
+msgid " Command-line completion (^V^N^P)"
+msgstr ""
+
+#: ../edit.c:94
+msgid " User defined completion (^U^N^P)"
+msgstr ""
+
+#: ../edit.c:95
+msgid " Omni completion (^O^N^P)"
+msgstr ""
+
+#: ../edit.c:96
+msgid " Spelling suggestion (s^N^P)"
+msgstr ""
+
+#: ../edit.c:97
+msgid " Keyword Local completion (^N^P)"
+msgstr ""
+
+#: ../edit.c:100
+msgid "Hit end of paragraph"
+msgstr ""
+
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
+msgid "'dictionary' option is empty"
+msgstr ""
+
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr ""
+
+#: ../edit.c:2655
+#, c-format
+msgid "Scanning dictionary: %s"
+msgstr ""
+
+#: ../edit.c:3079
+msgid " (insert) Scroll (^E/^Y)"
+msgstr ""
+
+#: ../edit.c:3081
+msgid " (replace) Scroll (^E/^Y)"
+msgstr ""
+
+#: ../edit.c:3587
+#, c-format
+msgid "Scanning: %s"
+msgstr ""
+
+#: ../edit.c:3614
+msgid "Scanning tags."
+msgstr ""
+
+#: ../edit.c:4519
+msgid " Adding"
+msgstr ""
+
+#. showmode might reset the internal line pointers, so it must
+#. * be called before line = ml_get(), or when this address is no
+#. * longer needed.  -- Acevedo.
+#.
+#: ../edit.c:4562
+msgid "-- Searching..."
+msgstr ""
+
+#: ../edit.c:4618
+msgid "Back at original"
+msgstr ""
+
+#: ../edit.c:4621
+msgid "Word from other line"
+msgstr ""
+
+#: ../edit.c:4624
+#, fuzzy
+msgid "The only match"
+msgstr "Keys do not match!"
+
+#: ../edit.c:4680
+#, c-format
+msgid "match %d of %d"
+msgstr ""
+
+#: ../edit.c:4684
+#, c-format
+msgid "match %d"
+msgstr ""
+
+#: ../eval.c:137
+msgid "E18: Unexpected characters in :let"
+msgstr ""
+
+#: ../eval.c:138
+#, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr ""
+
+#: ../eval.c:139
+#, c-format
+msgid "E121: Undefined variable: %s"
+msgstr ""
+
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr ""
+
+#: ../eval.c:141
+#, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr ""
+
+#: ../eval.c:143
+#, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: Cannot find temp file for writing"
+
+#: ../eval.c:145
+msgid "E714: List required"
+msgstr ""
+
+#: ../eval.c:146
+msgid "E715: Dictionary required"
+msgstr ""
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr ""
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
+#, c-format
+msgid "E122: Function %s already exists, add ! to replace it"
+msgstr ""
+
+#: ../eval.c:151
+msgid "E717: Dictionary entry already exists"
+msgstr ""
+
+#: ../eval.c:152
+msgid "E718: Funcref required"
+msgstr ""
+
+#: ../eval.c:153
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr ""
+
+#: ../eval.c:154
+#, fuzzy, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr "E738: Cannot list variables for %s"
+
+#: ../eval.c:155
+#, c-format
+msgid "E130: Unknown function: %s"
+msgstr ""
+
+#: ../eval.c:156
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr ""
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Cannot list variables for %s"
 
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+msgid "E690: Missing \"in\" after :for"
+msgstr ""
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr ""
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr ""
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr ""
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+msgid "E692: Invalid operation for Lists"
+msgstr ""
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+msgid "E736: Invalid operation for Dictionary"
+msgstr ""
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+msgid "E694: Invalid operation for Funcrefs"
+msgstr ""
+
+#: ../eval.c:4277
+msgid "E804: Cannot use '%' with Float"
+msgstr ""
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr ""
+
+#: ../eval.c:4609
+msgid "E695: Cannot index a Funcref"
+msgstr ""
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr ""
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr ""
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr ""
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr ""
+
+#: ../eval.c:5084
+#, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr ""
+
+#: ../eval.c:5091
+#, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr ""
+
+#: ../eval.c:6475
+#, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:6524
+#, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr ""
+
+#: ../eval.c:6555
+msgid "E724: variable nested too deep for displaying"
+msgstr ""
+
+#: ../eval.c:7188
+#, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr ""
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr ""
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr ""
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr ""
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr ""
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+msgid "E808: Number or Float required"
+msgstr ""
+
+#: ../eval.c:7503
+msgid "add() argument"
+msgstr ""
+
+#: ../eval.c:7907
+msgid "E699: Too many arguments"
+msgstr ""
+
+#: ../eval.c:8073
+msgid "E785: complete() can only be used in Insert mode"
+msgstr ""
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr ""
+
+#: ../eval.c:8676
+#, c-format
+msgid "E737: Key already exists: %s"
+msgstr ""
+
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+msgid "map() argument"
+msgstr ""
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr ""
+
+#: ../eval.c:9291
+#, c-format
+msgid "E700: Unknown function: %s"
+msgstr ""
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr ""
+
+#: ../eval.c:10771
+msgid "insert() argument"
+msgstr ""
+
+#: ../eval.c:10841
+msgid "E786: Range not allowed"
+msgstr ""
+
+#: ../eval.c:11140
+msgid "E701: Invalid type for len()"
+msgstr ""
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
+
+#: ../eval.c:12466
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr ""
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "uniq() argument"
+msgstr ""
+
+#: ../eval.c:13776
+msgid "E702: Sort compare function failed"
+msgstr ""
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr ""
+
+#: ../eval.c:14590
+msgid "E677: Error writing temp file"
+msgstr ""
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+msgid "E730: using List as a String"
+msgstr ""
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr ""
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: Cannot list variables for %s"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr ""
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr ""
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E482: Cannot create file %s"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
+#, c-format
+msgid "E123: Undefined function: %s"
+msgstr ""
+
+#: ../eval.c:17260
+#, c-format
+msgid "E124: Missing '(': %s"
+msgstr ""
+
+#: ../eval.c:17293
+msgid "E862: Cannot use g: here"
+msgstr ""
+
+#: ../eval.c:17312
+#, c-format
+msgid "E125: Illegal argument: %s"
+msgstr ""
+
+#: ../eval.c:17323
+#, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr ""
+
+#: ../eval.c:17416
+msgid "E126: Missing :endfunction"
+msgstr ""
+
+#: ../eval.c:17537
+#, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr ""
+
+#: ../eval.c:17549
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr ""
+
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E781: .sug file does not match .spl file: %s"
+
+#: ../eval.c:17716
+msgid "E129: Function name required"
+msgstr ""
+
+#: ../eval.c:17824
+#, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+
+#: ../eval.c:17833
+#, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+
+#: ../eval.c:18336
+#, c-format
+msgid "E131: Cannot delete function %s: It is in use"
+msgstr ""
+
+#: ../eval.c:18441
+msgid "E132: Function call depth is higher than 'maxfuncdepth'"
+msgstr ""
+
+#: ../eval.c:18568
+#, c-format
+msgid "calling %s"
+msgstr ""
+
+#: ../eval.c:18651
+#, c-format
+msgid "%s aborted"
+msgstr ""
+
+#: ../eval.c:18653
+#, c-format
+msgid "%s returning #%<PRId64>"
+msgstr ""
+
+#: ../eval.c:18670
+#, c-format
+msgid "%s returning %s"
+msgstr ""
+
+#: ../eval.c:18691 ../ex_cmds2.c:2695
+#, c-format
+msgid "continuing in %s"
+msgstr ""
+
+#: ../eval.c:18795
+msgid "E133: :return not inside a function"
+msgstr ""
+
+#: ../eval.c:19159
+msgid ""
+"\n"
+"# global variables:\n"
+msgstr ""
+
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+
+#: ../eval.c:19272
+msgid "No old files"
+msgstr ""
+
+#: ../ex_cmds.c:122
+#, c-format
+msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
+msgstr ""
+
+#: ../ex_cmds.c:145
+#, c-format
+msgid "> %d, Hex %04x, Octal %o"
+msgstr ""
+
+#: ../ex_cmds.c:146
+#, c-format
+msgid "> %d, Hex %08x, Octal %o"
+msgstr ""
+
+#: ../ex_cmds.c:684
+msgid "E134: Move lines into themselves"
+msgstr ""
+
+#: ../ex_cmds.c:747
+msgid "1 line moved"
+msgstr ""
+
+#: ../ex_cmds.c:749
+#, c-format
+msgid "%<PRId64> lines moved"
+msgstr ""
+
+#: ../ex_cmds.c:1175
+#, c-format
+msgid "%<PRId64> lines filtered"
+msgstr ""
+
+#: ../ex_cmds.c:1194
+msgid "E135: *Filter* Autocommands must not change current buffer"
+msgstr ""
+
+#: ../ex_cmds.c:1244
+msgid "[No write since last change]\n"
+msgstr ""
+
+#: ../ex_cmds.c:1424
+#, c-format
+msgid "%sviminfo: %s in line: "
+msgstr ""
+
+#: ../ex_cmds.c:1431
+msgid "E136: viminfo: Too many errors, skipping rest of file"
+msgstr ""
+
+#: ../ex_cmds.c:1458
+#, c-format
+msgid "Reading viminfo file \"%s\"%s%s%s"
+msgstr ""
+
+#: ../ex_cmds.c:1460
+msgid " info"
+msgstr ""
+
+#: ../ex_cmds.c:1461
+msgid " marks"
+msgstr ""
+
+#: ../ex_cmds.c:1462
+msgid " oldfiles"
+msgstr ""
+
+#: ../ex_cmds.c:1463
+msgid " FAILED"
+msgstr ""
+
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
+#, c-format
+msgid "E137: Viminfo file is not writable: %s"
+msgstr ""
+
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Cannot write viminfo file %s!"
 
+#: ../ex_cmds.c:1635
+#, fuzzy, c-format
+msgid "Writing viminfo file \"%s\""
+msgstr "E138: Cannot write viminfo file %s!"
+
+#. Write the info:
+#: ../ex_cmds.c:1720
+#, c-format
+msgid "# This viminfo file was generated by Vim %s.\n"
+msgstr ""
+
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -51,240 +1125,5183 @@ msgstr ""
 "# You may edit it if you are careful!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
+msgid "# Value of 'encoding' when this file was written\n"
+msgstr ""
+
+#: ../ex_cmds.c:1800
+msgid "Illegal starting char"
+msgstr ""
+
+#: ../ex_cmds.c:2162
+msgid "Write partial file?"
+msgstr ""
+
+#: ../ex_cmds.c:2166
+msgid "E140: Use ! to write partial buffer"
+msgstr ""
+
+#: ../ex_cmds.c:2281
+#, c-format
+msgid "Overwrite existing file \"%s\"?"
+msgstr ""
+
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr ""
+
+#: ../ex_cmds.c:2381
+#, c-format
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr ""
+
+#: ../ex_cmds.c:2412
+msgid "E142: File not written: Writing is disabled by 'write' option"
+msgstr ""
+
+#: ../ex_cmds.c:2434
+#, c-format
+msgid ""
+"'readonly' option is set for \"%s\".\n"
+"Do you wish to write anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
+
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "E508: Cannot read file for backup (add ! to override)"
+
+#: ../ex_cmds.c:3120
+#, c-format
+msgid "E143: Autocommands unexpectedly deleted new buffer %s"
+msgstr ""
+
+#: ../ex_cmds.c:3313
+msgid "E144: non-numeric argument to :z"
+msgstr ""
+
+#: ../ex_cmds.c:3404
+msgid "E145: Shell commands not allowed in rvim"
+msgstr ""
+
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regular expressions cannot be delimited by letters"
 
+#: ../ex_cmds.c:3964
+#, c-format
+msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
+msgstr ""
+
+#: ../ex_cmds.c:4379
+msgid "(Interrupted) "
+msgstr ""
+
+#: ../ex_cmds.c:4384
+msgid "1 match"
+msgstr ""
+
+#: ../ex_cmds.c:4384
+msgid "1 substitution"
+msgstr ""
+
+#: ../ex_cmds.c:4387
+#, c-format
+msgid "%<PRId64> matches"
+msgstr ""
+
+#: ../ex_cmds.c:4388
+#, c-format
+msgid "%<PRId64> substitutions"
+msgstr ""
+
+#: ../ex_cmds.c:4392
+msgid " on 1 line"
+msgstr ""
+
+#: ../ex_cmds.c:4395
+#, c-format
+msgid " on %<PRId64> lines"
+msgstr ""
+
+#: ../ex_cmds.c:4438
+msgid "E147: Cannot do :global recursive"
+msgstr ""
+
+#: ../ex_cmds.c:4467
+#, fuzzy
+msgid "E148: Regular expression missing from global"
+msgstr "E146: Regular expressions cannot be delimited by letters"
+
+#: ../ex_cmds.c:4508
+#, c-format
+msgid "Pattern found in every line: %s"
+msgstr ""
+
+#: ../ex_cmds.c:4510
+#, c-format
+msgid "Pattern not found: %s"
+msgstr ""
+
+#: ../ex_cmds.c:4587
+msgid ""
+"\n"
+"# Last Substitute String:\n"
+"$"
+msgstr ""
+
+#: ../ex_cmds.c:4679
+msgid "E478: Don't panic!"
+msgstr ""
+
+#: ../ex_cmds.c:4717
+#, c-format
+msgid "E661: Sorry, no '%s' help for %s"
+msgstr ""
+
+#: ../ex_cmds.c:4719
+#, c-format
+msgid "E149: Sorry, no help for %s"
+msgstr ""
+
+#: ../ex_cmds.c:4751
+#, c-format
+msgid "Sorry, help file \"%s\" not found"
+msgstr ""
+
+#: ../ex_cmds.c:5323
+#, c-format
+msgid "E150: Not a directory: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5446
+#, fuzzy, c-format
+msgid "E152: Cannot open %s for writing"
+msgstr "E212: Cannot open file for writing"
+
+#: ../ex_cmds.c:5471
+#, fuzzy, c-format
+msgid "E153: Unable to open %s for reading"
+msgstr "E212: Cannot open file for writing"
+
+#: ../ex_cmds.c:5500
+#, c-format
+msgid "E670: Mix of help file encodings within a language: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5565
+#, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
+msgstr ""
+
+#: ../ex_cmds.c:5687
+#, c-format
+msgid "E160: Unknown sign command: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5704
+msgid "E156: Missing sign name"
+msgstr ""
+
+#: ../ex_cmds.c:5746
+msgid "E612: Too many signs defined"
+msgstr ""
+
+#: ../ex_cmds.c:5813
+#, c-format
+msgid "E239: Invalid sign text: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
+#, c-format
+msgid "E155: Unknown sign: %s"
+msgstr ""
+
+#: ../ex_cmds.c:5877
+msgid "E159: Missing sign number"
+msgstr ""
+
+#: ../ex_cmds.c:5971
+#, c-format
+msgid "E158: Invalid buffer name: %s"
+msgstr ""
+
+#: ../ex_cmds.c:6008
+#, c-format
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr ""
+
+#: ../ex_cmds.c:6066
+msgid " (not supported)"
+msgstr ""
+
+#: ../ex_cmds.c:6169
+msgid "[Deleted]"
+msgstr ""
+
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr ""
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr ""
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr ""
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr ""
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr ""
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr ""
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr ""
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr ""
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr ""
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr ""
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr ""
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr ""
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr ""
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr ""
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr ""
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr ""
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr ""
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr ""
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr ""
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr ""
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr ""
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr ""
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr ""
+
+#: ../ex_cmds2.c:3404
+#, fuzzy, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E738: Cannot list variables for %s"
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
+msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
+msgstr ""
+
+#: ../ex_docmd.c:428
+msgid "E501: At end-of-file"
+msgstr ""
+
+#: ../ex_docmd.c:513
+msgid "E169: Command too recursive"
+msgstr ""
+
+#: ../ex_docmd.c:1006
+#, c-format
+msgid "E605: Exception not caught: %s"
+msgstr ""
+
+#: ../ex_docmd.c:1085
+msgid "End of sourced file"
+msgstr ""
+
+#: ../ex_docmd.c:1086
+msgid "End of function"
+msgstr ""
+
+#: ../ex_docmd.c:1628
+msgid "E464: Ambiguous use of user-defined command"
+msgstr ""
+
+#: ../ex_docmd.c:1638
+msgid "E492: Not an editor command"
+msgstr ""
+
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Backward range given"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Backward range given, OK to swap"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
+msgid "E494: Use w or w>>"
+msgstr ""
+
+#: ../ex_docmd.c:3454
+msgid "E319: Sorry, the command is not available in this version"
+msgstr ""
+
+#: ../ex_docmd.c:3752
+msgid "E172: Only one file name allowed"
+msgstr ""
+
+#: ../ex_docmd.c:4238
+msgid "1 more file to edit.  Quit anyway?"
+msgstr ""
+
+#: ../ex_docmd.c:4242
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "%d more files to edit.  Quit anyway?"
+msgstr ""
+
+#: ../ex_docmd.c:4248
+msgid "E173: 1 more file to edit"
+msgstr ""
+
+#: ../ex_docmd.c:4250
+#, c-format
+msgid "E173: %<PRId64> more files to edit"
+msgstr ""
+
+#: ../ex_docmd.c:4320
+msgid "E174: Command already exists: add ! to replace it"
+msgstr ""
+
+#: ../ex_docmd.c:4432
+msgid ""
+"\n"
+"    Name        Args Range Complete  Definition"
+msgstr ""
+
+#: ../ex_docmd.c:4516
+msgid "No user-defined commands found"
+msgstr ""
+
+#: ../ex_docmd.c:4538
+msgid "E175: No attribute specified"
+msgstr ""
+
+#: ../ex_docmd.c:4583
+msgid "E176: Invalid number of arguments"
+msgstr ""
+
+#: ../ex_docmd.c:4594
+msgid "E177: Count cannot be specified twice"
+msgstr ""
+
+#: ../ex_docmd.c:4603
+msgid "E178: Invalid default value for count"
+msgstr ""
+
+#: ../ex_docmd.c:4625
+msgid "E179: argument required for -complete"
+msgstr ""
+
+#: ../ex_docmd.c:4635
+#, c-format
+msgid "E181: Invalid attribute: %s"
+msgstr ""
+
+#: ../ex_docmd.c:4678
+msgid "E182: Invalid command name"
+msgstr ""
+
+#: ../ex_docmd.c:4691
+msgid "E183: User defined commands must start with an uppercase letter"
+msgstr ""
+
+#: ../ex_docmd.c:4696
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr ""
+
+#: ../ex_docmd.c:4751
+#, c-format
+msgid "E184: No such user-defined command: %s"
+msgstr ""
+
+#: ../ex_docmd.c:5219
+#, c-format
+msgid "E180: Invalid complete value: %s"
+msgstr ""
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr ""
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr ""
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Cannot find colour scheme %s"
 
-msgid "Can't find temp file for conversion"
-msgstr "Cannot find temp file for conversion"
+#: ../ex_docmd.c:5263
+msgid "Greetings, Vim user!"
+msgstr ""
 
-msgid "can't read output of 'charconvert'"
-msgstr "cannot read output of 'charconvert'"
+#: ../ex_docmd.c:5431
+msgid "E784: Cannot close last tab page"
+msgstr ""
 
-msgid "E506: Can't write to backup file (add ! to override)"
+#: ../ex_docmd.c:5462
+msgid "Already only one tab page"
+msgstr ""
+
+#: ../ex_docmd.c:6004
+#, c-format
+msgid "Tab page %d"
+msgstr ""
+
+#: ../ex_docmd.c:6295
+msgid "No swap file"
+msgstr ""
+
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E506: Cannot write to backup file (add ! to override)"
 
-msgid "E508: Can't read file for backup (add ! to override)"
-msgstr "E508: Cannot read file for backup (add ! to override)"
+#: ../ex_docmd.c:6485
+msgid "E186: No previous directory"
+msgstr ""
 
-msgid "E510: Can't make backup file (add ! to override)"
-msgstr "E510: Cannot make backup file (add ! to override)"
+#: ../ex_docmd.c:6530
+msgid "E187: Unknown"
+msgstr ""
 
-msgid "E214: Can't find temp file for writing"
-msgstr "E214: Cannot find temp file for writing"
+#: ../ex_docmd.c:6610
+msgid "E465: :winsize requires two number arguments"
+msgstr ""
 
-msgid "E166: Can't open linked file for writing"
-msgstr "E166: Cannot open linked file for writing"
+#: ../ex_docmd.c:6655
+msgid "E188: Obtaining window position not implemented for this platform"
+msgstr ""
 
-msgid "E212: Can't open file for writing"
-msgstr "E212: Cannot open file for writing"
+#: ../ex_docmd.c:6662
+msgid "E466: :winpos requires two number arguments"
+msgstr ""
 
-msgid "E205: Patchmode: can't save original file"
-msgstr "E205: Patchmode: cannot save original file"
-
-msgid "E206: patchmode: can't touch empty original file"
-msgstr "E206: patchmode: cannot touch empty original file"
-
-msgid "E207: Can't delete backup file"
-msgstr "E207: Cannot delete backup file"
-
-msgid "don't quit the editor until the file is successfully written!"
-msgstr "do not quit the editor until the file is successfully written!"
-
-msgid "E217: Can't execute autocommands for ALL events"
-msgstr "E217: Cannot execute autocommands for ALL events"
-
-#, c-format
-msgid "E482: Can't create file %s"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
 msgstr "E482: Cannot create file %s"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Cannot get temp file name"
+#: ../ex_docmd.c:7268
+#, fuzzy, c-format
+msgid "E189: \"%s\" exists (add ! to override)"
+msgstr "E510: Cannot make backup file (add ! to override)"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Cannot open file %s"
+#: ../ex_docmd.c:7273
+#, fuzzy, c-format
+msgid "E190: Cannot open \"%s\" for writing"
+msgstr "E212: Cannot open file for writing"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Cannot read file %s"
-
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Cannot open errorfile %s"
-
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Could not read in sign data!"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Cannot allocate colour %s"
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: cannot get font %s"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: cannot return to current directory"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: cannot get current directory"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#. set mark
+#: ../ex_docmd.c:7294
+msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr ""
-"Vim E458: Cannot allocate colourmap entry, some colours may be incorrect"
 
+#: ../ex_docmd.c:7333
+msgid "E192: Recursive use of :normal too deep"
+msgstr ""
+
+#: ../ex_docmd.c:7807
+msgid "E194: No alternate file name to substitute for '#'"
+msgstr ""
+
+#: ../ex_docmd.c:7841
+msgid "E495: no autocommand file name to substitute for \"<afile>\""
+msgstr ""
+
+#: ../ex_docmd.c:7850
+msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
+msgstr ""
+
+#: ../ex_docmd.c:7861
+msgid "E497: no autocommand match name to substitute for \"<amatch>\""
+msgstr ""
+
+#: ../ex_docmd.c:7870
+msgid "E498: no :source file name to substitute for \"<sfile>\""
+msgstr ""
+
+#: ../ex_docmd.c:7876
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr ""
+
+#: ../ex_docmd.c:7903
 #, c-format
-msgid "E624: Can't open file \"%s\""
-msgstr "E624: Cannot open file \"%s\""
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
+msgstr ""
 
+#: ../ex_docmd.c:7905
+msgid "E500: Evaluates to an empty string"
+msgstr ""
+
+#: ../ex_docmd.c:8838
+#, fuzzy
+msgid "E195: Cannot open viminfo file for reading"
+msgstr "E166: Cannot open linked file for writing"
+
+#: ../ex_eval.c:464
+msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
+msgstr ""
+
+#. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: Cannot read PostScript resource file \"%s\""
+msgid "Exception thrown: %s"
+msgstr ""
 
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: Cannot open PostScript output file"
-
+#: ../ex_eval.c:545
 #, c-format
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: Cannot open file \"%s\""
+msgid "Exception finished: %s"
+msgstr ""
 
-msgid "E456: Can't find PostScript resource file \"prolog.ps\""
-msgstr "E456: Cannot find PostScript resource file \"prolog.ps\""
-
-msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
-msgstr "E456: Cannot find PostScript resource file \"cidfont.ps\""
-
+#: ../ex_eval.c:546
 #, c-format
-msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: Cannot find PostScript resource file \"%s.ps\""
+msgid "Exception discarded: %s"
+msgstr ""
 
-msgid "couldn't open buffer"
-msgstr "could not open buffer"
+#: ../ex_eval.c:588 ../ex_eval.c:634
+#, c-format
+msgid "%s, line %<PRId64>"
+msgstr ""
 
-msgid "can't delete OutputObject attributes"
-msgstr "cannot delete OutputObject attributes"
+#. always scroll up, don't overwrite
+#: ../ex_eval.c:608
+#, c-format
+msgid "Exception caught: %s"
+msgstr ""
 
-msgid "--literal\t\tDon't expand wildcards"
-msgstr "--literal\t\tDo not expand wildcards"
+#: ../ex_eval.c:676
+#, c-format
+msgid "%s made pending"
+msgstr ""
 
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  or  --nofork\tForeground: Do not fork when starting GUI"
+#: ../ex_eval.c:679
+#, c-format
+msgid "%s resumed"
+msgstr ""
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tDo not use newcli to open window"
+#: ../ex_eval.c:683
+#, c-format
+msgid "%s discarded"
+msgstr ""
 
-msgid "--noplugin\t\tDon't load plugin scripts"
-msgstr "--noplugin\t\tDo not load plugin scripts"
+#: ../ex_eval.c:708
+msgid "Exception"
+msgstr ""
 
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  Same, do not complain if there is no server"
+#: ../ex_eval.c:713
+msgid "Error and interrupt"
+msgstr ""
 
+#: ../ex_eval.c:715
+msgid "Error"
+msgstr ""
+
+#. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
+msgid "Interrupt"
+msgstr ""
+
+#: ../ex_eval.c:795
+msgid "E579: :if nesting too deep"
+msgstr ""
+
+#: ../ex_eval.c:830
+msgid "E580: :endif without :if"
+msgstr ""
+
+#: ../ex_eval.c:873
+msgid "E581: :else without :if"
+msgstr ""
+
+#: ../ex_eval.c:876
+msgid "E582: :elseif without :if"
+msgstr ""
+
+#: ../ex_eval.c:880
+msgid "E583: multiple :else"
+msgstr ""
+
+#: ../ex_eval.c:883
+msgid "E584: :elseif after :else"
+msgstr ""
+
+#: ../ex_eval.c:941
+msgid "E585: :while/:for nesting too deep"
+msgstr ""
+
+#: ../ex_eval.c:1028
+msgid "E586: :continue without :while or :for"
+msgstr ""
+
+#: ../ex_eval.c:1061
+msgid "E587: :break without :while or :for"
+msgstr ""
+
+#: ../ex_eval.c:1102
+msgid "E732: Using :endfor with :while"
+msgstr ""
+
+#: ../ex_eval.c:1104
+msgid "E733: Using :endwhile with :for"
+msgstr ""
+
+#: ../ex_eval.c:1247
+msgid "E601: :try nesting too deep"
+msgstr ""
+
+#: ../ex_eval.c:1317
+msgid "E603: :catch without :try"
+msgstr ""
+
+#. Give up for a ":catch" after ":finally" and ignore it.
+#. * Just parse.
+#: ../ex_eval.c:1332
+msgid "E604: :catch after :finally"
+msgstr ""
+
+#: ../ex_eval.c:1451
+msgid "E606: :finally without :try"
+msgstr ""
+
+#. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
+msgid "E607: multiple :finally"
+msgstr ""
+
+#: ../ex_eval.c:1571
+msgid "E602: :endtry without :try"
+msgstr ""
+
+#: ../ex_eval.c:2026
+msgid "E193: :endfunction not inside a function"
+msgstr ""
+
+#: ../ex_getln.c:1643
+msgid "E788: Not allowed to edit another buffer now"
+msgstr ""
+
+#: ../ex_getln.c:1656
+msgid "E811: Not allowed to change buffer information now"
+msgstr ""
+
+#: ../ex_getln.c:3178
+msgid "tagname"
+msgstr ""
+
+#: ../ex_getln.c:3181
+msgid " kind file\n"
+msgstr ""
+
+#: ../ex_getln.c:4799
+msgid "'history' option is zero"
+msgstr ""
+
+#: ../ex_getln.c:5046
+#, c-format
 msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
+"\n"
+"# %s History (newest to oldest):\n"
 msgstr ""
-"--remote-wait-silent <files>  Same, do not complain if there is no server"
 
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <colour>\tUse <colour> for the background (also: -bg)"
+#: ../ex_getln.c:5047
+msgid "Command Line"
+msgstr ""
 
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <colour>\tUse <colour> for normal text (also: -fg)"
+#: ../ex_getln.c:5048
+msgid "Search String"
+msgstr ""
 
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tDo not use reverse video (also: +rv)"
+#: ../ex_getln.c:5049
+msgid "Expression"
+msgstr ""
 
-msgid "E288: input method doesn't support any style"
-msgstr "E288: input method does not support any style"
+#: ../ex_getln.c:5050
+msgid "Input Line"
+msgstr ""
 
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: input method does not support my preedit type"
+#: ../ex_getln.c:5117
+msgid "E198: cmd_pchar beyond the command length"
+msgstr ""
 
-msgid "E298: Didn't get block nr 0?"
-msgstr "E298: Did not get block nr 0?"
+#: ../ex_getln.c:5279
+msgid "E199: Active window or buffer deleted"
+msgstr ""
 
-msgid "E298: Didn't get block nr 1?"
-msgstr "E298: Did not get block nr 1?"
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
 
-msgid "E298: Didn't get block nr 2?"
-msgstr "E298: Did not get block nr 2?"
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
 
-msgid "E304: ml_upd_block0(): Didn't get block 0??"
-msgstr "E304: ml_upd_block0(): Did not get block 0??"
-
-msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
-msgstr "Messages maintainer: Mike Williams <mrw@eandem.co.uk>"
-
-msgid "Keys don't match!"
-msgstr "Keys do not match!"
-
+#: ../file_search.c:1505
 #, c-format
 msgid "E344: Can't find directory \"%s\" in cdpath"
 msgstr "E344: Cannot find directory \"%s\" in cdpath"
 
+#: ../file_search.c:1508
 #, c-format
 msgid "E345: Can't find file \"%s\" in path"
 msgstr "E345: Cannot find file \"%s\" in path"
 
-msgid "E597: can't select fontset"
-msgstr "E597: cannot select fontset"
+#: ../file_search.c:1512
+#, fuzzy, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E344: Cannot find directory \"%s\" in cdpath"
 
-msgid "E533: can't select wide font"
-msgstr "E533: cannot select wide font"
+#: ../file_search.c:1515
+#, fuzzy, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E447: Cannot find file \"%s\" in path"
 
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Cannot open window!\n"
+#: ../fileio.c:137
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr ""
 
+#: ../fileio.c:368
+msgid "Illegal file name"
+msgstr ""
+
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
+msgid "is a directory"
+msgstr ""
+
+#: ../fileio.c:397
+msgid "is not a file"
+msgstr ""
+
+#: ../fileio.c:508 ../fileio.c:3522
+msgid "[New File]"
+msgstr ""
+
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
+msgid "[Permission Denied]"
+msgstr ""
+
+#: ../fileio.c:653
+msgid "E200: *ReadPre autocommands made the file unreadable"
+msgstr ""
+
+#: ../fileio.c:655
+msgid "E201: *ReadPre autocommands must not change current buffer"
+msgstr ""
+
+#: ../fileio.c:672
+msgid "Vim: Reading from stdin...\n"
+msgstr ""
+
+#. Re-opening the original file failed!
+#: ../fileio.c:909
+msgid "E202: Conversion made file unreadable!"
+msgstr ""
+
+#. fifo or socket
+#: ../fileio.c:1782
+msgid "[fifo/socket]"
+msgstr ""
+
+#. fifo
+#: ../fileio.c:1788
+msgid "[fifo]"
+msgstr ""
+
+#. or socket
+#: ../fileio.c:1794
+msgid "[socket]"
+msgstr ""
+
+#. or character special
+#: ../fileio.c:1801
+msgid "[character special]"
+msgstr ""
+
+#: ../fileio.c:1815
+msgid "[CR missing]"
+msgstr ""
+
+#: ../fileio.c:1819
+msgid "[long lines split]"
+msgstr ""
+
+#: ../fileio.c:1823 ../fileio.c:3512
+msgid "[NOT converted]"
+msgstr ""
+
+#: ../fileio.c:1826 ../fileio.c:3515
+msgid "[converted]"
+msgstr ""
+
+#: ../fileio.c:1831
+#, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr ""
+
+#: ../fileio.c:1835
+#, c-format
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr ""
+
+#: ../fileio.c:1838
+msgid "[READ ERRORS]"
+msgstr ""
+
+#: ../fileio.c:2104
+msgid "Can't find temp file for conversion"
+msgstr "Cannot find temp file for conversion"
+
+#: ../fileio.c:2110
+msgid "Conversion with 'charconvert' failed"
+msgstr ""
+
+#: ../fileio.c:2113
+msgid "can't read output of 'charconvert'"
+msgstr "cannot read output of 'charconvert'"
+
+#: ../fileio.c:2437
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr ""
+
+#: ../fileio.c:2466
+msgid "E203: Autocommands deleted or unloaded buffer to be written"
+msgstr ""
+
+#: ../fileio.c:2486
+msgid "E204: Autocommand changed number of lines in unexpected way"
+msgstr ""
+
+#: ../fileio.c:2548 ../fileio.c:2565
+msgid "is not a file or writable device"
+msgstr ""
+
+#: ../fileio.c:2601
+#, fuzzy
+msgid "is read-only (add ! to override)"
+msgstr "E508: Cannot read file for backup (add ! to override)"
+
+#: ../fileio.c:2886
+msgid "E506: Can't write to backup file (add ! to override)"
+msgstr "E506: Cannot write to backup file (add ! to override)"
+
+#: ../fileio.c:2898
+#, fuzzy
+msgid "E507: Close error for backup file (add ! to override)"
+msgstr "E506: Cannot write to backup file (add ! to override)"
+
+#: ../fileio.c:2901
+msgid "E508: Can't read file for backup (add ! to override)"
+msgstr "E508: Cannot read file for backup (add ! to override)"
+
+#: ../fileio.c:2923
+#, fuzzy
+msgid "E509: Cannot create backup file (add ! to override)"
+msgstr "E510: Cannot make backup file (add ! to override)"
+
+#: ../fileio.c:3008
+msgid "E510: Can't make backup file (add ! to override)"
+msgstr "E510: Cannot make backup file (add ! to override)"
+
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
+msgid "E214: Can't find temp file for writing"
+msgstr "E214: Cannot find temp file for writing"
+
+#: ../fileio.c:3134
+msgid "E213: Cannot convert (add ! to write without conversion)"
+msgstr ""
+
+#: ../fileio.c:3169
+msgid "E166: Can't open linked file for writing"
+msgstr "E166: Cannot open linked file for writing"
+
+#: ../fileio.c:3173
+msgid "E212: Can't open file for writing"
+msgstr "E212: Cannot open file for writing"
+
+#: ../fileio.c:3363
+msgid "E667: Fsync failed"
+msgstr ""
+
+#: ../fileio.c:3398
+msgid "E512: Close failed"
+msgstr ""
+
+#: ../fileio.c:3436
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
+msgstr ""
+
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
+msgid "E514: write error (file system full?)"
+msgstr ""
+
+#: ../fileio.c:3506
+msgid " CONVERSION ERROR"
+msgstr ""
+
+#: ../fileio.c:3509
+#, c-format
+msgid " in line %<PRId64>;"
+msgstr ""
+
+#: ../fileio.c:3519
+msgid "[Device]"
+msgstr ""
+
+#: ../fileio.c:3522
+msgid "[New]"
+msgstr ""
+
+#: ../fileio.c:3535
+msgid " [a]"
+msgstr ""
+
+#: ../fileio.c:3535
+msgid " appended"
+msgstr ""
+
+#: ../fileio.c:3537
+msgid " [w]"
+msgstr ""
+
+#: ../fileio.c:3537
+msgid " written"
+msgstr ""
+
+#: ../fileio.c:3579
+msgid "E205: Patchmode: can't save original file"
+msgstr "E205: Patchmode: cannot save original file"
+
+#: ../fileio.c:3602
+msgid "E206: patchmode: can't touch empty original file"
+msgstr "E206: patchmode: cannot touch empty original file"
+
+#: ../fileio.c:3616
+msgid "E207: Can't delete backup file"
+msgstr "E207: Cannot delete backup file"
+
+#: ../fileio.c:3672
+msgid ""
+"\n"
+"WARNING: Original file may be lost or damaged\n"
+msgstr ""
+
+#: ../fileio.c:3675
+msgid "don't quit the editor until the file is successfully written!"
+msgstr "do not quit the editor until the file is successfully written!"
+
+#: ../fileio.c:3795
+msgid "[dos]"
+msgstr ""
+
+#: ../fileio.c:3795
+msgid "[dos format]"
+msgstr ""
+
+#: ../fileio.c:3801
+msgid "[mac]"
+msgstr ""
+
+#: ../fileio.c:3801
+msgid "[mac format]"
+msgstr ""
+
+#: ../fileio.c:3807
+msgid "[unix]"
+msgstr ""
+
+#: ../fileio.c:3807
+msgid "[unix format]"
+msgstr ""
+
+#: ../fileio.c:3831
+msgid "1 line, "
+msgstr ""
+
+#: ../fileio.c:3833
+#, c-format
+msgid "%<PRId64> lines, "
+msgstr ""
+
+#: ../fileio.c:3836
+msgid "1 character"
+msgstr ""
+
+#: ../fileio.c:3838
+#, c-format
+msgid "%<PRId64> characters"
+msgstr ""
+
+#: ../fileio.c:3849
+msgid "[noeol]"
+msgstr ""
+
+#: ../fileio.c:3849
+msgid "[Incomplete last line]"
+msgstr ""
+
+#. don't overwrite messages here
+#. must give this prompt
+#. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
+msgid "WARNING: The file has been changed since reading it!!!"
+msgstr ""
+
+#: ../fileio.c:3867
+msgid "Do you really want to write to it"
+msgstr ""
+
+#: ../fileio.c:4648
+#, c-format
+msgid "E208: Error writing to \"%s\""
+msgstr ""
+
+#: ../fileio.c:4655
+#, c-format
+msgid "E209: Error closing \"%s\""
+msgstr ""
+
+#: ../fileio.c:4657
+#, c-format
+msgid "E210: Error reading \"%s\""
+msgstr ""
+
+#: ../fileio.c:4883
+msgid "E246: FileChangedShell autocommand deleted buffer"
+msgstr ""
+
+#: ../fileio.c:4894
+#, c-format
+msgid "E211: File \"%s\" no longer available"
+msgstr ""
+
+#: ../fileio.c:4906
+#, c-format
+msgid ""
+"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
+"well"
+msgstr ""
+
+#: ../fileio.c:4907
+msgid "See \":help W12\" for more info."
+msgstr ""
+
+#: ../fileio.c:4910
+#, c-format
+msgid "W11: Warning: File \"%s\" has changed since editing started"
+msgstr ""
+
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr ""
+
+#: ../fileio.c:4914
+#, c-format
+msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
+msgstr ""
+
+#: ../fileio.c:4915
+msgid "See \":help W16\" for more info."
+msgstr ""
+
+#: ../fileio.c:4927
+#, c-format
+msgid "W13: Warning: File \"%s\" has been created after editing started"
+msgstr ""
+
+#: ../fileio.c:4947
+msgid "Warning"
+msgstr ""
+
+#: ../fileio.c:4948
+msgid ""
+"&OK\n"
+"&Load File"
+msgstr ""
+
+#: ../fileio.c:5065
+#, c-format
+msgid "E462: Could not prepare for reloading \"%s\""
+msgstr ""
+
+#: ../fileio.c:5078
+#, fuzzy, c-format
+msgid "E321: Could not reload \"%s\""
+msgstr "E255: Could not read in sign data!"
+
+#: ../fileio.c:5601
+msgid "--Deleted--"
+msgstr ""
+
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
+#. the group doesn't exist
+#: ../fileio.c:5772
+#, c-format
+msgid "E367: No such group: \"%s\""
+msgstr ""
+
+#: ../fileio.c:5897
+#, c-format
+msgid "E215: Illegal character after *: %s"
+msgstr ""
+
+#: ../fileio.c:5905
+#, c-format
+msgid "E216: No such event: %s"
+msgstr ""
+
+#: ../fileio.c:5907
+#, c-format
+msgid "E216: No such group or event: %s"
+msgstr ""
+
+#. Highlight title
+#: ../fileio.c:6090
+msgid ""
+"\n"
+"--- Auto-Commands ---"
+msgstr ""
+
+#: ../fileio.c:6293
+#, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr ""
+
+#: ../fileio.c:6370
+msgid "E217: Can't execute autocommands for ALL events"
+msgstr "E217: Cannot execute autocommands for ALL events"
+
+#: ../fileio.c:6393
+msgid "No matching autocommands"
+msgstr ""
+
+#: ../fileio.c:6831
+msgid "E218: autocommand nesting too deep"
+msgstr ""
+
+#: ../fileio.c:7143
+#, c-format
+msgid "%s Auto commands for \"%s\""
+msgstr ""
+
+#: ../fileio.c:7149
+#, c-format
+msgid "Executing %s"
+msgstr ""
+
+#: ../fileio.c:7211
+#, c-format
+msgid "autocommand %s"
+msgstr ""
+
+#: ../fileio.c:7795
+msgid "E219: Missing {."
+msgstr ""
+
+#: ../fileio.c:7797
+msgid "E220: Missing }."
+msgstr ""
+
+#: ../fold.c:93
+msgid "E490: No fold found"
+msgstr ""
+
+#: ../fold.c:544
+msgid "E350: Cannot create fold with current 'foldmethod'"
+msgstr ""
+
+#: ../fold.c:546
+msgid "E351: Cannot delete fold with current 'foldmethod'"
+msgstr ""
+
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr ""
+
+#. buffer has already been read
+#: ../getchar.c:273
+msgid "E222: Add to read buffer"
+msgstr ""
+
+#: ../getchar.c:2040
+msgid "E223: recursive mapping"
+msgstr ""
+
+#: ../getchar.c:2849
+#, c-format
+msgid "E224: global abbreviation already exists for %s"
+msgstr ""
+
+#: ../getchar.c:2852
+#, c-format
+msgid "E225: global mapping already exists for %s"
+msgstr ""
+
+#: ../getchar.c:2952
+#, c-format
+msgid "E226: abbreviation already exists for %s"
+msgstr ""
+
+#: ../getchar.c:2955
+#, c-format
+msgid "E227: mapping already exists for %s"
+msgstr ""
+
+#: ../getchar.c:3008
+msgid "No abbreviation found"
+msgstr ""
+
+#: ../getchar.c:3010
+msgid "No mapping found"
+msgstr ""
+
+#: ../getchar.c:3974
+msgid "E228: makemap: Illegal mode"
+msgstr ""
+
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr ""
+
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr ""
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr ""
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr ""
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr ""
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr ""
+
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr ""
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr ""
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr ""
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr ""
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr ""
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr ""
+
+#: ../globals.h:1009
+#, fuzzy
+msgid "E13: File exists (add ! to override)"
+msgstr "E510: Cannot make backup file (add ! to override)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr ""
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr ""
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr ""
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr ""
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr ""
+
+#: ../globals.h:1015
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr ""
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr ""
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr ""
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr ""
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr ""
+
+#: ../globals.h:1020
+msgid "E900: Invalid job id"
+msgstr ""
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
+msgstr ""
+
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
+
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr ""
+
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr ""
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr ""
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr ""
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr ""
+
+#: ../globals.h:1031
+#, fuzzy
+msgid "E23: No alternate file"
+msgstr "E482: Cannot create file %s"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr ""
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr ""
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr ""
+
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr ""
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr ""
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr ""
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr ""
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr ""
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr ""
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr ""
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr ""
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr ""
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr ""
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr ""
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr ""
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Cannot create file %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Cannot get temp file name"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Cannot open file %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Cannot read file %s"
+
+#: ../globals.h:1054
+#, fuzzy
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E506: Cannot write to backup file (add ! to override)"
+
+#: ../globals.h:1055
+msgid "E37: No write since last change"
+msgstr ""
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr ""
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr ""
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Cannot open errorfile %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr ""
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr ""
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr ""
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr ""
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr ""
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr ""
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr ""
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr ""
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr ""
+
+#: ../globals.h:1071
+#, fuzzy
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E510: Cannot make backup file (add ! to override)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E456: Cannot open file \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E738: Cannot list variables for %s"
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr ""
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr ""
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr ""
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr ""
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr ""
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr ""
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Could not read in sign data!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr ""
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr ""
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr ""
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr ""
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr ""
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr ""
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr ""
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr ""
+
+#: ../globals.h:1094
+#, fuzzy
+msgid "E79: Cannot expand wildcards"
+msgstr "--literal\t\tDo not expand wildcards"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr ""
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr ""
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr ""
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "E40: Cannot open errorfile %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr ""
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr ""
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr ""
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr ""
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr ""
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr ""
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr ""
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr ""
+
+#: ../hardcopy.c:240
+msgid "E550: Missing colon"
+msgstr ""
+
+#: ../hardcopy.c:252
+msgid "E551: Illegal component"
+msgstr ""
+
+#: ../hardcopy.c:259
+msgid "E552: digit expected"
+msgstr ""
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr ""
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr ""
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr ""
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr ""
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr ""
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr ""
+
+#: ../hardcopy.c:1365
+#, fuzzy
+msgid "E455: Error writing to PostScript output file"
+msgstr "E324: Cannot open PostScript output file"
+
+#: ../hardcopy.c:1747
+#, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E624: Cannot open file \"%s\""
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: Cannot read PostScript resource file \"%s\""
+
+#: ../hardcopy.c:1772
+#, fuzzy, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E457: Cannot read PostScript resource file \"%s\""
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, fuzzy, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr "E457: Cannot read PostScript resource file \"%s\""
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr ""
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: Cannot open PostScript output file"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: Cannot open file \"%s\""
+
+#: ../hardcopy.c:2583
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E456: Cannot find PostScript resource file \"prolog.ps\""
+
+#: ../hardcopy.c:2593
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E456: Cannot find PostScript resource file \"cidfont.ps\""
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E456: Cannot find PostScript resource file \"%s.ps\""
+
+#: ../hardcopy.c:2654
+#, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr ""
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr ""
+
+#: ../hardcopy.c:2881
+#, fuzzy
+msgid "E365: Failed to print PostScript file"
+msgstr "E324: Cannot open PostScript output file"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr ""
+
+#: ../if_cscope.c:85
+msgid "Add a new database"
+msgstr ""
+
+#: ../if_cscope.c:87
+msgid "Query for a pattern"
+msgstr ""
+
+#: ../if_cscope.c:89
+msgid "Show this message"
+msgstr ""
+
+#: ../if_cscope.c:91
+msgid "Kill a connection"
+msgstr ""
+
+#: ../if_cscope.c:93
+msgid "Reinit all connections"
+msgstr ""
+
+#: ../if_cscope.c:95
+msgid "Show connections"
+msgstr ""
+
+#: ../if_cscope.c:101
+#, c-format
+msgid "E560: Usage: cs[cope] %s"
+msgstr ""
+
+#: ../if_cscope.c:225
+msgid "This cscope command does not support splitting the window.\n"
+msgstr ""
+
+#: ../if_cscope.c:266
+msgid "E562: Usage: cstag <ident>"
+msgstr ""
+
+#: ../if_cscope.c:313
+msgid "E257: cstag: tag not found"
+msgstr ""
+
+#: ../if_cscope.c:461
+#, c-format
+msgid "E563: stat(%s) error: %d"
+msgstr ""
+
+#: ../if_cscope.c:551
+#, c-format
+msgid "E564: %s is not a directory or a valid cscope database"
+msgstr ""
+
+#: ../if_cscope.c:566
+#, c-format
+msgid "Added cscope database %s"
+msgstr ""
+
+#: ../if_cscope.c:616
+#, c-format
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr ""
+
+#: ../if_cscope.c:711
+msgid "E561: unknown cscope search type"
+msgstr ""
+
+#: ../if_cscope.c:752 ../if_cscope.c:789
+msgid "E566: Could not create cscope pipes"
+msgstr ""
+
+#: ../if_cscope.c:767
+msgid "E622: Could not fork for cscope"
+msgstr ""
+
+#: ../if_cscope.c:849
+msgid "cs_create_connection setpgid failed"
+msgstr ""
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
+msgid "cs_create_connection exec failed"
+msgstr ""
+
+#: ../if_cscope.c:863 ../if_cscope.c:902
+msgid "cs_create_connection: fdopen for to_fp failed"
+msgstr ""
+
+#: ../if_cscope.c:865 ../if_cscope.c:906
+msgid "cs_create_connection: fdopen for fr_fp failed"
+msgstr ""
+
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr ""
+
+#: ../if_cscope.c:932
+msgid "E567: no cscope connections"
+msgstr ""
+
+#: ../if_cscope.c:1009
+#, c-format
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr ""
+
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr ""
+
+#: ../if_cscope.c:1142
+msgid "cscope commands:\n"
+msgstr ""
+
+#: ../if_cscope.c:1150
+#, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
+msgstr ""
+
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
+
+#: ../if_cscope.c:1226
+msgid "E568: duplicate cscope database not added"
+msgstr ""
+
+#: ../if_cscope.c:1335
+#, c-format
+msgid "E261: cscope connection %s not found"
+msgstr ""
+
+#: ../if_cscope.c:1364
+#, c-format
+msgid "cscope connection %s closed"
+msgstr ""
+
+#. should not reach here
+#: ../if_cscope.c:1486
+msgid "E570: fatal error in cs_manage_matches"
+msgstr ""
+
+#: ../if_cscope.c:1693
+#, c-format
+msgid "Cscope tag: %s"
+msgstr ""
+
+#: ../if_cscope.c:1711
+msgid ""
+"\n"
+"   #   line"
+msgstr ""
+
+#: ../if_cscope.c:1713
+msgid "filename / context / line\n"
+msgstr ""
+
+#: ../if_cscope.c:1809
+#, fuzzy, c-format
+msgid "E609: Cscope error: %s"
+msgstr "E40: Cannot open errorfile %s"
+
+#: ../if_cscope.c:2053
+msgid "All cscope databases reset"
+msgstr ""
+
+#: ../if_cscope.c:2123
+msgid "no cscope connections\n"
+msgstr ""
+
+#: ../if_cscope.c:2126
+msgid " # pid    database name                       prepend path\n"
+msgstr ""
+
+#: ../main.c:144
+msgid "Unknown option argument"
+msgstr ""
+
+#: ../main.c:146
+msgid "Too many edit arguments"
+msgstr ""
+
+#: ../main.c:148
+msgid "Argument missing after"
+msgstr ""
+
+#: ../main.c:150
+msgid "Garbage after option argument"
+msgstr ""
+
+#: ../main.c:152
+msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
+msgstr ""
+
+#: ../main.c:154
+msgid "Invalid argument for"
+msgstr ""
+
+#: ../main.c:294
+#, c-format
+msgid "%d files to edit\n"
+msgstr ""
+
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr ""
+
+#: ../main.c:1350
+#, fuzzy
+msgid "Cannot open for reading: \""
+msgstr "E212: Cannot open file for writing"
+
+#: ../main.c:1393
+#, fuzzy
+msgid "Cannot open for script output: \""
+msgstr "E324: Cannot open PostScript output file"
+
+#: ../main.c:1622
+msgid "Vim: Warning: Output is not to a terminal\n"
+msgstr ""
+
+#: ../main.c:1624
+msgid "Vim: Warning: Input is not from a terminal\n"
+msgstr ""
+
+#. just in case..
+#: ../main.c:1891
+msgid "pre-vimrc command line"
+msgstr ""
+
+#: ../main.c:1964
+#, fuzzy, c-format
+msgid "E282: Cannot read from \"%s\""
+msgstr "E485: Cannot read file %s"
+
+#: ../main.c:2149
+msgid ""
+"\n"
+"More info with: \"vim -h\"\n"
+msgstr ""
+
+#: ../main.c:2178
+msgid "[file ..]       edit specified file(s)"
+msgstr ""
+
+#: ../main.c:2179
+msgid "-               read text from stdin"
+msgstr ""
+
+#: ../main.c:2180
+msgid "-t tag          edit file where tag is defined"
+msgstr ""
+
+#: ../main.c:2181
+msgid "-q [errorfile]  edit file with first error"
+msgstr ""
+
+#: ../main.c:2187
+msgid ""
+"\n"
+"\n"
+"usage:"
+msgstr ""
+
+#: ../main.c:2189
+msgid " vim [arguments] "
+msgstr ""
+
+#: ../main.c:2193
+msgid ""
+"\n"
+"   or:"
+msgstr ""
+
+#: ../main.c:2196
+msgid ""
+"\n"
+"\n"
+"Arguments:\n"
+msgstr ""
+
+#: ../main.c:2197
+msgid "--\t\t\tOnly file names after this"
+msgstr ""
+
+#: ../main.c:2199
+msgid "--literal\t\tDon't expand wildcards"
+msgstr "--literal\t\tDo not expand wildcards"
+
+#: ../main.c:2201
+msgid "-v\t\t\tVi mode (like \"vi\")"
+msgstr ""
+
+#: ../main.c:2202
+msgid "-e\t\t\tEx mode (like \"ex\")"
+msgstr ""
+
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
+msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
+msgstr ""
+
+#: ../main.c:2205
+msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
+msgstr ""
+
+#: ../main.c:2206
+msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
+msgstr ""
+
+#: ../main.c:2207
+msgid "-R\t\t\tReadonly mode (like \"view\")"
+msgstr ""
+
+#: ../main.c:2208
+msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
+msgstr ""
+
+#: ../main.c:2209
+msgid "-m\t\t\tModifications (writing files) not allowed"
+msgstr ""
+
+#: ../main.c:2210
+msgid "-M\t\t\tModifications in text not allowed"
+msgstr ""
+
+#: ../main.c:2211
+msgid "-b\t\t\tBinary mode"
+msgstr ""
+
+#: ../main.c:2212
+msgid "-l\t\t\tLisp mode"
+msgstr ""
+
+#: ../main.c:2213
+msgid "-C\t\t\tCompatible with Vi: 'compatible'"
+msgstr ""
+
+#: ../main.c:2214
+msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
+msgstr ""
+
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
+
+#: ../main.c:2216
+msgid "-D\t\t\tDebugging mode"
+msgstr ""
+
+#: ../main.c:2217
+msgid "-n\t\t\tNo swap file, use memory only"
+msgstr ""
+
+#: ../main.c:2218
+msgid "-r\t\t\tList swap files and exit"
+msgstr ""
+
+#: ../main.c:2219
+msgid "-r (with file name)\tRecover crashed session"
+msgstr ""
+
+#: ../main.c:2220
+msgid "-L\t\t\tSame as -r"
+msgstr ""
+
+#: ../main.c:2221
+msgid "-A\t\t\tstart in Arabic mode"
+msgstr ""
+
+#: ../main.c:2222
+msgid "-H\t\t\tStart in Hebrew mode"
+msgstr ""
+
+#: ../main.c:2223
+msgid "-F\t\t\tStart in Farsi mode"
+msgstr ""
+
+#: ../main.c:2224
+msgid "-T <terminal>\tSet terminal type to <terminal>"
+msgstr ""
+
+#: ../main.c:2225
+msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
+msgstr ""
+
+#: ../main.c:2226
+msgid "--noplugin\t\tDon't load plugin scripts"
+msgstr "--noplugin\t\tDo not load plugin scripts"
+
+#: ../main.c:2227
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr ""
+
+#: ../main.c:2228
+msgid "-o[N]\t\tOpen N windows (default: one for each file)"
+msgstr ""
+
+#: ../main.c:2229
+msgid "-O[N]\t\tLike -o but split vertically"
+msgstr ""
+
+#: ../main.c:2230
+msgid "+\t\t\tStart at end of file"
+msgstr ""
+
+#: ../main.c:2231
+msgid "+<lnum>\t\tStart at line <lnum>"
+msgstr ""
+
+#: ../main.c:2232
+msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
+msgstr ""
+
+#: ../main.c:2233
+msgid "-c <command>\t\tExecute <command> after loading the first file"
+msgstr ""
+
+#: ../main.c:2235
+msgid "-S <session>\t\tSource file <session> after loading the first file"
+msgstr ""
+
+#: ../main.c:2236
+msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
+msgstr ""
+
+#: ../main.c:2237
+msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
+msgstr ""
+
+#: ../main.c:2238
+msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
+msgstr ""
+
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
+
+#: ../main.c:2242
+msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
+msgstr ""
+
+#: ../main.c:2243
+msgid "-h  or  --help\tPrint Help (this message) and exit"
+msgstr ""
+
+#: ../main.c:2244
+msgid "--version\t\tPrint version information and exit"
+msgstr ""
+
+#: ../mark.c:676
+msgid "No marks set"
+msgstr ""
+
+#: ../mark.c:678
+#, c-format
+msgid "E283: No marks matching \"%s\""
+msgstr ""
+
+#. Highlight title
+#: ../mark.c:687
+msgid ""
+"\n"
+"mark line  col file/text"
+msgstr ""
+
+#. Highlight title
+#: ../mark.c:789
+msgid ""
+"\n"
+" jump line  col file/text"
+msgstr ""
+
+#. Highlight title
+#: ../mark.c:831
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
+
+#: ../mark.c:1238
+msgid ""
+"\n"
+"# File marks:\n"
+msgstr ""
+
+#. Write the jumplist with -'
+#: ../mark.c:1271
+msgid ""
+"\n"
+"# Jumplist (newest first):\n"
+msgstr ""
+
+#: ../mark.c:1352
+msgid ""
+"\n"
+"# History of marks within files (newest to oldest):\n"
+msgstr ""
+
+#: ../mark.c:1431
+msgid "Missing '>'"
+msgstr ""
+
+#: ../memfile.c:426
+msgid "E293: block was not locked"
+msgstr ""
+
+#: ../memfile.c:799
+msgid "E294: Seek error in swap file read"
+msgstr ""
+
+#: ../memfile.c:803
+msgid "E295: Read error in swap file"
+msgstr ""
+
+#: ../memfile.c:849
+msgid "E296: Seek error in swap file write"
+msgstr ""
+
+#: ../memfile.c:865
+msgid "E297: Write error in swap file"
+msgstr ""
+
+#: ../memfile.c:1036
+msgid "E300: Swap file already exists (symlink attack?)"
+msgstr ""
+
+#: ../memline.c:318
+msgid "E298: Didn't get block nr 0?"
+msgstr "E298: Did not get block nr 0?"
+
+#: ../memline.c:361
+msgid "E298: Didn't get block nr 1?"
+msgstr "E298: Did not get block nr 1?"
+
+#: ../memline.c:377
+msgid "E298: Didn't get block nr 2?"
+msgstr "E298: Did not get block nr 2?"
+
+#. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
+msgid "E301: Oops, lost the swap file!!!"
+msgstr ""
+
+#: ../memline.c:477
+msgid "E302: Could not rename swap file"
+msgstr ""
+
+#: ../memline.c:554
+#, c-format
+msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
+msgstr ""
+
+#: ../memline.c:666
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
+msgstr "E304: ml_upd_block0(): Did not get block 0??"
+
+#. no swap files found
+#: ../memline.c:830
+#, c-format
+msgid "E305: No swap file found for %s"
+msgstr ""
+
+#: ../memline.c:839
+msgid "Enter number of swap file to use (0 to quit): "
+msgstr ""
+
+#: ../memline.c:879
+#, fuzzy, c-format
+msgid "E306: Cannot open %s"
+msgstr "E456: Cannot open file \"%s\""
+
+#: ../memline.c:897
+msgid "Unable to read block 0 from "
+msgstr ""
+
+#: ../memline.c:900
+msgid ""
+"\n"
+"Maybe no changes were made or Vim did not update the swap file."
+msgstr ""
+
+#: ../memline.c:909
+msgid " cannot be used with this version of Vim.\n"
+msgstr ""
+
+#: ../memline.c:911
+msgid "Use Vim version 3.0.\n"
+msgstr ""
+
+#: ../memline.c:916
+#, c-format
+msgid "E307: %s does not look like a Vim swap file"
+msgstr ""
+
+#: ../memline.c:922
+msgid " cannot be used on this computer.\n"
+msgstr ""
+
+#: ../memline.c:924
+msgid "The file was created on "
+msgstr ""
+
+#: ../memline.c:928
+msgid ""
+",\n"
+"or the file has been damaged."
+msgstr ""
+
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
+#, c-format
+msgid "Using swap file \"%s\""
+msgstr ""
+
+#: ../memline.c:980
+#, c-format
+msgid "Original file \"%s\""
+msgstr ""
+
+#: ../memline.c:995
+msgid "E308: Warning: Original file may have been changed"
+msgstr ""
+
+#: ../memline.c:1061
+#, c-format
+msgid "E309: Unable to read block 1 from %s"
+msgstr ""
+
+#: ../memline.c:1065
+msgid "???MANY LINES MISSING"
+msgstr ""
+
+#: ../memline.c:1076
+msgid "???LINE COUNT WRONG"
+msgstr ""
+
+#: ../memline.c:1082
+msgid "???EMPTY BLOCK"
+msgstr ""
+
+#: ../memline.c:1103
+msgid "???LINES MISSING"
+msgstr ""
+
+#: ../memline.c:1128
+#, c-format
+msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
+msgstr ""
+
+#: ../memline.c:1133
+msgid "???BLOCK MISSING"
+msgstr ""
+
+#: ../memline.c:1147
+msgid "??? from here until ???END lines may be messed up"
+msgstr ""
+
+#: ../memline.c:1164
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr ""
+
+#: ../memline.c:1181
+msgid "???END"
+msgstr ""
+
+#: ../memline.c:1238
+msgid "E311: Recovery Interrupted"
+msgstr ""
+
+#: ../memline.c:1243
+msgid ""
+"E312: Errors detected while recovering; look for lines starting with ???"
+msgstr ""
+
+#: ../memline.c:1245
+msgid "See \":help E312\" for more information."
+msgstr ""
+
+#: ../memline.c:1249
+msgid "Recovery completed. You should check if everything is OK."
+msgstr ""
+
+#: ../memline.c:1251
+msgid ""
+"\n"
+"(You might want to write out this file under another name\n"
+msgstr ""
+
+#: ../memline.c:1252
+msgid "and run diff with the original file to check for changes)"
+msgstr ""
+
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+msgid ""
+"\n"
+"You may want to delete the .swp file now.\n"
+"\n"
+msgstr ""
+
+#. use msg() to start the scrolling properly
+#: ../memline.c:1327
+msgid "Swap files found:"
+msgstr ""
+
+#: ../memline.c:1446
+msgid "   In current directory:\n"
+msgstr ""
+
+#: ../memline.c:1448
+msgid "   Using specified name:\n"
+msgstr ""
+
+#: ../memline.c:1450
+msgid "   In directory "
+msgstr ""
+
+#: ../memline.c:1465
+msgid "      -- none --\n"
+msgstr ""
+
+#: ../memline.c:1527
+msgid "          owned by: "
+msgstr ""
+
+#: ../memline.c:1529
+msgid "   dated: "
+msgstr ""
+
+#: ../memline.c:1532 ../memline.c:3231
+msgid "             dated: "
+msgstr ""
+
+#: ../memline.c:1548
+msgid "         [from Vim version 3.0]"
+msgstr ""
+
+#: ../memline.c:1550
+msgid "         [does not look like a Vim swap file]"
+msgstr ""
+
+#: ../memline.c:1552
+msgid "         file name: "
+msgstr ""
+
+#: ../memline.c:1558
+msgid ""
+"\n"
+"          modified: "
+msgstr ""
+
+#: ../memline.c:1559
+msgid "YES"
+msgstr ""
+
+#: ../memline.c:1559
+msgid "no"
+msgstr ""
+
+#: ../memline.c:1562
+msgid ""
+"\n"
+"         user name: "
+msgstr ""
+
+#: ../memline.c:1568
+msgid "   host name: "
+msgstr ""
+
+#: ../memline.c:1570
+msgid ""
+"\n"
+"         host name: "
+msgstr ""
+
+#: ../memline.c:1575
+msgid ""
+"\n"
+"        process ID: "
+msgstr ""
+
+#: ../memline.c:1579
+msgid " (still running)"
+msgstr ""
+
+#: ../memline.c:1586
+msgid ""
+"\n"
+"         [not usable on this computer]"
+msgstr ""
+
+#: ../memline.c:1590
+msgid "         [cannot be read]"
+msgstr ""
+
+#: ../memline.c:1593
+msgid "         [cannot be opened]"
+msgstr ""
+
+#: ../memline.c:1698
+msgid "E313: Cannot preserve, there is no swap file"
+msgstr ""
+
+#: ../memline.c:1747
+msgid "File preserved"
+msgstr ""
+
+#: ../memline.c:1749
+msgid "E314: Preserve failed"
+msgstr ""
+
+#: ../memline.c:1819
+#, c-format
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr ""
+
+#: ../memline.c:1851
+#, c-format
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr ""
+
+#: ../memline.c:2236
+msgid "E317: pointer block id wrong 3"
+msgstr ""
+
+#: ../memline.c:2311
+msgid "stack_idx should be 0"
+msgstr ""
+
+#: ../memline.c:2369
+msgid "E318: Updated too many blocks?"
+msgstr ""
+
+#: ../memline.c:2511
+msgid "E317: pointer block id wrong 4"
+msgstr ""
+
+#: ../memline.c:2536
+msgid "deleted block 1?"
+msgstr ""
+
+#: ../memline.c:2707
+#, c-format
+msgid "E320: Cannot find line %<PRId64>"
+msgstr ""
+
+#: ../memline.c:2916
+msgid "E317: pointer block id wrong"
+msgstr ""
+
+#: ../memline.c:2930
+msgid "pe_line_count is zero"
+msgstr ""
+
+#: ../memline.c:2955
+#, c-format
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr ""
+
+#: ../memline.c:2959
+#, c-format
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr ""
+
+#: ../memline.c:2999
+msgid "Stack size increases"
+msgstr ""
+
+#: ../memline.c:3038
+msgid "E317: pointer block id wrong 2"
+msgstr ""
+
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
+msgid "E325: ATTENTION"
+msgstr ""
+
+#: ../memline.c:3222
+msgid ""
+"\n"
+"Found a swap file by the name \""
+msgstr ""
+
+#: ../memline.c:3226
+msgid "While opening file \""
+msgstr ""
+
+#: ../memline.c:3239
+msgid "      NEWER than swap file!\n"
+msgstr ""
+
+#: ../memline.c:3244
+msgid ""
+"\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
+msgstr ""
+
+#: ../memline.c:3245
+msgid "  Quit, or continue with caution.\n"
+msgstr ""
+
+#: ../memline.c:3246
+msgid "(2) An edit session for this file crashed.\n"
+msgstr ""
+
+#: ../memline.c:3247
+msgid "    If this is the case, use \":recover\" or \"vim -r "
+msgstr ""
+
+#: ../memline.c:3249
+msgid ""
+"\"\n"
+"    to recover the changes (see \":help recovery\").\n"
+msgstr ""
+
+#: ../memline.c:3250
+msgid "    If you did this already, delete the swap file \""
+msgstr ""
+
+#: ../memline.c:3252
+msgid ""
+"\"\n"
+"    to avoid this message.\n"
+msgstr ""
+
+#: ../memline.c:3450 ../memline.c:3452
+msgid "Swap file \""
+msgstr ""
+
+#: ../memline.c:3451 ../memline.c:3455
+msgid "\" already exists!"
+msgstr ""
+
+#: ../memline.c:3457
+msgid "VIM - ATTENTION"
+msgstr ""
+
+#: ../memline.c:3459
+msgid "Swap file already exists!"
+msgstr ""
+
+#: ../memline.c:3464
+msgid ""
+"&Open Read-Only\n"
+"&Edit anyway\n"
+"&Recover\n"
+"&Quit\n"
+"&Abort"
+msgstr ""
+
+#: ../memline.c:3467
+msgid ""
+"&Open Read-Only\n"
+"&Edit anyway\n"
+"&Recover\n"
+"&Delete it\n"
+"&Quit\n"
+"&Abort"
+msgstr ""
+
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
+msgid "E326: Too many swap files found"
+msgstr ""
+
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr ""
+
+#: ../menu.c:62
+msgid "E327: Part of menu-item path is not sub-menu"
+msgstr ""
+
+#: ../menu.c:63
+msgid "E328: Menu only exists in another mode"
+msgstr ""
+
+#: ../menu.c:64
+#, c-format
+msgid "E329: No menu \"%s\""
+msgstr ""
+
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
+msgid "E330: Menu path must not lead to a sub-menu"
+msgstr ""
+
+#: ../menu.c:365
+msgid "E331: Must not add menu items directly to menu bar"
+msgstr ""
+
+#: ../menu.c:370
+msgid "E332: Separator cannot be part of a menu path"
+msgstr ""
+
+#. Now we have found the matching menu, and we list the mappings
+#. Highlight title
+#: ../menu.c:762
+msgid ""
+"\n"
+"--- Menus ---"
+msgstr ""
+
+#: ../menu.c:1313
+msgid "E333: Menu path must lead to a menu item"
+msgstr ""
+
+#: ../menu.c:1330
+#, c-format
+msgid "E334: Menu not found: %s"
+msgstr ""
+
+#: ../menu.c:1396
+#, c-format
+msgid "E335: Menu not defined for %s mode"
+msgstr ""
+
+#: ../menu.c:1426
+msgid "E336: Menu path must lead to a sub-menu"
+msgstr ""
+
+#: ../menu.c:1447
+msgid "E337: Menu not found - check menu names"
+msgstr ""
+
+#: ../message.c:423
+#, c-format
+msgid "Error detected while processing %s:"
+msgstr ""
+
+#: ../message.c:445
+#, c-format
+msgid "line %4ld:"
+msgstr ""
+
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr ""
+
+#: ../message.c:745
+msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
+msgstr "Messages maintainer: Mike Williams <mrw@eandem.co.uk>"
+
+#: ../message.c:986
+msgid "Interrupt: "
+msgstr ""
+
+#: ../message.c:988
+msgid "Press ENTER or type command to continue"
+msgstr ""
+
+#: ../message.c:1843
+#, c-format
+msgid "%s line %<PRId64>"
+msgstr ""
+
+#: ../message.c:2392
+msgid "-- More --"
+msgstr ""
+
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
+
+#: ../message.c:3021 ../message.c:3031
+msgid "Question"
+msgstr ""
+
+#: ../message.c:3023
+msgid ""
+"&Yes\n"
+"&No"
+msgstr ""
+
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+
+#: ../message.c:3045
+msgid ""
+"&Yes\n"
+"&No\n"
+"Save &All\n"
+"&Discard All\n"
+"&Cancel"
+msgstr ""
+
+#: ../message.c:3058
+msgid "E766: Insufficient arguments for printf()"
+msgstr ""
+
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
+
+#: ../message.c:3873
+msgid "E767: Too many arguments to printf()"
+msgstr ""
+
+#: ../misc1.c:2256
+msgid "W10: Warning: Changing a readonly file"
+msgstr ""
+
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
+msgid "1 more line"
+msgstr ""
+
+#: ../misc1.c:2588
+msgid "1 line less"
+msgstr ""
+
+#: ../misc1.c:2593
+#, c-format
+msgid "%<PRId64> more lines"
+msgstr ""
+
+#: ../misc1.c:2596
+#, c-format
+msgid "%<PRId64> fewer lines"
+msgstr ""
+
+#: ../misc1.c:2599
+msgid " (Interrupted)"
+msgstr ""
+
+#: ../misc1.c:2635
+msgid "Beep!"
+msgstr ""
+
+#: ../misc2.c:738
+#, c-format
+msgid "Calling shell to execute: \"%s\""
+msgstr ""
+
+#: ../normal.c:183
+msgid "E349: No identifier under cursor"
+msgstr ""
+
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr ""
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr ""
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr ""
+
+#: ../normal.c:3937
+msgid "E352: Cannot erase folds with current 'foldmethod'"
+msgstr ""
+
+#: ../normal.c:5897
+msgid "E664: changelist is empty"
+msgstr ""
+
+#: ../normal.c:5899
+msgid "E662: At start of changelist"
+msgstr ""
+
+#: ../normal.c:5901
+msgid "E663: At end of changelist"
+msgstr ""
+
+#: ../normal.c:7053
+msgid "Type  :quit<Enter>  to exit Vim"
+msgstr ""
+
+#: ../ops.c:248
+#, c-format
+msgid "1 line %sed 1 time"
+msgstr ""
+
+#: ../ops.c:250
+#, c-format
+msgid "1 line %sed %d times"
+msgstr ""
+
+#: ../ops.c:253
+#, c-format
+msgid "%<PRId64> lines %sed 1 time"
+msgstr ""
+
+#: ../ops.c:256
+#, c-format
+msgid "%<PRId64> lines %sed %d times"
+msgstr ""
+
+#: ../ops.c:592
+#, c-format
+msgid "%<PRId64> lines to indent... "
+msgstr ""
+
+#: ../ops.c:634
+msgid "1 line indented "
+msgstr ""
+
+#: ../ops.c:636
+#, c-format
+msgid "%<PRId64> lines indented "
+msgstr ""
+
+#: ../ops.c:938
+msgid "E748: No previously used register"
+msgstr ""
+
+#. must display the prompt
+#: ../ops.c:1433
+msgid "cannot yank; delete anyway"
+msgstr ""
+
+#: ../ops.c:1929
+msgid "1 line changed"
+msgstr ""
+
+#: ../ops.c:1931
+#, c-format
+msgid "%<PRId64> lines changed"
+msgstr ""
+
+#: ../ops.c:2521
+msgid "block of 1 line yanked"
+msgstr ""
+
+#: ../ops.c:2523
+msgid "1 line yanked"
+msgstr ""
+
+#: ../ops.c:2525
+#, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr ""
+
+#: ../ops.c:2528
+#, c-format
+msgid "%<PRId64> lines yanked"
+msgstr ""
+
+#: ../ops.c:2710
+#, fuzzy, c-format
+msgid "E353: Nothing in register %s"
+msgstr "E394: Did not find region item for %s"
+
+#. Highlight title
+#: ../ops.c:3185
+msgid ""
+"\n"
+"--- Registers ---"
+msgstr ""
+
+#: ../ops.c:4455
+msgid "Illegal register name"
+msgstr ""
+
+#: ../ops.c:4533
+msgid ""
+"\n"
+"# Registers:\n"
+msgstr ""
+
+#: ../ops.c:4575
+#, c-format
+msgid "E574: Unknown register type %d"
+msgstr ""
+
+#: ../ops.c:5089
+#, c-format
+msgid "%<PRId64> Cols; "
+msgstr ""
+
+#: ../ops.c:5097
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+
+#: ../ops.c:5105
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+
+#: ../ops.c:5146
+#, c-format
+msgid "(+%<PRId64> for BOM)"
+msgstr ""
+
+#: ../option.c:1238
+msgid "%<%f%h%m%=Page %N"
+msgstr ""
+
+#: ../option.c:1574
+msgid "Thanks for flying Vim"
+msgstr ""
+
+#. found a mismatch: skip
+#: ../option.c:2698
+msgid "E518: Unknown option"
+msgstr ""
+
+#: ../option.c:2709
+msgid "E519: Option not supported"
+msgstr ""
+
+#: ../option.c:2740
+msgid "E520: Not allowed in a modeline"
+msgstr ""
+
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
+msgid "E521: Number required after ="
+msgstr ""
+
+#: ../option.c:3226 ../option.c:3864
+msgid "E522: Not found in termcap"
+msgstr ""
+
+#: ../option.c:3335
+#, c-format
+msgid "E539: Illegal character <%s>"
+msgstr ""
+
+#: ../option.c:3862
+msgid "E529: Cannot set 'term' to empty string"
+msgstr ""
+
+#: ../option.c:3885
+msgid "E589: 'backupext' and 'patchmode' are equal"
+msgstr ""
+
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
+
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
+msgid "E524: Missing colon"
+msgstr ""
+
+#: ../option.c:4165
+msgid "E525: Zero length string"
+msgstr ""
+
+#: ../option.c:4220
+#, c-format
+msgid "E526: Missing number after <%s>"
+msgstr ""
+
+#: ../option.c:4232
+msgid "E527: Missing comma"
+msgstr ""
+
+#: ../option.c:4239
+msgid "E528: Must specify a ' value"
+msgstr ""
+
+#: ../option.c:4271
+msgid "E595: contains unprintable or wide character"
+msgstr ""
+
+#: ../option.c:4469
+#, c-format
+msgid "E535: Illegal character after <%c>"
+msgstr ""
+
+#: ../option.c:4534
+msgid "E536: comma required"
+msgstr ""
+
+#: ../option.c:4543
+#, c-format
+msgid "E537: 'commentstring' must be empty or contain %s"
+msgstr ""
+
+#: ../option.c:4928
+msgid "E540: Unclosed expression sequence"
+msgstr ""
+
+#: ../option.c:4932
+msgid "E541: too many items"
+msgstr ""
+
+#: ../option.c:4934
+msgid "E542: unbalanced groups"
+msgstr ""
+
+#: ../option.c:5148
+msgid "E590: A preview window already exists"
+msgstr ""
+
+#: ../option.c:5311
+msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
+msgstr ""
+
+#: ../option.c:5623
+#, c-format
+msgid "E593: Need at least %d lines"
+msgstr ""
+
+#: ../option.c:5631
+#, c-format
+msgid "E594: Need at least %d columns"
+msgstr ""
+
+#: ../option.c:6011
+#, c-format
+msgid "E355: Unknown option: %s"
+msgstr ""
+
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr ""
+
+#: ../option.c:6149
+msgid ""
+"\n"
+"--- Terminal codes ---"
+msgstr ""
+
+#: ../option.c:6151
+msgid ""
+"\n"
+"--- Global option values ---"
+msgstr ""
+
+#: ../option.c:6153
+msgid ""
+"\n"
+"--- Local option values ---"
+msgstr ""
+
+#: ../option.c:6155
+msgid ""
+"\n"
+"--- Options ---"
+msgstr ""
+
+#: ../option.c:6816
+msgid "E356: get_varp ERROR"
+msgstr ""
+
+#: ../option.c:7696
+#, c-format
+msgid "E357: 'langmap': Matching character missing for %s"
+msgstr ""
+
+#: ../option.c:7715
+#, c-format
+msgid "E358: 'langmap': Extra characters after semicolon: %s"
+msgstr ""
+
+#: ../os/shell.c:194
+msgid ""
+"\n"
+"Cannot execute shell "
+msgstr ""
+
+#: ../os/shell.c:439
+msgid ""
+"\n"
+"shell returned "
+msgstr ""
+
+#: ../os_unix.c:465 ../os_unix.c:471
+msgid ""
+"\n"
+"Could not get security context for "
+msgstr ""
+
+#: ../os_unix.c:479
+msgid ""
+"\n"
+"Could not set security context for "
+msgstr ""
+
+#: ../os_unix.c:1558 ../os_unix.c:1647
+#, c-format
+msgid "dlerror = \"%s\""
+msgstr ""
+
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Cannot find file \"%s\" in path"
+
+#: ../quickfix.c:359
+#, c-format
+msgid "E372: Too many %%%c in format string"
+msgstr ""
+
+#: ../quickfix.c:371
+#, c-format
+msgid "E373: Unexpected %%%c in format string"
+msgstr ""
+
+#: ../quickfix.c:420
+msgid "E374: Missing ] in format string"
+msgstr ""
+
+#: ../quickfix.c:431
+#, c-format
+msgid "E375: Unsupported %%%c in format string"
+msgstr ""
+
+#: ../quickfix.c:448
+#, c-format
+msgid "E376: Invalid %%%c in format string prefix"
+msgstr ""
+
+#: ../quickfix.c:454
+#, c-format
+msgid "E377: Invalid %%%c in format string"
+msgstr ""
+
+#. nothing found
+#: ../quickfix.c:477
+msgid "E378: 'errorformat' contains no pattern"
+msgstr ""
+
+#: ../quickfix.c:695
+msgid "E379: Missing or empty directory name"
+msgstr ""
+
+#: ../quickfix.c:1305
+msgid "E553: No more items"
+msgstr ""
+
+#: ../quickfix.c:1674
+#, c-format
+msgid "(%d of %d)%s%s: "
+msgstr ""
+
+#: ../quickfix.c:1676
+msgid " (line deleted)"
+msgstr ""
+
+#: ../quickfix.c:1863
+msgid "E380: At bottom of quickfix stack"
+msgstr ""
+
+#: ../quickfix.c:1869
+msgid "E381: At top of quickfix stack"
+msgstr ""
+
+#: ../quickfix.c:1880
+#, c-format
+msgid "error list %d of %d; %d errors"
+msgstr ""
+
+#: ../quickfix.c:2427
+msgid "E382: Cannot write, 'buftype' option is set"
+msgstr ""
+
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "E624: Cannot open file \"%s\""
+
+#: ../quickfix.c:3429
+msgid "E681: Buffer is not loaded"
+msgstr ""
+
+#: ../quickfix.c:3487
+msgid "E777: String or List expected"
+msgstr ""
+
+#: ../regexp.c:359
+#, c-format
+msgid "E369: invalid item in %s%%[]"
+msgstr ""
+
+#: ../regexp.c:374
+#, c-format
+msgid "E769: Missing ] after %s["
+msgstr ""
+
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr ""
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr ""
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr ""
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr ""
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr ""
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr ""
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr ""
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr ""
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr ""
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr ""
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr ""
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr ""
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr ""
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr ""
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr ""
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr ""
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr ""
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr ""
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr ""
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr ""
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr ""
+
+#: ../regexp.c:3017
+#, c-format
+msgid "E554: Syntax error in %s{...}"
+msgstr ""
+
+#: ../regexp.c:3805
+msgid "External submatches:\n"
+msgstr ""
+
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr ""
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Cannot find temp file for writing"
+
+#: ../screen.c:7435
+msgid " VREPLACE"
+msgstr ""
+
+#: ../screen.c:7437
+msgid " REPLACE"
+msgstr ""
+
+#: ../screen.c:7440
+msgid " REVERSE"
+msgstr ""
+
+#: ../screen.c:7441
+msgid " INSERT"
+msgstr ""
+
+#: ../screen.c:7443
+msgid " (insert)"
+msgstr ""
+
+#: ../screen.c:7445
+msgid " (replace)"
+msgstr ""
+
+#: ../screen.c:7447
+msgid " (vreplace)"
+msgstr ""
+
+#: ../screen.c:7449
+msgid " Hebrew"
+msgstr ""
+
+#: ../screen.c:7454
+msgid " Arabic"
+msgstr ""
+
+#: ../screen.c:7456
+msgid " (lang)"
+msgstr ""
+
+#: ../screen.c:7459
+msgid " (paste)"
+msgstr ""
+
+#: ../screen.c:7469
+msgid " VISUAL"
+msgstr ""
+
+#: ../screen.c:7470
+msgid " VISUAL LINE"
+msgstr ""
+
+#: ../screen.c:7471
+msgid " VISUAL BLOCK"
+msgstr ""
+
+#: ../screen.c:7472
+msgid " SELECT"
+msgstr ""
+
+#: ../screen.c:7473
+msgid " SELECT LINE"
+msgstr ""
+
+#: ../screen.c:7474
+msgid " SELECT BLOCK"
+msgstr ""
+
+#: ../screen.c:7486 ../screen.c:7541
+msgid "recording"
+msgstr ""
+
+#: ../search.c:487
+#, c-format
+msgid "E383: Invalid search string: %s"
+msgstr ""
+
+#: ../search.c:832
+#, c-format
+msgid "E384: search hit TOP without match for: %s"
+msgstr ""
+
+#: ../search.c:835
+#, c-format
+msgid "E385: search hit BOTTOM without match for: %s"
+msgstr ""
+
+#: ../search.c:1200
+msgid "E386: Expected '?' or '/'  after ';'"
+msgstr ""
+
+#: ../search.c:4085
+msgid " (includes previously listed match)"
+msgstr ""
+
+#. cursor at status line
+#: ../search.c:4104
+msgid "--- Included files "
+msgstr ""
+
+#: ../search.c:4106
+msgid "not found "
+msgstr ""
+
+#: ../search.c:4107
+msgid "in path ---\n"
+msgstr ""
+
+#: ../search.c:4168
+msgid "  (Already listed)"
+msgstr ""
+
+#: ../search.c:4170
+msgid "  NOT FOUND"
+msgstr ""
+
+#: ../search.c:4211
+#, c-format
+msgid "Scanning included file: %s"
+msgstr ""
+
+#: ../search.c:4216
+#, c-format
+msgid "Searching included file %s"
+msgstr ""
+
+#: ../search.c:4405
+msgid "E387: Match is on current line"
+msgstr ""
+
+#: ../search.c:4517
+msgid "All included files were found"
+msgstr ""
+
+#: ../search.c:4519
+msgid "No included files"
+msgstr ""
+
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Could not find definition"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Could not find pattern"
 
+#: ../search.c:4668
+msgid "Substitute "
+msgstr ""
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+msgid "E759: Format error in spell file"
+msgstr ""
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, fuzzy, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:954
+#, fuzzy, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:955
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr ""
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "E624: Cannot open file \"%s\""
+
+#: ../spell.c:2496
+msgid "E757: This does not look like a spell file"
+msgstr ""
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+msgid "E770: Unsupported section in spell file"
+msgstr ""
+
+#: ../spell.c:3762
+#, c-format
+msgid "Warning: region %s not supported"
+msgstr ""
+
+#: ../spell.c:4550
+#, c-format
+msgid "Reading affix file %s ..."
+msgstr ""
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, fuzzy, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, fuzzy, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:4655
+#, fuzzy, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "Unrecognised or duplicate item in %s line %d: %s"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, fuzzy, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:4968
+#, fuzzy, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Unrecognised or duplicate item in %s line %d: %s"
 
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+msgid "Too many postponed prefixes"
+msgstr ""
+
+#: ../spell.c:5238
+msgid "Too many compound flags"
+msgstr ""
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, fuzzy, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr "Unrecognised or duplicate item in %s line %d: %s"
+
+#: ../spell.c:5334
+#, fuzzy, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, c-format
+msgid "Reading dictionary file %s ..."
+msgstr ""
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "Unrecognised or duplicate item in %s line %d: %s"
+
+#: ../spell.c:5694
+#, fuzzy, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr "Unrecognised or duplicate item in %s line %d: %s"
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, c-format
+msgid "Reading word file %s ..."
+msgstr ""
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, fuzzy, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr "Unrecognised or duplicate item in %s line %d: %s"
+
+#: ../spell.c:6180
+#, fuzzy, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr "Unrecognised or duplicate item in %s line %d: %s"
+
+#: ../spell.c:6185
+#, fuzzy, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:6198
+#, fuzzy, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "Unrecognised flags in %s line %d: %s"
+
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Unrecognised flags in %s line %d: %s"
 
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, c-format
+msgid "Writing suggestion file %s ..."
+msgstr ""
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr ""
+
+#: ../spell.c:7846
+#, c-format
+msgid "E755: Invalid region in %s"
+msgstr ""
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, c-format
+msgid "Writing spell file %s ..."
+msgstr ""
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr ""
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, c-format
+msgid "Change \"%.*s\" to:"
+msgstr ""
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+msgid "E752: No previous spell replacement"
+msgstr ""
+
+#: ../spell.c:8925
+#, c-format
+msgid "E753: Not found: %s"
+msgstr ""
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E781: .sug file does not match .spl file: %s"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug file does not match .spl file: %s"
 
+#: ../spell.c:9305
+#, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr ""
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr ""
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
+#, c-format
+msgid "E390: Illegal argument: %s"
+msgstr ""
+
+#: ../syntax.c:3299
+#, c-format
+msgid "E391: No such syntax cluster: %s"
+msgstr ""
+
+#: ../syntax.c:3433
+msgid "syncing on C-style comments"
+msgstr ""
+
+#: ../syntax.c:3439
+msgid "no syncing"
+msgstr ""
+
+#: ../syntax.c:3441
+msgid "syncing starts "
+msgstr ""
+
+#: ../syntax.c:3443 ../syntax.c:3506
+msgid " lines before top line"
+msgstr ""
+
+#: ../syntax.c:3448
+msgid ""
+"\n"
+"--- Syntax sync items ---"
+msgstr ""
+
+#: ../syntax.c:3452
+msgid ""
+"\n"
+"syncing on items"
+msgstr ""
+
+#: ../syntax.c:3457
+msgid ""
+"\n"
+"--- Syntax items ---"
+msgstr ""
+
+#: ../syntax.c:3475
+#, c-format
+msgid "E392: No such syntax cluster: %s"
+msgstr ""
+
+#: ../syntax.c:3497
+msgid "minimal "
+msgstr ""
+
+#: ../syntax.c:3503
+msgid "maximal "
+msgstr ""
+
+#: ../syntax.c:3513
+msgid "; match "
+msgstr ""
+
+#: ../syntax.c:3515
+msgid " line breaks"
+msgstr ""
+
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr ""
+
+#: ../syntax.c:4096
+msgid "E844: invalid cchar value"
+msgstr ""
+
+#: ../syntax.c:4107
+msgid "E393: group[t]here not accepted here"
+msgstr ""
+
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Did not find region item for %s"
 
+#: ../syntax.c:4188
+msgid "E397: Filename required"
+msgstr ""
+
+#: ../syntax.c:4221
+msgid "E847: Too many syntax includes"
+msgstr ""
+
+#: ../syntax.c:4303
+#, c-format
+msgid "E789: Missing ']': %s"
+msgstr ""
+
+#: ../syntax.c:4531
+#, c-format
+msgid "E398: Missing '=': %s"
+msgstr ""
+
+#: ../syntax.c:4666
+#, c-format
+msgid "E399: Not enough arguments: syntax region %s"
+msgstr ""
+
+#: ../syntax.c:4870
+msgid "E848: Too many syntax clusters"
+msgstr ""
+
+#: ../syntax.c:4954
+msgid "E400: No cluster specified"
+msgstr ""
+
+#. end delimiter not found
+#: ../syntax.c:4986
+#, c-format
+msgid "E401: Pattern delimiter not found: %s"
+msgstr ""
+
+#: ../syntax.c:5049
+#, c-format
+msgid "E402: Garbage after pattern: %s"
+msgstr ""
+
+#: ../syntax.c:5120
+msgid "E403: syntax sync: line continuations pattern specified twice"
+msgstr ""
+
+#: ../syntax.c:5169
+#, c-format
+msgid "E404: Illegal arguments: %s"
+msgstr ""
+
+#: ../syntax.c:5217
+#, c-format
+msgid "E405: Missing equal sign: %s"
+msgstr ""
+
+#: ../syntax.c:5222
+#, c-format
+msgid "E406: Empty argument: %s"
+msgstr ""
+
+#: ../syntax.c:5240
+#, c-format
+msgid "E407: %s not allowed here"
+msgstr ""
+
+#: ../syntax.c:5246
+#, c-format
+msgid "E408: %s must be first in contains list"
+msgstr ""
+
+#: ../syntax.c:5304
+#, c-format
+msgid "E409: Unknown group name: %s"
+msgstr ""
+
+#: ../syntax.c:5512
+#, c-format
+msgid "E410: Invalid :syntax subcommand: %s"
+msgstr ""
+
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
+#, c-format
+msgid "E411: highlight group not found: %s"
+msgstr ""
+
+#: ../syntax.c:6278
+#, c-format
+msgid "E412: Not enough arguments: \":highlight link %s\""
+msgstr ""
+
+#: ../syntax.c:6284
+#, c-format
+msgid "E413: Too many arguments: \":highlight link %s\""
+msgstr ""
+
+#: ../syntax.c:6302
+msgid "E414: group has settings, highlight link ignored"
+msgstr ""
+
+#: ../syntax.c:6367
+#, c-format
+msgid "E415: unexpected equal sign: %s"
+msgstr ""
+
+#: ../syntax.c:6395
+#, c-format
+msgid "E416: missing equal sign: %s"
+msgstr ""
+
+#: ../syntax.c:6418
+#, c-format
+msgid "E417: missing argument: %s"
+msgstr ""
+
+#: ../syntax.c:6446
+#, c-format
+msgid "E418: Illegal value: %s"
+msgstr ""
+
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: FG colour unknown"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: BG colour unknown"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Colour name or number not recognised: %s"
 
+#: ../syntax.c:6714
+#, c-format
+msgid "E422: terminal code too long: %s"
+msgstr ""
+
+#: ../syntax.c:6753
+#, c-format
+msgid "E423: Illegal argument: %s"
+msgstr ""
+
+#: ../syntax.c:6925
+msgid "E424: Too many different highlighting attributes in use"
+msgstr ""
+
+#: ../syntax.c:7427
+msgid "E669: Unprintable character in group name"
+msgstr ""
+
+#: ../syntax.c:7434
+msgid "W18: Invalid character in group name"
+msgstr ""
+
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
+msgid "E555: at bottom of tag stack"
+msgstr ""
+
+#: ../tag.c:105
+msgid "E556: at top of tag stack"
+msgstr ""
+
+#: ../tag.c:380
+msgid "E425: Cannot go before first matching tag"
+msgstr ""
+
+#: ../tag.c:504
+#, c-format
+msgid "E426: tag not found: %s"
+msgstr ""
+
+#: ../tag.c:528
+msgid "  # pri kind tag"
+msgstr ""
+
+#: ../tag.c:531
+msgid "file\n"
+msgstr ""
+
+#: ../tag.c:829
+msgid "E427: There is only one matching tag"
+msgstr ""
+
+#: ../tag.c:831
+msgid "E428: Cannot go beyond last matching tag"
+msgstr ""
+
+#: ../tag.c:850
+#, c-format
+msgid "File \"%s\" does not exist"
+msgstr ""
+
+#. Give an indication of the number of matching tags
+#: ../tag.c:859
+#, c-format
+msgid "tag %d of %d%s"
+msgstr ""
+
+#: ../tag.c:862
+msgid " or more"
+msgstr ""
+
+#: ../tag.c:864
+msgid "  Using tag with different case!"
+msgstr ""
+
+#: ../tag.c:909
+#, c-format
+msgid "E429: File \"%s\" does not exist"
+msgstr ""
+
+#. Highlight title
+#: ../tag.c:960
+msgid ""
+"\n"
+"  # TO tag         FROM line  in file/text"
+msgstr ""
+
+#: ../tag.c:1303
+#, c-format
+msgid "Searching tags file %s"
+msgstr ""
+
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
+
+#: ../tag.c:1915
+#, fuzzy, c-format
+msgid "E431: Format error in tags file \"%s\""
+msgstr "E624: Cannot open file \"%s\""
+
+#: ../tag.c:1917
+#, c-format
+msgid "Before byte %<PRId64>"
+msgstr ""
+
+#: ../tag.c:1929
+#, c-format
+msgid "E432: Tags file not sorted: %s"
+msgstr ""
+
+#. never opened any tags file
+#: ../tag.c:1960
+msgid "E433: No tags file"
+msgstr ""
+
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Cannot find tag pattern"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Could not find tag, just guessing!"
 
+#: ../tag.c:2797
+#, c-format
+msgid "Duplicate field name: %s"
+msgstr ""
+
+#: ../term.c:1442
+msgid "' not known. Available builtin terminals are:"
+msgstr ""
+
+#: ../term.c:1463
+msgid "defaulting to '"
+msgstr ""
+
+#: ../term.c:1731
+#, fuzzy
+msgid "E557: Cannot open termcap file"
+msgstr "E40: Cannot open errorfile %s"
+
+#: ../term.c:1735
+msgid "E558: Terminal entry not found in terminfo"
+msgstr ""
+
+#: ../term.c:1737
+msgid "E559: Terminal entry not found in termcap"
+msgstr ""
+
+#: ../term.c:1878
+#, c-format
+msgid "E436: No \"%s\" entry in termcap"
+msgstr ""
+
+#: ../term.c:2249
+msgid "E437: terminal capability \"cm\" required"
+msgstr ""
+
+#. Highlight title
+#: ../term.c:4376
+msgid ""
+"\n"
+"--- Terminal keys ---"
+msgstr ""
+
+#: ../ui.c:481
+msgid "Vim: Error reading input, exiting...\n"
+msgstr ""
+
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
+
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Cannot open file for writing"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, c-format
+msgid "Writing undo file: %s"
+msgstr ""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E138: Cannot write viminfo file %s!"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, c-format
+msgid "Reading undo file: %s"
+msgstr ""
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E212: Cannot open file for writing"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E484: Cannot open file %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Cannot open file %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, c-format
+msgid "Finished reading undo file %s"
+msgstr ""
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr ""
+
+#: ../undo.c:1979
+msgid "E438: u_undo: line numbers wrong"
+msgstr ""
+
+#: ../undo.c:2183
+msgid "more line"
+msgstr ""
+
+#: ../undo.c:2185
+msgid "more lines"
+msgstr ""
+
+#: ../undo.c:2187
+msgid "line less"
+msgstr ""
+
+#: ../undo.c:2189
+msgid "fewer lines"
+msgstr ""
+
+#: ../undo.c:2193
+msgid "change"
+msgstr ""
+
+#: ../undo.c:2195
+msgid "changes"
+msgstr ""
+
+#: ../undo.c:2225
+#, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+msgid "Nothing to undo"
+msgstr ""
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, c-format
+msgid "%<PRId64> seconds ago"
+msgstr ""
+
+#: ../undo.c:2372
+msgid "E790: undojoin is not allowed after undo"
+msgstr ""
+
+#: ../undo.c:2466
+msgid "E439: undo list corrupt"
+msgstr ""
+
+#: ../undo.c:2495
+msgid "E440: undo line missing"
+msgstr ""
+
+#: ../version.c:600
+msgid ""
+"\n"
+"Included patches: "
+msgstr ""
+
+#: ../version.c:627
+msgid ""
+"\n"
+"Extra patches: "
+msgstr ""
+
+#: ../version.c:639 ../version.c:864
+msgid "Modified by "
+msgstr ""
+
+#: ../version.c:646
+msgid ""
+"\n"
+"Compiled "
+msgstr ""
+
+#: ../version.c:649
+msgid "by "
+msgstr ""
+
+#: ../version.c:660
+msgid ""
+"\n"
+"Huge version "
+msgstr ""
+
+#: ../version.c:661
+msgid "without GUI."
+msgstr ""
+
+#: ../version.c:662
+msgid "  Features included (+) or not (-):\n"
+msgstr ""
+
+#: ../version.c:667
+msgid "   system vimrc file: \""
+msgstr ""
+
+#: ../version.c:672
+msgid "     user vimrc file: \""
+msgstr ""
+
+#: ../version.c:677
+msgid " 2nd user vimrc file: \""
+msgstr ""
+
+#: ../version.c:682
+msgid " 3rd user vimrc file: \""
+msgstr ""
+
+#: ../version.c:687
+msgid "      user exrc file: \""
+msgstr ""
+
+#: ../version.c:692
+msgid "  2nd user exrc file: \""
+msgstr ""
+
+#: ../version.c:699
+msgid "  fall-back for $VIM: \""
+msgstr ""
+
+#: ../version.c:705
+msgid " f-b for $VIMRUNTIME: \""
+msgstr ""
+
+#: ../version.c:709
+msgid "Compilation: "
+msgstr ""
+
+#: ../version.c:712
+msgid "Linking: "
+msgstr ""
+
+#: ../version.c:717
+msgid "  DEBUG BUILD"
+msgstr ""
+
+#: ../version.c:767
+msgid "VIM - Vi IMproved"
+msgstr ""
+
+#: ../version.c:769
+msgid "version "
+msgstr ""
+
+#: ../version.c:770
+msgid "by Bram Moolenaar et al."
+msgstr ""
+
+#: ../version.c:774
+msgid "Vim is open source and freely distributable"
+msgstr ""
+
+#: ../version.c:776
+msgid "Help poor children in Uganda!"
+msgstr ""
+
+#: ../version.c:777
+msgid "type  :help iccf<Enter>       for information "
+msgstr ""
+
+#: ../version.c:779
+msgid "type  :q<Enter>               to exit         "
+msgstr ""
+
+#: ../version.c:780
+msgid "type  :help<Enter>  or  <F1>  for on-line help"
+msgstr ""
+
+#: ../version.c:781
+msgid "type  :help version7<Enter>   for version info"
+msgstr ""
+
+#: ../version.c:784
+msgid "Running in Vi compatible mode"
+msgstr ""
+
+#: ../version.c:785
+msgid "type  :set nocp<Enter>        for Vim defaults"
+msgstr ""
+
+#: ../version.c:786
+msgid "type  :help cp-default<Enter> for info on this"
+msgstr ""
+
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr ""
+
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr ""
+
+#: ../version.c:831
+msgid "type  :help sponsor<Enter>    for information "
+msgstr ""
+
+#: ../version.c:832
+msgid "type  :help register<Enter>   for information "
+msgstr ""
+
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr ""
+
+#: ../window.c:119
+msgid "Already only one window"
+msgstr ""
+
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr ""
+
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Cannot split topleft and botright at the same time"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Cannot find file \"%s\" in path"
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr ""
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr ""
+
+#: ../window.c:1810
+msgid "E813: Cannot close autocmd window"
+msgstr ""
+
+#: ../window.c:1814
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr ""
+
+#: ../window.c:2717
+msgid "E445: Other window contains changes"
+msgstr ""
+
+#: ../window.c:4805
+msgid "E446: No file name under cursor"
+msgstr ""
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: cannot get font %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: cannot return to current directory"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: cannot get current directory"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Cannot allocate colourmap entry, some colours may be incorrect"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "could not open buffer"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "cannot delete OutputObject attributes"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  or  --nofork\tForeground: Do not fork when starting GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tDo not use newcli to open window"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <files>  Same, do not complain if there is no server"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  Same, do not complain if there is no server"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <colour>\tUse <colour> for the background (also: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <colour>\tUse <colour> for normal text (also: -fg)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tDo not use reverse video (also: +rv)"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: input method does not support any style"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: input method does not support my preedit type"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: cannot select fontset"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: cannot select wide font"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Cannot open window!\n"

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -23,7 +23,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Esperanto)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-05-27 04:50+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-05-27 04:55+0200\n"
 "Last-Translator: Dominique PELLÉ <dominique.pelle@gmail.com>\n"
 "Language-Team: \n"
@@ -32,164 +32,208 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() alvokita kun malplena pasvorto"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "fiaskis akiri valoron de opcio"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+#, fuzzy
+msgid "internal error: unknown option type"
+msgstr "interna eraro: neniu vim-a listero"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Misuzo de pezkomenca/pezfina en blowfish"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: Testo de sha256 fiaskis"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Testo de blowfish fiaskis"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Listo de lokoj]"
 
 # DP: Ĉu vere indas traduki Quickfix?
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Listo de rapidriparoj]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Aŭtokomandoj haltigis komandon"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Ne eblas disponigi iun ajn bufron, nun eliras..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Ne eblas disponigi bufron, nun uzas alian..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Neniu bufro estis malŝargita"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Neniu bufro estis forviŝita"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Neniu bufro estis detruita"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 bufro malŝargita"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d bufroj malŝargitaj"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 bufro forviŝita"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d bufroj forviŝitaj"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 bufro detruita"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d bufroj detruitaj"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Ne eblas malŝargi la lastan bufron"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Neniu modifita bufro trovita"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Estas neniu listigita bufro"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: La bufro %<PRId64> ne ekzistas"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Ne eblas iri preter la lastan bufron"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ne eblas iri antaŭ la unuan bufron"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
 "E89: Neniu skribo de post la lasta ŝanĝo de la bufro %<PRId64> (aldonu ! por "
 "transpasi)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Ne eblas malŝargi la lastan bufron"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Averto: Listo de dosiernomoj troas"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Bufro %<PRId64> ne trovita"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Pli ol unu kongruo kun %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Neniu bufro kongruas kun %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "linio %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufro kun tiu nomo jam ekzistas"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr "[Modifita]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Ne redaktita]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nova dosiero]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Eraroj de legado]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[Nurlegebla]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[nurlegebla]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 linio --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> linioj --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "linio %<PRId64> de %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Neniu nomo]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "helpo"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Helpo]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Antaŭvido]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Ĉio"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Subo"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Supro"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -197,10 +241,12 @@ msgstr ""
 "\n"
 "# Listo de bufroj:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Malneto]"
 
 # DP: Vidu ":help sign-support" por klarigo pri "Sign"
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -208,144 +254,200 @@ msgstr ""
 "\n"
 "--- Emfazaj simbolaĵoj ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Emfazaj simbolaĵoj de %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    linio=%<PRId64>  id=%d  nomo=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Mankas dupunkto"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Reĝimo nepermesata"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: cifero atendata"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Nevalida procento"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Ne eblas dosierdiferenci pli ol %<PRId64> bufrojn"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Ne eblas legi aŭ skribi provizorajn dosierojn"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Ne eblas krei dosierdiferencojn"
 
-msgid "Patch file"
-msgstr "Flika dosiero"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Ne eblas legi eliron de flikilo \"patch\""
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Ne eblas legi eliron de dosierdiferencilo \"diff\""
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktuala bufro ne estas en dosierdiferenca reĝimo"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Neniu alia bufro en dosierdiferenca reĝimo estas modifebla"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Neniu alia bufro en dosierdiferenca reĝimo"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Pli ol du bufroj en dosierdiferenca reĝimo, ne scias kiun uzi"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Ne eblas trovi bufron \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bufro \"%s\" ne estas en dosierdiferenca reĝimo"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Bufro ŝanĝiĝis neatendite"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Eskapsigno nepermesebla en duliteraĵo"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Dosiero de klavmapo ne troveblas"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Uzo de \":loadkeymap\" nur eblas en vim-skripto"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Malplena rikordo en klavmapo"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Kompletigo de ŝlosilvorto (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Reĝimo ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Kompletigo de tuta linio (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Kompletigo de dosiernomo (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Kompletigo de etikedo (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Kompletigo de ŝablona dosierindiko (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Kompletigo de difino (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Kompletigo de vortaro (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Kompletigo de tezaŭro (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Kompletigo de komanda linio (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Kompletigo difinita de uzanto (^U^N^P)"
 
 # DP: Ĉu eblas trovi pli bonan tradukon?
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Kompletigo Omni (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Sugesto de literumo (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Kompletigo loka de ŝlosilvorto (^N/^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Atingis finon de alineo"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Kompletiga funkcio ŝanĝis la fenestron"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Kompletiga funkcio forviŝis tekston"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "La opcio 'dictionary' estas malplena"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "La opcio 'thesaurus' estas malplena"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Analizas vortaron: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (enmeto) Rulumo (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (anstataŭigo) Rulumo (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Analizas: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Analizas etikedojn."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Aldonanta"
 
@@ -353,457 +455,572 @@ msgstr " Aldonanta"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Serĉanta..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Reveninta al originalo"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Vorto el alia linio"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "La sola kongruo"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "kongruo %d de %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "kongruo %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Neatenditaj signoj en \":let\""
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: indekso de listo ekster limoj: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nedifinita variablo: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Mankas ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argumento de %s devas esti Listo"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argumento de %s devas esti Listo aŭ Vortaro"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Ne eblas uzi malplenan ŝlosilon de Vortaro"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Listo bezonata"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Vortaro bezonata"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Tro da argumentoj por funkcio: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Ŝlosilo malekzistas en Vortaro: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: La funkcio %s jam ekzistas (aldonu ! por anstataŭigi ĝin)"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Rikordo de vortaro jam ekzistas"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref bezonata"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Uzo de [:] ne eblas kun Vortaro"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Nevalida datumtipo de variablo de %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Nekonata funkcio: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Nevalida nomo de variablo: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: uzo de Glitpunktnombro kiel Ĉeno"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Malpli da celoj ol Listeroj"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Pli da celoj ol Listeroj"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Duobla ; en listo de variabloj"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Ne eblas listigi variablojn de %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Nur eblas indeksi Liston aŭ Vortaron"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] devas esti laste"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] bezonas listan valoron"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Lista valoro havas pli da eroj ol la celo"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Lista valoro ne havas sufiĉe da eroj"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: \"in\" mankas post \":for\""
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Mankas krampoj: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Ne estas tia variablo: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variablo ingita tro profunde por malŝlosi"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Mankas ':' post '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Eblas nur kompari Liston kun Listo"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Nevalida operacio de Listoj"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Eblas nur kompari Vortaron kun Vortaro"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Nevalida operacio de Vortaro"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Eblas nur kompari Funcref kun Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Nevalida operacio de Funcref-oj"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Ne eblas uzi '%' kun Glitpunktnombro"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Mankas ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Ne eblas indeksi Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Mankas nomo de opcio: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Nekonata opcio: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Mankas citilo: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Mankas citilo: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Mankas komo en Listo: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Mankas fino de Listo ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Mankas dupunkto en la vortaro: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Ripetita ŝlosilo en la vortaro: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Mankas komo en la vortaro: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Mankas fino de vortaro '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variablo ingita tro profunde por vidigi"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Tro da argumentoj por funkcio: %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Nevalidaj argumentoj por funkcio: %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Nekonata funkcio: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Ne sufiĉe da argumentoj por funkcio: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> estas uzata ekster kunteksto de skripto: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Alvoko de funkcio dict sen Vortaro: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Nombro aŭ Glitpunktnombro bezonata"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "argumento de add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Tro da argumentoj"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() uzeblas nur en Enmeta reĝimo"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Bone"
 
-msgid "extend() argument"
-msgstr "argumento de extend()"
-
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Ŝlosilo jam ekzistas: %s"
 
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr "argumento de extend()"
+
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "argumento de map()"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "argumento de filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld linioj: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Nekonata funkcio: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&Bone\n"
-"&Rezigni"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "alvokis inputrestore() pli ofte ol inputsave()"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "argumento de insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Amplekso nepermesebla"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Nevalida datumtipo de len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Paŝo estas nul"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Komenco preter fino"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<malplena>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Neniu konekto al Vim-servilo"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Ne eblas sendi al %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Ne eblas legi respondon de servilo"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "argumento de remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Tro da simbolaj ligiloj (ĉu estas ciklo?)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "argumento de reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Ne eblas sendi al kliento"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "argumento de sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argumento de add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Ordiga funkcio fiaskis"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Ordiga funkcio fiaskis"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Nevalida)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Eraro dum skribo de provizora dosiero"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Uzo de Glitpunktnombro kiel Nombro"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Uzo de Funcref kiel Nombro"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Uzo de Listo kiel Nombro"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Uzo de Vortaro kiel Nombro"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: uzo de Funcref kiel Ĉeno"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: uzo de Listo kiel Ĉeno"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: uzo de Vortaro kiel Ĉeno"
 
-msgid "E806: using Float as a String"
-msgstr "E806: uzo de Glitpunktnombro kiel Ĉeno"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Nekongrua datumtipo de variablo: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Ne eblas forviŝi variablon %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Nomo de variablo Funcref devas finiĝi per majusklo: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Nomo de variablo konfliktas kun ekzistanta funkcio: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Valoro estas ŝlosita: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Nekonata"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Ne eblas ŝanĝi valoron de %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: variablo ingita tro profunde por fari kopion"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Nedifinita funkcio: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Mankas '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Ne eblas uzi g: ĉi tie"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Nevalida argumento: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Ripetita nomo de argumento: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Mankas \":endfunction\""
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Nomo de funkcio konfliktas kun variablo: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Ne eblas redifini funkcion %s: Estas nuntempe uzata"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Nomo de funkcio ne kongruas kun dosiernomo de skripto: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Nomo de funkcio bezonata"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: Nomo de funkcio devas eki per majusklo aŭ enhavi dupunkton: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Nomo de funkcio devas eki per majusklo aŭ enhavi dupunkton: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Ne eblas forviŝi funkcion %s: Estas nuntempe uzata"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Profundo de funkcia alvoko superas 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "alvokas %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s ĉesigita"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s liveras #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s liveras %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "daŭrigas en %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: \":return\" ekster funkcio"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -811,6 +1028,7 @@ msgstr ""
 "\n"
 "# mallokaj variabloj:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -818,82 +1036,104 @@ msgstr ""
 "\n"
 "\tLaste ŝaltita de "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Neniu malnova dosiero"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Deksesuma %02x,  Okuma %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Deksesuma %04x, Okuma %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Deksesuma %08x, Okuma %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Movas liniojn en ilin mem"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 linio movita"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> linioj movitaj"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> linioj filtritaj"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filtraj* Aŭtokomandoj ne rajtas ŝanĝi aktualan bufron"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Neniu skribo de post lasta ŝanĝo]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s en linio: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Tro da eraroj, nun ignoras la reston de la dosiero"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Legado de dosiero viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informo"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " markoj"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " malnovaj dosieroj"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FIASKIS"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Dosiero viminfo ne skribeblas: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Ne eblas skribi dosieron viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Skribas dosieron viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tiu dosiero viminfo estis kreita de Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -901,40 +1141,47 @@ msgstr ""
 "# Vi povas redakti ĝin se vi estas singarda.\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Valoro de 'encoding' kiam tiu dosiero estis kreita\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Nevalida eka signo"
 
-msgid "Save As"
-msgstr "Konservi kiel"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Ĉu skribi partan dosieron?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Uzu ! por skribi partan bufron"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Ĉu anstataŭigi ekzistantan dosieron \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Permutodosiero .swp \"%s\" ekzistas, ĉu tamen anstataŭigi ĝin?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Permutodosiero .swp ekzistas: %s (:silent! por transpasi)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Neniu dosiernomo de bufro %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Dosiero ne skribita: Skribo malŝaltita per la opcio 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -943,6 +1190,7 @@ msgstr ""
 "La opcio 'readonly' estas ŝaltita por \"%s\".\n"
 "Ĉu vi tamen volas skribi?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -953,69 +1201,84 @@ msgstr ""
 "Bonŝance ĝi eble skribeblus.\n"
 "Ĉu vi volas provi?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" estas nurlegebla (aldonu ! por transpasi)"
 
-msgid "Edit File"
-msgstr "Redakti dosieron"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Aŭtokomandoj neatendite forviŝis novan bufron %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nenumera argumento de :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Ŝelkomandoj nepermeseblaj en rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Ne eblas limigi regulesprimon per literoj"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "ĉu anstataŭigi per %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Interrompita) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 kongruo"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 anstataŭigo"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> kongruoj"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> anstataŭigoj"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " en 1 linio"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " en %<PRId64> linioj"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Ne eblas fari \":global\" rekursie"
 
 # DP: global estas por ":global" do mi ne tradukis ĝin
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Regulesprimo mankas el global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Ŝablono trovita en ĉiuj linioj: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Ŝablono ne trovita: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1026,264 +1289,335 @@ msgstr ""
 "$"
 
 # This message should *so* be E42!
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Ne paniku!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Bedaŭrinde estas neniu helpo '%s' por %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Bedaŭrinde estas neniu helpo por %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Bedaŭrinde, la helpdosiero \"%s\" ne troveblas"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Ne estas dosierujo: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Ne eblas malfermi %s en skribreĝimo"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Ne eblas malfermi %s en legreĝimo"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Miksaĵo de kodoprezento de helpa dosiero en lingvo: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Ripetita etikedo \"%s\" en dosiero %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Nekonata simbola komando: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Mankas nomo de simbolo"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Tro da simboloj estas difinitaj"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Nevalida teksto de simbolo: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Nekonata simbolo: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Mankas numero de simbolo"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Nevalida nomo de bufro: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Nevalida identigilo de simbolo: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr "  (NETROVITA)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (nesubtenata)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Forviŝita]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Eniras sencimigan reĝimon.  Tajpu \"cont\" por daŭrigi."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "linio %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "kmd: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Kontrolpunkto en \"%s%s\" linio %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Kontrolpunkto ne trovita: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Neniu kontrolpunkto estas difinita"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  linio %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Uzu unue \":profile start {dosiernomo}\""
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Ĉu konservi ŝanĝojn al \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Sen titolo"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Neniu skribo de post la lasta ŝanĝo por bufro \"%s\""
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "Averto: Eniris neatendite alian bufron (kontrolu aŭtokomandojn)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Estas nur unu redaktenda dosiero"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Ne eblas iri antaŭ ol la unuan dosieron"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Ne eblas iri preter la lastan dosieron"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: kompililo nesubtenata: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Serĉado de \"%s\" en \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Serĉado de \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "ne trovita en 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Ruli Vim-skripton"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Ne eblas ruli dosierujon: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "ne eblis ruli \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "linio %<PRId64>: ne eblis ruli \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "rulas \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "linio %<PRId64>: rulas \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "finis ruli %s"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "reĝimlinio"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd argumento"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c argumento"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "medivariablo"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "erartraktilo"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Averto: Neĝusta disigilo de linio, ^M eble mankas"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: \":scriptencoding\" uzita ekster rulita dosiero"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: \":finish\" uzita ekster rulita dosiero"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Aktuala %slingvo: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Ne eblas ŝanĝi la lingvon al \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Eniras reĝimon Ex. Tajpu \"visual\" por iri al reĝimo Normala."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Ĉe fino-de-dosiero"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Komando tro rekursia"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Escepto nekaptita: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Fino de rulita dosiero"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Fino de funkcio"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Ambigua uzo de komando difinita de uzanto"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Ne estas redaktila komando"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Inversa amplekso donita"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Inversa amplekso donita, permuteblas"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Uzu w aŭ w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Bedaŭrinde, tiu komando ne haveblas en tiu versio"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Nur unu dosiernomo permesebla"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 plia redaktenda dosiero. Ĉu tamen eliri?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d pliaj redaktendaj dosieroj. Ĉu tamen eliri?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 plia redaktenda dosiero"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> pliaj redaktendaj dosieroj"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: La komando jam ekzistas: aldonu ! por anstataŭigi ĝin"
 
 # DP: malfacilas traduki tion, kaj samtempe honori spacetojn
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1291,298 +1625,343 @@ msgstr ""
 "\n"
 "    Nomo        Arg Interv Kompleto  Difino"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Neniu komando difinita de uzanto trovita"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Neniu atributo specifita"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Nevalida nombro de argumentoj"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Kvantoro ne povas aperi dufoje"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Nevalida defaŭlta valoro de kvantoro"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: argumento bezonata por -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Nevalida atributo: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Nevalida komanda nomo"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Komandoj difinataj de uzanto devas eki per majusklo"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: Rezervita nomo, neuzebla por komando difinita de uzanto"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Neniu komando-difinita-de-uzanto kiel: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Nevalida valoro de kompletigo: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Argumento de kompletigo nur permesebla por kompletigo difinita de "
 "uzanto"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Uzula kompletigo bezonas funkcian argumenton"
 
-msgid "unknown"
-msgstr "nekonata"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Ne eblas trovi agordaron de koloroj '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Bonvenon, uzanto de Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Ne eblas fermi lastan langeton"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Jam nur unu langeto"
 
-msgid "Edit File in new window"
-msgstr "Redakti Dosieron en nova fenestro"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Langeto %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Neniu permutodosiero .swp"
 
-msgid "Append File"
-msgstr "Postaldoni dosieron"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Ne eblas ŝanĝi dosierujon, bufro estas ŝanĝita (aldonu ! por transpasi)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Neniu antaŭa dosierujo"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Nekonata"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: \":winsize\" bezonas du numerajn argumentojn"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Pozicio de fenestro: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Akiro de pozicio de fenestro ne estas realigita por tiu platformo"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: \":winpos\" bezonas du numerajn argumentojn"
 
-msgid "Save Redirection"
-msgstr "Konservi alidirekton"
-
-# DP: mi ne certas pri superflugo
-msgid "Save View"
-msgstr "Konservi superflugon"
-
-msgid "Save Session"
-msgstr "Konservi seancon"
-
-msgid "Save Setup"
-msgstr "Konservi agordaron"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Ne eblas krei dosierujon %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" ekzistas (aldonu ! por transpasi)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Ne eblas malfermi \"%s\" por skribi"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumento devas esti litero, citilo aŭ retrocitilo"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Tro profunda rekursia alvoko de \":normal\""
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< ne haveblas sen la eblo +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Neniu alterna dosiernomo por anstataŭigi al '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: neniu dosiernomo de aŭtokomando por anstataŭigi al \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr ""
 "E496: neniu numero de bufro de aŭtokomando por anstataŭigi al \"<abuf>\""
 
 # DP: ĉu match estas verbo aŭ nomo en la angla version?
 # AM: ĉi tie, nomo, ŝajnas al mi
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: neniu nomo de kongruo de aŭtokomando por anstataŭigi al \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: neniu dosiernomo \":source\" por anstataŭigi al \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: neniu uzebla numero de linio por \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Malplena dosiernomo por '%' aŭ '#', nur funkcias kun \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Liveras malplenan ĉenon"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Ne eblas malfermi dosieron viminfo en lega reĝimo"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Neniu duliteraĵo en tiu versio"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Ne eblas lanĉi (:throw) escepton kun prefikso 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Escepto lanĉita: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Escepto finiĝis: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Escepto ne konservita: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, linio %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Kaptis escepton: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s iĝis atendanta(j)"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s daŭrigita(j)"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s ne konservita(j)"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Escepto"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Eraro kaj interrompo"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Eraro"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Interrompo"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: \":if\" tro profunde ingita"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: \":endif\" sen \":if\""
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: \":else\" sen \":if\""
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: \":elseif\" sen \":if\""
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: pluraj \":else\""
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: \":elseif\" post \":else\""
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: \":while/:for\" ingita tro profunde"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: \":continue\" sen \":while\" aŭ \":for\""
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: \":break\" sen \":while\" aŭ \":for\""
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Uzo de \":endfor\" kun \":while\""
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Uzo de \":endwhile\" kun \":for\""
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: \":try\" ingita tro profunde"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: \":catch\" sen \":try\""
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: \":catch\" post \":finally\""
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: \":finally\" sen \":try\""
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: pluraj \":finally\""
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: \":endtry\" sen \":try\""
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: \":endfunction\" ekster funkcio"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Ne eblas redakti alian bufron nun"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Ne eblas ŝanĝi informon de bufro nun"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nomo de etikedo"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " tipo de dosiero\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "opcio 'history' estas nul"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1591,232 +1970,303 @@ msgstr ""
 "\n"
 "# Historio %s (de plej nova al plej malnova):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Komanda linio"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Serĉa ĉeno"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Esprimo"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Eniga linio"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar preter la longo de komando"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktiva fenestro aŭ bufro forviŝita"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: tro longa vojo por kompletigo"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Nevalida vojo: '**[nombro]' devas esti ĉe la fino de la vojo aŭ "
+"sekvita de '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Ne eblas trovi dosierujon \"%s\" en cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Ne eblas trovi dosieron \"%s\" en serĉvojo"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Ne plu trovis dosierujon \"%s\" en cdpath"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Ne plu trovis dosieron \"%s\" en serĉvojo"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Aŭtokomandoj ŝanĝis bufron aŭ nomon de bufro"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Nevalida dosiernomo"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "estas dosierujo"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "ne estas dosiero"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "estas aparatdosiero (malŝaltita per la opcio 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nova dosiero]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nova DOSIERUJO]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Dosiero tro granda]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Permeso rifuzita]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: La aŭtokomandoj *ReadPre igis la dosieron nelegebla"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: La aŭtokomandoj *ReadPre ne rajtas ŝanĝi la aktualan bufron"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Legado el stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Legado el stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Konverto igis la dosieron nelegebla!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[rektvica memoro/kontaktoskatolo]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[rektvica memoro]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[kontaktoskatolo]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[speciala signo]"
 
-msgid "[RO]"
-msgstr "[Nurlegebla]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR mankas]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[divido de longaj linioj]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NE konvertita]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[konvertita]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[ĉifrita]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ERARO DE KONVERTO en linio %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[NEVALIDA BAJTO en linio %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ERAROJ DE LEGADO]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Ne eblas trovi provizoran dosieron por konverti"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konverto kun 'charconvert' fiaskis"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "ne eblas legi la eligon de 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Dosiero estas ĉifrata per nekonata metodo"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Neniu kongrua aŭtokomando por la bufro acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Aŭtokomandoj forviŝis aŭ malŝargis la skribendan bufron"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Aŭtokomando ŝanĝis la nombron de linioj neatendite"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans malpermesas skribojn de neŝanĝitaj bufroj"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Partaj skriboj malpermesitaj ĉe bufroj NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "ne estas dosiero aŭ skribebla aparatdosiero"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "skribo al aparatdosiero malŝaltita per la opcio 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "estas nurlegebla (aldonu ! por transpasi)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Ne eblas skribi restaŭrkopion (aldonu ! por transpasi)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Eraro dum fermo de restaŭrkopio (aldonu ! transpasi)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Ne eblas legi restaŭrkopion (aldonu ! por transpasi)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Ne eblas krei restaŭrkopion (aldonu ! por transpasi)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Ne eblas krei restaŭrkopion (aldonu ! por transpasi)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: La rimeda forko estus perdita (aldonu ! por transpasi)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Ne eblas trovi provizoran dosieron por skribi"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Ne eblas konverti (aldonu ! por skribi sen konverto)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Ne eblas malfermi ligitan dosieron por skribi"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Ne eblas malfermi la dosieron por skribi"
 
 # AM: fsync: ne traduku (nomo de C-komando)
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync fiaskis"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Fermo fiaskis"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: skriberaro, konverto fiaskis (igu 'fenc' malplena por transpasi)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: skriberaro, konverto fiaskis en linio %<PRId64> (igu 'fenc' malplena  por "
-"transpasi)"
+"E513: skriberaro, konverto fiaskis en linio %<PRId64> (igu 'fenc' malplena  "
+"por transpasi)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: skriberaro (ĉu plena dosiersistemo?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ERARO DE KONVERTO"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " en linio %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Aparatdosiero]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nova]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " postaldonita(j)"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [s]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " skribita(j)"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: ne eblas konservi originalan dosieron"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: ne eblas tuŝi malplenan originalan dosieron"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Ne eblas forviŝi restaŭrkopion"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1824,76 +2274,96 @@ msgstr ""
 "\n"
 "AVERTO: Originala dosiero estas eble perdita aŭ difekta\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ne eliru el la redaktilo ĝis kiam la dosiero estas sukcese konservita!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[formato dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[formato mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unikso]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[formato unikso]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 linio, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> linioj, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 signo"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> signoj"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[sen EOL]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Nekompleta lasta linio]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "AVERTO: La dosiero estas ŝanĝita de post kiam ĝi estis legita!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Ĉu vi vere volas skribi al ĝi"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Eraro dum skribo de \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Eraro dum fermo de \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Eraro dum lego de \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Aŭtokomando FileChangedShell forviŝis bufron"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Dosiero \"%s\" ne plu haveblas"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1901,30 +2371,38 @@ msgid ""
 msgstr ""
 "W12: Averto: Dosiero \"%s\" ŝanĝiĝis kaj la bufro estis ŝanĝita ankaŭ en Vim"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Vidu \":help W12\" por pliaj informoj."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Averto: La dosiero \"%s\" ŝanĝiĝis ekde redakti ĝin"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Vidu \":help W11\" por pliaj informoj."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Averto: Permeso de dosiero \"%s\" ŝanĝiĝis ekde redakti ĝin"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Vidu \":help W16\" por pliaj informoj."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Averto: Dosiero \"%s\" kreiĝis post la komenco de redaktado"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Averto"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1932,39 +2410,48 @@ msgstr ""
 "&Bone\n"
 "Ŝ&argi Dosieron"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Ne eblis prepari por reŝargi \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Ne eblis reŝargi \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Forviŝita--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "aŭto-forviŝas aŭtokomandon: %s <bufro=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Ne ekzistas tia grupo: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Nevalida signo post *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Ne estas tia evento: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Ne ekzistas tia grupo aŭ evento: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1972,542 +2459,762 @@ msgstr ""
 "\n"
 "--- Aŭto-Komandoj ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <bufro=%d>: nevalida numero de bufro "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Ne eblas plenumi aŭtokomandojn por ĈIUJ eventoj"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Neniu kongrua aŭtokomando"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: aŭtokomando tro ingita"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Aŭtokomandoj por \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Plenumado de %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "aŭtokomando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Mankas {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Mankas }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Neniu faldo trovita"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Ne eblas krei faldon per la aktuala 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Ne eblas forviŝi faldon per la aktuala 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld linioj falditaj "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Aldoni al lega bufro"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursia mapo"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: malloka mallongigo jam ekzistas por %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: malloka mapo jam ekzistas por %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: mallongigo jam ekzistas por %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: mapo jam ekzistas por %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Neniu mallongigo trovita"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Neniu mapo trovita"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Nevalida reĝimo"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Ne sukcesis krei novan procezon por la grafika interfaco"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Neniu linio en bufro--"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: La ida procezo ne sukcesis startigi la grafikan interfacon"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: komando ĉesigita"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Ne eblas lanĉi la grafikan interfacon"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argumento bezonata"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Ne eblas legi el \"%s\""
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ devus esti sekvita de /, ? aŭ &"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E665: Ne eblas startigi grafikan interfacon, neniu valida tiparo trovita"
+"E11: Nevalida en fenestro de komanda linio; <CR> plenumas, CTRL-C eliras"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' nevalida"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Valoro de 'imactivatekey' estas nevalida"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Ne eblas disponigi koloron %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Neniu kongruo ĉe kursorpozicio, trovas sekvan"
-
-msgid "<cannot open> "
-msgstr "<ne eblas malfermi> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: ne eblas akiri tiparon %s"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: ne eblas reveni al la aktuala dosierujo"
-
-msgid "Pathname:"
-msgstr "Serĉvojo:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: ne eblas akiri aktualan dosierujon"
-
-msgid "OK"
-msgstr "Bone"
-
-msgid "Cancel"
-msgstr "Rezigni"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Fenestraĵo de rulumskalo: Ne eblis akiri geometrion de reduktita rastrumbildo"
+"E12: Nepermesebla komando el exrc/vimrc en aktuala dosierujo aŭ etikeda serĉo"
 
-msgid "Vim dialog"
-msgstr "Vim dialogo"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Mankas \":endif\""
 
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Ne eblas krei BalloonEval kun ambaŭ mesaĝo kaj reagfunkcio"
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Mankas \":endtry\""
 
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Mankas \":endwhile\""
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Mankas \":endfor\""
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: \":endwhile\" sen \":while\""
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: \":endfor\" sen \":for\""
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Dosiero ekzistas (aldonu ! por transpasi)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: La komando fiaskis"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Interna eraro"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Interrompita"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Nevalida adreso"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Nevalida argumento"
+
+#: ../globals.h:1015
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Nevalida argumento: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Nevalida esprimo: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Nevalida amplekso"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Nevalida komando"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" estas dosierujo"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Nevalida grando de rulumo"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Jes\n"
-"&Ne\n"
-"&Rezigni"
 
-# todo '_' is for hotkey, i guess?
-msgid "Input _Methods"
-msgstr "Enigaj _metodoj"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Serĉi kaj anstataŭigi..."
-
-msgid "VIM - Search..."
-msgstr "VIM- Serĉi..."
-
-msgid "Find what:"
-msgstr "Serĉi kion:"
-
-msgid "Replace with:"
-msgstr "Anstataŭigi per:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Kongrui kun nur plena vorto"
-
-#. match case button
-msgid "Match case"
-msgstr "Uskleca kongruo"
-
-msgid "Direction"
-msgstr "Direkto"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Supren"
-
-msgid "Down"
-msgstr "Suben"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Trovi sekvantan"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Anstataŭigi"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Anstataŭigi ĉiujn"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Ricevis peton \"die\" (morti) el la seanca administrilo\n"
-
-msgid "Close"
-msgstr "Fermi"
-
-msgid "New tab"
-msgstr "Nova langeto"
-
-msgid "Open Tab..."
-msgstr "Malfermi langeton..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Ĉefa fenestro neatendite detruiĝis\n"
-
-msgid "&Filter"
-msgstr "&Filtri"
-
-msgid "&Cancel"
-msgstr "&Rezigni"
-
-msgid "Directories"
-msgstr "Dosierujoj"
-
-msgid "Filter"
-msgstr "Filtri"
-
-msgid "&Help"
-msgstr "&Helpo"
-
-msgid "Files"
-msgstr "Dosieroj"
-
-msgid "&OK"
-msgstr "&Bone"
-
-msgid "Selection"
-msgstr "Apartigo"
-
-msgid "Find &Next"
-msgstr "Trovi &Sekvanta"
-
-msgid "&Replace"
-msgstr "&Anstataŭigi"
-
-msgid "Replace &All"
-msgstr "Anstataŭigi ĉi&on"
-
-msgid "&Undo"
-msgstr "&Malfari"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Ne eblas trovi titolon de fenestro \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Ne subtenata argumento: \"-%s\"; Uzu la version OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Ne eblas malfermi fenestron interne de aplikaĵo MDI"
-
-msgid "Close tab"
-msgstr "Fermi langeton"
-
-msgid "Open tab..."
-msgstr "Malfermi langeton..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Trovi ĉenon (uzu '\\\\' por trovi '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Trovi kaj anstataŭigi (uzu '\\\\' por trovi '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Ne uzata"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Dosierujo\t*.nenio\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Vim E458: Ne eblas disponigi rikordon de kolormapo, iuj koloroj estas eble "
-"neĝustaj"
 
+#: ../globals.h:1024
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Tiparoj de tiuj signaroj mankas en aro de tiparo %s:"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Alvoko al biblioteko fiaskis por \"%s()\""
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Marko havas nevalidan numeron de linio"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Marko ne estas agordita"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Ne eblas fari ŝanĝojn, 'modifiable' estas malŝaltita"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Tro profunde ingitaj skriptoj"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Neniu alterna dosiero"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Ne estas tia mallongigo"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Neniu ! permesebla"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Grafika interfaco ne uzeblas: Malŝaltita dum kompilado"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nomo de tiparo: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Neniu grupo de emfazo kiel: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Ankoraŭ neniu enmetita teksto"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Neniu antaŭa komanda linio"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Neniu tiel mapo"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Neniu kongruo"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Tiparo '%s' ne estas egallarĝa"
+msgid "E480: No match: %s"
+msgstr "E480: Neniu kongruo: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Neniu dosiernomo"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Neniu antaŭa regulesprimo de anstataŭigo"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Neniu antaŭa komando"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Neniu antaŭa regulesprimo"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Amplekso nepermesebla"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Ne sufiĉe da spaco"
+
+#: ../globals.h:1049
 #, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Nomo de tiparo: %s\n"
+msgid "E482: Can't create file %s"
+msgstr "E482: Ne eblas krei dosieron %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Ne eblas akiri provizoran dosiernomon"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
+msgid "E484: Can't open file %s"
+msgstr "E484: Ne eblas malfermi dosieron %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
+msgid "E485: Can't read file %s"
+msgstr "E485: Ne eblas legi dosieron %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Neniu skribo de post lasta ŝanĝo (aldonu ! por transpasi)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Neniu skribo de post lasta ŝanĝo]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nula argumento"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nombro atendita"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Font%<PRId64> ne estas duoble pli larĝa ol font0\n"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Ne eblas malfermi eraran dosieron %s"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Ne plu restas memoro!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Ŝablono ne trovita"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Larĝo de font0: %<PRId64>\n"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Ŝablono ne trovita: %s"
 
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: La argumento devas esti pozitiva"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Ne eblas reiri al antaŭa dosierujo"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Neniu eraro"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Neniu listo de loko"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Difekta kongruenda ĉeno"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Difekta programo de regulesprimo"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: La opcio 'readonly' estas ŝaltita '(aldonu ! por transpasi)"
+
+#: ../globals.h:1073
 #, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
-msgstr ""
-"Larĝo de Font1: %<PRId64>\n"
-"\n"
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Ne eblas ŝanĝi nurlegeblan variablon \"%s\""
 
-msgid "Invalid font specification"
-msgstr "Nevalida tiparo specifita"
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Ne eblas agordi variablon en la sabloludejo: \"%s\""
 
-msgid "&Dismiss"
-msgstr "&Forlasi"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Eraro dum legado de erardosiero"
 
-msgid "no specific match"
-msgstr "Neniu specifa kongruo"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Nepermesebla en sabloludejo"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Elektilo de tiparo"
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Nepermesebla tie"
 
-msgid "Name:"
-msgstr "Nomo:"
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Reĝimo de ekrano ne subtenata"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Montri grandon en punktoj"
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Nevalida grando de rulumo"
 
-msgid "Encoding:"
-msgstr "Kodoprezento:"
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: La opcio 'shell' estas malplena"
 
-msgid "Font:"
-msgstr "Tiparo:"
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Ne eblis legi datumojn de simboloj!"
 
-msgid "Style:"
-msgstr "Stilo:"
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Eraro dum malfermo de permutodosiero .swp"
 
-msgid "Size:"
-msgstr "Grando:"
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: malplena stako de etikedo"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ERARO en aŭtomato de korea alfabeto"
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Komando tro kompleksa"
 
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Nomo tro longa"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Tro da ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Tro da dosiernomoj"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Vostaj signoj"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Nekonata marko"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Ne eblas malvolvi ĵokerojn"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' ne rajtas esti malpli ol 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' ne rajtas esti malpli ol 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Eraro dum skribado"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nul kvantoro"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Uzo de <SID> ekster kunteksto de skripto"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Interna eraro: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: ŝablono uzas pli da memoro ol 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: malplena bufro"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Nevalida serĉa ŝablono aŭ disigilo"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Dosiero estas ŝargita en alia bufro"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: La opcio '%s' ne estas ŝaltita"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Nevalida nomo de reĝistro"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "serĉo atingis SUPRON, daŭrigonte al SUBO"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "serĉo atingis SUBON, daŭrigonte al SUPRO"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Mankas dupunkto"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Nevalida komponento"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: cifero atendita"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Paĝo %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Neniu presenda teksto"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Presas paĝon %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopio %d de %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Presis: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Presado ĉesigita"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Eraro dum skribo de PostSkripta eliga dosiero"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Ne eblas malfermi dosieron \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Ne eblas legi dosieron de PostSkripta rimedo \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: \"%s\" ne estas dosiero de PostSkripta rimedo"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: \"%s\" ne estas subtenata dosiero de PostSkripta rimedo"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" dosiero de rimedo havas neĝustan version"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Nekongrua plurbajta kodoprezento kaj signaro."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr ""
 "E674: printmbcharset ne rajtas esti malplena kun plurbajta kodoprezento."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Neniu defaŭlta tiparo specifita por plurbajta presado."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Ne eblas malfermi eligan PostSkriptan dosieron"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Ne eblas malfermi dosieron \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Dosiero de PostSkripta rimedo \"prolog.ps\" ne troveblas"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Dosiero de PostSkripta rimedo \"cidfont.ps\" ne troveblas"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Dosiero de PostSkripta rimedo \"%s.ps\" ne troveblas"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Ne eblas konverti al la presa kodoprezento \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Sendas al presilo..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Presado de PostSkripta dosiero fiaskis"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Laboro de presado sendita."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Aldoni novan datumbazon"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Serĉi ŝablonon"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Montri tiun mesaĝon"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Ĉesigi konekton"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Repravalorizi ĉiujn konektojn"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Montri konektojn"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Uzo: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Tiu ĉi komando de cscope ne subtenas dividon de fenestro.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Uzo: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: etikedo netrovita"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: Eraro de stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: Eraro de stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s ne estas dosierujo aŭ valida datumbazo de cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Aldonis datumbazon de cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: eraro dum legado de konekto de cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: nekonata tipo de serĉo de cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Ne eblis krei duktojn de cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Ne eblis forki cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "plenumo de cs_create_connection fiaskis"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "plenumo de cs_create_connection fiaskis"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen de to_fp fiaskis"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen de fr_fp fiaskis"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Ne eblis naskigi procezon cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: neniu konekto al cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: nevalida flago cscopequickfix %c de %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: neniu kongruo trovita por serĉo per cscope %s de %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "komandoj de cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Uzo: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2529,32 +3236,31 @@ msgstr ""
 "       s: Trovi tiun C-simbolon\n"
 "       t: Trovi tiun ĉenon\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: ne eblas malfermi datumbazon de cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: ne eblas akiri informojn pri la datumbazo de cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: ripetita datumbazo de cscope ne aldonita"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: konekto cscope %s netrovita"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "konekto cscope %s fermita"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: neriparebla eraro en cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Etikedo de cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2562,374 +3268,87 @@ msgstr ""
 "\n"
 " nro   linio"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "dosiernomo / kunteksto / linio\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Eraro de cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Reŝargo de ĉiuj datumbazoj de cscope"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "neniu konekto de cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    nomo de datumbazo                   prefiksa vojo\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "La biblioteko Lua no ŝargeblis."
-
-msgid "cannot save undo information"
-msgstr "ne eblas konservi informojn de malfaro"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Bedaŭrinde, tiu komando estas malŝaltita, ne eblis ŝargi la "
-"bibliotekojn."
-
-msgid "invalid expression"
-msgstr "nevalida esprimo"
-
-msgid "expressions disabled at compile time"
-msgstr "esprimoj malŝaltitaj dum kompilado"
-
-msgid "hidden option"
-msgstr "kaŝita opcio"
-
-msgid "unknown option"
-msgstr "nekonata opcio"
-
-msgid "window index is out of range"
-msgstr "indekso de fenestro estas ekster limoj"
-
-msgid "couldn't open buffer"
-msgstr "ne eblis malfermi bufron"
-
-msgid "cannot delete line"
-msgstr "ne eblas forviŝi linion"
-
-msgid "cannot replace line"
-msgstr "ne eblas anstataŭigi linion"
-
-msgid "cannot insert line"
-msgstr "ne eblas enmeti linion"
-
-msgid "string cannot contain newlines"
-msgstr "ĉeno ne rajtas enhavi liniavancojn"
-
-msgid "error converting Scheme values to Vim"
-msgstr "eraro dum konverto de Scheme-valoro al Vim"
-
-msgid "Vim error: ~a"
-msgstr "Eraro de Vim: ~a"
-
-msgid "Vim error"
-msgstr "Eraro de Vim"
-
-msgid "buffer is invalid"
-msgstr "bufro estas nevalida"
-
-msgid "window is invalid"
-msgstr "fenestro estas nevalida"
-
-msgid "linenr out of range"
-msgstr "numero de linio ekster limoj"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "nepermesebla en sabloludejo de Vim"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Vim ne povas plenumi :python post uzo de :py3"
-
-msgid "only string keys are allowed"
-msgstr "nur ĉenaj ŝlosiloj estas permeseblaj"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Bedaŭrinde tiu komando estas malŝaltita: la biblioteko de Pitono ne "
-"ŝargeblis."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Ne eblas alvoki Pitonon rekursie"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Vim ne povas plenumi :py3  post uzo de :python"
-
-msgid "index must be int or slice"
-msgstr "indekso devas esti 'int' aŭ 'slice'"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ devas esti apero de Ĉeno"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Bedaŭrinde tiu komando estas malŝaltita, la biblioteko Ruby ne "
-"ŝargeblis."
-
-msgid "E267: unexpected return"
-msgstr "E267: \"return\" neatendita"
-
-msgid "E268: unexpected next"
-msgstr "E268: \"next\" neatendita"
-
-msgid "E269: unexpected break"
-msgstr "E269: \"break\" neatendita"
-
-msgid "E270: unexpected redo"
-msgstr "E270: \"redo\" neatendita"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: \"retry\" ekster klaŭzo \"rescue\""
-
-msgid "E272: unhandled exception"
-msgstr "E272: netraktita escepto"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: nekonata stato de longjmp: %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Baskuligi realigon/difinon"
-
-msgid "Show base class of"
-msgstr "Vidigi bazan klason de"
-
-msgid "Show overridden member function"
-msgstr "Montri anajn homonimigajn funkciojn"
-
-msgid "Retrieve from file"
-msgstr "Rekuperi el dosiero"
-
-msgid "Retrieve from project"
-msgstr "Rekuperi el projekto"
-
-msgid "Retrieve from all projects"
-msgstr "Rekuperi de ĉiuj projektoj"
-
-msgid "Retrieve"
-msgstr "Rekuperi"
-
-msgid "Show source of"
-msgstr "Vidigi fonton de"
-
-msgid "Find symbol"
-msgstr "Trovi simbolon"
-
-msgid "Browse class"
-msgstr "Foliumi klasojn"
-
-msgid "Show class in hierarchy"
-msgstr "Montri klason en hierarkio"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Montri klason en hierarkio restriktita"
-
-# todo
-msgid "Xref refers to"
-msgstr "Xref ligas al"
-
-msgid "Xref referred by"
-msgstr "Xref ligiĝas de"
-
-msgid "Xref has a"
-msgstr "Xref havas"
-
-msgid "Xref used by"
-msgstr "Xref uzita de"
-
-# DP: mi ne certas pri kio temas
-msgid "Show docu of"
-msgstr "Vidigi dokumentaron de"
-
-msgid "Generate docu for"
-msgstr "Krei dokumentaron de"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Konekto al SNiFF+ neeblas. Kontrolu medion (sniffemacs trovendas en $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Eraro dum lego. Malkonektita"
-
-# DP: Tiuj 3 mesaĝoj estas kune
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ estas aktuale "
-
-msgid "not "
-msgstr "ne "
-
-msgid "connected"
-msgstr "konektita"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Nekonata peto de SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Eraro dum konekto al SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ ne estas konektita"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ne estas bufro SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Eraro dum skribo. Malkonektita"
-
-msgid "invalid buffer number"
-msgstr "nevalida numero de bufro"
-
-msgid "not implemented yet"
-msgstr "ankoraŭ ne realigita"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "ne eblas meti la linio(j)n"
-
-msgid "invalid mark name"
-msgstr "nevalida nomo de marko"
-
-msgid "mark not set"
-msgstr "marko ne estas metita"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "linio %d kolumno %d"
-
-msgid "cannot insert/append line"
-msgstr "ne eblas enmeti/postaldoni linion"
-
-msgid "line number out of range"
-msgstr "numero de linio ekster limoj"
-
-msgid "unknown flag: "
-msgstr "nekonata flago: "
-
-# DP: ĉu traduki vimOption
-msgid "unknown vimOption"
-msgstr "nekonata vimOption"
-
-msgid "keyboard interrupt"
-msgstr "klavara interrompo"
-
-msgid "vim error"
-msgstr "eraro de Vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "ne eblas krei komandon de bufro/fenestro: objekto estas forviŝiĝanta"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"ne eblas registri postalvokan komandon: bufro/fenestro estas jam forviŝiĝanta"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: NERIPAREBLA TCL-ERARO: reflist difekta!? Bv. retpoŝti al vim-dev@vim."
-"org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"ne eblas registri postalvokan komandon: referenco de bufro/fenestro ne "
-"troveblas"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Bedaŭrinde tiu komando estas malŝaltita: la biblioteko Tcl ne "
-"ŝargeblis."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: elira kodo %d"
-
-msgid "cannot get line"
-msgstr "ne eblas akiri linion"
-
-msgid "Unable to register a command server name"
-msgstr "Ne eblas registri nomon de komanda servilo"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Sendo de komando al cela programo fiaskis"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Nevalida identigilo de servilo uzita: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: Ecoj de registro de apero de VIM estas nevalide formata. Forviŝita!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Nekonata argumento de opcio"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Tro da argumentoj de redakto"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argumento mankas post"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Forĵetindaĵo post argumento de opcio"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Tro da argumentoj \"+komando\", \"-c komando\" aŭ \"--cmd komando\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Nevalida argumento por"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d redaktendaj dosieroj\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans ne estas subtenata kun tiu grafika interfaco\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Tiu Vim ne estis kompilita kun la kompara eblo."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' ne uzeblas: malŝaltita dum kompilado\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Provas malfermi skriptan dosieron denove: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Ne eblas malfermi en lega reĝimo: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Ne eblas malfermi por eligo de skripto: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Eraro: Fiaskis lanĉi gvim el NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Averto: Eligo ne estas al terminalo\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Averto: Enigo ne estas el terminalo\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "komanda linio pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Ne eblas legi el \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2938,18 +3357,23 @@ msgstr ""
 "Pliaj informoj per: \"vim -h\"\n"
 
 # DP: tajpu "vim --help" por testi tiujn mesaĝojn
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[dosiero...]     redakti specifita(j)n dosiero(j)n"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                legi tekston el stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t etikedo       redakti dosieron kie etikedo estas difinata"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [erardosiero] redakti dosieron kun unua eraro"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2959,9 +3383,11 @@ msgstr ""
 "\n"
 "  uzo:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumentoj] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2969,13 +3395,7 @@ msgstr ""
 "\n"
 "   aŭ:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Kie uskleco estas ignorita antaŭaldonu / por igi flagon majuskla"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2985,328 +3405,197 @@ msgstr ""
 "\n"
 "Argumentoj:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tNur dosiernomoj post tio"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNe malvolvi ĵokerojn"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistri tiun gvim al OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tMalregistri gvim de OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tRuli per grafika interfaco (kiel \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  aŭ  --nofork\tMalfono: ne forki kiam lanĉas grafikan interfacon"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tReĝimo Vi (kiel \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tReĝimo Ex (kiel \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tPlibonigita Ex-reĝimo"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tSilenta (stapla) reĝimo (nur por \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tKompara reĝimo (kiel \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tFacila reĝimo (kiel \"evim\", senreĝima)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tNurlegebla reĝimo (kiel \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tLimigita reĝimo (kiel \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tŜanĝoj (skribo al dosieroj) nepermeseblaj"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tŜanĝoj al teksto nepermeseblaj"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tDuuma reĝimo"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tReĝimo Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKongrua kun Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNe tute kongrua kun Vi: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 "-V[N][dosiernomo]\tEsti babilema [nivelo N] [konservi mesaĝojn al dosiernomo]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tSencimiga reĝimo"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNeniu permutodosiero .swp, uzas nur memoron"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tListigi permutodosierojn .swp kaj eliri"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (kun dosiernomo)\tRestaŭri kolapsintan seancon"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tKiel -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNe uzi newcli por malfermi fenestrojn"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <aparatdosiero>\t\tUzi <aparatdosiero>-n por eneligo"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tKomenci en araba reĝimo"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tKomenci en hebrea reĝimo"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tKomenci en persa reĝimo"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminalo>\tAgordi terminalon al <terminalo>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tUzi <vimrc> anstataŭ iun ajn .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tUzi <gvimrc> anstataŭ iun ajn .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNe ŝargi kromaĵajn skriptojn"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tMalfermi N langetojn (defaŭlto: po unu por ĉiu dosiero)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tMalfermi N fenestrojn (defaŭlto: po unu por ĉiu dosiero)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tKiel -o sed dividi vertikale"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tKomenci ĉe la fino de la dosiero"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<numL>\t\tKomenci ĉe linio <numL>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr ""
 "--cmd <komando>\tPlenumi <komando>-n antaŭ ol ŝargi iun ajn dosieron vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <komando>\t\tPlenumi <komando>-n post kiam la unua dosiero ŝargiĝis"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <seanco>\t\tRuli dosieron <seanco>-n post kiam la unua dosiero ŝargiĝis"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skripto>\t\tLegi komandojn en Normala reĝimo el dosiero <skripto>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr ""
 "-w <eligaskripto>\tPostaldoni ĉiujn tajpitajn komandojn al dosiero "
 "<eligaskripto>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr ""
 "-W <eligaskripto>\tSkribi ĉiujn tajpitajn komandojn al dosiero <eligaskripto>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tRedakti ĉifradan dosieron"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <ekrano>\tKonekti Vim al tiu X-servilo"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNe konekti al X-servilo"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <dosieroj>\tRedakti <dosieroj>-n en Vim-servilo se eblas"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <dosieroj>  Same, sed ne plendi se ne estas servilo"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <dosieroj>  Kiel --remote sed atendi ĝis dosieroj estas "
-"redaktitaj"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <dosieroj> Same, sed ne plendi se ne estas servilo"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <dosieroj> Kiel --remote sed uzi langeton por "
-"ĉiu dosiero"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <klavoj> Sendi <klavoj>-n al Vim-servilo kaj eliri"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <espr>\tKomputi <espr> en Vim-servilo kaj afiŝi rezulton"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tListigi haveblajn nomojn de Vim-serviloj kaj eliri"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nomo>\tSendu al/iĝi la Vim-servilo <nomo>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <dosiero>  Skribi mesaĝojn de komenca tempomezurado al "
 "<dosiero>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUzi <viminfo> anstataŭ .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  aŭ  --help\tAfiŝi Helpon (tiun mesaĝon) kaj eliri"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tAfiŝi informon de versio kaj eliri"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumentoj agnoskitaj de gvim (versio Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumentoj agnoskitaj de gvim (versio neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumentoj agnoskitaj de gvim (versio Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <ekrano>\tLanĉi vim sur <ekrano>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tLanĉi vim piktograme"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <koloro>\tUzi <koloro>-n por la fona koloro (ankaŭ: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <koloro>\tUzi <koloro>-n por la malfona koloro (ankaŭ: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <tiparo>\tUzi <tiparo>-n por normala teksto (ankaŭ: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <tiparo>\tUzi <tiparo>-n por grasa teksto"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <tiparo>\tUzi <tiparo>-n por kursiva teksto"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\tUzi <geom> kiel komenca geometrio (ankaŭ: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <larĝo>\tUzi <larĝo>-n kiel larĝo de bordero (ankaŭ: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <larĝo>  Uzi <larĝo>-n kiel larĝo de rulumskalo (ankaŭ: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <alto>\tUzi <alto>-n kiel alto de menuzona alto (ankaŭ: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tUzi inversan videon (ankaŭ: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNe uzi inversan videon (ankaŭ: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <rimedo>\tAgordi la specifitan <rimedo>-n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumentoj agnoskitaj de gvim (versio GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <ekrano>\tLanĉi Vim sur tiu <ekrano> (ankaŭ: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <rolo>\tDoni unikan rolon por identigi la ĉefan fenestron"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tMalfermi Vim en alia GTK fenestraĵo"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tIgas gvim afiŝi la identigilon de vindozo sur stdout"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <gepatra titolo>\tMalfermi Vim en gepatra aplikaĵo"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tMalfermi Vim en alia win32 fenestraĵo"
-
-msgid "No display"
-msgstr "Neniu ekrano"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Sendo fiaskis.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Sendo fiaskis. Provo de loka plenumo\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d de %d redaktita(j)"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Neniu ekrano: Sendado de esprimo fiaskis.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Sendado de esprimo fiaskis.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Neniu marko"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Neniu marko kongruas kun \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3315,6 +3604,7 @@ msgstr ""
 "mark linio kol dosiero/teksto"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3323,6 +3613,7 @@ msgstr ""
 " salt linio kol dosiero/teksto"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3330,6 +3621,7 @@ msgstr ""
 "\n"
 "ŝanĝo  linio kol teksto"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3338,6 +3630,7 @@ msgstr ""
 "# Markoj de dosiero:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3345,6 +3638,7 @@ msgstr ""
 "\n"
 "# Saltlisto (plej novaj unue):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3352,90 +3646,85 @@ msgstr ""
 "\n"
 "# Historio de markoj en dosieroj (de plej nova al plej malnova):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Mankas '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Nevalida kodpaĝo"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Ne eblas agordi valorojn de IC"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Ne eblis krei enigan kuntekston"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Ne eblis malfermi enigan metodon"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Averto: Ne eblis agordi detruan reagfunkcion al IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: eniga metodo subtenas neniun stilon"
-
-# DP: mi ne scias, kio estas "preedit"
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: eniga metodo ne subtenas mian antaŭredaktan tipon"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: bloko ne estis ŝlosita"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Eraro de enpoziciigo dum lego de permutodosiero .swp"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Eraro de lego en permutodosiero .swp"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Eraro de enpoziciigo dum skribo de permutodosiero .swp"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Skriberaro en permutodosiero .swp"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Permutodosiero .swp jam ekzistas (ĉu atako per simbola ligilo?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Ĉu ne akiris blokon n-ro 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Ĉu ne akiris blokon n-ro 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Ĉu ne akiris blokon n-ro 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Eraro dum ĝisdatigo de ĉifrada permutodosiero .swp"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ve, perdis la permutodosieron .swp!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Ne eblis renomi la permutodosieron .swp"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Ne eblas malfermi permutodosieron .swp de \"%s\", restaŭro neeblas"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Ne akiris blokon 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Neniu permutodosiero .swp trovita por %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Entajpu la uzendan numeron de permutodosiero .swp (0 por eliri): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Ne eblas malfermi %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Ne eblas legi blokon 0 de "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3443,22 +3732,28 @@ msgstr ""
 "\n"
 "Eble neniu ŝanĝo estis farita aŭ Vim ne ĝisdatigis la permutodosieron .swp."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " ne uzeblas per tiu versio de vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Uzu version 3.0 de Vim\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ne aspektas kiel permutodosiero .swp de Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " ne uzeblas per tiu komputilo.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "La dosiero estas kreita je "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3466,104 +3761,85 @@ msgstr ""
 ",\n"
 "aŭ la dosiero estas difekta."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s estas ĉifrata kaj tiu versio de Vim ne subtenas ĉifradon"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " difektiĝis (paĝa grando pli malgranda ol minimuma valoro).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Uzado de permutodosiero .swp \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Originala dosiero \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Averto: Originala dosiero eble ŝanĝiĝis"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Perumutodosiero .swp estas ĉifrata: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Se vi tajpis novan ŝlosilon de ĉifrado sed ne skribis la tekstan dosieron,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"tajpu la novan ŝlosilon de ĉifrado."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Se vi skribis la tekstan dosieron post ŝanĝo de la ŝlosilo de ĉifrado, premu "
-"enenklavon"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"por uzi la saman ŝlosilon por la teksta dosiero kaj permuto dosiero .swp"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Ne eblas legi blokon 1 de %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???MULTAJ LINIOJ MANKAS"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???NOMBRO DE LINIOJ NE ĜUSTAS"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???MALPLENA BLOKO"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LINIOJ MANKANTAJ"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr ""
 "E310: Nevalida identigilo de bloko 1 (ĉu %s ne estas permutodosiero .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???MANKAS BLOKO"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? ekde tie ĝis ???FINO linioj estas eble difektaj"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? ekde tie ĝis ???FINO linioj estas eble enmetitaj/forviŝitaj"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???FINO"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Restaŭro interrompita"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Eraroj dum restaŭro; rigardu liniojn komencantajn per ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Vidu \":help E312\" por pliaj informoj."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Restaŭro finiĝis. Indus kontroli ĉu ĉio estas en ordo."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3571,13 +3847,16 @@ msgstr ""
 "\n"
 "(Indas konservi tiun dosieron per alia nomo\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "kaj lanĉi diff kun la originala dosiero por kontroli la ŝanĝojn)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr ""
 "Restaŭro finiĝis. La enhavo de la bufro samas kun la enhavo de la dosiero."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3587,44 +3866,52 @@ msgstr ""
 "La dosiero .swp nun forviŝindas.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr ""
-"Uzas ŝlosilon de ĉifrado el permuto dosiero .swp por la teksta dosiero.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Permutodosiero .swp trovita:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   En la aktuala dosierujo:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Uzado de specifita nomo:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   En dosierujo "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "     -- nenio --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "       posedata de: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    dato: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              dato: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [de Vim versio 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ne aspektas kiel permutodosiero .swp de Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "        dosiernomo: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3632,12 +3919,15 @@ msgstr ""
 "\n"
 "          modifita: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JES"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ne"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3645,9 +3935,11 @@ msgstr ""
 "\n"
 "        uzantonomo: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr " komputila nomo: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3655,6 +3947,7 @@ msgstr ""
 "\n"
 "    komputila nomo: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3662,16 +3955,11 @@ msgstr ""
 "\n"
 "        proceza ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (ankoraŭ ruliĝas)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [ne uzebla per tiu versio de Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3679,75 +3967,97 @@ msgstr ""
 "\n"
 "         [neuzebla per tiu komputilo]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [nelegebla]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [nemalfermebla]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Ne eblas konservi, ne estas permutodosiero .swp"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Dosiero konservita"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Konservo fiaskis"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: nevalida lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: ne eblas trovi linion %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: nevalida referenco de bloko id 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx devus esti 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Ĉu ĝisdatigis tro da blokoj?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: nevalida referenco de bloko id 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "ĉu forviŝita bloko 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Ne eblas trovi linion %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: nevalida referenco de bloko id"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count estas nul"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: numero de linio ekster limoj: %<PRId64> preter la fino"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: nevalida nombro de linioj en bloko %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Stako pligrandiĝas"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: nevalida referenco de bloko id 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Buklo de simbolaj ligiloj por \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ATENTO"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3755,14 +4065,15 @@ msgstr ""
 "\n"
 "Trovis permutodosieron .swp kun la nomo \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Dum malfermo de dosiero \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      PLI NOVA ol permutodosiero .swp!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3774,15 +4085,19 @@ msgstr ""
 "    Se jes, estu singarda por ne havi du malsamajn\n"
 "    aperojn de la sama dosiero, kiam vi faros ŝanĝojn."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Eliru, aŭ daŭrigu singarde.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Redakta seanco de tiu dosiero kolapsis.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Se veras, uzu \":recover\" aŭ \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3790,9 +4105,11 @@ msgstr ""
 "\"\n"
 "    por restaŭri la ŝanĝojn (vidu \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Se vi jam faris ĝin, forviŝu la permutodosieron .swp \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3800,20 +4117,25 @@ msgstr ""
 "\"\n"
 "    por eviti tiun mesaĝon.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Permutodosiero .swp \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" jam ekzistas!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ATENTO"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Permutodosiero .swp jam ekzistas!"
 
 # AM: ĉu Vim konvertos la unuliterajn respondojn de la uzulo?
 # DP: jes, la '&' respondoj bone funkcias (mi kontrolis)
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3827,6 +4149,7 @@ msgstr ""
 "&Eliri\n"
 "Ĉe&sigi"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3842,34 +4165,56 @@ msgstr ""
 "&Eliri\n"
 "Ĉe&sigi"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Tro da dosieroj trovitaj"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Ne plu restas memoro! (disponigo de %<PRIu64> bajtoj)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Parto de vojo de menuero ne estas sub-menuo"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menuo nur ekzistas en alia reĝimo"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Neniu menuo \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Malplena nomo de menuo"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Vojo de menuo ne rajtas konduki al sub-menuo"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Aldono de menueroj direkte al menuzono estas malpermesita"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Disigilo ne rajtas esti ero de vojo de menuo"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3877,60 +4222,73 @@ msgstr ""
 "\n"
 "--- Menuoj ---"
 
-msgid "Tear off this menu"
-msgstr "Disigi tiun menuon"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Vojo de menuo devas konduki al menuero"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Menuo netrovita: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menuo ne estas difinita por reĝimo %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Vojo de menuo devas konduki al sub-menuo"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Menuo ne trovita - kontrolu nomojn de menuoj"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Eraro okazis dum traktado de %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "linio %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nevalida nomo de reĝistro: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Flegado de mesaĝoj: Dominique PELLÉ <dominique.pelle@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Interrompo: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Premu ENEN-KLAVON aŭ tajpu komandon por daŭrigi"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s linio %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Pli --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACETO/d/j: ekrano/paĝo/sub linio, b/u/k: supre, q: eliri "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Demando"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3938,8 +4296,19 @@ msgstr ""
 "&Jes\n"
 "&Ne"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Jes\n"
+"&Ne\n"
+"&Rezigni"
+
 # AM: ĉu Vim konvertos unuliterajn respondojn?
 # DP: jes, '&' bone funkcias (mi kontrolis)
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3953,274 +4322,175 @@ msgstr ""
 "&Forlasi Ĉion\n"
 "&Rezigni"
 
-msgid "Select Directory dialog"
-msgstr "Dialogujo de dosiera elekto"
-
-msgid "Save File dialog"
-msgstr "Dialogujo de dosiera konservo"
-
-msgid "Open File dialog"
-msgstr "Dialogujo de dosiera malfermo"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Bedaŭrinde ne estas dosierfoliumilo en konzola reĝimo"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Ne sufiĉaj argumentoj por printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Atendis Glitpunktnombron kiel argumento de printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Tro da argumentoj al printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Averto: Ŝanĝo de nurlegebla dosiero"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "Tajpu nombron kaj <Enenklavon> aŭ alklaku per la muso (malpleno rezignas): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Tajpu nombron kaj <Enenklavon> (malpleno rezignas): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 plia linio"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 malplia linio"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> pliaj linioj"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> malpliaj linioj"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Interrompita)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Bip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: konservo de dosieroj...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Finita.\n"
-
-msgid "ERROR: "
-msgstr "ERARO: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bajtoj] totalaj disponigitaj/maldisponigitaj %<PRIu64>-%<PRIu64>, nun uzataj %<PRIu64>, "
-"kulmina uzo %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[alvokoj] totalaj re/malloc() %<PRIu64>, totalaj free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Linio iĝas tro longa"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Interna eraro: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Ne plu restas memoro! (disponigo de %<PRIu64> bajtoj)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Alvokas ŝelon por plenumi: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Mankas dupunkto"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Reĝimo nepermesata"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Nevalida formo de muskursoro"
-
-msgid "E548: digit expected"
-msgstr "E548: cifero atendata"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Nevalida procento"
-
-msgid "Enter encryption key: "
-msgstr "Tajpu la ŝlosilon de ĉifrado: "
-
-msgid "Enter same key again: "
-msgstr "Tajpu la ŝlosilon denove: "
-
-msgid "Keys don't match!"
-msgstr "Ŝlosiloj ne kongruas!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: tro longa vojo por kompletigo"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Nevalida vojo: '**[nombro]' devas esti ĉe la fino de la vojo aŭ "
-"sekvita de '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Ne eblas trovi dosierujon \"%s\" en cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Ne eblas trovi dosieron \"%s\" en serĉvojo"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Ne plu trovis dosierujon \"%s\" en cdpath"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Ne plu trovis dosieron \"%s\" en serĉvojo"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Ne eblas konekti al Netbeans n-ro 2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Ne eblas konekti al Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Nevalida permeso de dosiero de informo de konekto NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "lego el kontaktoskatolo de Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Konekto de NetBeans perdita por bufro %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans ne estas subtenata kun tiu grafika interfaco"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: nebeans jam konektata"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s estas nurlegebla (aldonu ! por transpasi)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Neniu identigilo sub la kursoro"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' estas malplena"
 
-# DP: ĉu Eval devas esti tradukita?
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval eblo ne disponeblas"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Averto: terminalo ne povas emfazi"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Neniu ĉeno sub la kursoro"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Ne eblas forviŝi faldon per aktuala 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Listo de ŝanĝoj estas malplena"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Ĉe komenco de ŝanĝlisto"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Ĉe fino de ŝanĝlisto"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Tajpu \":quit<Enenklavo>\" por eliri el Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 linio %sita 1 foje"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 linio %sita %d foje"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> linio %sita 1 foje"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> linioj %sitaj %d foje"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> krommarĝenendaj linioj... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 linio krommarĝenita "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> linioj krommarĝenitaj "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Neniu reĝistro antaŭe uzata"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "ne eblas kopii; forviŝi tamene"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 linio ŝanĝita"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> linioj ŝanĝitaj"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "malokupas %<PRId64> liniojn"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "bloko de 1 linio kopiita"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 linio kopiita"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "bloko de %<PRId64> linioj kopiita"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> linioj kopiitaj"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Nenio en reĝistro %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4228,9 +4498,11 @@ msgstr ""
 "\n"
 "--- Reĝistroj ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Nevalida nomo de reĝistro"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4238,162 +4510,181 @@ msgstr ""
 "\n"
 "# Reĝistroj:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Nekonata tipo de reĝistro %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kolumnoj; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Apartigis %s%<PRId64> de %<PRId64> Linioj; %<PRId64> de %<PRId64> Vortoj; %<PRId64> de %<PRId64> Bajtoj"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Apartigis %s%<PRId64> de %<PRId64> Linioj; %<PRId64> de %<PRId64> Vortoj; %<PRId64> de %<PRId64> Signoj; %<PRId64> de "
-"%<PRId64> Bajtoj"
+"Apartigis %s%<PRId64> de %<PRId64> Linioj; %<PRId64> de %<PRId64> Vortoj; "
+"%<PRId64> de %<PRId64> Bajtoj"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s de %s; Linio %<PRId64> de %<PRId64>; Vorto %<PRId64> de %<PRId64>; Bajto %<PRId64> de %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s de %s; Linio %<PRId64> de %<PRId64>; Vorto %<PRId64> de %<PRId64>; Signo %<PRId64> de %<PRId64>; Bajto "
-"%<PRId64> de %<PRId64>"
+"Apartigis %s%<PRId64> de %<PRId64> Linioj; %<PRId64> de %<PRId64> Vortoj; "
+"%<PRId64> de %<PRId64> Signoj; %<PRId64> de %<PRId64> Bajtoj"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s de %s; Linio %<PRId64> de %<PRId64>; Vorto %<PRId64> de %<PRId64>; "
+"Bajto %<PRId64> de %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s de %s; Linio %<PRId64> de %<PRId64>; Vorto %<PRId64> de %<PRId64>; "
+"Signo %<PRId64> de %<PRId64>; Bajto %<PRId64> de %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> por BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Folio %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dankon pro flugi per Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Nekonata opcio"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opcio ne subtenata"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Nepermesebla en reĝimlinio"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Klavkodo ne agordita"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Nombro bezonata post ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Netrovita en termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Nevalida signo <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Ne eblas agordi 'term' al malplena ĉeno"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: term ne ŝanĝeblas en grafika interfaco"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Uzu \":gui\" por lanĉi la grafikan interfacon"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' kaj 'patchmode' estas egalaj"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Konfliktoj kun la valoro de 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Konfliktoj kun la valoro de 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Ne ŝanĝeblas en la grafika interfaco GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Mankas dupunkto"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Ĉeno de nula longo"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Mankas nombro post <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Mankas komo"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Devas specifi ' valoron"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: enhavas nepreseblan aŭ plurĉellarĝan signon"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Nevalida(j) tiparo(j)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: ne eblas elekti tiparon"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Nevalida tiparo"
-
-msgid "E533: can't select wide font"
-msgstr "E533: ne eblas elekti larĝan tiparon"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Nevalida larĝa tiparo"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Nevalida signo post <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: komo bezonata"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' devas esti malplena aŭ enhavi %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Neniu muso subtenata"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: '}' mankas"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: tro da elementoj"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: misekvilibritaj grupoj"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Antaŭvida fenestro jam ekzistas"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: La araba bezonas UTF-8, tajpu \":set encoding=utf-8\""
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Bezonas almenaŭ %d liniojn"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Bezonas almenaŭ %d kolumnojn"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Nekonata opcio: %s"
@@ -4401,10 +4692,12 @@ msgstr "E355: Nekonata opcio: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Nombro bezonata: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4412,6 +4705,7 @@ msgstr ""
 "\n"
 "--- Kodoj de terminalo ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4419,6 +4713,7 @@ msgstr ""
 "\n"
 "--- Mallokaj opcioj ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4426,6 +4721,7 @@ msgstr ""
 "\n"
 "--- Valoroj de lokaj opcioj ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4433,140 +4729,21 @@ msgstr ""
 "\n"
 "--- Opcioj ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ERARO get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Kongrua signo mankas por %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Ekstraj signoj post punktokomo: %s"
 
-msgid "cannot open "
-msgstr "ne eblas malfermi "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Ne eblas malfermi fenestron!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Bezonas version 2.04 de Amigados aŭ pli novan\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Bezonas %s-on versio %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Ne eblas malfermi NIL:\n"
-
-msgid "Cannot create "
-msgstr "Ne eblas krei "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim eliras kun %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "ne eblas ŝanĝi reĝimon de konzolo?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: ne estas konzolo??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Ne eblas plenumi ŝelon kun opcio -f"
-
-msgid "Cannot execute "
-msgstr "Ne eblas plenumi "
-
-msgid "shell "
-msgstr "ŝelo "
-
-msgid " returned\n"
-msgstr " liveris\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE tro malgranda."
-
-msgid "I/O ERROR"
-msgstr "ERARO DE ENIGO/ELIGO"
-
-msgid "Message"
-msgstr "Mesaĝo"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' ne estas 80, ne eblas plenumi eksternajn komandojn"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Elekto de presilo fiaskis"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "al %s de %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Nekonata tiparo de presilo: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Eraro de presado: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Presas '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Nevalida nomo de signaro \"%s\" en nomo de tiparo \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Nevalida signo '%c' en nomo de tiparo \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Duobla signalo, eliranta\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Kaptis mortigantan signalon %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Kaptis mortigantan signalon\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Malfermo de vidigo X daŭris %<PRId64> msek"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Alvenis X eraro\n"
-
-msgid "Testing the X display failed"
-msgstr "Testo de la vidigo X fiaskis"
-
-msgid "Opening the X display timed out"
-msgstr "Tempolimo okazis dum malfermo de vidigo X"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Ne povis akiri kuntekston de sekureco por "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Ne povis ŝalti kuntekston de sekureco por "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4574,13 +4751,7 @@ msgstr ""
 "\n"
 "Ne eblas plenumi ŝelon "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Ne eblas plenumi ŝelon sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4588,255 +4759,235 @@ msgstr ""
 "\n"
 "ŝelo liveris "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Ne eblas krei duktojn\n"
+"Ne povis akiri kuntekston de sekureco por "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Ne eblas forki\n"
+"Ne povis ŝalti kuntekston de sekureco por "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Komando terminigita\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP perdis la konekton ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Malfermo de vidigo X fiaskis"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP: traktado de peto konservi-mem"
-
-msgid "XSMP opening connection"
-msgstr "XSMP: malfermo de konekto"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP: kontrolo de konekto ICE fiaskis"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP: SmcOpenConnection fiaskis: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Ne eblas trovi dosieron \"%s\" en serĉvojo"
 
-msgid "At line"
-msgstr "Ĉe linio"
-
-msgid "Could not load vim32.dll!"
-msgstr "Ne eblis ŝargi vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Eraro de VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Ne eblis ripari referencojn de funkcioj al la DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "la ŝelo liveris %d"
-
-# DP: la eventoj estas tiuj, kiuj estas en la sekvantaj ĉenoj
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Kaptis eventon %s\n"
-
-msgid "close"
-msgstr "fermo"
-
-msgid "logoff"
-msgstr "elsaluto"
-
-msgid "shutdown"
-msgstr "sistemfermo"
-
-msgid "E371: Command not found"
-msgstr "E371: Netrovebla komando"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE ne troveblas en via $PATH.\n"
-"Eksteraj komandoj ne paŭzos post kompletigo.\n"
-"Vidu  :help win32-vimrun  por pliaj informoj."
-
-msgid "Vim Warning"
-msgstr "Averto de Vim"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Tro da %%%c en formata ĉeno"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Neatendita %%%c en formata ĉeno"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Mankas ] en formata ĉeno"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Nesubtenata %%%c en formata ĉeno"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Nevalida %%%c en prefikso de formata ĉeno"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Nevalida %%%c en formata ĉeno"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' enhavas neniun ŝablonon"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Nomo de dosierujo mankas aŭ estas malplena"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Ne plu estas eroj"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d de %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (forviŝita linio)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Ĉe la subo de stako de rapidriparo"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Ĉe la supro de stako de rapidriparo"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "listo de eraroj %d de %d; %d eraroj"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Ne eblas skribi, opcio 'buftype' estas ŝaltita"
 
-msgid "Error file"
-msgstr "Erara Dosiero"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Dosiernomo mankas aŭ nevalida ŝablono"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Ne eblas malfermi dosieron \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Bufro ne estas ŝargita"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Ĉeno aŭ Listo atendita"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: nevalida ano en %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Mankas ] post %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Neekvilibra %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Neekvilibra %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Neekvilibra %s"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Ŝablono tro longa"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Tro da \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Tro da %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Neekvilibra \\z("
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: nevalida signo post %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Tro da kompleksaj %s{...}-oj"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Ingita %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Ingita %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: nevalida uzo de \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c sekvas nenion"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Nevalida retro-referenco"
-
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( estas permesebla tie"
 
 # DP: vidu http://www.thefreedictionary.com/et+al.
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 kaj aliaj estas nepermeseblaj tie"
 
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Nevalida signo post \\z"
-
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Mankas ] post %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: Malplena %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Ŝablono tro longa"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Tro da \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Tro da %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Neekvilibra \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: nevalida signo post %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Tro da kompleksaj %s{...}-oj"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Ingita %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Ingita %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: nevalida uzo de \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c sekvas nenion"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Nevalida retro-referenco"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Nevalida signo post \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Nevalida signo post %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Nevalida signo post %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Sintaksa eraro en %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Eksteraj subkongruoj:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
@@ -4844,42 +4995,65 @@ msgstr ""
 "E864: \\%#= povas nur esti sekvita de 0, 1, aŭ 2. La aŭtomata motoro de "
 "regulesprimo estos uzata "
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) Trovis finon de regulesprimo tro frue"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA-regulesprimo) Mispoziciigita %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) Trovis finon de regulesprimo tro frue"
+#: ../regexp_nfa.c:242
+#, fuzzy, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr "E877: (NFA-regulesprimo) Nevalida klaso de signo "
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Nekonata operatoro '\\z%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Eraro dum prekomputado de NFA kun ekvivalentoklaso!"
+#: ../regexp_nfa.c:1387
+#, fuzzy, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr "E867: (NFA) Nekonata operatoro '\\z%c'"
 
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Nekonata operatoro '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFS-regulesprimo) Eraro dum legado de limoj de ripeto"
 
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr ""
 "E871: (NFA-regulesprimo) Ne povas havi mult-selekton tuj post alia mult-"
 "selekto!"
 
+#. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA-regulesprimo) tro da '('"
 
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E872: (NFA-regulesprimo) tro da '('"
+
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA-regulesprimo) propra end-eraro"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Ne povis elpreni de la staplo!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
@@ -4887,147 +5061,177 @@ msgstr ""
 "E875: (NFA-regulesprimo) (dum konverto de postmeto al NFA), restas tro da "
 "statoj en la staplo"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA-regulesprimo) ne sufiĉa spaco por enmomorigi la tutan NFA "
 
-msgid "E999: (NFA regexp internal error) Should not process NOT node !"
-msgstr ""
-"E999: (interna eraro de NFA-regulesprimo) Ne devus procezi nodon 'NOT'!"
-
-#. should not be here :P
-msgid "E877: (NFA regexp) Invalid character class "
-msgstr "E877: (NFA-regulesprimo) Nevalida klaso de signo "
-
-#, c-format
-msgid "(NFA) COULD NOT OPEN %s !"
-msgstr "(NFA) NE POVIS MALFERMI %s!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
 "Ne povis malfermi provizoran protokolan dosieron por skribi, nun montras sur "
 "stderr ..."
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Ne povis asigni memoron por traigi branĉojn!"
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr "(NFA) NE POVIS MALFERMI %s!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Ne povis malfermi la provizoran protokolan dosieron por skribi "
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-ANSTATAŬIGO"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ANSTATAŬIGO"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " INVERSI"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " ENMETO"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (enmeto)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (anstataŭigo)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-anstataŭigo)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hebrea"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " araba"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lingvo)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (algluo)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VIDUMA"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VIDUMA LINIO"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VIDUMA BLOKO"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " APARTIGO"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " APARTIGITA LINIO"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " APARTIGITA BLOKO"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "registrado"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Nevalida serĉenda ĉeno: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: serĉo atingis SUPRON sen trovi: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: serĉo atingis SUBON sen trovi: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Atendis '?' aŭ '/' post ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (enhavas antaŭe listigitajn kongruojn)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Inkluzivitaj dosieroj "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "netrovitaj "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "en serĉvojo ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Jam listigita)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NETROVITA"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Skanado de inkluzivitaj dosieroj: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Serĉado de inkluzivitaj dosieroj %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Kongruo estas ĉe aktuala linio"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Ĉiuj inkluzivitaj dosieroj estis trovitaj"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Neniu inkluzivita dosiero"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Ne eblis trovi difinon"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Ne eblis trovi ŝablonon"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Anstataŭigi "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5038,84 +5242,97 @@ msgstr ""
 "# Lasta serĉa ŝablono %s:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Eraro de formato en literuma dosiero"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Trunkita literuma dosiero"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Vosta teksto en %s linio %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Nomo de afikso tro longa en %s linio %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Eraro de formato en afiksa dosiero FOL, LOW aŭ UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Signo en FOL, LOW aŭ UPP estas ekster limoj"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Densigas arbon de vortoj..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Literumilo ne estas ŝaltita"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr "Averto: Ne eblas trovi vortliston \"%s_%s.spl\" aŭ \"%s_ascii.spl\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Averto: Ne eblas trovi vortliston \"%s.%s.spl\" aŭ \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Legado de literuma dosiero \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Tio ne ŝajnas esti literuma dosiero"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Malnova literuma dosiero, ĝisdatigo bezonata"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Literuma dosiero estas por pli nova versio de Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Nesubtenata sekcio en literuma dosiero"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Averto: regiono %s ne subtenata"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Legado de afiksa dosiero %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Malsukceso dum konverto de vorto en %s linio %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konverto en %s nesubtenata: de %s al %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konverto en %s nesubtenata"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Nevalida valoro de FLAG en %s linio %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG post flagoj en %s linio %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5124,6 +5341,7 @@ msgstr ""
 "Difino de COMPOUNDFORBIDFLAG post ano PFX povas doni neĝustajn rezultojn en "
 "%s linio %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5132,34 +5350,42 @@ msgstr ""
 "Difino de COMPOUNDPERMITFLAG post ano PFX povas doni neĝustajn rezultojn en "
 "%s linio %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Nevalida valoro de COMPOUNDRULES en %s linio %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Nevalida valoro de COMPOUNDWORDMAX en %s linio %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Nevalida valoro de COMPOUNDMIN en %s linio %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Nevalida valoro de COMPOUNDSYLMAX en %s linio %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Nevalida valoro de CHECKCOMPOUNDPATTERN en %s linio %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "Malsama flago de kombino en daŭra bloko de afikso en %s linio %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Ripetita afikso en %s linio %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5168,270 +5394,334 @@ msgstr ""
 "Afikso ankaŭ uzata por BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST en "
 "%s linio %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Y aŭ N atendita en %s linio %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Nevalida kondiĉo en %s linio %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Neatendita nombro REP(SAL) en %s linio %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Neatendita nombro de MAPen %s linio %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Ripetita signo en MAP en %s linio %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Neagnoskita aŭ ripetita ano en %s linio %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Mankas linio FOL/LOW/UPP en %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX uzita sen SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Tro da prokrastitaj prefiksoj"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Tro da kunmetitaj flagoj"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Tro da prokrastitaj prefiksoj kaj/aŭ kunmetitaj flagoj"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Mankas SOFO%s-aj linioj en %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Ambaŭ SAL kaj SOFO linioj en %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flago ne estas nombro en %s linio %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Nevalida flago en %s linio %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Valoro de %s malsamas ol tiu en alia dosiero .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Legado de vortardosiero %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Ne estas nombro de vortoj en %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "linio %6d, vorto %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Ripetita vorto en %s linio %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Unua ripetita vorto en %s linio %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d ripetita(j) vorto(j) en %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "%d ignorita(j) vorto(j) kun neaskiaj signoj en %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Legado de dosiero de vortoj %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Ripetita linio /encoding= ignorita en %s linio %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Linio /encoding= post vorto ignorita en %s linio %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Ripetita linio /regions= ignorita en %s linio %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Tro da regionoj en %s linio %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Linio / ignorita en %s linio %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Nevalida regiono nr en %s linio %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nekonata flago en %s linio %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignoris %d vorto(j)n kun neaskiaj signoj"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Ne sufiĉe da memoro, vortlisto estos nekompleta."
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Densigis %d de %d nodoj; %d (%d%%) restantaj"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Relegas la dosieron de literumo..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Fonetika analizado..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Nombro de vortoj post fonetika analizado: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Totala nombro de vortoj: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Skribado de dosiero de sugesto %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Evaluo de memoro uzata: %d bajtoj"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Nomo de eliga dosiero ne devas havi nomon de regiono"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Nur 8 regionoj subtenataj"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Nevalida regiono en %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Averto: ambaŭ NOBREAK kaj NOBREAK specifitaj"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Skribado de literuma dosiero %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Farita!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' ne havas %<PRId64> rikordojn"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Vorto fortirita el %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Vorto aldonita al %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Signoj de vorto malsamas tra literumaj dosieroj"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Bedaŭrinde ne estas sugestoj"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Bedaŭrinde estas nur %<PRId64> sugestoj"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Anstataŭigi \"%.*s\" per:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Neniu antaŭa literuma anstataŭigo"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Netrovita: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Tio ne ŝajnas esti dosiero .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Malnova dosiero .sug, bezonas ĝisdatigon: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Dosiero .sug estas por pli nova versio de Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Dosiero .sug ne kongruas kun dosiero .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: eraro dum legado de dosiero .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: ripetita signo en rikordo MAP"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Neniu sintaksa elemento difinita por tiu bufro"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Nevalida argumento: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Nenia sintaksa fasko: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Neniu sintaksa elemento difinita por tiu bufro"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "sinkronigo per C-stilaj komentoj"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "neniu sinkronigo"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "sinkronigo ekas "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " linioj antaŭ supra linio"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5439,6 +5729,7 @@ msgstr ""
 "\n"
 "--- Eroj de sintaksa sinkronigo ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5446,6 +5737,7 @@ msgstr ""
 "\n"
 "sinkronigo per eroj"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5453,208 +5745,272 @@ msgstr ""
 "\n"
 "--- Sintakseroj ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Nenia sintaksa fasko: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimuma "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksimuma "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; kongruo "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " liniavancoj"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: La argumento \"contains\" ne akcepteblas tie"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: nevalida valoro de cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: La argumento \"group[t]here\" ne akcepteblas tie"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Ne trovis regionan elementon por %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Dosiernomo bezonata"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Tro da sintaksaj inkluzivoj"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Mankas ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Mankas '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Ne sufiĉaj argumentoj: sintaksa regiono %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Tro da sintaksaj grupoj"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Neniu fasko specifita"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Disigilo de ŝablono netrovita: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Forĵetindaĵo post ŝablono: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: sintaksa sinkronigo: ŝablono de linia daŭrigo specifita dufoje"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Nevalidaj argumentoj: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Mankas egalsigno: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Malplena argumento: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s ne estas permesebla tie"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s devas esti la unua ano de la listo \"contains\""
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nekonata nomo de grupo: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Nevalida \":syntax\" subkomando: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursia buklo dum ŝargo de syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: emfaza grupo netrovita: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Ne sufiĉaj argumentoj: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Tro argumentoj: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: grupo havas agordojn, ligilo de emfazo ignorita"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: neatendita egalsigno: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: mankas egalsigno: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: mankas argumento: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Nevalida valoro: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Nekonata malfona koloro"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Nekonata fona koloro"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Kolora nomo aŭ nombro nerekonita: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: kodo de terminalo estas tro longa: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Nevalida argumento: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Tro da malsamaj atributoj de emfazo uzataj"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Nepresebla signo en nomo de grupo"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Nevalida signo en nomo de grupo"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Tro da emfazaj kaj sintaksaj grupoj"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: ĉe subo de stako de etikedoj"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: ĉe supro de stako de etikedoj"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Ne eblas iri antaŭ la unuan kongruan etikedon"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: etikedo netrovita: %s"
 
 # DP: "pri" estas "priority"
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "nro pri tipo etikedo"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "dosiero\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Estas nur unu kongrua etikedo"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Ne eblas iri preter lastan kongruan etikedon"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "La dosiero \"%s\" ne ekzistas"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "etikedo %d de %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " aŭ pli"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Uzo de etikedo kun malsama uskleco!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Dosiero \"%s\" ne ekzistas"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5662,66 +6018,79 @@ msgstr ""
 "\n"
 "nro AL etikedo     DE   linio en dosiero/teksto"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Serĉado de dosiero de etikedoj %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Vojo de etikeda dosiero trunkita por %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ignoro de longa linio en etikeda dosiero"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Eraro de formato en etikeda dosiero \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Antaŭ bajto %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Etikeda dosiero ne estas ordigita: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Neniu etikeda dosiero"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Ne eblas trovi ŝablonon de etikedo"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Ne eblis trovi etikedon, nur divenas!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Ripetita kamponomo: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' nekonata. Haveblaj terminaloj estas:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "defaŭlto al '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Ne eblas malfermi la dosieron termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Ne trovis rikordon de terminalo terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Ne trovis rikordon de terminalo en termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Neniu rikordo \"%s\" en termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: kapablo de terminalo \"cm\" bezonata"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5729,244 +6098,169 @@ msgstr ""
 "\n"
 "--- Klavoj de terminalo ---"
 
-msgid "new shell started\n"
-msgstr "nova ŝelo lanĉita\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Eraro dum legado de eniro, elironta...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Uzis CUT_BUFFER0 anstataŭ malplenan apartigon"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Nombro de linioj ŝanĝiĝis neatendite"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Malfaro neebla; daŭrigi tamene"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Ne eblas malfermi la malfaran dosieron por skribi: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Difektita malfara dosiero (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Ne eblis skribi malfaran dosieron en iu dosiero ajn de 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Ne superskribos malfaran dosieron, ne eblis legi: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Ne superskribos, tio ne estas malfara dosiero: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Preterpasas skribon de malfara dosiero, nenio por malfari"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Skribas malfaran dosieron: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Skriberaro en malfara dosiero: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Ne legas malfaran dosieron, posedanto malsamas: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Legado de malfara dosiero: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Ne eblas malfermi malfaran dosieron por legi: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Ne estas malfara dosiero: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Ne ĉifrata dosiero havas ĉifratan malfaran dosieron: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Malĉifrado de malfara dosiero fiaskis: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Malfara dosiero estas ĉifrata: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Malkongrua malfara dosiero: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Enhavo de dosiero ŝanĝiĝis, ne eblas uzi malfarajn informojn"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Finis legi malfaran dosieron %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Jam al la plej malnova ŝanĝo"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Jam al la plej nova ŝanĝo"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Malfara numero %<PRId64> netrovita"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: nevalidaj numeroj de linioj"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "plia linio"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "pliaj linioj"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "malpli linio"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "malpli linioj"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "ŝanĝo"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "ŝanĝoj"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "antaŭ"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "post"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nenio por malfari"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "numero ŝanĝoj   tempo              konservita"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "antaŭ %<PRId64> sekundoj"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin estas nepermesebla post malfaro"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: listo de malfaro estas difekta"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: linio de malfaro mankas"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Grafika versio MS-Vindozo 16/32-bitoj"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Grafika versio MS-Vindozo 64-bitoj"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Grafika versio MS-Vindozo 32-bitoj"
-
-msgid " in Win32s mode"
-msgstr " en reĝimo Win32s"
-
-msgid " with OLE support"
-msgstr " kun subteno de OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Versio konzola MS-Vindozo 64-bitoj"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Versio konzola MS-Vindozo 32-bitoj"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Versio MS-Vindozo 16-bitoj"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versio MS-DOS 32-bitoj"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versio MS-DOS 16-bitoj"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Versio Mak OS X (unikso)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Versio Mak OS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Versio Mak OS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Versio OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5974,6 +6268,7 @@ msgstr ""
 "\n"
 "Flikaĵoj inkluzivitaj: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5981,9 +6276,11 @@ msgstr ""
 "\n"
 "Ekstraj flikaĵoj: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modifita de "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5991,9 +6288,11 @@ msgstr ""
 "\n"
 "Kompilita "
 
+#: ../version.c:649
 msgid "by "
 msgstr "de "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6001,809 +6300,1888 @@ msgstr ""
 "\n"
 "Grandega versio "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Granda versio "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normala versio "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Malgranda versio "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Malgrandega versio "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "sen grafika interfaco."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "kun grafika interfaco GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "kun grafika interfaco GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "kun grafika interfaco X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "kun grafika interfaco X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "kun grafika interfaco X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "kun grafika interfaco Photon."
-
-msgid "with GUI."
-msgstr "sen grafika interfaco."
-
-msgid "with Carbon GUI."
-msgstr "kun grafika interfaco Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "kun grafika interfaco Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "kun (klasika) grafika interfaco."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Ebloj inkluzivitaj (+) aŭ ne (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "          sistema dosiero vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        dosiero vimrc de uzanto: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "    2-a dosiero vimrc de uzanto: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "    3-a dosiero vimrc de uzanto: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         dosiero exrc de uzanto: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "     2-a dosiero exrc de uzanto: \""
 
-msgid "  system gvimrc file: \""
-msgstr "         sistema dosiero gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       dosiero gvimrc de uzanto: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "   2-a dosiero gvimrc de uzanto: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "   3-a dosiero gvimrc de uzanto: \""
-
-msgid "    system menu file: \""
-msgstr "       dosiero de sistema menuo: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "               defaŭlto de $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "         defaŭlto de VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilado: "
 
-msgid "Compiler: "
-msgstr "Kompililo: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Ligado: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  SENCIMIGA MUNTO"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi plibonigita"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versio "
 
 # DP: vidu http://www.thefreedictionary.com/et+al.
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "de Bram Moolenaar kaj aliuloj"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim estas libera programo kaj disdoneblas libere"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Helpu malriĉajn infanojn en Ugando!"
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "tajpu  :help iccf<Enenklavo>      por pliaj informoj   "
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "tajpu  :q<Enenklavo>              por eliri            "
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "tajpu  :help<Enenklavo>  aŭ  <F1> por aliri la helpon  "
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "tajpu  :help version7<Enenklavo>  por informo de versio"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Ruliĝas en reĝimo kongrua kun Vi"
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "tajpu :set nocp<Enenklavo>        por Vim defaŭltoj    "
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "tajpu :help cp-default<Enenklavo> por pliaj informoj   "
 
-# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
-msgid "menu  Help->Orphans           for information    "
-msgstr "menuo  Help->Orfinoj              por pliaj informoj   "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Ruliĝas senreĝime, tajpita teksto estas enmetita"
-
-# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menuo Redakti->Mallokaj Agordoj->Baskuligi Enmetan Reĝimon"
-
-# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
-msgid "                              for two modes      "
-msgstr "                                  por du reĝimoj       "
-
-# DP: tiu ĉeno pli longas (mi ne volas igi ĉiujn aliajn ĉenojn
-#     pli longajn)
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menuo Redakti->Mallokaj Agordoj->Baskuligi Reĝimon Kongruan kun Vi"
-
-# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
-msgid "                              for Vim defaults   "
-msgstr "                                  por defaŭltoj de Vim "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Subtenu la programadon de Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Iĝu registrita uzanto de Vim!"
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "tajpu  :help sponsor<Enenklavo>   por pliaj informoj   "
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "tajpu  :help register<Enenklavo>  por pliaj informoj   "
 
 # DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menuo Helpo->Subteni/Registri     por pliaj informoj   "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "AVERTO: Trovis Vindozon 95/98/ME"
-
-# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "tajpu  :help windows95<Enenklavo> por pliaj informoj   "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Jam nur unu fenestro"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Ne estas antaŭvida fenestro"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Ne eblas dividi supralivan kaj subdekstran samtempe"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Ne eblas rotacii kiam alia fenestro estas dividita"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Ne eblas fermi la lastan fenestron"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Ne eblas fermi la fenestron de aŭtokomandoj"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Ne eblas fermi fenestron, nur la fenestro de aŭtokomandoj restus"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: La alia fenestro enhavas ŝanĝojn"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Neniu dosiernomo sub la kursoro"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Ne eblas trovi dosieron \"%s\" en serĉvojo"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() alvokita kun malplena pasvorto"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Ne eblis ŝargi bibliotekon %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Bedaŭrinde tiu komando estas malŝaltita: la biblioteko de Perl ne ŝargeblis."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Misuzo de pezkomenca/pezfina en blowfish"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Plenumo de Perl esprimoj malpermesata en sabloludejo sen la modulo Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: Testo de sha256 fiaskis"
 
-msgid "Edit with &multiple Vims"
-msgstr "Redakti per &pluraj Vim-oj"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Testo de blowfish fiaskis"
 
-msgid "Edit with single &Vim"
-msgstr "Redakti per unuopa &Vim"
+#~ msgid "Patch file"
+#~ msgstr "Flika dosiero"
 
-msgid "Diff with Vim"
-msgstr "Kompari per Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&Bone\n"
+#~ "&Rezigni"
 
-msgid "Edit with &Vim"
-msgstr "Redakti per &Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Neniu konekto al Vim-servilo"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Redakti per ekzistanta Vim - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Ne eblas sendi al %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Redakti la apartigita(j)n dosiero(j)n per Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Ne eblas legi respondon de servilo"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Eraro dum kreo de procezo: Kontrolu ĉu gvim estas en via serĉvojo!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Ne eblas sendi al kliento"
 
-msgid "gvimext.dll error"
-msgstr "Eraro de gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Konservi kiel"
 
-msgid "Path length too long!"
-msgstr "Serĉvojo estas tro longa!"
+#~ msgid "Edit File"
+#~ msgstr "Redakti dosieron"
 
-msgid "--No lines in buffer--"
-msgstr "--Neniu linio en bufro--"
+#~ msgid " (NOT FOUND)"
+#~ msgstr "  (NETROVITA)"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: komando ĉesigita"
+#~ msgid "Source Vim script"
+#~ msgstr "Ruli Vim-skripton"
 
-msgid "E471: Argument required"
-msgstr "E471: Argumento bezonata"
+#~ msgid "unknown"
+#~ msgstr "nekonata"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ devus esti sekvita de /, ? aŭ &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Redakti Dosieron en nova fenestro"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Nevalida en fenestro de komanda linio; <CR> plenumas, CTRL-C eliras"
+#~ msgid "Append File"
+#~ msgstr "Postaldoni dosieron"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Nepermesebla komando el exrc/vimrc en aktuala dosierujo aŭ etikeda serĉo"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Pozicio de fenestro: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Mankas \":endif\""
+#~ msgid "Save Redirection"
+#~ msgstr "Konservi alidirekton"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Mankas \":endtry\""
+# DP: mi ne certas pri superflugo
+#~ msgid "Save View"
+#~ msgstr "Konservi superflugon"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Mankas \":endwhile\""
+#~ msgid "Save Session"
+#~ msgstr "Konservi seancon"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Mankas \":endfor\""
+#~ msgid "Save Setup"
+#~ msgstr "Konservi agordaron"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: \":endwhile\" sen \":while\""
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< ne haveblas sen la eblo +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: \":endfor\" sen \":for\""
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Neniu duliteraĵo en tiu versio"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Dosiero ekzistas (aldonu ! por transpasi)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "estas aparatdosiero (malŝaltita per la opcio 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: La komando fiaskis"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Legado el stdin..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Nekonata familio de tiparo: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Nekonata tiparo: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[ĉifrita]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: La tiparo \"%s\" ne estas egallarĝa"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Dosiero estas ĉifrata per nekonata metodo"
 
-msgid "E473: Internal error"
-msgstr "E473: Interna eraro"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans malpermesas skribojn de neŝanĝitaj bufroj"
 
-msgid "Interrupted"
-msgstr "Interrompita"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Partaj skriboj malpermesitaj ĉe bufroj NetBeans"
 
-msgid "E14: Invalid address"
-msgstr "E14: Nevalida adreso"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "skribo al aparatdosiero malŝaltita per la opcio 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Nevalida argumento"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: La rimeda forko estus perdita (aldonu ! por transpasi)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Nevalida argumento: %s"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Ne sukcesis krei novan procezon por la grafika interfaco"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Nevalida esprimo: %s"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: La ida procezo ne sukcesis startigi la grafikan interfacon"
 
-msgid "E16: Invalid range"
-msgstr "E16: Nevalida amplekso"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Ne eblas lanĉi la grafikan interfacon"
 
-msgid "E476: Invalid command"
-msgstr "E476: Nevalida komando"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Ne eblas legi el \"%s\""
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" estas dosierujo"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Ne eblas startigi grafikan interfacon, neniu valida tiparo trovita"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Alvoko al biblioteko fiaskis por \"%s()\""
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' nevalida"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Ne eblis ŝargi bibliotekan funkcion %s"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Valoro de 'imactivatekey' estas nevalida"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Marko havas nevalidan numeron de linio"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Ne eblas disponigi koloron %s"
 
-msgid "E20: Mark not set"
-msgstr "E20: Marko ne estas agordita"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Neniu kongruo ĉe kursorpozicio, trovas sekvan"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Ne eblas fari ŝanĝojn, 'modifiable' estas malŝaltita"
+#~ msgid "<cannot open> "
+#~ msgstr "<ne eblas malfermi> "
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Tro profunde ingitaj skriptoj"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: ne eblas akiri tiparon %s"
 
-msgid "E23: No alternate file"
-msgstr "E23: Neniu alterna dosiero"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: ne eblas reveni al la aktuala dosierujo"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Ne estas tia mallongigo"
+#~ msgid "Pathname:"
+#~ msgstr "Serĉvojo:"
 
-msgid "E477: No ! allowed"
-msgstr "E477: Neniu ! permesebla"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: ne eblas akiri aktualan dosierujon"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Grafika interfaco ne uzeblas: Malŝaltita dum kompilado"
+#~ msgid "OK"
+#~ msgstr "Bone"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: La hebrea ne uzeblas: Malŝaltita dum kompilado\n"
+#~ msgid "Cancel"
+#~ msgstr "Rezigni"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: La persa ne uzeblas: Malŝaltita dum kompilado\n"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Fenestraĵo de rulumskalo: Ne eblis akiri geometrion de reduktita "
+#~ "rastrumbildo"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: La araba ne uzeblas: Malŝaltita dum kompilado\n"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim dialogo"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Neniu grupo de emfazo kiel: %s"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Ne eblas krei BalloonEval kun ambaŭ mesaĝo kaj reagfunkcio"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Ankoraŭ neniu enmetita teksto"
+# todo '_' is for hotkey, i guess?
+#~ msgid "Input _Methods"
+#~ msgstr "Enigaj _metodoj"
 
-msgid "E30: No previous command line"
-msgstr "E30: Neniu antaŭa komanda linio"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Serĉi kaj anstataŭigi..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Neniu tiel mapo"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM- Serĉi..."
 
-msgid "E479: No match"
-msgstr "E479: Neniu kongruo"
+#~ msgid "Find what:"
+#~ msgstr "Serĉi kion:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Neniu kongruo: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Anstataŭigi per:"
 
-msgid "E32: No file name"
-msgstr "E32: Neniu dosiernomo"
+#~ msgid "Match whole word only"
+#~ msgstr "Kongrui kun nur plena vorto"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Neniu antaŭa regulesprimo de anstataŭigo"
+#~ msgid "Match case"
+#~ msgstr "Uskleca kongruo"
 
-msgid "E34: No previous command"
-msgstr "E34: Neniu antaŭa komando"
+#~ msgid "Direction"
+#~ msgstr "Direkto"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Neniu antaŭa regulesprimo"
+#~ msgid "Up"
+#~ msgstr "Supren"
 
-msgid "E481: No range allowed"
-msgstr "E481: Amplekso nepermesebla"
+#~ msgid "Down"
+#~ msgstr "Suben"
 
-msgid "E36: Not enough room"
-msgstr "E36: Ne sufiĉe da spaco"
+#~ msgid "Find Next"
+#~ msgstr "Trovi sekvantan"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: neniu registrita servilo nomita \"%s\""
+#~ msgid "Replace"
+#~ msgstr "Anstataŭigi"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Ne eblas krei dosieron %s"
+#~ msgid "Replace All"
+#~ msgstr "Anstataŭigi ĉiujn"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Ne eblas akiri provizoran dosiernomon"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Ricevis peton \"die\" (morti) el la seanca administrilo\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Ne eblas malfermi dosieron %s"
+#~ msgid "Close"
+#~ msgstr "Fermi"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Ne eblas legi dosieron %s"
+#~ msgid "New tab"
+#~ msgstr "Nova langeto"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Neniu skribo de post lasta ŝanĝo (aldonu ! por transpasi)"
+#~ msgid "Open Tab..."
+#~ msgstr "Malfermi langeton..."
 
-msgid "E38: Null argument"
-msgstr "E38: Nula argumento"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Ĉefa fenestro neatendite detruiĝis\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Nombro atendita"
+#~ msgid "&Filter"
+#~ msgstr "&Filtri"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Ne eblas malfermi eraran dosieron %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Rezigni"
 
-msgid "E233: cannot open display"
-msgstr "E233: ne eblas malfermi vidigon"
+#~ msgid "Directories"
+#~ msgstr "Dosierujoj"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Ne plu restas memoro!"
+#~ msgid "Filter"
+#~ msgstr "Filtri"
 
-msgid "Pattern not found"
-msgstr "Ŝablono ne trovita"
+#~ msgid "&Help"
+#~ msgstr "&Helpo"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Ŝablono ne trovita: %s"
+#~ msgid "Files"
+#~ msgstr "Dosieroj"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: La argumento devas esti pozitiva"
+#~ msgid "&OK"
+#~ msgstr "&Bone"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Ne eblas reiri al antaŭa dosierujo"
+#~ msgid "Selection"
+#~ msgstr "Apartigo"
 
-msgid "E42: No Errors"
-msgstr "E42: Neniu eraro"
+#~ msgid "Find &Next"
+#~ msgstr "Trovi &Sekvanta"
 
-msgid "E776: No location list"
-msgstr "E776: Neniu listo de loko"
+#~ msgid "&Replace"
+#~ msgstr "&Anstataŭigi"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Difekta kongruenda ĉeno"
+#~ msgid "Replace &All"
+#~ msgstr "Anstataŭigi ĉi&on"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Difekta programo de regulesprimo"
+#~ msgid "&Undo"
+#~ msgstr "&Malfari"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: La opcio 'readonly' estas ŝaltita '(aldonu ! por transpasi)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Ne eblas trovi titolon de fenestro \"%s\""
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Ne eblas ŝanĝi nurlegeblan variablon \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Ne subtenata argumento: \"-%s\"; Uzu la version OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Ne eblas agordi variablon en la sabloludejo: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Ne eblas malfermi fenestron interne de aplikaĵo MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Eraro dum legado de erardosiero"
+#~ msgid "Close tab"
+#~ msgstr "Fermi langeton"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Nepermesebla en sabloludejo"
+#~ msgid "Open tab..."
+#~ msgstr "Malfermi langeton..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Nepermesebla tie"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Trovi ĉenon (uzu '\\\\' por trovi '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Reĝimo de ekrano ne subtenata"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Trovi kaj anstataŭigi (uzu '\\\\' por trovi '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Nevalida grando de rulumo"
+#~ msgid "Not Used"
+#~ msgstr "Ne uzata"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: La opcio 'shell' estas malplena"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Dosierujo\t*.nenio\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Ne eblis legi datumojn de simboloj!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Ne eblas disponigi rikordon de kolormapo, iuj koloroj estas "
+#~ "eble neĝustaj"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Eraro dum malfermo de permutodosiero .swp"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Tiparoj de tiuj signaroj mankas en aro de tiparo %s:"
 
-msgid "E73: tag stack empty"
-msgstr "E73: malplena stako de etikedo"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nomo de tiparo: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Komando tro kompleksa"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Tiparo '%s' ne estas egallarĝa"
 
-msgid "E75: Name too long"
-msgstr "E75: Nomo tro longa"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Nomo de tiparo: %s\n"
 
-msgid "E76: Too many ["
-msgstr "E76: Tro da ["
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E77: Too many file names"
-msgstr "E77: Tro da dosiernomoj"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Vostaj signoj"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Font%<PRId64> ne estas duoble pli larĝa ol font0\n"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Nekonata marko"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Larĝo de font0: %<PRId64>\n"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Ne eblas malvolvi ĵokerojn"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Larĝo de Font1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' ne rajtas esti malpli ol 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Nevalida tiparo specifita"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' ne rajtas esti malpli ol 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "&Forlasi"
 
-msgid "E80: Error while writing"
-msgstr "E80: Eraro dum skribado"
+#~ msgid "no specific match"
+#~ msgstr "Neniu specifa kongruo"
 
-msgid "Zero count"
-msgstr "Nul kvantoro"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Elektilo de tiparo"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Uzo de <SID> ekster kunteksto de skripto"
+#~ msgid "Name:"
+#~ msgstr "Nomo:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Nevalida esprimo ricevita"
+#~ msgid "Show size in Points"
+#~ msgstr "Montri grandon en punktoj"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Regiono estas gardita, ne eblas ŝanĝi"
+#~ msgid "Encoding:"
+#~ msgstr "Kodoprezento:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans ne permesas ŝanĝojn en nurlegeblaj dosieroj"
+#~ msgid "Font:"
+#~ msgstr "Tiparo:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Interna eraro: %s"
+#~ msgid "Style:"
+#~ msgstr "Stilo:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: ŝablono uzas pli da memoro ol 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Grando:"
 
-msgid "E749: empty buffer"
-msgstr "E749: malplena bufro"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ERARO en aŭtomato de korea alfabeto"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Nevalida serĉa ŝablono aŭ disigilo"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: Eraro de stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Dosiero estas ŝargita en alia bufro"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: ne eblas malfermi datumbazon de cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: La opcio '%s' ne estas ŝaltita"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: ne eblas akiri informojn pri la datumbazo de cscope"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Nevalida nomo de reĝistro"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "La biblioteko Lua no ŝargeblis."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "serĉo atingis SUPRON, daŭrigonte al SUBO"
+#~ msgid "cannot save undo information"
+#~ msgstr "ne eblas konservi informojn de malfaro"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "serĉo atingis SUBON, daŭrigonte al SUPRO"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Bedaŭrinde, tiu komando estas malŝaltita, ne eblis ŝargi la "
+#~ "bibliotekojn."
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Ŝlosilo de ĉifrado bezonata por \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "nevalida esprimo"
 
-msgid "can't delete OutputObject attributes"
-msgstr "ne eblas forviŝi atributojn de OutputObject"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "esprimoj malŝaltitaj dum kompilado"
 
-msgid "softspace must be an integer"
-msgstr "malmolspaceto (softspace) devas esti entjero"
+#~ msgid "hidden option"
+#~ msgstr "kaŝita opcio"
 
-msgid "invalid attribute"
-msgstr "nevalida atributo"
+#~ msgid "unknown option"
+#~ msgstr "nekonata opcio"
 
-msgid "writelines() requires list of strings"
-msgstr "writelines() bezonas liston de ĉenoj"
+#~ msgid "window index is out of range"
+#~ msgstr "indekso de fenestro estas ekster limoj"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Pitono: Eraro de pravalorizo de eneligaj objektoj"
+#~ msgid "couldn't open buffer"
+#~ msgstr "ne eblis malfermi bufron"
 
-msgid "empty keys are not allowed"
-msgstr "malplenaj ŝlosiloj nepermeseblaj"
+#~ msgid "cannot delete line"
+#~ msgstr "ne eblas forviŝi linion"
 
-msgid "Cannot delete DictionaryObject attributes"
-msgstr "ne eblas forviŝi atributojn de DictionaryObject"
+#~ msgid "cannot replace line"
+#~ msgstr "ne eblas anstataŭigi linion"
 
-msgid "Cannot modify fixed dictionary"
-msgstr "Ne eblas ŝanĝi fiksan vortaron"
+#~ msgid "cannot insert line"
+#~ msgstr "ne eblas enmeti linion"
 
-msgid "Cannot set this attribute"
-msgstr "Ne eblas agordi tiun atributon"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "ĉeno ne rajtas enhavi liniavancojn"
 
-msgid "dict is locked"
-msgstr "vortaro estas ŝlosita"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "eraro dum konverto de Scheme-valoro al Vim"
 
-msgid "failed to add key to dictionary"
-msgstr "aldono de ŝlosilo al vortaro fiaskis"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Eraro de Vim: ~a"
 
-msgid "list index out of range"
-msgstr "indekso de listo ekster limoj"
+#~ msgid "Vim error"
+#~ msgstr "Eraro de Vim"
 
-msgid "internal error: failed to get vim list item"
-msgstr "interna eraro: obteno de vim-a listero fiaskis"
+#~ msgid "buffer is invalid"
+#~ msgstr "bufro estas nevalida"
 
-msgid "list is locked"
-msgstr "listo estas ŝlosita"
+#~ msgid "window is invalid"
+#~ msgstr "fenestro estas nevalida"
 
-msgid "Failed to add item to list"
-msgstr "Aldono de listero fiaskis"
+#~ msgid "linenr out of range"
+#~ msgstr "numero de linio ekster limoj"
 
-msgid "internal error: no vim list item"
-msgstr "interna eraro: neniu vim-a listero"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "nepermesebla en sabloludejo de Vim"
 
-msgid "can only assign lists to slice"
-msgstr "nur eblas pravalorizi listojn al segmento"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Vim ne povas plenumi :python post uzo de :py3"
 
-msgid "internal error: failed to add item to list"
-msgstr "interna eraro: aldono de listero fiaskis"
+#~ msgid "only string keys are allowed"
+#~ msgstr "nur ĉenaj ŝlosiloj estas permeseblaj"
 
-msgid "can only concatenate with lists"
-msgstr "eblas nur kunmeti kun listoj"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Bedaŭrinde tiu komando estas malŝaltita: la biblioteko de Pitono ne "
+#~ "ŝargeblis."
 
-msgid "cannot delete vim.dictionary attributes"
-msgstr "ne eblas forviŝi atributojn de 'vim.dictionary'"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Ne eblas alvoki Pitonon rekursie"
 
-msgid "cannot modify fixed list"
-msgstr "ne eblas ŝanĝi fiksan liston"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Vim ne povas plenumi :py3  post uzo de :python"
 
-msgid "cannot set this attribute"
-msgstr "ne eblas agordi tiun atributon"
+#~ msgid "index must be int or slice"
+#~ msgstr "indekso devas esti 'int' aŭ 'slice'"
 
-msgid "'self' argument must be a dictionary"
-msgstr "argumento 'self' devas esti vortaro"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ devas esti apero de Ĉeno"
 
-msgid "failed to run function"
-msgstr "fiaskis ruli funkcion"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Bedaŭrinde tiu komando estas malŝaltita, la biblioteko Ruby ne "
+#~ "ŝargeblis."
 
-msgid "unable to get option value"
-msgstr "fiaskis akiri valoron de opcio"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: \"return\" neatendita"
 
-msgid "unable to unset global option"
-msgstr "ne povis malŝalti mallokan opcion"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: \"next\" neatendita"
 
-msgid "unable to unset option without global value"
-msgstr "ne povis malŝalti opcion sen malloka valoro"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: \"break\" neatendita"
 
-msgid "object must be integer"
-msgstr "objekto devas esti entjero."
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: \"redo\" neatendita"
 
-msgid "object must be string"
-msgstr "objekto devas esti ĉeno"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: \"retry\" ekster klaŭzo \"rescue\""
 
-msgid "attempt to refer to deleted tab page"
-msgstr "provo de referenco al forviŝita langeto"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: netraktita escepto"
 
-#, c-format
-msgid "<tabpage object (deleted) at %p>"
-msgstr "<langeta objekto (forviŝita) ĉe %p>"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: nekonata stato de longjmp: %d"
 
-#, c-format
-msgid "<tabpage object (unknown) at %p>"
-msgstr "<langeta objekto (nekonata) ĉe %p>"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Baskuligi realigon/difinon"
 
-#, c-format
-msgid "<tabpage %d>"
-msgstr "<langeto %d>"
+#~ msgid "Show base class of"
+#~ msgstr "Vidigi bazan klason de"
 
-msgid "no such tab page"
-msgstr "ne estas tia langeto"
+#~ msgid "Show overridden member function"
+#~ msgstr "Montri anajn homonimigajn funkciojn"
 
-msgid "attempt to refer to deleted window"
-msgstr "provo de referenco al forviŝita fenestro"
+#~ msgid "Retrieve from file"
+#~ msgstr "Rekuperi el dosiero"
 
-msgid "readonly attribute"
-msgstr "nurlegebla atributo"
+#~ msgid "Retrieve from project"
+#~ msgstr "Rekuperi el projekto"
 
-msgid "cursor position outside buffer"
-msgstr "kursoro poziciita ekster bufro"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Rekuperi de ĉiuj projektoj"
 
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<fenestra objekto (forviŝita) ĉe %p>"
+#~ msgid "Retrieve"
+#~ msgstr "Rekuperi"
 
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<objekta fenestro (nekonata) ĉe %p>"
+#~ msgid "Show source of"
+#~ msgstr "Vidigi fonton de"
 
-#, c-format
-msgid "<window %d>"
-msgstr "<fenestro %d>"
+#~ msgid "Find symbol"
+#~ msgstr "Trovi simbolon"
 
-msgid "no such window"
-msgstr "ne estas tia fenestro"
+#~ msgid "Browse class"
+#~ msgstr "Foliumi klasojn"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "provo de referenco al forviŝita bufro"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Montri klason en hierarkio"
 
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<bufra objekto (forviŝita) ĉe %p>"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Montri klason en hierarkio restriktita"
 
-msgid "key must be integer"
-msgstr "ŝlosilo devas esti entjero."
+# todo
+#~ msgid "Xref refers to"
+#~ msgstr "Xref ligas al"
 
-msgid "expected vim.buffer object"
-msgstr "atendis objekton vim.buffer"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref ligiĝas de"
 
-msgid "failed to switch to given buffer"
-msgstr "ne povis salti al la specifita bufro"
+#~ msgid "Xref has a"
+#~ msgstr "Xref havas"
 
-msgid "expected vim.window object"
-msgstr "atendis objekton vim.window"
+#~ msgid "Xref used by"
+#~ msgstr "Xref uzita de"
 
-msgid "failed to find window in the current tab page"
-msgstr "ne povis trovi vindozon en la nuna langeto"
+# DP: mi ne certas pri kio temas
+#~ msgid "Show docu of"
+#~ msgstr "Vidigi dokumentaron de"
 
-msgid "did not switch to the specified window"
-msgstr "ne saltis al la specifita vindozo"
+#~ msgid "Generate docu for"
+#~ msgstr "Krei dokumentaron de"
 
-msgid "expected vim.tabpage object"
-msgstr "atendis objekton vim.tabpage"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Konekto al SNiFF+ neeblas. Kontrolu medion (sniffemacs trovendas en "
+#~ "$PATH).\n"
 
-msgid "did not switch to the specified tab page"
-msgstr "ne saltis al la specifita langeto"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Eraro dum lego. Malkonektita"
 
-msgid "failed to run the code"
-msgstr "fiaskis ruli la kodon"
+# DP: Tiuj 3 mesaĝoj estas kune
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ estas aktuale "
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval ne revenis kun valida python-objekto"
+#~ msgid "not "
+#~ msgstr "ne "
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Konverto de revena python-objekto al vim-valoro fiaskis"
+#~ msgid "connected"
+#~ msgstr "konektita"
 
-msgid "unable to convert to vim structure"
-msgstr "ne povis konverti al vim-strukturo"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Nekonata peto de SNiFF+: %s"
 
-msgid "NULL reference passed"
-msgstr "NULL-referenco argumento"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Eraro dum konekto al SNiFF+"
 
-msgid "internal error: invalid value type"
-msgstr "interna eraro: nevalida tipo de valoro"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ ne estas konektita"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ne estas bufro SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Eraro dum skribo. Malkonektita"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "nevalida numero de bufro"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ankoraŭ ne realigita"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "ne eblas meti la linio(j)n"
+
+#~ msgid "invalid mark name"
+#~ msgstr "nevalida nomo de marko"
+
+#~ msgid "mark not set"
+#~ msgstr "marko ne estas metita"
+
+#~ msgid "row %d column %d"
+#~ msgstr "linio %d kolumno %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "ne eblas enmeti/postaldoni linion"
+
+#~ msgid "line number out of range"
+#~ msgstr "numero de linio ekster limoj"
+
+#~ msgid "unknown flag: "
+#~ msgstr "nekonata flago: "
+
+# DP: ĉu traduki vimOption
+#~ msgid "unknown vimOption"
+#~ msgstr "nekonata vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "klavara interrompo"
+
+#~ msgid "vim error"
+#~ msgstr "eraro de Vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "ne eblas krei komandon de bufro/fenestro: objekto estas forviŝiĝanta"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "ne eblas registri postalvokan komandon: bufro/fenestro estas jam "
+#~ "forviŝiĝanta"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: NERIPAREBLA TCL-ERARO: reflist difekta!? Bv. retpoŝti al vim-"
+#~ "dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "ne eblas registri postalvokan komandon: referenco de bufro/fenestro ne "
+#~ "troveblas"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Bedaŭrinde tiu komando estas malŝaltita: la biblioteko Tcl ne "
+#~ "ŝargeblis."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: elira kodo %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "ne eblas akiri linion"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Ne eblas registri nomon de komanda servilo"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Sendo de komando al cela programo fiaskis"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Nevalida identigilo de servilo uzita: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Ecoj de registro de apero de VIM estas nevalide formata. Forviŝita!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans ne estas subtenata kun tiu grafika interfaco\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Tiu Vim ne estis kompilita kun la kompara eblo."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' ne uzeblas: malŝaltita dum kompilado\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Eraro: Fiaskis lanĉi gvim el NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Kie uskleco estas ignorita antaŭaldonu / por igi flagon majuskla"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistri tiun gvim al OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tMalregistri gvim de OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tRuli per grafika interfaco (kiel \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  aŭ  --nofork\tMalfono: ne forki kiam lanĉas grafikan interfacon"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNe uzi newcli por malfermi fenestrojn"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <aparatdosiero>\t\tUzi <aparatdosiero>-n por eneligo"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tUzi <gvimrc> anstataŭ iun ajn .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tRedakti ĉifradan dosieron"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <ekrano>\tKonekti Vim al tiu X-servilo"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNe konekti al X-servilo"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <dosieroj>\tRedakti <dosieroj>-n en Vim-servilo se eblas"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <dosieroj>  Same, sed ne plendi se ne estas servilo"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <dosieroj>  Kiel --remote sed atendi ĝis dosieroj estas "
+#~ "redaktitaj"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <dosieroj> Same, sed ne plendi se ne estas servilo"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <dosieroj> Kiel --remote sed uzi langeton "
+#~ "por ĉiu dosiero"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <klavoj> Sendi <klavoj>-n al Vim-servilo kaj eliri"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <espr>\tKomputi <espr> en Vim-servilo kaj afiŝi rezulton"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tListigi haveblajn nomojn de Vim-serviloj kaj eliri"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nomo>\tSendu al/iĝi la Vim-servilo <nomo>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentoj agnoskitaj de gvim (versio Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentoj agnoskitaj de gvim (versio neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentoj agnoskitaj de gvim (versio Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <ekrano>\tLanĉi vim sur <ekrano>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tLanĉi vim piktograme"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr ""
+#~ "-background <koloro>\tUzi <koloro>-n por la fona koloro (ankaŭ: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <koloro>\tUzi <koloro>-n por la malfona koloro (ankaŭ: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <tiparo>\tUzi <tiparo>-n por normala teksto (ankaŭ: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <tiparo>\tUzi <tiparo>-n por grasa teksto"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <tiparo>\tUzi <tiparo>-n por kursiva teksto"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\tUzi <geom> kiel komenca geometrio (ankaŭ: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <larĝo>\tUzi <larĝo>-n kiel larĝo de bordero (ankaŭ: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <larĝo>  Uzi <larĝo>-n kiel larĝo de rulumskalo (ankaŭ: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <alto>\tUzi <alto>-n kiel alto de menuzona alto (ankaŭ: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tUzi inversan videon (ankaŭ: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNe uzi inversan videon (ankaŭ: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <rimedo>\tAgordi la specifitan <rimedo>-n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentoj agnoskitaj de gvim (versio GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <ekrano>\tLanĉi Vim sur tiu <ekrano> (ankaŭ: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <rolo>\tDoni unikan rolon por identigi la ĉefan fenestron"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tMalfermi Vim en alia GTK fenestraĵo"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tIgas gvim afiŝi la identigilon de vindozo sur stdout"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <gepatra titolo>\tMalfermi Vim en gepatra aplikaĵo"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tMalfermi Vim en alia win32 fenestraĵo"
+
+#~ msgid "No display"
+#~ msgstr "Neniu ekrano"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Sendo fiaskis.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Sendo fiaskis. Provo de loka plenumo\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d de %d redaktita(j)"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Neniu ekrano: Sendado de esprimo fiaskis.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Sendado de esprimo fiaskis.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Nevalida kodpaĝo"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Ne eblas agordi valorojn de IC"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Ne eblis krei enigan kuntekston"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Ne eblis malfermi enigan metodon"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Averto: Ne eblis agordi detruan reagfunkcion al IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: eniga metodo subtenas neniun stilon"
+
+# DP: mi ne scias, kio estas "preedit"
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: eniga metodo ne subtenas mian antaŭredaktan tipon"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Eraro dum ĝisdatigo de ĉifrada permutodosiero .swp"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s estas ĉifrata kaj tiu versio de Vim ne subtenas ĉifradon"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Perumutodosiero .swp estas ĉifrata: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Se vi tajpis novan ŝlosilon de ĉifrado sed ne skribis la tekstan dosieron,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "tajpu la novan ŝlosilon de ĉifrado."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Se vi skribis la tekstan dosieron post ŝanĝo de la ŝlosilo de ĉifrado, "
+#~ "premu enenklavon"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "por uzi la saman ŝlosilon por la teksta dosiero kaj permuto dosiero .swp"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr ""
+#~ "Uzas ŝlosilon de ĉifrado el permuto dosiero .swp por la teksta dosiero.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [ne uzebla per tiu versio de Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Disigi tiun menuon"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialogujo de dosiera elekto"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialogujo de dosiera konservo"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialogujo de dosiera malfermo"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Bedaŭrinde ne estas dosierfoliumilo en konzola reĝimo"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: konservo de dosieroj...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Finita.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ERARO: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtoj] totalaj disponigitaj/maldisponigitaj %<PRIu64>-%<PRIu64>, nun "
+#~ "uzataj %<PRIu64>, kulmina uzo %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[alvokoj] totalaj re/malloc() %<PRIu64>, totalaj free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Linio iĝas tro longa"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Interna eraro: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Nevalida formo de muskursoro"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Tajpu la ŝlosilon de ĉifrado: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Tajpu la ŝlosilon denove: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Ŝlosiloj ne kongruas!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Ne eblas konekti al Netbeans n-ro 2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Ne eblas konekti al Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Nevalida permeso de dosiero de informo de konekto NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "lego el kontaktoskatolo de Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Konekto de NetBeans perdita por bufro %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans ne estas subtenata kun tiu grafika interfaco"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: nebeans jam konektata"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s estas nurlegebla (aldonu ! por transpasi)"
+
+# DP: ĉu Eval devas esti tradukita?
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval eblo ne disponeblas"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "malokupas %<PRId64> liniojn"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: term ne ŝanĝeblas en grafika interfaco"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Uzu \":gui\" por lanĉi la grafikan interfacon"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Ne ŝanĝeblas en la grafika interfaco GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Nevalida(j) tiparo(j)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: ne eblas elekti tiparon"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Nevalida tiparo"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: ne eblas elekti larĝan tiparon"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Nevalida larĝa tiparo"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Neniu muso subtenata"
+
+#~ msgid "cannot open "
+#~ msgstr "ne eblas malfermi "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Ne eblas malfermi fenestron!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Bezonas version 2.04 de Amigados aŭ pli novan\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Bezonas %s-on versio %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Ne eblas malfermi NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Ne eblas krei "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim eliras kun %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "ne eblas ŝanĝi reĝimon de konzolo?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: ne estas konzolo??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Ne eblas plenumi ŝelon kun opcio -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Ne eblas plenumi "
+
+#~ msgid "shell "
+#~ msgstr "ŝelo "
+
+#~ msgid " returned\n"
+#~ msgstr " liveris\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE tro malgranda."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ERARO DE ENIGO/ELIGO"
+
+#~ msgid "Message"
+#~ msgstr "Mesaĝo"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' ne estas 80, ne eblas plenumi eksternajn komandojn"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Elekto de presilo fiaskis"
+
+#~ msgid "to %s on %s"
+#~ msgstr "al %s de %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Nekonata tiparo de presilo: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Eraro de presado: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Presas '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Nevalida nomo de signaro \"%s\" en nomo de tiparo \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Nevalida signo '%c' en nomo de tiparo \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Duobla signalo, eliranta\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Kaptis mortigantan signalon %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Kaptis mortigantan signalon\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Malfermo de vidigo X daŭris %<PRId64> msek"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Alvenis X eraro\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Testo de la vidigo X fiaskis"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Tempolimo okazis dum malfermo de vidigo X"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ne eblas plenumi ŝelon sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ne eblas krei duktojn\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ne eblas forki\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Komando terminigita\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP perdis la konekton ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Malfermo de vidigo X fiaskis"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP: traktado de peto konservi-mem"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP: malfermo de konekto"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP: kontrolo de konekto ICE fiaskis"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP: SmcOpenConnection fiaskis: %s"
+
+#~ msgid "At line"
+#~ msgstr "Ĉe linio"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Ne eblis ŝargi vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Eraro de VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Ne eblis ripari referencojn de funkcioj al la DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "la ŝelo liveris %d"
+
+# DP: la eventoj estas tiuj, kiuj estas en la sekvantaj ĉenoj
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Kaptis eventon %s\n"
+
+#~ msgid "close"
+#~ msgstr "fermo"
+
+#~ msgid "logoff"
+#~ msgstr "elsaluto"
+
+#~ msgid "shutdown"
+#~ msgstr "sistemfermo"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Netrovebla komando"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE ne troveblas en via $PATH.\n"
+#~ "Eksteraj komandoj ne paŭzos post kompletigo.\n"
+#~ "Vidu  :help win32-vimrun  por pliaj informoj."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Averto de Vim"
+
+#~ msgid "Error file"
+#~ msgstr "Erara Dosiero"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: Eraro dum prekomputado de NFA kun ekvivalentoklaso!"
+
+#~ msgid "E999: (NFA regexp internal error) Should not process NOT node !"
+#~ msgstr ""
+#~ "E999: (interna eraro de NFA-regulesprimo) Ne devus procezi nodon 'NOT'!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) Ne povis asigni memoron por traigi branĉojn!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr "Averto: Ne eblas trovi vortliston \"%s_%s.spl\" aŭ \"%s_ascii.spl\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konverto en %s nesubtenata"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: Ne sufiĉe da memoro, vortlisto estos nekompleta."
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Vojo de etikeda dosiero trunkita por %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "nova ŝelo lanĉita\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Uzis CUT_BUFFER0 anstataŭ malplenan apartigon"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Malfaro neebla; daŭrigi tamene"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Ne ĉifrata dosiero havas ĉifratan malfaran dosieron: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Malĉifrado de malfara dosiero fiaskis: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Malfara dosiero estas ĉifrata: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Grafika versio MS-Vindozo 16/32-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Grafika versio MS-Vindozo 64-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Grafika versio MS-Vindozo 32-bitoj"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " en reĝimo Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " kun subteno de OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio konzola MS-Vindozo 64-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio konzola MS-Vindozo 32-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio MS-Vindozo 16-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio MS-DOS 32-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio MS-DOS 16-bitoj"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio Mak OS X (unikso)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio Mak OS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio Mak OS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versio OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Granda versio "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normala versio "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malgranda versio "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malgrandega versio "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "kun grafika interfaco GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "kun grafika interfaco GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "kun grafika interfaco X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "kun grafika interfaco X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "kun grafika interfaco X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "kun grafika interfaco Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "sen grafika interfaco."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "kun grafika interfaco Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "kun grafika interfaco Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "kun (klasika) grafika interfaco."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "         sistema dosiero gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       dosiero gvimrc de uzanto: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "   2-a dosiero gvimrc de uzanto: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "   3-a dosiero gvimrc de uzanto: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "       dosiero de sistema menuo: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompililo: "
+
+# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menuo  Help->Orfinoj              por pliaj informoj   "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Ruliĝas senreĝime, tajpita teksto estas enmetita"
+
+# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menuo Redakti->Mallokaj Agordoj->Baskuligi Enmetan Reĝimon"
+
+# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#~ msgid "                              for two modes      "
+#~ msgstr "                                  por du reĝimoj       "
+
+# DP: tiu ĉeno pli longas (mi ne volas igi ĉiujn aliajn ĉenojn
+#     pli longajn)
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menuo Redakti->Mallokaj Agordoj->Baskuligi Reĝimon Kongruan kun Vi"
+
+# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                  por defaŭltoj de Vim "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "AVERTO: Trovis Vindozon 95/98/ME"
+
+# DP: atentu al la spacetoj: ĉiuj ĉenoj devas havi la saman longon
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "tajpu  :help windows95<Enenklavo> por pliaj informoj   "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Ne eblis ŝargi bibliotekon %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Bedaŭrinde tiu komando estas malŝaltita: la biblioteko de Perl ne "
+#~ "ŝargeblis."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Plenumo de Perl esprimoj malpermesata en sabloludejo sen la modulo "
+#~ "Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Redakti per &pluraj Vim-oj"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Redakti per unuopa &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Kompari per Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Redakti per &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Redakti per ekzistanta Vim - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Redakti la apartigita(j)n dosiero(j)n per Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Eraro dum kreo de procezo: Kontrolu ĉu gvim estas en via serĉvojo!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "Eraro de gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Serĉvojo estas tro longa!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Nekonata familio de tiparo: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Nekonata tiparo: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: La tiparo \"%s\" ne estas egallarĝa"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Ne eblis ŝargi bibliotekan funkcion %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: La hebrea ne uzeblas: Malŝaltita dum kompilado\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: La persa ne uzeblas: Malŝaltita dum kompilado\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: La araba ne uzeblas: Malŝaltita dum kompilado\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: neniu registrita servilo nomita \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: ne eblas malfermi vidigon"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Nevalida esprimo ricevita"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Regiono estas gardita, ne eblas ŝanĝi"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans ne permesas ŝanĝojn en nurlegeblaj dosieroj"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Ŝlosilo de ĉifrado bezonata por \"%s\""
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "ne eblas forviŝi atributojn de OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "malmolspaceto (softspace) devas esti entjero"
+
+#~ msgid "invalid attribute"
+#~ msgstr "nevalida atributo"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() bezonas liston de ĉenoj"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Pitono: Eraro de pravalorizo de eneligaj objektoj"
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "malplenaj ŝlosiloj nepermeseblaj"
+
+#~ msgid "Cannot delete DictionaryObject attributes"
+#~ msgstr "ne eblas forviŝi atributojn de DictionaryObject"
+
+#~ msgid "Cannot modify fixed dictionary"
+#~ msgstr "Ne eblas ŝanĝi fiksan vortaron"
+
+#~ msgid "Cannot set this attribute"
+#~ msgstr "Ne eblas agordi tiun atributon"
+
+#~ msgid "dict is locked"
+#~ msgstr "vortaro estas ŝlosita"
+
+#~ msgid "failed to add key to dictionary"
+#~ msgstr "aldono de ŝlosilo al vortaro fiaskis"
+
+#~ msgid "list index out of range"
+#~ msgstr "indekso de listo ekster limoj"
+
+#~ msgid "internal error: failed to get vim list item"
+#~ msgstr "interna eraro: obteno de vim-a listero fiaskis"
+
+#~ msgid "list is locked"
+#~ msgstr "listo estas ŝlosita"
+
+#~ msgid "Failed to add item to list"
+#~ msgstr "Aldono de listero fiaskis"
+
+#~ msgid "can only assign lists to slice"
+#~ msgstr "nur eblas pravalorizi listojn al segmento"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "interna eraro: aldono de listero fiaskis"
+
+#~ msgid "can only concatenate with lists"
+#~ msgstr "eblas nur kunmeti kun listoj"
+
+#~ msgid "cannot delete vim.dictionary attributes"
+#~ msgstr "ne eblas forviŝi atributojn de 'vim.dictionary'"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "ne eblas ŝanĝi fiksan liston"
+
+#~ msgid "cannot set this attribute"
+#~ msgstr "ne eblas agordi tiun atributon"
+
+#~ msgid "'self' argument must be a dictionary"
+#~ msgstr "argumento 'self' devas esti vortaro"
+
+#~ msgid "failed to run function"
+#~ msgstr "fiaskis ruli funkcion"
+
+#~ msgid "unable to unset global option"
+#~ msgstr "ne povis malŝalti mallokan opcion"
+
+#~ msgid "unable to unset option without global value"
+#~ msgstr "ne povis malŝalti opcion sen malloka valoro"
+
+#~ msgid "object must be integer"
+#~ msgstr "objekto devas esti entjero."
+
+#~ msgid "object must be string"
+#~ msgstr "objekto devas esti ĉeno"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "provo de referenco al forviŝita langeto"
+
+#~ msgid "<tabpage object (deleted) at %p>"
+#~ msgstr "<langeta objekto (forviŝita) ĉe %p>"
+
+#~ msgid "<tabpage object (unknown) at %p>"
+#~ msgstr "<langeta objekto (nekonata) ĉe %p>"
+
+#~ msgid "<tabpage %d>"
+#~ msgstr "<langeto %d>"
+
+#~ msgid "no such tab page"
+#~ msgstr "ne estas tia langeto"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "provo de referenco al forviŝita fenestro"
+
+#~ msgid "readonly attribute"
+#~ msgstr "nurlegebla atributo"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "kursoro poziciita ekster bufro"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<fenestra objekto (forviŝita) ĉe %p>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<objekta fenestro (nekonata) ĉe %p>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<fenestro %d>"
+
+#~ msgid "no such window"
+#~ msgstr "ne estas tia fenestro"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "provo de referenco al forviŝita bufro"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<bufra objekto (forviŝita) ĉe %p>"
+
+#~ msgid "key must be integer"
+#~ msgstr "ŝlosilo devas esti entjero."
+
+#~ msgid "expected vim.buffer object"
+#~ msgstr "atendis objekton vim.buffer"
+
+#~ msgid "failed to switch to given buffer"
+#~ msgstr "ne povis salti al la specifita bufro"
+
+#~ msgid "expected vim.window object"
+#~ msgstr "atendis objekton vim.window"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "ne povis trovi vindozon en la nuna langeto"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "ne saltis al la specifita vindozo"
+
+#~ msgid "expected vim.tabpage object"
+#~ msgstr "atendis objekton vim.tabpage"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "ne saltis al la specifita langeto"
+
+#~ msgid "failed to run the code"
+#~ msgstr "fiaskis ruli la kodon"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval ne revenis kun valida python-objekto"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Konverto de revena python-objekto al vim-valoro fiaskis"
+
+#~ msgid "unable to convert to vim structure"
+#~ msgstr "ne povis konverti al vim-strukturo"
+
+#~ msgid "NULL reference passed"
+#~ msgstr "NULL-referenco argumento"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "interna eraro: nevalida tipo de valoro"
 
 #~ msgid "E863: return value must be an instance of str"
 #~ msgstr "E863: elira valoro devas esti apero de str"

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -1855,10 +1855,6 @@ msgstr "%<PRId64> linioj, "
 msgid "1 character"
 msgstr "1 signo"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> signoj"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -10,191 +10,219 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.2.284 (rev 1692)\n"
-"Report-Msgid-Bugs-To: vim@bugs.org\n"
-"POT-Creation-Date: 2009-11-25 02:05+0100\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2009-12-04 18:52+0100\n"
 "Last-Translator: Omar Campagne <ocampagne@gmail.com>\n"
 "Language-Team: vim-doc-es http://www.assembla.com/wiki/show/vim-doc-es\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: octect-stream\n"
 
-#: buffer.c:102
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Basura después de la opción"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Lista de ubicaciones]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Lista de cambios rápidos]"
+
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: *Filtro* Las auto-órdenes no deben cambiar el búfer en uso"
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: No se pudo asignar memoria para ningún búfer, saliendo..."
 
-#: buffer.c:105
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: No se pudo asignar memoria para el búfer, usando otro..."
 
-#: buffer.c:879
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: No se descargó ningún búfer"
 
-#: buffer.c:881
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: No se borró ningún búfer"
 
-#: buffer.c:883
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: No se eliminó ningún búfer"
 
-#: buffer.c:891
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Se descargó un (1) búfer"
 
-#: buffer.c:893
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Se descargaron %d búfers"
 
-#: buffer.c:898
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Se suprimió un (1) búfer"
 
-#: buffer.c:900
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Se suprimieron %d búfers"
 
-#: buffer.c:905
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Se eliminó un (1) búfer"
 
-#: buffer.c:907
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Se eliminaron %d búfers"
 
-#: buffer.c:965
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: No se pudo descargar el último búfer"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: No se encontró ningún búfer modificado"
 
 # back where we started, didn't find anything.
 #. back where we started, didn't find anything.
-#: buffer.c:1004
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: No hay búfers en la lista"
 
-#: buffer.c:1016
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: El búfer %<PRId64> no existe"
 
-#: buffer.c:1019
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: No se pudo ir más allá del último búfer"
 
-#: buffer.c:1021
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: No se pudo regresar antes del primer búfer"
 
-#: buffer.c:1063
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: No se guardó el archivo desde el último cambio del búfer %<PRId64> (añada \"!"
-"\" para forzar)"
+"E89: No se guardó el archivo desde el último cambio del búfer %<PRId64> "
+"(añada \"!\" para forzar)"
 
-#: buffer.c:1080
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: No se pudo descargar el último búfer"
-
-#: buffer.c:1651
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Advertencia: La lista de nombres de archivos es muy larga"
 
-#: buffer.c:1850 quickfix.c:3632
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: No se encontró el búfer %<PRId64>"
 
-#: buffer.c:2125
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Hay más de una coincidencia con %s"
 
-#: buffer.c:2127
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: No hay un búfer que coincida con %s"
 
-#: buffer.c:2579
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "línea %<PRId64>"
 
-#: buffer.c:2666
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Ya existe un búfer con este nombre"
 
-#: buffer.c:2993
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modificado]"
 
-#: buffer.c:2998
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Sin editar]"
 
-#: buffer.c:3003
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Archivo nuevo]"
 
-#: buffer.c:3004
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Errores de lectura]"
 
-#: buffer.c:3006 fileio.c:2391 netbeans.c:3632
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[Sólo lectura]"
 
-#: buffer.c:3029
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 línea --%d%%--"
 
-#: buffer.c:3032
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> líneas --%d%%--"
 
-#: buffer.c:3039
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "línea %<PRId64> de %<PRId64> --%d%%-- col "
 
-#: buffer.c:3160 buffer.c:5126 memline.c:1727
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Sin nombre]"
 
 # must be a help buffer
 #. must be a help buffer
-#: buffer.c:3198
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ayuda"
 
-#: buffer.c:3826 screen.c:5817
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Ayuda]"
 
-#: buffer.c:3860 screen.c:5823
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Vista previa]"
 
-#: buffer.c:4182
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Todo"
 
-#: buffer.c:4182
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Final"
 
-#: buffer.c:4185
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Comienzo"
 
-#: buffer.c:5061
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -202,19 +230,11 @@ msgstr ""
 "\n"
 "# Lista de búfers:\n"
 
-#: buffer.c:5110
-msgid "[Location List]"
-msgstr "[Lista de ubicaciones]"
-
-#: buffer.c:5112
-msgid "[Quickfix List]"
-msgstr "[Lista de cambios rápidos]"
-
-#: buffer.c:5122
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[De cero]"
 
-#: buffer.c:5439
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -222,182 +242,203 @@ msgstr ""
 "\n"
 "--- Signos ---"
 
-#: buffer.c:5449
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Signos para %s:"
 
-#: buffer.c:5455
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    línea=%<PRId64> id=%d nombre=%s"
 
-#: diff.c:141
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Falta un símbolo de dos puntos"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Modo de operación ilegal"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Se esperaba un dígito"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Porcentaje ilegal"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: No se puede usar \"diff\" con más de %<PRId64> búfers"
 
-#: diff.c:777
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: No se puede leer o escribir en archivos temporales"
 
-#: diff.c:778
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: No se pudieron crear las \"diffs\" (diferencias)"
 
-#: diff.c:901
-msgid "Patch file"
-msgstr "Archivo de parches"
-
-#: diff.c:1005
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: No se pudo leer la salida del parche"
 
-#: diff.c:1227
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: No se pudo leer la salida de \"diff\""
 
-#: diff.c:2086
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: El búfer actual no está en modo de diferencias"
 
-#: diff.c:2105
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Ningún otro búfer está en modo de diferencias"
 
-#: diff.c:2107
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Ningún otro búfer está en modo de diferencias"
 
-#: diff.c:2117
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Más de dos búfers en modo de diferencias, no se cual usar"
 
-#: diff.c:2140
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: No se pudo encontrar el búfer %s"
 
-#: diff.c:2148
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: El búfer \"%s\" no está en modo de diferencias"
 
-#: diff.c:2192
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: El búfer cambió inesperadamente"
 
-#: digraph.c:2251
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: El código de escape no se permite en un dígrafo"
 
-#: digraph.c:2444
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: No se encontró el archivo \"keymap\""
 
-#: digraph.c:2471
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Usando \":loadkeymap\" en el archivo suministrado"
 
-#: digraph.c:2510
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Definición de \"keymap\" vacía"
 
-#: edit.c:42
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Completar palabra clave (^N^P)"
 
 # ctrl_x_mode == 0, ^P/^N compl.
 #. ctrl_x_mode == 0, ^P/^N compl.
-#: edit.c:43
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Modo ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
-#: edit.c:45
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Completar toda la línea (^L^N^P)"
 
-#: edit.c:46
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Completar nombre de archivo (^F^N^P)"
 
-#: edit.c:47
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Completar etiquetas (^]^N^P)"
 
-#: edit.c:48
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Completar patrón de ruta (^N^P)"
 
-#: edit.c:49
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Completar definición (^D^N^P)"
 
-#: edit.c:51
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Completar diccionario (^K^N^P)"
 
-#: edit.c:52
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Completar palabras con tesauro (^T^N^P)"
 
-#: edit.c:53
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Compleción de línea de órdenes (^V^N^P)"
 
-#: edit.c:54
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Completar definido por usuario (^U^N^P)"
 
-#: edit.c:55
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Completar con método Omni (^O^N^P)"
 
-#: edit.c:56
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Sugerencia de ortografía (s^N^P)"
 
 # Scroll has it's own msgs, in it's place there is the msg for local
 # * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-#: edit.c:57
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Completar palabra clave local (^N^P)"
 
-#: edit.c:60
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Se llegó al final del párrafo"
 
-#: edit.c:2038
+#: ../edit.c:101
+#, fuzzy
+msgid "E839: Completion function changed window"
+msgstr "E813: No se puede cerrar la ventana de autocmd"
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "La opción 'dictionary' está vacía"
 
-#: edit.c:2039
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "La opción 'thesaurus' (tesauro) está vacía"
 
-#: edit.c:2999
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Buscando en el diccionario: %s"
 
-#: edit.c:3484
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (insertar) Desplazamiento (^E/^Y)"
 
-#: edit.c:3486
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (reemplazar) Desplazamiento (^E/^Y)"
 
-#: edit.c:3963
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Buscando: %s"
 
-#: edit.c:3998
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Buscando etiquetas."
 
-#: edit.c:5010
+#: ../edit.c:4519
 msgid " Adding"
 msgstr "Añadiendo"
 
@@ -409,556 +450,592 @@ msgstr "Añadiendo"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
-#: edit.c:5057
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Buscando..."
 
-#: edit.c:5116
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "De vuelta al original"
 
-#: edit.c:5121
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Palabra proveniente de otra línea"
 
-#: edit.c:5126
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "La única coincidencia"
 
-#: edit.c:5191
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "coincidencia %d de %d"
 
-#: edit.c:5195
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "coincidencia %d"
 
-#: eval.c:96
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caracteres inesperados en :let"
 
-#: eval.c:97
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: índice de lista fuera de rango: %<PRId64>"
 
-#: eval.c:98
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Variable sin definir: %s"
 
-#: eval.c:99
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Falta un \"]\""
 
-#: eval.c:100
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: El argumento de %s debe ser una lista"
 
-#: eval.c:101
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: El argumento de %s debe ser una lista o un diccionario"
 
-#: eval.c:102
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: No se puede usar una llave vacía para el diccionario"
 
-#: eval.c:103
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Se requiere una lista"
 
-#: eval.c:104
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Se requiere de un diccionario"
 
-#: eval.c:105
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Demasiados argumentos para la función: %s"
 
-#: eval.c:106
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: No se encuentra la llave en el diccionario. %s"
 
-#: eval.c:107
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: La función %s ya existe, añada \"!\" para reemplazarla"
 
-#: eval.c:108
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Esta entrada ya existe en el diccionario"
 
-#: eval.c:109
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Se requiere una referencia de función"
 
 # if Vim opened a window: Executing a shell may cause crashes
-#: eval.c:110
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: No puede usar [:] con un diccionario"
 
-#: eval.c:111
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Tipo de variable incorrecta para %s="
 
-#: eval.c:112
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Función desconocida: %s"
 
-#: eval.c:113
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Nombre ilegal para una variable: %s"
 
-#: eval.c:1898
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Usando \"Float\" como \"String\""
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Menos blancos que elementos en la lista"
 
-#: eval.c:1903
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Más blancos que elementos en la lista"
 
-#: eval.c:1989
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Duplicado ; en la lista de variables"
 
-#: eval.c:2208
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: No se pudo enumerar las variables de %s"
 
-#: eval.c:2554
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Solo puedo indexar una lista o un diccionario"
 
-#: eval.c:2560
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] debe ir al final"
 
-#: eval.c:2612
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] requiere un valor de la lista"
 
-#: eval.c:2848
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: La lista de valores tiene más elementos que blancos"
 
-#: eval.c:2852
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: La lista de valores no tiene suficientes elementos"
 
-#: eval.c:3087
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Falta \"in\" después de :for"
 
-#: eval.c:3320
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Faltan paréntesis: %s"
 
-#: eval.c:3559
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: No existe la variable: \"%s\""
 
-#: eval.c:3646
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: La variable está anidada muy profundamente para (des)bloquear"
 
-#: eval.c:3994
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Falta un \":\" después de \"?\""
 
-#: eval.c:4296
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Solo se puede comparar una lista con otra lista"
 
-#: eval.c:4298
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Operación inválida para listas"
 
-#: eval.c:4325
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Solo se puede comparar un diccionario con otro diccionario"
 
-#: eval.c:4327
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Operación inválida para diccionario"
 
-#: eval.c:4347
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Solo se puede comparar un \"Funref\" con otro \"Funcref\""
 
-#: eval.c:4349
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Operación inválida para \"Funcrefs\""
 
 # if Vim opened a window: Executing a shell may cause crashes
-#: eval.c:4769
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: No se puede usar '%' con \"Float\""
 
-#: eval.c:4989
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Falta un \")\""
 
-#: eval.c:5141
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: No se puede crear un índice de un \"Funcref\""
 
-#: eval.c:5398
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Falta el nombre de la opción: %s"
 
-#: eval.c:5416
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Opción desconocida: %s"
 
-#: eval.c:5482
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Faltan las comillas: %s"
 
-#: eval.c:5618
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Faltan las comillas: %s"
 
-#: eval.c:5697
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Falta una coma en la lista: %s"
 
-#: eval.c:5705
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Falta una marca de final de lista ']': %s"
 
-#: eval.c:7195
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Falta una marca de dos puntos en el diccionario: %s"
 
-#: eval.c:7224
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Llave duplicada en el diccionario: %s"
 
-#: eval.c:7244
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Falta una coma en el diccionario: %s"
 
-#: eval.c:7252
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Falta una marca de cierre '}' en el diccionario: %s"
 
-#: eval.c:7290
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: La variable está anidada demasiado profundamente para mostrarla"
 
-#: eval.c:7974
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Demasiados argumentos para la función: %s"
 
-#: eval.c:7976
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Argumentos inválidos para la función: %s"
 
-#: eval.c:8181
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Función desconocida: %s"
 
-#: eval.c:8187
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: No hay suficientes argumentos para la función: %s"
 
-#: eval.c:8191
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Usando <SID> en un contexto que no es de \"script\": %s"
 
-#: eval.c:8195
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Llamando una función \"dict\" sin un diccionario: %s"
 
-#: eval.c:8423
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Se requiere \"Number\" o \"Float\""
 
-#: eval.c:8808
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c [argumentos]"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Demasiados argumentos"
 
-#: eval.c:8977
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() solo se puede usar en modo \"Insert\""
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
-#: eval.c:9077 gui.c:4871 gui_gtk.c:2144 os_mswin.c:598
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
-#: eval.c:9727
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Ya existe una llave: %s"
 
-#: eval.c:10301
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd [argumentos]"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c [argumentos]"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c [argumentos]"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld líneas: "
 
-#: eval.c:10389
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Función desconocida: %s"
 
-#: eval.c:12379
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&Aceptar\n"
-"&Cancelar"
-
-#: eval.c:12461
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Se invocó \"inputrestore()\" más veces que \"inputsave()\""
 
-#: eval.c:12595
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c [argumentos]"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: El rango no está permitido"
 
-#: eval.c:12795
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: No es un tipo válido para len()"
 
-#: eval.c:13788
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: El largo es cero"
 
-#: eval.c:13790
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: El inicio está más allá del final"
 
-#: eval.c:13843 eval.c:17576
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<vacio>"
 
-#: eval.c:14077
-msgid "E240: No connection to Vim server"
-msgstr "E240: No hay conexión al servidor Vim"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd [argumentos]"
 
-#: eval.c:14125
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Incapaz de enviar a %s"
-
-#: eval.c:14272
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Incapaz de leer una respuesta del servidor"
-
-#: eval.c:14522
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Demasiados enlaces simbólicos (¿referencia circular?)"
 
-#: eval.c:15243
-msgid "E258: Unable to send to client"
-msgstr "E258: Incapaz de enviar al cliente"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c [argumentos]"
 
-#: eval.c:15950
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c [argumentos]"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c [argumentos]"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Fallo al ordenar funciones comparadas"
 
-#: eval.c:16275
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Fallo al ordenar funciones comparadas"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(No es válido)"
 
-#: eval.c:16760
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Error al escribir el archivo temporal"
 
-#: eval.c:18602
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Usando \"Float\" como un \"Number\""
 
-#: eval.c:18606
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Usando una función de referencia como \"Number\""
 
-#: eval.c:18614
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Usando una \"Lista\" como \"Number\""
 
-#: eval.c:18617
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Usando un Diccionario como \"Number\""
 
-#: eval.c:18720
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Usando una Función de referencia como \"String\""
 
-#: eval.c:18723
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Usando una \"List\" como \"String\""
 
-#: eval.c:18726
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Usando un Diccionario como \"String\""
 
-#: eval.c:18730
-msgid "E806: using Float as a String"
-msgstr "E806: Usando \"Float\" como \"String\""
+#: ../eval.c:16619
+#, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E706: Tipo de variable no concuerda con : %s"
 
-#: eval.c:19090
+#: ../eval.c:16705
+#, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E795: No se pudo borrar la variable %s"
+
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr ""
 "E704: El nombre de una variable de Función de referencia debe empezar con "
 "mayúscula: %s"
 
-#: eval.c:19095
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Nombre de variable en conflicto con una función existente: %s"
 
-#: eval.c:19128
-#, c-format
-msgid "E706: Variable type mismatch for: %s"
-msgstr "E706: Tipo de variable no concuerda con : %s"
-
-#: eval.c:19237
-#, c-format
-msgid "E795: Cannot delete variable %s"
-msgstr "E795: No se pudo borrar la variable %s"
-
-#: eval.c:19254
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: El valor está bloqueado: %s"
 
-#: eval.c:19255 eval.c:19261 message.c:2132 os_mswin.c:2258
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: eval.c:19260
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: No se pudo cambiar el valor de %s"
 
-#: eval.c:19345
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: La variable está anidada muy profundamente para hacer una copia"
 
-#: eval.c:19818
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Función indefinida: %s"
 
-#: eval.c:19831
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Falta un \"(\": %s"
 
-#: eval.c:19887
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: No se pudo fijar los valores IC"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Argumento ilegal: %s"
 
-#: eval.c:19997
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Argumento ilegal: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Falta un \":endfunction\""
 
-#: eval.c:20134
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: El nombre de la función entran en conflicto con la variable: %s"
 
-#: eval.c:20149
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: No se puede redefinir la función %s: Está en uso"
 
-#: eval.c:20214
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Nombre de función no concuerda con el nombre de archivo: %s"
 
-#: eval.c:20332
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Se requiere el nombre de la función"
 
-#: eval.c:20452
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: El nombre de una función debe empezar con mayúscula o contener el "
 "signo de dos puntos: %s"
 
-#: eval.c:20984
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: El nombre de una función debe empezar con mayúscula o contener el "
+"signo de dos puntos: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: No se pudo eliminar la función %s: Está en uso"
 
-#: eval.c:21104
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr ""
 "E132: La recursión de llamada de la función es mayor que \"maxfuncdepth\""
 
 # always scroll up, don't overwrite
-#: eval.c:21243
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "Invocando %s"
 
-#: eval.c:21335
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "Abortada la ejecución de %s"
 
-#: eval.c:21337
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s devuelve #%<PRId64>"
 
-#: eval.c:21353
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s devuelve %s"
 
 # always scroll up, don't overwrite
-#: eval.c:21377 ex_cmds2.c:3145
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "continuando en %s"
 
-#: eval.c:21496
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: \":return\" no está dentro de una función"
 
-#: eval.c:21909
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -966,7 +1043,7 @@ msgstr ""
 "\n"
 "# variables globales:\n"
 
-#: eval.c:22026
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -974,106 +1051,105 @@ msgstr ""
 "\n"
 "\tSe definió por última vez en "
 
-#: eval.c:22046
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "No hay archivos antiguos"
 
-#: ex_cmds.c:101
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
-#: ex_cmds.c:128
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
-#: ex_cmds.c:129
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
-#: ex_cmds.c:739
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Moviendo líneas sobre sí mismas"
 
-#: ex_cmds.c:808
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 línea movida"
 
-#: ex_cmds.c:810
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> líneas movidas"
 
-#: ex_cmds.c:1305
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> líneas filtradas"
 
-#: ex_cmds.c:1329
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filtro* Las auto-órdenes no deben cambiar el búfer en uso"
 
-#: ex_cmds.c:1414
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[No se ha escrito nada al disco desde el último cambio]\n"
 
-#: ex_cmds.c:1672
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s en la línea: "
 
-#: ex_cmds.c:1680
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Demasiados errores, omitiendo el resto del archivo"
 
-#: ex_cmds.c:1709
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Leyendo el archivo \"viminfo\" \"%s\"%s%s%s"
 
-#: ex_cmds.c:1711
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
-#: ex_cmds.c:1712
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " marcas"
 
-#: ex_cmds.c:1713
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " archivos antiguos"
 
-#: ex_cmds.c:1714
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FALLÓ"
 
 #. avoid a wait_return for this message, it's annoying
-#: ex_cmds.c:1810
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: No hay permisos de escritura para el archivo \"viminfo\": %s"
 
-#: ex_cmds.c:1963
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: ¡No se pudo escribir el archivo \"viminfo\" %s!"
 
-#: ex_cmds.c:1973
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Escribiendo archivo \"viminfo\" \"%s\""
 
 # Write the info:
 #. Write the info:
-#: ex_cmds.c:2081
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Vim %s generó este archivo \"viminfo\".\n"
 
-#: ex_cmds.c:2083
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1081,55 +1157,50 @@ msgstr ""
 "# Puede editarlo, ¡sólo si tiene cuidado!\n"
 "\n"
 
-#: ex_cmds.c:2085
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Valor de 'encoding' cuando se escribió este archivo\n"
 
-#: ex_cmds.c:2185
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Carácter de comienzo ilegal"
 
-#: ex_cmds.c:2551 ex_cmds2.c:1407
-msgid "Save As"
-msgstr "Guardar como"
-
-#: ex_cmds.c:2628
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "¿Escribir un archivo parcial?"
 
-#: ex_cmds.c:2635
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Use \"!\" para escribir un búfer parcial"
 
-#: ex_cmds.c:2777
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "¿Escribir sobre el archivo existente \"%s\"?"
 
-#: ex_cmds.c:2820
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Ya existe un archivo de intercambio \"%s\", desea sobreescribirlo? "
 
-#: ex_cmds.c:2833
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr ""
 "E768: El archivo de intercambio ya existe: %s (use ! para sobreescribir)"
 
-#: ex_cmds.c:2901
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: No existe un nombre de archivo para el búfer %<PRId64>"
 
-#: ex_cmds.c:2940
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr ""
 "E142: No se ha escrito el archivo: escritura desactivada por \n"
 "la opción 'write'"
 
-#: ex_cmds.c:2970
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1138,7 +1209,7 @@ msgstr ""
 "Se ha activado la opción de solo lectura ('readonly') para %s.\n"
 "¿Desea escribir de todas formas?"
 
-#: ex_cmds.c:2973
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1149,83 +1220,83 @@ msgstr ""
 "sólo lectura. Cabe la posibilidad de escribir\n"
 "en él. ¿Desea intentarlo?"
 
-#: ex_cmds.c:2990
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" es de solo lectura (añada ! para sobreescribir)"
 
-#: ex_cmds.c:3177
-msgid "Edit File"
-msgstr "Editar archivo"
-
-#: ex_cmds.c:3847
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Las auto-órdenes han eliminado al nuevo búfer %s"
 
-#: ex_cmds.c:4063
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Argumento no numérico para \":z\""
 
-#: ex_cmds.c:4162
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: No se permiten órdenes de consola en rvim"
 
-#: ex_cmds.c:4261
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Las expresiones regulares no se pueden delimitar con letras"
 
-#: ex_cmds.c:4721
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "¿Reemplazar con %s (y/n/a/q/l/^E/^Y)?"
 
-#: ex_cmds.c:5166
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Interrumpido)"
 
-#: ex_cmds.c:5171
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "Una (1) coincidencia"
 
-#: ex_cmds.c:5171
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "Una (1) sustitución"
 
-#: ex_cmds.c:5174
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> coincidencias"
 
-#: ex_cmds.c:5174
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> sustituciones"
 
-#: ex_cmds.c:5179
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " en una (1) línea"
 
-#: ex_cmds.c:5182
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " en %<PRId64> líneas"
 
-#: ex_cmds.c:5229
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: \":global\" no puede ser recursivo"
 
-#: ex_cmds.c:5264
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Falta una expresión regular en \":global\""
 
-#: ex_cmds.c:5313
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Patrón encontrado en cada línea: %s"
 
-#: ex_cmds.c:5398
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "No se encontró el patrón de búsqueda"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1235,345 +1306,342 @@ msgstr ""
 "# Última cadena de sustitución:\n"
 "$"
 
-#: ex_cmds.c:5511
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: ¡No entre en pánico!"
 
-#: ex_cmds.c:5557
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Lo siento, no hay ayuda '%s' para \"%s\""
 
-#: ex_cmds.c:5560
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Lo siento, no hay ayuda para \"%s\""
 
-#: ex_cmds.c:5602
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Lo siento, no encuentro el archivo de ayuda \"%s\""
 
-#: ex_cmds.c:6180
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: No es un directorio: %s"
 
-#: ex_cmds.c:6323
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: No se pudo abrir %s para escritura"
 
-#: ex_cmds.c:6360
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Incapaz de abrir %s para lectura"
 
-#: ex_cmds.c:6396
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr ""
 "E670: Mezcla de codificaciones en archivos de ayuda dentro de un lenguaje: %s"
 
-#: ex_cmds.c:6474
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Etiqueta \"%s\" duplicada en el archivo %s/%s"
 
-#: ex_cmds.c:6610
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Orden de signo desconocida: %s"
 
-#: ex_cmds.c:6627
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Falta el nombre del signo"
 
-#: ex_cmds.c:6673
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Demasiados signos definidos"
 
-#: ex_cmds.c:6741
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: El texto de signo no es válido: %s"
 
-#: ex_cmds.c:6772 ex_cmds.c:6947
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Signo desconocido: %s"
 
-#: ex_cmds.c:6805
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Falta el número del signo"
 
-#: ex_cmds.c:6887
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: El nombre del búfer no es válido: %s"
 
-#: ex_cmds.c:6926
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: La identificación del signo no es válida: %<PRId64>"
 
-#: ex_cmds.c:6996
-msgid " (NOT FOUND)"
-msgstr " (NO ENCONTRADO)"
-
-#: ex_cmds.c:6998
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (no hay apoyo para la función pedida)"
 
-#: ex_cmds.c:7122
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Suprimido]"
 
-#: ex_cmds2.c:138
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Iniciando modo de depuración. Escriba \"cont\" para continuar."
 
-#: ex_cmds2.c:142 ex_docmd.c:1081
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "línea %<PRId64>: %s"
 
-#: ex_cmds2.c:144
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
-#: ex_cmds2.c:344
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "\"Breakpoint\" en \"%s%s\" línea %<PRId64>"
 
-#: ex_cmds2.c:656
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: No se ha encontrado el \"breakpoint\": %s"
 
-#: ex_cmds2.c:692
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "No se han definido \"breakpoints\""
 
-#: ex_cmds2.c:697
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  línea %<PRId64>"
 
-#: ex_cmds2.c:1095
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Primero use \":profile start <nombre_de_archivo>\""
 
-#: ex_cmds2.c:1432
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "¿Guardar los cambios en \"%s\"?"
 
-#: ex_cmds2.c:1434 ex_docmd.c:10814
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Sin título"
 
-#: ex_cmds2.c:1563
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: No se ha grabado nada desde el último cambio en el búfer \"%s\""
 
-#: ex_cmds2.c:1634
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Advertencia: se ha entrado en otro búfer de forma inesperada (verifique las "
 "auto-órdenes)"
 
-#: ex_cmds2.c:2078
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Hay sólo un archivo para editar"
 
-#: ex_cmds2.c:2080
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: No se pudo regresar antes del primer archivo"
 
-#: ex_cmds2.c:2082
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: No se pudo ir más allá del último archivo"
 
-#: ex_cmds2.c:2511
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: El compilador no es compatible en esta versión: %s"
 
-#: ex_cmds2.c:2612
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Buscando \"%s\" en \"%s\""
 
-#: ex_cmds2.c:2639
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Buscando \"%s\""
 
-#: ex_cmds2.c:2665
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "No se ha encontrado en 'runtimepath': %s"
 
-#: ex_cmds2.c:2700
-msgid "Source Vim script"
-msgstr "Ejecute archivo de órdenes de Vim"
-
-#: ex_cmds2.c:2875
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "No se pudo ejecutar un directorio: %s"
 
-#: ex_cmds2.c:2932
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "No pude ejecutar %s"
 
-#: ex_cmds2.c:2934
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "línea %<PRId64>: no se pudo ejecutar %s"
 
-#: ex_cmds2.c:2950
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "ejecutando %s"
 
-#: ex_cmds2.c:2952
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "línea %<PRId64>: ejecutando %s"
 
-#: ex_cmds2.c:3143
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "La ejecución de %s ha terminado"
 
-#: ex_cmds2.c:3224
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modeline"
 
-#: ex_cmds2.c:3226
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd [argumentos]"
 
-#: ex_cmds2.c:3228
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c [argumentos]"
 
-#: ex_cmds2.c:3230
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "variable de entorno"
 
-#: ex_cmds2.c:3232
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "administrador de errores"
 
-#: ex_cmds2.c:3524
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Advertencia: separador de línea incorrecto, puede que falte ^M"
 
-#: ex_cmds2.c:3657
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr ""
 "E167: Ha usado \":scriptencoding\" fuera de un archivo de instrucciones "
 "ejecutables"
 
-#: ex_cmds2.c:3690
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr ""
 "E168: Ha usado \":finish\" fuera de un archivo de instrucciones ejecutables"
 
-#: ex_cmds2.c:4012
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Idioma actual %s: \"%s\""
 
-#: ex_cmds2.c:4029
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: No se pudo establecer la opción del idioma a \"%s\""
 
-#: ex_docmd.c:626
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Entrando al modo Ex. Escriba \"visual\" para ir al modo Normal"
 
 # must be at EOF
-#: ex_docmd.c:681
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Estoy al final del archivo"
 
-#: ex_docmd.c:780
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Orden demasiado recursiva"
 
-#: ex_docmd.c:1359
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: La excepción %s no se atrapó"
 
-#: ex_docmd.c:1447
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Fin del archivo de instrucciones ejecutables"
 
-#: ex_docmd.c:1448
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Fin de la función"
 
-#: ex_docmd.c:2096
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Uso ambiguo de una orden definida por el usuario"
 
-#: ex_docmd.c:2110
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: No es una orden del editor"
 
-#: ex_docmd.c:2242
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Me ha dado un rango invertido"
 
-#: ex_docmd.c:2246
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Se devolvió un rango invertido, ¿puedo intercambiarlo?"
 
-#: ex_docmd.c:2309
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Use \"w\" o \"w>>\""
 
-#: ex_docmd.c:4076
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Lo siento, esa orden no está disponible en esta versión"
 
-#: ex_docmd.c:4425
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Solo se permite un nombre de archivo"
 
-#: ex_docmd.c:5036
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Un (1) archivo más para editar. ¿Cerrar de todas formas?"
 
-#: ex_docmd.c:5039
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Hay %d archivos más en edición. ¿Cerrar de todas formas?"
 
-#: ex_docmd.c:5046
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Un (1) archivo más para editar"
 
-#: ex_docmd.c:5048
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Hay %<PRId64> archivos en edición"
 
-#: ex_docmd.c:5142
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Ya existe esa orden. Añada \"!\" para reemplazarla"
 
-#: ex_docmd.c:5264
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1581,339 +1649,313 @@ msgstr ""
 "\n"
 "    Nombre      Args Rango Completar  Definición"
 
-#: ex_docmd.c:5357
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "No se han encontrado órdenes definidos por el usuario"
 
-#: ex_docmd.c:5389
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: No se ha especificado el atributo"
 
-#: ex_docmd.c:5441
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: El número de argumentos no es válido"
 
-#: ex_docmd.c:5456
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: El recuento no se puede especificar dos veces"
 
-#: ex_docmd.c:5466
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: El valor predeterminado para el recuento no es válido"
 
-#: ex_docmd.c:5494
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: se necesita un argumento para \"-complete\""
 
-#: ex_docmd.c:5506
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: El atributo no es válido: %s"
 
-#: ex_docmd.c:5552
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: El nombre de la orden no es válido"
 
-#: ex_docmd.c:5567
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr ""
 "E183: Las órdenes definidas por el usuario deben comenzar con mayúscula"
 
-#: ex_docmd.c:5635
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Uso ambiguo de una orden definida por el usuario"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: No existe esa orden definida por el usuario: %s"
 
-#: ex_docmd.c:6187
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: El valor para completar no es válido: %s"
 
-#: ex_docmd.c:6198
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: El argumento de finalización solo se permite en finalizaciones "
 "definidas por el usuario"
 
-#: ex_docmd.c:6206
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr ""
 "E467: Las finalizaciones definidas por el usuario requieren de un argumento "
 "de función"
 
-#: ex_docmd.c:6222
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: No se pudo encontrar el esquema de colores %s"
 
-#: ex_docmd.c:6230
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "¡Saludos, usuario de Vim!"
 
-#: ex_docmd.c:6448
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: No se pudo cerrar la última ventana"
 
-#: ex_docmd.c:6490
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Solo hay una ventana"
 
-#: ex_docmd.c:7177
-msgid "Edit File in new window"
-msgstr "Editar archivo en una ventana nueva"
-
-#: ex_docmd.c:7303
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Página %d"
 
-#: ex_docmd.c:7695
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "No hay archivo de intercambio"
 
-#: ex_docmd.c:7800
-msgid "Append File"
-msgstr "Añadir archivo"
-
-#: ex_docmd.c:7899
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: No se pudo cambiar de directorio, el búfer fue modificado (añada ! "
 "para forzar la orden)"
 
-#: ex_docmd.c:7908
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: No hay un directorio previo"
 
-#: ex_docmd.c:7989
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Desconocido"
 
-#: ex_docmd.c:8084
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: \":winsize\" requiere de dos argumentos numéricos"
 
-#: ex_docmd.c:8146
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Posición de la ventana: X %d, Y %d"
-
-#: ex_docmd.c:8151
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Obtener la posición de la ventana no está implementado en esta "
 "plataforma"
 
-#: ex_docmd.c:8161
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: \":winpos\" requiere de dos argumentos numéricos"
 
-#: ex_docmd.c:8499
-msgid "Save Redirection"
-msgstr "Guardar redirección"
-
-#: ex_docmd.c:8730
-msgid "Save View"
-msgstr "Guardar vista"
-
-#: ex_docmd.c:8731
-msgid "Save Session"
-msgstr "Guardar sesión"
-
-#: ex_docmd.c:8733
-msgid "Save Setup"
-msgstr "Guardar configuración"
-
-#: ex_docmd.c:8889
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: No se pudo crear directorio: %s"
 
-#: ex_docmd.c:8918
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" ya existe (añada ! para sobreescribir.)"
 
-#: ex_docmd.c:8923
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: No se pudo abrir \"%s\" para escrbir"
 
 # set mark
 #. set mark
-#: ex_docmd.c:8947
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr ""
 "E191: El argumento debe ser una letra o una comilla simple/comilla simple "
 "invertida"
 
-#: ex_docmd.c:8994
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Excesivo uso recursivo de \":normal\""
 
-#: ex_docmd.c:9593
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< no está disponible sin la característica \"+eval\""
-
-#: ex_docmd.c:9602
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: No hay un nombre de archivo alterno que sustituya a '#'"
 
-#: ex_docmd.c:9643
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr ""
 "E495: No se ha dado un nombre de archivo de auto-órdenes para sustituir a  "
 "\"<afile>\""
 
-#: ex_docmd.c:9652
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: No existe un búfer de auto-órdenes para sustituir por \"<abuf>\""
 
-#: ex_docmd.c:9663
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: Ningún nombre de auto-orden concuerda para sustituir \"<amatch>\""
 
-#: ex_docmd.c:9673
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr ""
 "E498: No hay un nombre de archivo \":source\" que sustituya a \"<sfile>\""
 
-#: ex_docmd.c:9715
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr ""
+"E498: No hay un nombre de archivo \":source\" que sustituya a \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr ""
 "E499: Un nombre de archivo vacío para \"%\" o \"#\" solo funciona con \":p:h"
 "\""
 
-#: ex_docmd.c:9717
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: La expresión evalúa a una cadena vacía"
 
-#: ex_docmd.c:10794
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: No se pudo abrir el archivo \"viminfo\" para lectura"
 
-#: ex_docmd.c:10964
-msgid "E196: No digraphs in this version"
-msgstr "E196: No hay dígrafos en esta versión"
-
-#: ex_eval.c:441
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr ""
 "E608: No se pudo lanzar (':throw') excepciones si tienen el prefijo 'Vim'"
 
 # always scroll up, don't overwrite
 #. always scroll up, don't overwrite
-#: ex_eval.c:534
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Excepción lanzada: %s"
 
-#: ex_eval.c:588
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Excepción terminada: %s"
 
-#: ex_eval.c:589
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Excepción descartada: %s"
 
-#: ex_eval.c:635 ex_eval.c:687
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, en la línea %<PRId64>"
 
 # always scroll up, don't overwrite
 #. always scroll up, don't overwrite
-#: ex_eval.c:657
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Excepción atrapada: %s"
 
-#: ex_eval.c:737
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s ha pasado a la lista de pendientes"
 
-#: ex_eval.c:740
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s continuado"
 
-#: ex_eval.c:744
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s descartado"
 
-#: ex_eval.c:771
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Excepción"
 
-#: ex_eval.c:777
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Error e interrupción"
 
-#: ex_eval.c:779 gui.c:4870 gui_xmdlg.c:689 gui_xmdlg.c:808 os_mswin.c:597
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Error"
 
 # if (pending & CSTP_INTERRUPT)
 #. if (pending & CSTP_INTERRUPT)
-#: ex_eval.c:781
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Interrupción"
 
-#: ex_eval.c:873
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: ¡\":if\" anidado en exceso!"
 
-#: ex_eval.c:910
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: ¡\":endif\" sin un \":if\"!"
 
-#: ex_eval.c:955
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: ¡\":else\" sin un \":if\"!"
 
-#: ex_eval.c:958
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: ¡\":elseif\" sin un \":if\"!"
 
-#: ex_eval.c:965
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: ¡\":else\" múltiple!"
 
-#: ex_eval.c:968
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: ¡\":elseif\" después de \":else\"!"
 
-#: ex_eval.c:1035
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: ¡\":while\" anidado en exceso!"
 
-#: ex_eval.c:1133
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: ¡\":continue\" sin un \":while\" o \":for\"!"
 
-#: ex_eval.c:1172
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: ¡\":break\" sin \":while\" o \":for\"!"
 
-#: ex_eval.c:1222
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Usando \":endfor\" con \":while\""
 
-#: ex_eval.c:1224
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Usando \":endwhile\" con \":for\""
 
-#: ex_eval.c:1399
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: ¡\":try\" anidado en exceso!"
 
-#: ex_eval.c:1479
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: ¡\":catch\" sin un \":try\"!"
 
@@ -1921,49 +1963,49 @@ msgstr "E603: ¡\":catch\" sin un \":try\"!"
 # * Just parse.
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
-#: ex_eval.c:1498
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: ¡\":catch\" después de \":finally\"!"
 
-#: ex_eval.c:1632
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: ¡\":finally\" sin un \":try\"!"
 
 # Give up for a multiple ":finally" and ignore it.
 #. Give up for a multiple ":finally" and ignore it.
-#: ex_eval.c:1652
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: ¡\":finally\" múltiple!"
 
-#: ex_eval.c:1762
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: ¡\":endtry\" sin un \":try\"!"
 
-#: ex_eval.c:2267
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: ¡\":endfunction\" no está dentro de una función!"
 
-#: ex_getln.c:2010
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: No se permite editar otro búfer en este momento"
 
-#: ex_getln.c:2025
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: No se permite cambiar la información del búfer en este momento"
 
-#: ex_getln.c:3924
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "Nombre de la etiqueta (\"tagname\")"
 
-#: ex_getln.c:3927
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " tipo de archivo\n"
 
-#: ex_getln.c:5676
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "La opción 'history' (historia) es cero"
 
-#: ex_getln.c:5947
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1972,316 +2014,319 @@ msgstr ""
 "\n"
 "# Historia de %s (de lo más nuevo a lo más antiguo):\n"
 
-#: ex_getln.c:5948
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Línea de órdenes"
 
-#: ex_getln.c:5949
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Cadena de búsqueda"
 
-#: ex_getln.c:5950
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Expresión"
 
-#: ex_getln.c:5951
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Línea de entrada"
 
-#: ex_getln.c:5989
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: \"cmd_pchar\" más allá de la longitud de la orden"
 
-#: ex_getln.c:6190
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Se borró la ventana o el búfer activo"
 
-#: fileio.c:153
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Ruta no válida: '**[número]' debe estar al final de la ruta\n"
+"o seguido de %s."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: No se pudo encontrar el directorio \"%s\" en \"cdpath\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: No se pudo encontrar el archivo %s en la ruta"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: No se han encontrado mas directorios \"%s\" en \"cdpath\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: No se han encontrado mas archivos \"%s\" en la ruta"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: *Filtro* Las auto-órdenes no deben cambiar el búfer en uso"
 
-#: fileio.c:408
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Nombre de archivo ilegal"
 
-#: fileio.c:437 fileio.c:591 fileio.c:3320 fileio.c:3371
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "es un directorio"
 
-#: fileio.c:439
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "no es un archivo"
 
-#: fileio.c:452
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "es un dispositivo (desactivado con la opción 'opendevice')"
-
-#: fileio.c:628 fileio.c:4605
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Archivo nuevo]"
 
-#: fileio.c:631
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Directorio nuevo]"
 
-#: fileio.c:665
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[El archivo es demasiado grande]"
 
-#: fileio.c:667
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Permiso denegado]"
 
-#: fileio.c:800
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Las auto-órdenes \"*ReadPre\" hicieron ilegible el archivo"
 
-#: fileio.c:802
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Las auto-órdenes \"*ReadPre\" no deben cambiar el búfer en uso"
 
-#: fileio.c:823
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Leyendo la entrada estándar...\n"
 
-#: fileio.c:829
-msgid "Reading from stdin..."
-msgstr "Leyendo la entrada estándar..."
-
 # Re-opening the original file failed!
 #. Re-opening the original file failed!
-#: fileio.c:1128
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: ¡La conversión ha hecho ilegible el archivo!"
 
-#: fileio.c:2362
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
-#: fileio.c:2369
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
-#: fileio.c:2376
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-#: fileio.c:2384
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[carácter especial]"
 
-#: fileio.c:2391 netbeans.c:3632
-msgid "[RO]"
-msgstr "[RO]"
-
-#: fileio.c:2401
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[Falta un CR]"
 
-#: fileio.c:2406
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[se han dividido las líneas largas]"
 
-#: fileio.c:2412 fileio.c:4589
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NO se ha convertido]"
 
-#: fileio.c:2417 fileio.c:4594
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[convertido]"
 
-#: fileio.c:2424 fileio.c:4619
-msgid "[crypted]"
-msgstr "[cifrado]"
-
-#: fileio.c:2432
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ERROR DE CONVERSIÓN en línea %<PRId64>]"
 
-#: fileio.c:2438
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[BYTE ILEGAL en la línea %<PRId64>]"
 
-#: fileio.c:2445
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ERRORES DE LECTURA]"
 
-#: fileio.c:2723
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "No se pudo encontrar el archivo temporal para la conversión"
 
-#: fileio.c:2730
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Falló la conversión con 'charconvert'"
 
-#: fileio.c:2733
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "No se pudo leer el resultado de 'charconvert'"
 
-#: fileio.c:3165
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: No coincide ninguna auto-orden para \"acwrite\"en el búfer"
 
-#: fileio.c:3200
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Las auto-órdenes fueron suprimidas o el búfer se descargó para ser "
 "grabado en disco"
 
-#: fileio.c:3223
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr ""
 "E204: La auto-orden ha cambiado el número de líneas en forma inesperada"
 
-#: fileio.c:3263
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans no permite que se escriba sobre búfers sin modificar"
-
-#: fileio.c:3271
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "No se permite la escritura parcial de los búfers de NetBeans"
-
-#: fileio.c:3326 fileio.c:3344
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "no es un archivo o dispositivo en el que se pueda escribir"
 
-#: fileio.c:3355
-msgid "writing to device disabled with 'opendevice' option"
-msgstr ""
-"se ha desactivado la escritura en dispositivo con la opción 'opendevice'"
-
-#: fileio.c:3397 netbeans.c:3694
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "es de solo lectura (añada ! para sobreescribir)"
 
-#: fileio.c:3761
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: No se pudo escribir en el archivo de recuperación\n"
 "(añada ! para forzar la orden)"
 
-#: fileio.c:3773
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: Error al cerrar el archivo de la copia de seguridad (añada ! para "
 "forzar la orden)"
 
-#: fileio.c:3775
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: No se pudo leer el archivo para crear la copia de seguridad (añada ! "
 "para forzar la orden)"
 
-#: fileio.c:3794
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: No se pudo crear el archivo para la copia de seguridad (añada ! para "
 "forzar la orden)"
 
-#: fileio.c:3896
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: No se pudo hacer un archivo de copia de seguridad (añada ! para forzar "
 "la orden)"
 
-#: fileio.c:3958
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr ""
-"E460: Se perdería el segmento (\"fork\") de recursos (añada ! para forzar la "
-"orden)"
-
-#: fileio.c:4067
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: No se pudo encontrar el archivo temporal para escribir en él"
 
-#: fileio.c:4085
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: No se pudo convertir (añada \"!\" para escribir el archivo sin "
 "conversión)"
 
-#: fileio.c:4120
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: No se pudo abrir el archivo enlazado para escribir"
 
-#: fileio.c:4124
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: No se pudo abrir el archivo para escribir en él"
 
-#: fileio.c:4405
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Falló \"fsync\" (sincronización de archivo)"
 
-#: fileio.c:4444
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Falló el cierre del archivo"
 
-#: fileio.c:4496
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Error de escritura, la conversión falló (vacíe 'fenc' para forzar)."
 
-#: fileio.c:4501
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Error de escritura, la conversión falló en la línea %<PRId64>(vacíe 'fenc' "
-"para forzar)"
+"E513: Error de escritura, la conversión falló en la línea %<PRId64>(vacíe "
+"'fenc' para forzar)"
 
-#: fileio.c:4510
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Error de escritura (¿Sistema de archivos lleno?)"
 
-#: fileio.c:4578
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ERROR DE CONVERSIÓN"
 
-#: fileio.c:4583
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "en la línea %<PRId64>"
 
-#: fileio.c:4600
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Dispositivo]"
 
-#: fileio.c:4605
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nuevo]"
 
-#: fileio.c:4627
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
-#: fileio.c:4627
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " añadido"
 
-#: fileio.c:4629
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
-#: fileio.c:4629
+#: ../fileio.c:3537
 msgid " written"
 msgstr " escritos"
 
-#: fileio.c:4684
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Modo de parcheo: no se puede guardar el archivo original"
 
-#: fileio.c:4707
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Modo de parcheo: no se puede tocar el archivo original vacío"
 
-#: fileio.c:4722
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: No se pudo borrar el archivo de respaldo"
 
-#: fileio.c:4788
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -2289,57 +2334,57 @@ msgstr ""
 "\n"
 "ADVERTENCIA: el archivo original puede haberse perdido o dañado\n"
 
-#: fileio.c:4790
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "¡no salga del editor hasta que el archivo se haya escrito!"
 
-#: fileio.c:4932
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[DOS]"
 
-#: fileio.c:4932
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[formato DOS]"
 
-#: fileio.c:4939
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[Mac]"
 
-#: fileio.c:4939
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[formato Mac]"
 
-#: fileio.c:4946
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[UNIX]"
 
-#: fileio.c:4946
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[formato UNIX]"
 
-#: fileio.c:4973
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 línea, "
 
-#: fileio.c:4975
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> líneas, "
 
-#: fileio.c:4978
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 carácter"
 
-#: fileio.c:4980
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> caracteres"
 
-#: fileio.c:4990 netbeans.c:3637
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[no hay fin de línea]"
 
-#: fileio.c:4990 netbeans.c:3637
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Última línea incompleta]"
 
@@ -2349,39 +2394,39 @@ msgstr "[Última línea incompleta]"
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
-#: fileio.c:5009
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ADVERTENCIA: ¡¡¡El archivo ha cambiado desde que se leyó!!!"
 
-#: fileio.c:5011
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "¿Desea realmente escribir al archivo?"
 
-#: fileio.c:6375
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Error al escribir a \"%s\""
 
-#: fileio.c:6382
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Error al cerrar \"%s\""
 
-#: fileio.c:6385
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Error al leer \"%s\""
 
-#: fileio.c:6647
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: La auto-orden \"FileChangedShell\" ha borrado el búfer"
 
-#: fileio.c:6662
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: El archivo \"%s\" ya no está disponible"
 
-#: fileio.c:6677
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -2390,43 +2435,43 @@ msgstr ""
 "W12: Advertencia: el archivo \"%s\" ha cambiado y el búfer se modificó "
 "también en Vim"
 
-#: fileio.c:6678
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Véase \":help W12\" para más información"
 
-#: fileio.c:6682
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
 "W11: Advertencia: el archivo \"%s\" ha cambiado desde que comenzó la edición"
 
-#: fileio.c:6683
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Véase \":help W11\" para más información."
 
-#: fileio.c:6687
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Advertencia: el modo del archivo \"%s\" ha cambiado desde que comenzó "
 "la edición"
 
-#: fileio.c:6688
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Véase \":help W16\" para más información."
 
-#: fileio.c:6703
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Advertencia: la creación del archivo \"%s\" es posterior al inicio de "
 "la edición"
 
-#: fileio.c:6733
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Advertencia"
 
-#: fileio.c:6734
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -2434,50 +2479,50 @@ msgstr ""
 "&OK\n"
 "&Cargar archivo"
 
-#: fileio.c:6857
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: No pude prepararme para recargar \"%s\""
 
-#: fileio.c:6876
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: No pude recargar \"%s\""
 
-#: fileio.c:7490
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Suprimido--"
 
-#: fileio.c:7643
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "Auto-removiendo autocomando: %s <búfer=%d>"
 
 # the group doesn't exist
 #. the group doesn't exist
-#: fileio.c:7689
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: No existe el grupo: %s"
 
-#: fileio.c:7836
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Carácter ilegal después de *: %s"
 
-#: fileio.c:7848
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: No existe tal evento: %s"
 
-#: fileio.c:7850
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: No existe tal grupo o evento: %s"
 
 # Highlight title
 #. Highlight title
-#: fileio.c:8058
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -2485,713 +2530,780 @@ msgstr ""
 "\n"
 "--- Auto-órdenes ---"
 
-#: fileio.c:8294
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: número de <búfer=%d> no válido"
 
-#: fileio.c:8391
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: No se pueden ejecutar las auto-órdenes para TODOS los eventos"
 
-#: fileio.c:8414
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "No coincide ninguna auto-orden"
 
-#: fileio.c:8862
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: La auto-orden se anida en exceso"
 
-#: fileio.c:9215
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto-órdenes para \"%s\""
 
-#: fileio.c:9225
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Ejecutando %s"
 
 # always scroll up, don't overwrite
-#: fileio.c:9294
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "auto-orden %s"
 
-#: fileio.c:9977
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Falta un {."
 
-#: fileio.c:9979
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Falta un }."
 
-#: fold.c:68
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: No se encontró ningún pliegue"
 
-#: fold.c:593
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: No se puede crear el pliegue con el 'foldmethod' actual activo"
 
-#: fold.c:595
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: No se puede borrar el pliegue con el 'foldmethod' activo"
 
-#: fold.c:1999
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld líneas plegadas"
 
-#: getchar.c:252
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Añadir al búfer de lectura"
 
-#: getchar.c:2407
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Asociación recursiva"
 
-#: getchar.c:3366
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Ya existe una abreviatura global para %s"
 
-#: getchar.c:3369
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Ya existe una asociación global para %s"
 
-#: getchar.c:3501
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Ya existe una abreviatura para %s"
 
-#: getchar.c:3504
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Ya existe una asociación para %s"
 
-#: getchar.c:3572
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "No se encontró ninguna abreviatura"
 
-#: getchar.c:3574
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "No se encontró ninguna asociación de teclado"
 
-#: getchar.c:4687
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: \"makemap\": modo ilegal"
 
-#: gui.c:226
-msgid "E229: Cannot start the GUI"
-msgstr "E229: No se pudo iniciar la interfaz gráfica"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--No hay líneas en el búfer--"
 
-#: gui.c:361
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: No se pudo leer desde \"%s\""
+#
+# * The error messages that can be shared are included here.
+# * Excluded are errors that are only used once and debugging messages.
+#
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: La orden se ha interrumpido"
 
-#: gui.c:487
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Es necesario un argumento"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ debería ir seguido de \"/\", \"?\" o \"&\""
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E665: No se pudo iniciar la interfaz gráfica (GUI), no se encontró ninguna "
-"tipografía de impresión válida"
+"E11: Inválido en la ventana de la línea de órdenes: <CR> ejecuta, CTRL-C "
+"cierra"
 
-#: gui.c:492
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: El valor de 'guifontwide' no es válido"
-
-#: gui.c:603
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: El valor de 'imactivatekey' no es válido"
-
-#: gui.c:4526
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: No se pudo asignar el color %s"
-
-#: gui.c:5107
-msgid "No match at cursor, finding next"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"No hay correspondencia en la posición del cursor, buscando la siguiente"
+"E12: Orden no permitida desde exrc/vimrc en el directorio \n"
+"en uso o al buscar etiquetas"
 
-#: gui_at_fs.c:300
-msgid "<cannot open> "
-msgstr "<no se puede abrir> "
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Falta \":endif\""
 
-#: gui_at_fs.c:1133
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Falta \":endtry\""
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Falta \":endwhile\""
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Falta \":endfor\""
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: \":endwhile\" sin \":while\""
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: \":endfor\" sin un \":for\""
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: El archivo ya existe (use \"!\" para sobreescribir)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: La orden falló"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Error interno"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Interrumpido"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: La dirección no es válida"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: El argumento no es válido"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: El argumento no es válido: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: La expresión no es válida: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: El rango no es válido"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: La orden no es válida"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" es un directorio"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: La longitud de desplazamiento no es válida"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"E616: \"vim_SelFile\": No se puede hallar la tipografía de impresión %s"
 
-#: gui_at_fs.c:2764
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: \"vim_SelFile\": no puedo regresar al directorio actual"
-
-#: gui_at_fs.c:2784
-msgid "Pathname:"
-msgstr "Nombre de la ruta:"
-
-#: gui_at_fs.c:2790
-msgid "E615: vim_SelFile: can't get current directory"
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"E615: \"vim_SelFile\": No se pudo obtener la ubicación del directorio actual"
 
-#: gui_at_fs.c:2798 gui_xmdlg.c:931
-msgid "OK"
-msgstr "OK"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Falló la llamada a la biblioteca para \"%s()\""
 
-#: gui_at_fs.c:2798 gui_gtk.c:2831 gui_xmdlg.c:940
-msgid "Cancel"
-msgstr "Cancelar"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: El número de línea de la marca no es válido"
 
-#: gui_at_sb.c:490
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: No se ha colocado una marca"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: No se pudo modificar, 'modifiable' está desactivado"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Demasiados archivos de órdenes anidados"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: No hay un archivo alterno"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: No existe esa abreviatura"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: \"!\" no está permitido"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
 msgstr ""
-"Scrollbar Widget: No pude obtener la geometría de la miniatura \"pixmap\""
+"E25: No se puede usar la interfaz gráfica de usuario: No se activó al "
+"compilar"
 
-#: gui_athena.c:2160 gui_motif.c:2588
-msgid "Vim dialog"
-msgstr "Diálogo de Vim"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: No existe un grupo de resaltado de nombre: %s"
 
-#: gui_beval.c:200 gui_w32.c:4728
-msgid "E232: Cannot create BalloonEval with both message and callback"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Aún no ha insertado texto"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: No hay una línea de órdenes previa"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: No existe tal asociación"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: No hay coincidencia"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: No coincide: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: No hay un nombre de archivo"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: No existe una expresión regular de sustitución previa"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: No existe una orden previa"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: No existe una expresión regular previa"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: El rango no está permitido"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: No hay espacio suficiente"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: No se pudo crear el archivo \"%s\""
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: No se pudo obtener el nombre del archivo temporal"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: No se pudo abrir el archivo \"%s\""
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: No se pudo leer el archivo \"%s\""
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
 msgstr ""
-"E232: No se pudo crear un \"BalloonEval\" que contenga tanto el mensaje como "
-"la llamada de retorno"
+"E37: No guardó el archivo desde el último cambio (añada \"!\" para forzar)"
 
-#: gui_gtk.c:1694
-msgid "Vim dialog..."
-msgstr "Diálogo de Vim..."
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[No se ha escrito nada al disco desde el último cambio]\n"
 
-#: gui_gtk.c:2145 message.c:3654
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
-msgstr ""
-"&Si\n"
-"&No\n"
-"&Cancelar"
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Argumento nulo"
 
-#: gui_gtk.c:2356
-msgid "Input _Methods"
-msgstr "Métodos de Entrada (\"Input Methods\")"
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Se esperaba un número"
 
-#: gui_gtk.c:2634 gui_motif.c:3760
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Buscar y reemplazar..."
-
-#: gui_gtk.c:2642 gui_motif.c:3762
-msgid "VIM - Search..."
-msgstr "VIM - Buscar..."
-
-#: gui_gtk.c:2674 gui_motif.c:3871
-msgid "Find what:"
-msgstr "¿Encontrar qué?:"
-
-#: gui_gtk.c:2692 gui_motif.c:3904
-msgid "Replace with:"
-msgstr "Reemplazar con:"
-
-# whole word only button
-#. whole word only button
-#: gui_gtk.c:2724 gui_motif.c:4025
-msgid "Match whole word only"
-msgstr "Encontrar solo palabras completas"
-
-# match case button
-#. match case button
-#: gui_gtk.c:2735 gui_motif.c:4037
-msgid "Match case"
-msgstr "La única coincidencia"
-
-#: gui_gtk.c:2745 gui_motif.c:3976
-msgid "Direction"
-msgstr "Dirección"
-
-# 'Up' and 'Down' buttons
-#. 'Up' and 'Down' buttons
-#: gui_gtk.c:2757 gui_motif.c:3989
-msgid "Up"
-msgstr "Hacia arriba"
-
-#: gui_gtk.c:2761 gui_motif.c:3998
-msgid "Down"
-msgstr "Hacia abajo"
-
-#: gui_gtk.c:2783 gui_gtk.c:2785
-msgid "Find Next"
-msgstr "Encontrar siguiente"
-
-#: gui_gtk.c:2802 gui_gtk.c:2804
-msgid "Replace"
-msgstr "Reemplazar"
-
-#: gui_gtk.c:2815 gui_gtk.c:2817
-msgid "Replace All"
-msgstr "Reemplazar todos"
-
-#: gui_gtk_x11.c:2417
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Recibí una solicitud \"die\" del administrador de sesiones.\n"
-
-#: gui_gtk_x11.c:3244
-msgid "Close"
-msgstr "Cerrar"
-
-#: gui_gtk_x11.c:3245 gui_w48.c:2375
-msgid "New tab"
-msgstr "Pestaña nueva"
-
-#: gui_gtk_x11.c:3246
-msgid "Open Tab..."
-msgstr "Abrir pestaña..."
-
-#: gui_gtk_x11.c:4025
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: La ventana principal fue destruida inesperadamente.\n"
-
-#: gui_gtk_x11.c:4746
-msgid "Font Selection"
-msgstr "Selección de tipos de letra"
-
-#: gui_motif.c:2355
-msgid "&Filter"
-msgstr "&Filtro"
-
-#: gui_motif.c:2356 gui_motif.c:3839
-msgid "&Cancel"
-msgstr "&Cancelar"
-
-#: gui_motif.c:2357
-msgid "Directories"
-msgstr "Directorios"
-
-#: gui_motif.c:2358
-msgid "Filter"
-msgstr "Filtro"
-
-#: gui_motif.c:2359
-msgid "&Help"
-msgstr "&Ayuda"
-
-#: gui_motif.c:2360
-msgid "Files"
-msgstr "Archivos"
-
-#: gui_motif.c:2361
-msgid "&OK"
-msgstr "&OK"
-
-#: gui_motif.c:2362
-msgid "Selection"
-msgstr "Selección"
-
-#: gui_motif.c:3791
-msgid "Find &Next"
-msgstr "Encontrar &Siguiente"
-
-#: gui_motif.c:3806
-msgid "&Replace"
-msgstr "&Reemplazar"
-
-#: gui_motif.c:3817
-msgid "Replace &All"
-msgstr "Reemplazar &Todos"
-
-#: gui_motif.c:3828
-msgid "&Undo"
-msgstr "&Deshacer"
-
-#: gui_w32.c:1177
+#: ../globals.h:1058
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: No se pudo encontrar el título de la ventana \"%s\""
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: No se pudo abrir el archivo de errores \"%s\""
 
-#: gui_w32.c:1190
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: ¡Memoria agotada!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "No se encontró el patrón de búsqueda"
+
+#: ../globals.h:1061
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argumento no admitido: \"-%s\"; use la versión OLE."
+msgid "E486: Pattern not found: %s"
+msgstr "E486: No se encontró el patrón de búsqueda: %s"
 
-#: gui_w32.c:1442
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Incapaz de abrir ventana dentro de la aplicación MDI"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: El argumento debe ser positivo"
 
-#: gui_w48.c:2374
-msgid "Close tab"
-msgstr "Cerrar Ventana"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: No se pudo regresar al directorio previo"
 
-#: gui_w48.c:2377
-msgid "Open tab..."
-msgstr "Abrir pestaña..."
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: No hay errores"
 
-#: gui_w48.c:2633
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Buscar cadena (use '\\\\' para encontrar un '\\')"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: No hay una lista de posiciones"
 
-#: gui_w48.c:2669
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Buscar y reemplazar (use '\\\\' para encontrar un '\\')"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Cadena de coincidencia dañada"
 
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-#: gui_w48.c:3463
-msgid "Not Used"
-msgstr "Sin usar"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: El programa \"regexp\" está corrupto"
 
-#: gui_w48.c:3464
-msgid "Directory\t*.nothing\n"
-msgstr "Directorio\t*.nada\n"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: La opción 'readonly' está activada (añada \"!\" para forzar)"
 
-#: gui_x11.c:1546
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr ""
-"Vim E458: no se puede asignar una entrada al mapa de colores; algunos "
-"colores tal vez no sean correctos"
-
-#: gui_x11.c:2138
+#: ../globals.h:1073
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr ""
-"E250: Faltan los tipos de letras para los siguientes conjuntos de caracteres "
-"en el conjunto de fuentes %s:"
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: No puede cambiar la variable de solo lectura \"%s\""
 
-#: gui_x11.c:2181
+#: ../globals.h:1075
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nombre del conjunto de tipos de letra: %s"
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: No se puede definir la variable en el \"sandbox\": \"%s\""
 
-#: gui_x11.c:2182
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Error al leer el archivo de errores"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: No se permite en el ambiente protegido"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: No se permite aquí"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: La configuración de la pantalla no es válida"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: La longitud de desplazamiento no es válida"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: La opción 'shell' (intérprete de órdenes) está vacía"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: ¡No se pudo cargar los signos!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Error de cierre en el archivo de intercambio"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: La pila de etiquetas ('tagstack') está vacía"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: La orden es demasiado compleja"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: El nombre es demasiado largo"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Hay demasiados ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Hay demasiados nombres de archivos"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Caracteres en exceso al final de la línea"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Marca desconocida"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: No se pudo expandir los comodines"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: \"winheight\" no puede ser más pequeño que \"winminheight\""
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: \"winwidth\" no puede ser más pequeño que \"winminwidth\""
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Error al escribir el archivo"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "El recuento es cero"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Usando <SID> en un contexto que no es de archivo de órdenes"
+
+#: ../globals.h:1102
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "La tipografía de impresión '%s' no es de ancho fijo"
+msgid "E685: Internal error: %s"
+msgstr "E685: Error interno: %s"
 
-#: gui_x11.c:2201
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: El patrón usa más memoria que 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Búfer vacío"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Patrón de búsqueda o delimitador no válido"
+
+# Overwriting a file that is loaded in another buffer is not a
+# * good idea.
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: El archivo ya se ha cargado en otro búfer"
+
+#: ../globals.h:1110
 #, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Nombre del conjunto de tipografías de impresión: %s\n"
+msgid "E764: Option '%s' is not set"
+msgstr "E764: No se ha definido la opción '%s'"
 
-#: gui_x11.c:2202
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Tipo de letra de impresión 0: %s\n"
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Nombre de registro no válido: '%s'"
 
-#: gui_x11.c:2203
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Tipo de letra de impresión 1: %s\n"
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "La búsqueda ha llegado al PRINCIPIO, continuando desde el FINAL"
 
-#: gui_x11.c:2204
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr ""
-"La anchura del tipo de letra de impresión %<PRId64> no es el doble de la \n"
-"de la tipografía de impresión 0\n"
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "La búsqueda ha llegado al FINAL, continuando desde el PRINCIPIO"
 
-#: gui_x11.c:2205
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Anchura del tipo de letra de impresión 0: %<PRId64>\n"
-
-#: gui_x11.c:2206
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
-msgstr ""
-"Anchura del tipo de letra de impresión 1: %<PRId64>\n"
-"\n"
-
-#: gui_xmdlg.c:690 gui_xmdlg.c:809
-msgid "Invalid font specification"
-msgstr "La especificación de tipo de letra no es válida"
-
-#: gui_xmdlg.c:691 gui_xmdlg.c:810
-msgid "&Dismiss"
-msgstr "&Cerrar"
-
-#: gui_xmdlg.c:700
-msgid "no specific match"
-msgstr "no hay una coincidencia especifica"
-
-#: gui_xmdlg.c:909
-msgid "Vim - Font Selector"
-msgstr "Vim - Selector de tipos de letra"
-
-#: gui_xmdlg.c:978
-msgid "Name:"
-msgstr "Nombre:"
-
-#. create toggle button
-#: gui_xmdlg.c:1018
-msgid "Show size in Points"
-msgstr "Mostrar tamaño en puntos"
-
-#: gui_xmdlg.c:1037
-msgid "Encoding:"
-msgstr "Codificando:"
-
-#: gui_xmdlg.c:1083
-msgid "Font:"
-msgstr "Tipo de letra:"
-
-#: gui_xmdlg.c:1116
-msgid "Style:"
-msgstr "Estilo:"
-
-#: gui_xmdlg.c:1148
-msgid "Size:"
-msgstr "Tamaño:"
-
-#: hangulin.c:610
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ERROR del autómata Hangul"
-
-#: hardcopy.c:210
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Falta un símbolo de dos puntos"
 
-#: hardcopy.c:222
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Componente ilegal"
 
-#: hardcopy.c:230
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: Se esperaba un dígito"
 
-#: hardcopy.c:501
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Página %d"
 
-#: hardcopy.c:658
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "No hay texto que imprimir"
 
-#: hardcopy.c:736
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Imprimiendo la página %d (%d%%)"
 
-#: hardcopy.c:748
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr "Copia %d de %d"
 
-#: hardcopy.c:806
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Impreso: %s"
 
-#: hardcopy.c:814
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Impresión interrumpida"
 
-#: hardcopy.c:1469
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Error escribiendo al archivo PostScript de salida"
 
-#: hardcopy.c:1931
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: No se pudo abrir el archivo \"%s\""
 
-#: hardcopy.c:1941 hardcopy.c:2822
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: No se pudo leer el archivo de recursos de PostScript \"%s\""
 
-#: hardcopy.c:1957
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: El archivo \"%s\" no es un archivo de recursos PostScript"
 
-#: hardcopy.c:1975 hardcopy.c:1994 hardcopy.c:2037
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: El archivo \"%s\" no es un recurso PostScript que pueda usar"
 
-#: hardcopy.c:2056
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: La versión del archivo de recursos \"%s\" es incorrecta"
 
-#: hardcopy.c:2543
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Codificación y set de caracteres multi-byte incompatibles"
 
-#: hardcopy.c:2560
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr ""
 "E674: \"printmbcharset\" no puede estar vacío en una codificación multi-byte"
 
-#: hardcopy.c:2578
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr ""
 "E675: No se ha definido un tipo de letra predeterminado para impresión\n"
 "multi-byte"
 
-#: hardcopy.c:2771
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: No se pudo abrir el archivo PostScript de salida"
 
-#: hardcopy.c:2808
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: No se pudo abrir el archivo %s"
 
-#: hardcopy.c:2942
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: No se encontró el archivo de recursos PostScript \"prolog.ps\""
 
-#: hardcopy.c:2955
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: No se encontró el archivo de recursos PostScript \"cidfont.ps\""
 
-#: hardcopy.c:2993 hardcopy.c:3015 hardcopy.c:3044
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: No se encontró el archivo de recursos PostScript \"%s.ps\""
 
-#: hardcopy.c:3031
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: No se pudo convertir a la codificación de impresión \"%s\""
 
-#: hardcopy.c:3285
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Enviando a la impresora..."
 
-#: hardcopy.c:3289
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Falló la impresión del archivo PostScript"
 
-#: hardcopy.c:3291
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Se ha enviado la tarea de impresión."
 
-#: if_cscope.c:77
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Añadir una nueva base de datos"
 
-#: if_cscope.c:79
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Petición de un patrón"
 
-#: if_cscope.c:81
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Mostrar este mensaje"
 
-#: if_cscope.c:83
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Matar una conexión"
 
-#: if_cscope.c:85
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Reiniciar todas las conexiones"
 
-#: if_cscope.c:87
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Mostrar las conexiones"
 
-#: if_cscope.c:95
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Forma de uso: cs[cope] %s"
 
-#: if_cscope.c:236
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Esta orden \"cscope\" no admite la división de la ventana.\n"
 
-#: if_cscope.c:287
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Forma de uso: cstag <identificador>"
 
-#: if_cscope.c:345
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: no se encontró la etiqueta"
 
-#: if_cscope.c:515
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: Error en stat(%s): %d"
 
-#: if_cscope.c:525
-msgid "E563: stat error"
-msgstr "E563: error en la función \"stat\""
-
-#: if_cscope.c:622
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: \"%s\" no es un directorio ni una base de datos válida de cscope"
 
-#: if_cscope.c:640
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Se ha añadido la base de datos \"cscope\" %s"
 
-#: if_cscope.c:695
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Error al leer la conexión %<PRId64> con \"cscope\""
 
-#: if_cscope.c:802
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Tipo de búsqueda desconocido para \"cscope\""
 
-#: if_cscope.c:866 if_cscope.c:905
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Falló la conexión \"pipe\" para comunicarse con \"cscope\""
 
-#: if_cscope.c:882
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr ""
 "E622: No se pudo crear un nuevo proceso (\"fork\") para usar \"cscope\""
 
-#: if_cscope.c:992 if_cscope.c:1029
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "Falló la ejecución de \"cs_create_connection\""
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "Falló la ejecución de \"cs_create_connection\""
 
-#: if_cscope.c:1002 if_cscope.c:1042
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "\"cs_create_connection\": Falló \"fdopen\" para \"to_fp\""
 
-#: if_cscope.c:1004 if_cscope.c:1046
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "\"cs_create_connection\": Falló \"fdopen\" para \"fr_fp\""
 
-#: if_cscope.c:1030
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: No se pudo crear un nuevo proceso (\"spawn\") de \"cscope\""
 
-#: if_cscope.c:1074
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: No hay conexiones con \"cscope\""
 
-#: if_cscope.c:1154
+#: ../if_cscope.c:1009
+#, c-format
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr "E469: La marca \"cscopequickfix\" %c para %c no es válida"
+
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr ""
 "E259: No se encontraron coincidencias para la búsqueda \"cscope\" %s de %s"
 
-#: if_cscope.c:1215
-#, c-format
-msgid "E469: invalid cscopequickfix flag %c for %c"
-msgstr "E469: La marca \"cscopequickfix\" %c para %c no es válida"
-
-#: if_cscope.c:1307
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "órdenes de \"cscope\":\n"
 
-#: if_cscope.c:1316
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Modo de uso: %s)"
 
-#: if_cscope.c:1321
+#: ../if_cscope.c:1155
+#, fuzzy
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -3201,7 +3313,7 @@ msgid ""
 "       g: Find this definition\n"
 "       i: Find files #including this file\n"
 "       s: Find this C symbol\n"
-"       t: Find assignments to\n"
+"       t: Find this text string\n"
 msgstr ""
 "\n"
 "       c: Encontrar funciones que invocan esta función\n"
@@ -3213,42 +3325,32 @@ msgstr ""
 "       s: Encontrar este símbolo de C\n"
 "       t: Encontrar asignaciones a\n"
 
-#: if_cscope.c:1409
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: No se pudo abrir la base de datos \"cscope\": %s"
-
-#: if_cscope.c:1427
-msgid "E626: cannot get cscope database information"
-msgstr ""
-"E626: No se pudo obtener información acerca de la base de datos \"cscope\""
-
-#: if_cscope.c:1452
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Intentó añadir una base de datos de \"cscope\" duplicada"
 
-#: if_cscope.c:1597
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: No se ha encontrado la conexión \"cscope\" %s"
 
-#: if_cscope.c:1631
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "Conexión \"cscope\" %s cerrada"
 
 # should not reach here
 #. should not reach here
-#: if_cscope.c:1771
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Error fatal en \"cs_manage_matches\""
 
-#: if_cscope.c:2033
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Etiqueta de \"cscope\": %s"
 
-#: if_cscope.c:2055
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -3256,535 +3358,90 @@ msgstr ""
 "\n"
 "   #   línea"
 
-#: if_cscope.c:2057
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "nombre del archivo / contexto / línea\n"
 
-#: if_cscope.c:2169
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Error de \"cscope\": %s"
 
-#: if_cscope.c:2438
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Se han vaciado todas las bases de datos de \"cscope\""
 
-#: if_cscope.c:2505
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "no hay conexiones \"cscope\"\n"
 
-#: if_cscope.c:2509
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " nº pid    base de datos                       prefijo ruta\n"
 
-#: if_mzsch.c:1045
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Lo siento, esta orden está desactivada, no se pudo cargar las "
-"bibliotecas de MzScheme"
-
-#: if_mzsch.c:1469 if_python.c:1271 if_tcl.c:1404
-msgid "invalid expression"
-msgstr "expresión no válida"
-
-#: if_mzsch.c:1477 if_python.c:1290 if_tcl.c:1409
-msgid "expressions disabled at compile time"
-msgstr "expresiones desactivadas al compilar"
-
-#: if_mzsch.c:1566
-msgid "hidden option"
-msgstr "opción oculta"
-
-#: if_mzsch.c:1568 if_tcl.c:501
-msgid "unknown option"
-msgstr "opción desconocida"
-
-#: if_mzsch.c:1727
-msgid "window index is out of range"
-msgstr "indice de ventana fuera del rango"
-
-#: if_mzsch.c:1887
-msgid "couldn't open buffer"
-msgstr "No se pudo abrir el búfer"
-
-#: if_mzsch.c:2167 if_mzsch.c:2197 if_mzsch.c:2294 if_mzsch.c:2358
-#: if_mzsch.c:2479 if_mzsch.c:2536 if_python.c:2508 if_python.c:2542
-#: if_python.c:2601 if_python.c:2668 if_python.c:2790 if_python.c:2842
-#: if_tcl.c:684 if_tcl.c:729 if_tcl.c:803 if_tcl.c:875 if_tcl.c:2017
-msgid "cannot save undo information"
-msgstr "No se pudo guardar la información para deshacer"
-
-#: if_mzsch.c:2172 if_mzsch.c:2302 if_mzsch.c:2372 if_python.c:2510
-#: if_python.c:2608 if_python.c:2679
-msgid "cannot delete line"
-msgstr "no puedo suprimir la línea"
-
-#: if_mzsch.c:2203 if_mzsch.c:2387 if_python.c:2547 if_python.c:2695
-#: if_tcl.c:690 if_tcl.c:2039
-msgid "cannot replace line"
-msgstr "no se pudo reemplazar la línea"
-
-#: if_mzsch.c:2402 if_mzsch.c:2485 if_mzsch.c:2546 if_python.c:2713
-#: if_python.c:2792 if_python.c:2850
-msgid "cannot insert line"
-msgstr "no se pudo insertar la línea"
-
-#: if_mzsch.c:2637 if_python.c:2962
-msgid "string cannot contain newlines"
-msgstr "La cadena no puede contener quiebres de línea"
-
-#: if_mzsch.c:2859
-msgid "Vim error: ~a"
-msgstr "Error de Vim: ~a"
-
-#: if_mzsch.c:2892
-msgid "Vim error"
-msgstr "Error de Vim"
-
-#: if_mzsch.c:2958
-msgid "buffer is invalid"
-msgstr "El búfer no es valido"
-
-#: if_mzsch.c:2967
-msgid "window is invalid"
-msgstr "La ventana no es válida"
-
-#: if_mzsch.c:2987
-msgid "linenr out of range"
-msgstr "El número de la línea está fuera del rango"
-
-#: if_mzsch.c:3138 if_mzsch.c:3180
-msgid "not allowed in the Vim sandbox"
-msgstr "No permitido en la \"sandbox\" de vim"
-
-#: if_python.c:517
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Lo siento, esta orden está desactivada, no se pudo cargar la \n"
-"biblioteca de Python"
-
-#: if_python.c:583
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: No se pudo invocar a Python recursivamente"
-
-#: if_python.c:776
-msgid "can't delete OutputObject attributes"
-msgstr "No se pueden borrar los atributos de \"OutputObject\""
-
-#: if_python.c:783
-msgid "softspace must be an integer"
-msgstr "\"softspace\" debe ser un entero"
-
-#: if_python.c:791
-msgid "invalid attribute"
-msgstr "Atributo no válido"
-
-#: if_python.c:830 if_python.c:844
-msgid "writelines() requires list of strings"
-msgstr "\"writelines()\" requiere una lista de cadenas"
-
-#: if_python.c:970
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: error de iniciación de los objetos de I/O"
-
-#: if_python.c:1303
-msgid "attempt to refer to deleted buffer"
-msgstr "Intento de referirse a un búfer suprimido"
-
-#: if_python.c:1318 if_python.c:1359 if_python.c:1423 if_tcl.c:1216
-msgid "line number out of range"
-msgstr "El número de la línea está fuera del rango"
-
-#: if_python.c:1558
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<objeto de búfer (suprimido) en %p>"
-
-#: if_python.c:1649 if_tcl.c:836
-msgid "invalid mark name"
-msgstr "Nombre de marca no válido"
-
-#: if_python.c:1927
-msgid "no such buffer"
-msgstr "No existe tal búfer"
-
-#: if_python.c:2015
-msgid "attempt to refer to deleted window"
-msgstr "Intento de referirse a una ventana suprimida"
-
-#: if_python.c:2060
-msgid "readonly attribute"
-msgstr "Atributo de solo lectura"
-
-#: if_python.c:2074
-msgid "cursor position outside buffer"
-msgstr "Posición del cursor fuera del búfer"
-
-#: if_python.c:2157
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<objeto ventana (suprimido) en %p>"
-
-#: if_python.c:2169
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<objeto ventana (desconocido) en %p>"
-
-#: if_python.c:2172
-#, c-format
-msgid "<window %d>"
-msgstr "<ventana %d>"
-
-#: if_python.c:2246
-msgid "no such window"
-msgstr "No existe tal ventana"
-
-#: if_ruby.c:365
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ debe ser una instancia de \"String\""
-
-#: if_ruby.c:426
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Lo siento, esta orden está desactivada, no se pudo cargar\n"
-"la biblioteca de Ruby"
-
-#: if_ruby.c:455
-msgid "E267: unexpected return"
-msgstr "E267: \"return\" inesperado"
-
-#: if_ruby.c:458
-msgid "E268: unexpected next"
-msgstr "E268: \"next\" inesperado"
-
-#: if_ruby.c:461
-msgid "E269: unexpected break"
-msgstr "E269: \"break\" inesperado"
-
-#: if_ruby.c:464
-msgid "E270: unexpected redo"
-msgstr "E270: \"redo\" inesperado"
-
-#: if_ruby.c:467
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: \"retry\" fuera de una cláusula \"rescue\""
-
-#: if_ruby.c:474
-msgid "E272: unhandled exception"
-msgstr "E272: excepción sin manejar"
-
-#: if_ruby.c:489
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: El estado %d de \"longjmp\" es desconocido"
-
-#: if_sniff.c:64
-msgid "Toggle implementation/definition"
-msgstr "Intercambiar implementación/definición"
-
-#: if_sniff.c:65
-msgid "Show base class of"
-msgstr "Mostrar la clase base de"
-
-#: if_sniff.c:66
-msgid "Show overridden member function"
-msgstr "Mostrar la función miembro que se ha sobrepasado con el código nuevo"
-
-#: if_sniff.c:67
-msgid "Retrieve from file"
-msgstr "Restaurar del archivo"
-
-#: if_sniff.c:68
-msgid "Retrieve from project"
-msgstr "Restaurar del proyecto"
-
-#: if_sniff.c:70
-msgid "Retrieve from all projects"
-msgstr "Restaurar de todos los proyectos"
-
-#: if_sniff.c:71
-msgid "Retrieve"
-msgstr "Restaurar"
-
-#: if_sniff.c:72
-msgid "Show source of"
-msgstr "Mostrar el origen de "
-
-#: if_sniff.c:73
-msgid "Find symbol"
-msgstr "Buscar símbolo"
-
-#: if_sniff.c:74
-msgid "Browse class"
-msgstr "Navegador de Clases"
-
-#: if_sniff.c:75
-msgid "Show class in hierarchy"
-msgstr "Mostrar la clase en su jerarquía"
-
-#: if_sniff.c:76
-msgid "Show class in restricted hierarchy"
-msgstr "Mostrar la clase en jerarquía restringida"
-
-#: if_sniff.c:77
-msgid "Xref refers to"
-msgstr "Xref se refiere a"
-
-#: if_sniff.c:78
-msgid "Xref referred by"
-msgstr "Xref referida por"
-
-#: if_sniff.c:79
-msgid "Xref has a"
-msgstr "Xref tiene un"
-
-#: if_sniff.c:80
-msgid "Xref used by"
-msgstr "Xref usada por"
-
-#: if_sniff.c:81
-msgid "Show docu of"
-msgstr "Mostrar \"docu\" de"
-
-#: if_sniff.c:82
-msgid "Generate docu for"
-msgstr "Generar \"docu\" de"
-
-#: if_sniff.c:94
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"No se pudo conectar a SNiFF+. Verifique el entorno (\"sniffemacs\" debe\n"
-"estar en \"$PATH\").\n"
-
-#: if_sniff.c:422
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Error al leer. Desconectado"
-
-#: if_sniff.c:550
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ está actualmente "
-
-#: if_sniff.c:552
-msgid "not "
-msgstr "no "
-
-#: if_sniff.c:553
-msgid "connected"
-msgstr "conectado"
-
-#: if_sniff.c:589
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Petición de SNiFF+ desconocida: %s"
-
-#: if_sniff.c:602
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Error al conectarme a SNiFF+"
-
-#: if_sniff.c:1013
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ no está conectado"
-
-#: if_sniff.c:1022
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: No es un búfer de SNiFF+"
-
-#: if_sniff.c:1089
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: error al escribir. Desconectado"
-
-#: if_tcl.c:419
-msgid "invalid buffer number"
-msgstr "Número de búfer no válido"
-
-#: if_tcl.c:465 if_tcl.c:935 if_tcl.c:1115
-msgid "not implemented yet"
-msgstr "Aún no implementado"
-
-# ???
-#. ???
-#: if_tcl.c:774
-msgid "cannot set line(s)"
-msgstr "No se puede(n) definir la/s línea/s"
-
-#: if_tcl.c:845
-msgid "mark not set"
-msgstr "Marca sin definir"
-
-#: if_tcl.c:852 if_tcl.c:1071
-#, c-format
-msgid "row %d column %d"
-msgstr "fila %d columna %d"
-
-#: if_tcl.c:884
-msgid "cannot insert/append line"
-msgstr "No se puede insertar/añadir línea"
-
-#: if_tcl.c:1270
-msgid "unknown flag: "
-msgstr "Indicador desconocido: "
-
-#: if_tcl.c:1340
-msgid "unknown vimOption"
-msgstr "\"vimOption\" desconocida"
-
-#: if_tcl.c:1425
-msgid "keyboard interrupt"
-msgstr "Interrupción desde el teclado"
-
-#: if_tcl.c:1430
-msgid "vim error"
-msgstr "Error de Vim"
-
-#: if_tcl.c:1474
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "No se pudo crear la orden de búfer/ventana: el objeto se suprimirá"
-
-#: if_tcl.c:1550
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"No se pudo registrar el orden \"callback\": El búfer o la ventana ya se \n"
-"eliminó"
-
-# This should never happen.  Famous last word?
-#. This should never happen.  Famous last word?
-#: if_tcl.c:1569
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: ERROR FATAL DE TCL: ¿¡\"reflist\" dañada!? Por favor, informe de \n"
-"esto a vim-dev@vim.org"
-
-#: if_tcl.c:1570
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"No se pudo registrar la orden de retorno de llamada: No se pudo encontrar\n"
-"la referencia al búfer o la ventana"
-
-#: if_tcl.c:1742
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Lo siento, esta orden está desactivada pues no se pudo\n"
-"cargar la biblioteca de Tcl"
-
-#: if_tcl.c:1904
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: ERROR DE TCL: ¿¡el código de salida no es \"int\"!? Por favor\n"
-"informe a vim-dev@vim.org"
-
-#: if_tcl.c:1909
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: código de salida %d"
-
-#: if_tcl.c:2025
-msgid "cannot get line"
-msgstr "No puedo obtener la línea"
-
-#: if_xcmdsrv.c:233
-msgid "Unable to register a command server name"
-msgstr "Incapaz de registrar un nombre de servidor de órdenes"
-
-#: if_xcmdsrv.c:492
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: No pude enviar la orden al programa de destino"
-
-#: if_xcmdsrv.c:765
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: El ID de usuario no es válido en el servidor: %s"
-
-#: if_xcmdsrv.c:1146
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: La propiedad de registro de VIM es incorrecta. ¡Eliminada!"
-
-#: main.c:138
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Opción de argumento desconocida"
 
-#: main.c:140
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Demasiados argumentos de edición"
 
-#: main.c:142
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Falta el argumento después de"
 
-#: main.c:144
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Basura después de la opción"
 
-#: main.c:146
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Demasiados argumentos tales como: \"+orden\", \"-c orden\" \n"
 "o \"--cmd orden\""
 
-#: main.c:148
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Argumento no válido para"
 
-#: main.c:514
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d archivos que editar\n"
 
-#: main.c:1510
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Este Vim no se ha compilado con la opción \"diff\""
-
-#: main.c:1612
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' no se puede usar: no se ha activado al compilar\n"
-
-#: main.c:2135
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Intento de abrir de nuevo el archivo de órdenes: \""
 
-#: main.c:2144
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "No se pudo abrir para leer: \""
 
-#: main.c:2198
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "No se pudo abrir para escribir la salida del archivo de órdenes: \""
 
-#: main.c:2364
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Error: Imposible iniciar gvim para NetBeans\n"
-
-#: main.c:2369
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Advertencia: la salida no es un terminal\n"
 
-#: main.c:2371
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Advertencia: la entrada no es desde un terminal\n"
 
 # just in case..
 #. just in case..
-#: main.c:2688
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "Línea de órdenes previa a \"vimrc\""
 
-#: main.c:2785
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: No se pudo leer desde \"%s\""
 
-#: main.c:3002
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -3792,23 +3449,23 @@ msgstr ""
 "\n"
 "Más información con: \"vim -h\"\n"
 
-#: main.c:3035
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[archivo ..]   Editar el/los archivos/s especificado/s"
 
-#: main.c:3036
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               Leer texto de la entrada estándar"
 
-#: main.c:3037
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t etiqueta    Editar el archivo donde está definida la etiqueta"
 
-#: main.c:3039
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [fich. err.] Editar el archivo con el primer error"
 
-#: main.c:3048
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -3818,11 +3475,11 @@ msgstr ""
 "\n"
 "Uso:"
 
-#: main.c:3051
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumentos]"
 
-#: main.c:3055
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -3830,16 +3487,7 @@ msgstr ""
 "\n"
 "  o:"
 
-#: main.c:3058
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Cuando mayúscula y minúscula son ignoradas añada \"/\" para \n"
-"cambiar la marca (\"flag\") a mayúscula"
-
-#: main.c:3061
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -3849,465 +3497,202 @@ msgstr ""
 "\n"
 "Argumentos:\n"
 
-#: main.c:3062
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tSolo nombres de archivos a partir de aquí"
 
-#: main.c:3064
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNo expandir comodines"
 
-#: main.c:3067
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistrar este \"gvim\" para \"OLE\""
-
-#: main.c:3068
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tSuprimir el registro de \"gvim\" para \"OLE\""
-
-#: main.c:3071
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tEjecutar usando el GUI (como \"gvim\")"
-
-#: main.c:3072
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr ""
-"-f  o  --nofork\tPrimer plano: No separarse (\"fork\") cuando se\n"
-"                      \tinicia la interfaz gráfica (GUI)"
-
-#: main.c:3074
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tModo vi"
 
-#: main.c:3075
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tModo ex"
 
-#: main.c:3076
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tModo silencioso de ejecución por lotes (\"ex\")"
 
-#: main.c:3078
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tModo de diferencias (como \"vimdiff\")"
 
-#: main.c:3080
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tModo fácil (como \"evim\", sin modo)"
 
-#: main.c:3081
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModo de solo lectura (como \"view\")"
 
-#: main.c:3082
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tModo restringido (como \"rvim\")"
 
-#: main.c:3083
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModificación de archivos desactivada"
 
-#: main.c:3084
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModificación de texto desactivada"
 
-#: main.c:3085
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tModo binario"
 
-#: main.c:3087
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tModo LISP"
 
-#: main.c:3089
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tCompatible con vi: \"compatible\""
 
-#: main.c:3090
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tParcialmente compatible con vi: \"nocompatible\""
 
-#: main.c:3091
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 "-V[N][nombre_archivo]\t\tCon verbosidad [nivel N] [guardar mensajes en "
 "nombre_archivo]"
 
-#: main.c:3093
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tModo de depuración"
 
-#: main.c:3095
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tSin archivo de intercambio, solo usa RAM"
 
-#: main.c:3096
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tDar una lista de los archivo de intercambio y salir"
 
-#: main.c:3097
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r \"archivo\"\tRecuperar sesión fallida"
 
-#: main.c:3098
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tIgual que \"-r\""
 
-#: main.c:3100
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNo usar \"newcli\" para abrir ventanas"
-
-#: main.c:3101
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <dispositivo>\t\tUsar <dispositivo> para I/O"
-
-#: main.c:3104
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tIniciar en modo árabe"
 
-#: main.c:3107
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tIniciar en modo hebreo"
 
-#: main.c:3110
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tIniciar en modo persa (farsi)"
 
-#: main.c:3112
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tEstablecer el tipo de salida visual a <terminal>"
 
-#: main.c:3113
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tUsar <vimrc> en lugar de cualquier \".vimrc\""
 
-#: main.c:3115
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tUsar <gvimrc> en lugar de otro \".gvimrc\""
-
-#: main.c:3117
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNo cargar los módulos de expansión"
 
-#: main.c:3119
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tAbrir N ventanas (valor predeterminado: una por archivo)"
 
-#: main.c:3120
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tAbrir N ventanas (valor predeterminado: una por archivo)"
 
-#: main.c:3121
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tComo \"-o\" pero divide las ventanas verticalmente"
 
-#: main.c:3123
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tComenzar al final del archivo"
 
-#: main.c:3124
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<número_de_línea>\tComienza en la línea <número_de_línea>"
 
-#: main.c:3125
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <orden>\tEjecutar la <orden> antes de cargar algún archivo vimrc"
 
-#: main.c:3126
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <orden>\t\tEjecutar <orden> después de cargar el primer archivo"
 
-#: main.c:3127
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sesión>\t\tEjecutar las órdenes del archivo <sesión> después\n"
 "           \t\tde cargar el primer archivo"
 
-#: main.c:3128
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr ""
 "-s <scriptin>\tLeer las órdenes en modo Normal del archivo\n"
 "                    \t\"módulo de expansión\" de entrada>"
 
-#: main.c:3129
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr ""
 "-w <scriptout>\tAñadir todas las órdenes escritas al archivo\n"
 "                     \t\"módulo de expansión\" de salida"
 
-#: main.c:3130
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr ""
 "-W <scriptout>\tGrabar todas las órdenes escritas al archivo\n"
 "                     \t\"módulo de expansión\" de salida"
 
-#: main.c:3132
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEditar archivos cifrados"
-
-#: main.c:3136
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <pantalla>\tConectar vim a este servidor X en particular"
-
-#: main.c:3138
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tEvitar la conexión al servidor X"
-
-#: main.c:3141
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr ""
-"--remote <archivos>\tEditar <archivos> en un servidor Vim si es posible"
-
-#: main.c:3142
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-silent \"archivos\"\tLo mismo pero no se queja si no existe un\n"
-"                                   \tservidor disponible"
-
-#: main.c:3143
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait \"archivos\"\tComo --remote pero espera a que los archivos\n"
-"                                 \tterminen de editarse"
-
-#: main.c:3144
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent \"archivos\"\tLo mismo pero no se queja si no hay un\n"
-"                                        \tservidor disponible"
-
-#: main.c:3146
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <archivos>  Como \"--remote\" pero usa una "
-"pestaña por página"
-
-#: main.c:3148
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <teclas>\tEnvíar <teclas> a un servidor Vim y cerrar"
-
-#: main.c:3149
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <expr>\tEvaluar <expr> en un servidor Vim e imprimir el "
-"resultado"
-
-#: main.c:3150
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr ""
-"--serverlist\t\tEmitir una lista de los servidores Vim disponibles y cerrar"
-
-#: main.c:3151
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr ""
-"--servername \"nombre\"\tEnvíar a/se convierte en el servidor Vim con <nombre>"
-
-#: main.c:3154
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
-msgstr "-- startuptime <archivo>\tGuardar los mensajes de tiempo de inicio "
-"a <archivo>."
+msgstr ""
+"-- startuptime <archivo>\tGuardar los mensajes de tiempo de inicio a "
+"<archivo>."
 
-#: main.c:3157
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUsar <viminfo> en lugar de \".viminfo\""
 
-#: main.c:3159
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  or  --help\tImpresión de la ayuda (este mensaje) y cerrar"
 
-#: main.c:3160
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tImpresión de la información de versión y cerrar"
 
-#: main.c:3164
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumentos reconocidos por gvim (versión Motif):\n"
-
-#: main.c:3168
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumentos reconocidos por gvim (versión neXtaw):\n"
-
-#: main.c:3170
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumentos reconocidos por gvim (versión Athena):\n"
-
-#: main.c:3174
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <pantalla>\tEjecuta vim en <pantalla>"
-
-#: main.c:3175
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tArranca vim \"iconizado\""
-
-#: main.c:3177
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <nombre>\t\tUsa un recurso como si vim fuese <nombre>"
-
-#: main.c:3178
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Sin implementar)\n"
-
-#: main.c:3180
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\tUsa <color> para el fondo (también: -bg)"
-
-#: main.c:3181
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\tUsa <color> para el texto normal (también: -fg)"
-
-#: main.c:3182 main.c:3202
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr ""
-"-font <tipo>\t\tUse <tipo de letra de impresión> para el texto normal\n"
-"(también: -fn)"
-
-#: main.c:3183
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr ""
-"-boldfont <tipo>\tUsa <tipo de letra de impresión> para texto en\n"
-"negrita"
-
-#: main.c:3184
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr ""
-"-italicfont <tipo>\tUse <tipo de letra de impresión> para texto\n"
-"en cursiva"
-
-#: main.c:3185 main.c:3203
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tUse <geom> para la geometría inicial (también: -geom)"
-
-#: main.c:3186
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <ancho>\tUsa un ancho de borde de <ancho> (también: -bw)"
-
-#: main.c:3187
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <ancho>\tUsa una barra de desplazamiento de ancho <ancho>\n"
-"                              \t(también: -sw)"
-
-#: main.c:3189
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <alt>\tUsa una barra de menú de altura <alt> (también: -mh)"
-
-#: main.c:3191 main.c:3204
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tUsar vídeo inverso (también: -rv)"
-
-#: main.c:3192
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNo usar vídeo inverso (también: +rv)"
-
-#: main.c:3193
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <recurso>\tEstablece el recurso especificado"
-
-#: main.c:3196
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argumentos reconocidos por gvim (versión para RISC OS):\n"
-
-#: main.c:3197
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <número>\tAnchura inicial de la ventana, en columnas"
-
-#: main.c:3198
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <número>\tAltura inicial de la ventana, en filas"
-
-#: main.c:3201
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumentos reconocidos por gvim (versión GTK+):\n"
-
-#: main.c:3205
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <pantalla>\tEjecuta vim en <pantalla> (también: --display)"
-
-#: main.c:3207
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <role>\tDefine un rol único para identificar la ventana principal"
-
-#: main.c:3209
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tAbre a Vim dentro de otro \"widget\" GTK"
-
-#: main.c:3212
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <título ventana padre>\tAbrir a Vim dentro de la aplicación padre"
-
-#: main.c:3213
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tAbrir Vim dentro de otro objeto de win32"
-
-#: main.c:3557
-msgid "No display"
-msgstr "No hay una ventana"
-
-# Failed to send, abort.
-#. Failed to send, abort.
-#: main.c:3572
-msgid ": Send failed.\n"
-msgstr ": Falló el envío.\n"
-
-# Let vim start normally.
-#. Let vim start normally.
-#: main.c:3578
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ""
-": Falló el inicio de sesión remota (\"send\"). Intentado una\n"
-"ejecución local\n"
-
-#: main.c:3616 main.c:3637
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d de %d editados"
-
-#: main.c:3659
-msgid "No display: Send expression failed.\n"
-msgstr "No hay una ventana en el destino: El envío de la expresión falló.\n"
-
-#: main.c:3671
-msgid ": Send expression failed.\n"
-msgstr ": Falló el envío de la expresión.\n"
-
-#: mark.c:761
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "No se han fijado marcas"
 
-#: mark.c:763
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: No hay marcas que coincidan con %s"
 
 # Highlight title
 #. Highlight title
-#: mark.c:774
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -4317,7 +3702,7 @@ msgstr ""
 
 # Highlight title
 #. Highlight title
-#: mark.c:896
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -4327,7 +3712,7 @@ msgstr ""
 
 # Highlight title
 #. Highlight title
-#: mark.c:943
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -4335,8 +3720,7 @@ msgstr ""
 "\n"
 "cambio línea  col archivo/texto"
 
-#: mark.c:1437
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -4346,8 +3730,7 @@ msgstr ""
 
 # Write the jumplist with -'
 #. Write the jumplist with -'
-#: mark.c:1472
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -4355,8 +3738,7 @@ msgstr ""
 "\n"
 "# Lista de saltos (el más reciente va primero):\n"
 
-#: mark.c:1573
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -4365,132 +3747,89 @@ msgstr ""
 "# Historia de las marcas en los archivos (de la más reciente a la más "
 "antigua):\n"
 
-#: mark.c:1677
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Falta \">\""
 
-#: mbyte.c:532
-msgid "E543: Not a valid codepage"
-msgstr "E543: No es una página de código válida"
-
-#: mbyte.c:4852
-msgid "E284: Cannot set IC values"
-msgstr "E284: No se pudo fijar los valores IC"
-
-#: mbyte.c:5004
-msgid "E285: Failed to create input context"
-msgstr "E285: Falló la creación del contexto de entrada"
-
-#: mbyte.c:5162
-msgid "E286: Failed to open input method"
-msgstr "E286: Falló la apertura del método de entrada"
-
-#: mbyte.c:5175
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Advertencia: No pude crear una llamada de retorno\n"
-"de destrucción al IM"
-
-#: mbyte.c:5181
-msgid "E288: input method doesn't support any style"
-msgstr "E288: el método de entrada no admite ningún estilo"
-
-#: mbyte.c:5240
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: El método de entrada no soporta mi tipo de pre-edición"
-
-#: mbyte.c:5316
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: El estilo \"sobre el punto\" requiere del uso de un \"fontset\""
-
-#: mbyte.c:5352
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr ""
-"E291: Su versión de GTK+ es anterior a 1.2.3. Área de estado\n"
-"desactivada"
-
-#: mbyte.c:5663
-msgid "E292: Input Method Server is not running"
-msgstr "E292: El servidor de método de entrada (IME) no está funcionando"
-
-#: memfile.c:501
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: El bloque no estaba asegurado"
 
-#: memfile.c:1044
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Error de búsqueda al leer el archivo de intercambio"
 
-#: memfile.c:1049
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Error de lectura en el archivo de intercambio"
 
-#: memfile.c:1101
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Error de búsqueda al escribir en el archivo de intercambio"
 
-#: memfile.c:1119
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Error de escritura en el archivo de intercambio"
 
-#: memfile.c:1316
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr ""
 "E300: Ya existe un archivo de intercambio (¿ataque de enlace simbólico?)"
 
-#: memline.c:312
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: ¿No se obtuvo el bloque Nº 0?"
 
-#: memline.c:359
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: ¿No se obtuvo el bloque Nº 1?"
 
-#: memline.c:377
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: ¿No se obtuvo el bloque Nº 2?"
 
 # could not (re)open the swap file, what can we do????
 #. could not (re)open the swap file, what can we do????
-#: memline.c:490
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: ¡¡¡Perdí el archivo de intercambio!!!"
 
-#: memline.c:502
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: No pude cambiar el nombre del archivo de intercambio"
 
-#: memline.c:592
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Incapaz de abrir el archivo de intercambio para %s,\n"
 "recuperación imposible"
 
-#: memline.c:703
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: \"ml_upd_block0()\": ¿No se obtuvo el bloque 0?"
 
-#: memline.c:904
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: No se encontró el archivo de intercambio para %s"
 
-#: memline.c:914
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Introduzca el número del archivo de intercambio a usar (0 para salir): "
 
-#: memline.c:959
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: No se pudo abrir %s"
 
-#: memline.c:981
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Incapaz de leer el bloque 0 de "
 
-#: memline.c:984
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -4498,28 +3837,28 @@ msgstr ""
 "\n"
 "Tal vez no hay cambios o Vim no actualizó el archivo de intercambio."
 
-#: memline.c:994 memline.c:1011
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " no puede usarse con esta versión de Vim.\n"
 
-#: memline.c:996
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Use la versión 3.0 de Vim.\n"
 
-#: memline.c:1002
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s no parece un archivo de intercambio de Vim"
 
-#: memline.c:1015
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr "no puede usarse en este ordenador.\n"
 
-#: memline.c:1017
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "El archivo se creó el "
 
-#: memline.c:1021
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -4527,88 +3866,88 @@ msgstr ""
 ",\n"
 "o el archivo se ha dañado"
 
-#: memline.c:1039
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " se ha dañado (el tamaño de la página es menor al valor minimo).\n"
 
-#: memline.c:1071
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Usando el archivo de intercambio \"%s\""
 
-#: memline.c:1077
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Archivo original %s"
 
-#: memline.c:1090
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Advertencia: el archivo original puede haber cambiado"
 
-#: memline.c:1164
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Incapaz de leer el bloque 1 de %s"
 
-#: memline.c:1168
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???FALTAN MUCHAS LÍNEAS"
 
-#: memline.c:1184
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???RECUENTO DE LÍNEAS EQUIVOCADO"
 
-#: memline.c:1191
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???BLOQUE VACÍO"
 
-#: memline.c:1217
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???FALTAN LÍNEAS"
 
-#: memline.c:1249
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: El ID del bloque 1 es incorrecto (¿No es %s un archivo .swp?)"
 
-#: memline.c:1254
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???FALTA UN BLOQUE"
 
-#: memline.c:1270
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? desde aquí hasta ???FIN las líneas pueden estar desordenadas"
 
-#: memline.c:1286
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr ""
 "??? desde aquí hasta ???FIN las líneas pueden haber sido\n"
 "insertadas/borradas"
 
-#: memline.c:1306
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???FIN"
 
-#: memline.c:1333
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Recuperación interrumpida"
 
-#: memline.c:1338
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Se han detectado errores al recuperar; busque líneas que\n"
 "empiecen con ???"
 
-#: memline.c:1340
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Vea \":help E312\" para más información."
 
-#: memline.c:1345
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Recuperación completa. Ud. debería comprobar que todo está bien"
 
-#: memline.c:1346
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -4616,14 +3955,21 @@ msgstr ""
 "\n"
 "(Podría querer guardar este archivo con otro nombre\n"
 
-#: memline.c:1347
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr ""
 "y ejecutar \"diff\" con el archivo original para comprobar los cambios)\n"
 
-#: memline.c:1348
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Elimine el archivo .swp después de terminar.\n"
@@ -4631,51 +3977,51 @@ msgstr ""
 
 # use msg() to start the scrolling properly
 #. use msg() to start the scrolling properly
-#: memline.c:1408
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Se han encontrado los siguientes archivos de intercambio:"
 
-#: memline.c:1593
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   En el directorio actual:\n"
 
-#: memline.c:1595
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Usando el nombre especificado:\n"
 
-#: memline.c:1599
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   En el directorio "
 
-#: memline.c:1617
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- ninguno --\n"
 
-#: memline.c:1692
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          propiedad de: "
 
-#: memline.c:1694
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   de fecha: "
 
-#: memline.c:1698 memline.c:3736
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             de fecha: "
 
-#: memline.c:1717
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "      [desde la versión 3.0 de Vim]"
 
-#: memline.c:1721
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [no parece un archivo de intercambio de Vim]"
 
-#: memline.c:1725
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         nombre del archivo: "
 
-#: memline.c:1731
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -4683,15 +4029,15 @@ msgstr ""
 "\n"
 "         modificado: "
 
-#: memline.c:1732
+#: ../memline.c:1559
 msgid "YES"
 msgstr "SI"
 
-#: memline.c:1732
+#: ../memline.c:1559
 msgid "no"
 msgstr "no"
 
-#: memline.c:1736
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -4699,11 +4045,11 @@ msgstr ""
 "\n"
 " nombre del usuario: "
 
-#: memline.c:1743
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "  nombre del servidor: "
 
-#: memline.c:1745
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -4711,7 +4057,7 @@ msgstr ""
 "\n"
 "       nombre del servidor: "
 
-#: memline.c:1751
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -4719,19 +4065,11 @@ msgstr ""
 "\n"
 "      ID del proceso: "
 
-#: memline.c:1757
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (aún en ejecución)"
 
-#: memline.c:1769
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [no se puede usar con esta versión de Vim]"
-
-#: memline.c:1772
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -4739,97 +4077,97 @@ msgstr ""
 "\n"
 "         [no se puede usar en este ordenador]"
 
-#: memline.c:1777
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [no se puede leer]"
 
-#: memline.c:1781
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [no se puede abrir]"
 
-#: memline.c:1971
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: No se pudo preservar, no existe un archivo de intercambio"
 
-#: memline.c:2024
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Archivo preservado"
 
-#: memline.c:2026
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Falló la preservación del archivo"
 
-#: memline.c:2103
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: \"ml_get\": número de línea no válido: %<PRId64>"
 
-#: memline.c:2138
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: \"ml_get\": no se pudo encontrar la línea %<PRId64>"
 
-#: memline.c:2552
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: El id del bloque de punteros es incorrecto. 3"
 
-#: memline.c:2632
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "\"stack_idx\" debería ser 0"
 
-#: memline.c:2694
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: ¿Demasiados bloques actualizados?"
 
-#: memline.c:2874
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: El id del bloque de punteros es incorrecto. 4"
 
-#: memline.c:2901
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "¿bloque 1 suprimido?"
 
-#: memline.c:3101
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: No se pudo encontrar la línea %<PRId64>"
 
-#: memline.c:3347
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: El id del bloque de punteros es incorrecto"
 
-#: memline.c:3363
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "\"pe_line_count\" es cero"
 
-#: memline.c:3392
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: número de línea fuera de rango: %<PRId64> más allá del final"
 
-#: memline.c:3396
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: recuento de líneas erróneo en el bloque %<PRId64>"
 
-#: memline.c:3445
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "El tamaño de la pila aumenta"
 
-#: memline.c:3492
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: El id del bloque de punteros es incorrecto. 2"
 
-#: memline.c:3531
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Bucle de symlinks para \"%s\""
 
-#: memline.c:3726
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ATENCIÓN"
 
-#: memline.c:3727
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -4837,47 +4175,46 @@ msgstr ""
 "\n"
 "Se ha encontrado un archivo de intercambio con el nombre \""
 
-#: memline.c:3731
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "al abrir el archivo \""
 
-#: memline.c:3744
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "     MÁS NUEVO que el archivo de intercambio!\n"
 
 # Some of these messages are long to allow translation to
 # * other languages.
-#. Some of these messages are long to allow translation to
-#. * other languages.
-#: memline.c:3748
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Puede que otro programa esté editando el mismo archivo.\n"
 "    De ser así, tenga cuidado de no acabar con dos\n"
 "    ejemplares diferentes del mismo archivo al hacer cambios.\n"
 
-#: memline.c:3749
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Salga del programa o continúe con precaución.\n"
 
-#: memline.c:3750
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Falló una sesión de edición de este archivo.\n"
 
-#: memline.c:3751
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Si es así, use \":recover\" o \"vim -r "
 
-#: memline.c:3753
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -4885,11 +4222,11 @@ msgstr ""
 "\"\n"
 "    para recuperar los cambios (véa \":help recovery\").\n"
 
-#: memline.c:3754
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Si Ud. ya ha hecho esto, borre el archivo de intercambio \""
 
-#: memline.c:3756
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -4897,23 +4234,23 @@ msgstr ""
 "\"\n"
 "    para evitar este mensaje.\n"
 
-#: memline.c:4175 memline.c:4179
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "¡El archivo de intercambio \""
 
-#: memline.c:4176 memline.c:4182
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ya existe!"
 
-#: memline.c:4185
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ATENCIÓN"
 
-#: memline.c:4187
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "¡Ya existe un archivo de intercambio!"
 
-#: memline.c:4191
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -4927,7 +4264,7 @@ msgstr ""
 "&Salir\n"
 "A&bortar"
 
-#: memline.c:4193
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -4942,38 +4279,51 @@ msgstr ""
 "&Borrar&Salir\n"
 "&Abortar"
 
-#: memline.c:4264
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Se han encontrado demasiados archivos de intercambio"
 
-#: menu.c:64
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: ¡Memoria agotada! (al asignar %<PRIu64> bytes)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Parte de la ruta del item del menú no es un sub-menú"
 
-#: menu.c:65
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: El menú solo existe en otro modo de operación"
 
-#: menu.c:66
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: No existe el menú \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
-#: menu.c:519
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Nombre de menú vacío"
 
-#: menu.c:537
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: La ruta del menú no debe conducir a un sub-menú"
 
-#: menu.c:576
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr ""
 "E331: No se deben añadir elementos del menú directamente a la barra del menú"
 
-#: menu.c:582
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: El separador no puede ser parte de una ruta de menú"
 
@@ -4981,7 +4331,7 @@ msgstr "E332: El separador no puede ser parte de una ruta de menú"
 # Highlight title
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
-#: menu.c:1127
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -4989,78 +4339,75 @@ msgstr ""
 "\n"
 "--- Menús ---"
 
-#: menu.c:2090
-msgid "Tear off this menu"
-msgstr "Desprender y flotar este menú"
-
-#: menu.c:2155
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: La ruta del menú debe conducir a un item del menú"
 
-#: menu.c:2175
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: No se ha encontrado el menú: %s"
 
-#: menu.c:2257
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: El menú no está definido para el modo %s"
 
-#: menu.c:2295
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: La ruta del menú debe conducir a un sub-menú"
 
-#: menu.c:2316
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: No se ha encontrado el menú - verifique los nombres de los menús"
 
-#: message.c:462
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Se ha detectado un error al procesar %s:"
 
-#: message.c:487
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "línea %4ld"
 
-#: message.c:685
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nombre de registro no válido: '%s'"
 
-#: message.c:833
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
-"Traducción: Proyecto vim-doc-es <http://www.assembla.com/wiki/show/vim-doc-es>"
+"Traducción: Proyecto vim-doc-es <http://www.assembla.com/wiki/show/vim-doc-"
+"es>"
 
-#: message.c:1090
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Interrupción: "
 
-#: message.c:1092
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Pulse INTRO o escriba una orden para continuar"
 
-#: message.c:2139
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s, en la línea %<PRId64>"
 
-#: message.c:2839
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Más --"
 
-#: message.c:2845
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " ESPACIO/d/j: pantalla/página/línea abajo, b/u/k: arriba, q: salir "
 
-#: message.c:3637 message.c:3652
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Pregunta"
 
-#: message.c:3639
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -5068,7 +4415,17 @@ msgstr ""
 "&Si\n"
 "&No"
 
-#: message.c:3672
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Si\n"
+"&No\n"
+"&Cancelar"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -5082,339 +4439,176 @@ msgstr ""
 "&Descartar todo\n"
 "&Cancelar"
 
-#: message.c:3713
-msgid "Select Directory dialog"
-msgstr "Diálogo: Selección de directorio"
-
-#: message.c:3715
-msgid "Save File dialog"
-msgstr "Diálogo: Guardar Archivos"
-
-#: message.c:3717
-msgid "Open File dialog"
-msgstr "Diálogo: Abrir Archivos"
-
-# TODO: non-GUI file selector here
-#. TODO: non-GUI file selector here
-#: message.c:3817
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Lo siento, no hay navegador de archivos en el modo de consola"
-
-#: message.c:3848
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Argumentos insuficientes para printf()"
 
-#: message.c:3924
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Se esperaba un argumento \"Float\" para printf()"
 
-#: message.c:4812
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Demasiados argumentos para printf()"
 
-#: misc1.c:2975
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Advertencia: cambiando un archivo de sólo lectura"
 
-#: misc1.c:3269
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Escriba un número e <Intro> o pulse con el ratón (la omisión cancela) "
 
-#: misc1.c:3271
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Escoja un número e <Intro> (la omisión cancela la acción): "
 
-#: misc1.c:3323
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 línea más"
 
-#: misc1.c:3325
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 línea menos"
 
-#: misc1.c:3330
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> líneas más"
 
-#: misc1.c:3332
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> líneas menos"
 
-#: misc1.c:3335
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Interrumpido)"
 
-#: misc1.c:3400
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "¡Bip!"
 
-#: misc1.c:8380
-msgid "Vim: preserving files...\n"
-msgstr "Vim: preservando archivos...\n"
-
-# close all memfiles, without deleting
-#. close all memfiles, without deleting
-#: misc1.c:8390
-msgid "Vim: Finished.\n"
-msgstr "Vim: Finalizado.\n"
-
-#: misc2.c:718 misc2.c:734
-#, c-format
-msgid "ERROR: "
-msgstr "ERROR: "
-
-#: misc2.c:738
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bytes] total liberados por alloc: %<PRIu64>-%<PRIu64>, en uso: %<PRIu64>, uso máximo: %<PRIu64>\n"
-
-#: misc2.c:740
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[llamadas] total re/malloc(): %<PRIu64>, total free(): %<PRIu64>\n"
-"\n"
-
-#: misc2.c:795
-msgid "E340: Line is becoming too long"
-msgstr "E340: La línea se está haciendo demasiado larga"
-
-#: misc2.c:839
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Error interno: lalloc(%<PRId64>, )"
-
-#: misc2.c:953
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: ¡Memoria agotada! (al asignar %<PRIu64> bytes)"
-
-#: misc2.c:3033
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Invocando al intérprete de órdenes para ejecutar: %s"
 
-#: misc2.c:3302
-msgid "E545: Missing colon"
-msgstr "E545: Falta un símbolo de dos puntos"
-
-#: misc2.c:3304 misc2.c:3331
-msgid "E546: Illegal mode"
-msgstr "E546: Modo de operación ilegal"
-
-#: misc2.c:3370
-msgid "E547: Illegal mouseshape"
-msgstr "E547: El \"mouseshape\" no es válido"
-
-#: misc2.c:3410
-msgid "E548: digit expected"
-msgstr "E548: Se esperaba un dígito"
-
-#: misc2.c:3415
-msgid "E549: Illegal percentage"
-msgstr "E549: Porcentaje ilegal"
-
-#: misc2.c:3737
-msgid "Enter encryption key: "
-msgstr "Introduzca la clave de cifrado: "
-
-#: misc2.c:3738
-msgid "Enter same key again: "
-msgstr "Introduzca la misma clave de cifrado otra vez: "
-
-#: misc2.c:3749
-msgid "Keys don't match!"
-msgstr "¡Las claves de cifrado no coinciden!"
-
-#: misc2.c:4290
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Ruta no válida: '**[número]' debe estar al final de la ruta\n"
-"o seguido de %s."
-
-#: misc2.c:5585
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: No se pudo encontrar el directorio \"%s\" en \"cdpath\""
-
-#: misc2.c:5588
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: No se pudo encontrar el archivo %s en la ruta"
-
-#: misc2.c:5594
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: No se han encontrado mas directorios \"%s\" en \"cdpath\""
-
-#: misc2.c:5597
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: No se han encontrado mas archivos \"%s\" en la ruta"
-
-# Get here when the server can't be found.
-#: netbeans.c:406
-msgid "Cannot connect to Netbeans #2"
-msgstr "No se pudo conectar a NetBeans #2"
-
-#: netbeans.c:415
-msgid "Cannot connect to Netbeans"
-msgstr "No se pudo conectar a NetBeans"
-
-# c-format
-#: netbeans.c:461
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: El dueño/a del archivo de conexión NetBeans no es válido: %s"
-
-#: netbeans.c:770
-msgid "read from Netbeans socket"
-msgstr "leído del socket NetBeans"
-
-#: netbeans.c:1872
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Se perdió la conexión NetBeans para el búfer %<PRId64>"
-
-#: netbeans.c:3692
-msgid "E505: "
-msgstr "E505: "
-
-#: normal.c:186
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: No hay ningún identificador bajo el cursor"
 
-#: normal.c:2198
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' está vacío"
 
-#: normal.c:2217
-msgid "E775: Eval feature not available"
-msgstr "E775: La característica \"eval\" no está disponible"
-
-#: normal.c:3221
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Advertencia: la terminal no puede resaltar el texto"
 
-#: normal.c:3516
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: No hay ninguna cadena bajo el cursor"
 
-#: normal.c:4868
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: No se pudo borrar pliegues con el 'folmethod' actual"
 
-#: normal.c:7365
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: La lista de cambios está vacía"
 
-#: normal.c:7367
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Al comienzo de la lista de cambios"
 
-#: normal.c:7369
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Al final de la lista de cambios"
 
-#: normal.c:8734
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Escriba \":quit<intro>\" para salir de Vim"
 
-#: ops.c:293
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 línea %sed 1 vez"
 
-#: ops.c:295
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 línea %sed %d veces"
 
-#: ops.c:300
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> líneas %sed 1 vez"
 
-#: ops.c:303
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> líneas %sed %d veces"
 
-#: ops.c:691
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> líneas por sangrar..."
 
-#: ops.c:742
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 línea sangrada"
 
-#: ops.c:744
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> líneas sangradas"
 
-#: ops.c:1170
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: No hay registro previamente en uso"
 
 # must display the prompt
 #. must display the prompt
-#: ops.c:1734
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "No se pudo copiar \"yank\"; ¿Lo borro de todas formas?"
 
-#: ops.c:2331
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 línea cambiada"
 
-#: ops.c:2333
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> líneas cambiadas"
 
-#: ops.c:2788
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "liberando %<PRId64> líneas"
-
-#: ops.c:3073
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "bloque de 1 línea copiada"
 
-#: ops.c:3076
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 línea copiada"
 
-#: ops.c:3080
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "bloque de %<PRId64> líneas copiadas"
 
-#: ops.c:3083
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> líneas copiadas"
 
-#: ops.c:3378
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: No hay nada en el registro %s"
 
 # Highlight title
 #. Highlight title
-#: ops.c:3970
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -5422,12 +4616,11 @@ msgstr ""
 "\n"
 "--- Registros ---"
 
-#: ops.c:5344
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Nombre de registro ilegal"
 
-#: ops.c:5440
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -5435,199 +4628,181 @@ msgstr ""
 "\n"
 "# Registros:\n"
 
-#: ops.c:5497
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Registro desconocido de tipo %d"
 
-#: ops.c:6435
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Cols; "
 
-#: ops.c:6444
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr ""
-"Selección %s%<PRId64> de %<PRId64> Líneas; %<PRId64> de %<PRId64> Palabras; %<PRId64> de %<PRId64> Caracteres"
-
-#: ops.c:6451
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Selección %s%<PRId64> de %<PRId64> Líneas; %<PRId64> de %<PRId64> Palabras; %<PRId64> de %<PRId64> Caracteres; %"
-"ld de %<PRId64> Bytes"
+"Selección %s%<PRId64> de %<PRId64> Líneas; %<PRId64> de %<PRId64> Palabras; "
+"%<PRId64> de %<PRId64> Caracteres"
 
-#: ops.c:6470
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col %s de %s; Línea %<PRId64> de %<PRId64>; Palabra %<PRId64> de %<PRId64>; Byte %<PRId64> de %<PRId64>"
-
-#: ops.c:6478
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Col %s de %s; Línea %<PRId64> de %<PRId64>; Palabra %<PRId64> de %<PRId64>; Carácter %<PRId64> de %<PRId64> Byte "
-"%<PRId64> de %<PRId64>"
+"Selección %s%<PRId64> de %<PRId64> Líneas; %<PRId64> de %<PRId64> Palabras; "
+"%<PRId64> de %<PRId64> Caracteres; %ld de %<PRId64> Bytes"
 
-#: ops.c:6490
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s de %s; Línea %<PRId64> de %<PRId64>; Palabra %<PRId64> de %<PRId64>; "
+"Byte %<PRId64> de %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s de %s; Línea %<PRId64> de %<PRId64>; Palabra %<PRId64> de %<PRId64>; "
+"Carácter %<PRId64> de %<PRId64> Byte %<PRId64> de %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> para BOM)"
 
-#: option.c:1953
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Página %N"
 
-#: option.c:2524
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Gracias por volar con Vim"
 
-#: option.c:4099 option.c:4242
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Opción desconocida"
 
-#: option.c:4112
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opción no admitida"
 
-#: option.c:4150
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: No permitido en una \"modeline\""
 
-#: option.c:4368
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Debe introducir un número después de \"=\""
 
-#: option.c:4693 option.c:5499
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: No lo encontré en el \"termcap\""
 
-#: option.c:4810
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Carácter ilegal <%s>"
 
-#: option.c:5491
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: No se pudo definir \"term\" como una cadena de caracteres vacía"
 
-#: option.c:5494
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: No se pudo cambiar \"term\" en la interfaz gráfica"
-
-#: option.c:5496
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Use \":gui\" para iniciar la interfaz gráfica"
-
-#: option.c:5525
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: \"backupext\" y \"patchmode\" son iguales"
 
-#: option.c:5753
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: No puede cambiarse en la interfaz gráfica de GTK+ 2"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
-#: option.c:5931
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Falta un símbolo de dos puntos"
 
-#: option.c:5933
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Cadena de caracteres de largo cero"
 
-#: option.c:6016
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Falta el número después de <%s>"
 
-#: option.c:6030
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Falta una coma"
 
-#: option.c:6037
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Debe especificar un valor "
 
-#: option.c:6086
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Contiene un carácter no imprimible o de más de un byte"
 
-#: option.c:6130
-msgid "E596: Invalid font(s)"
-msgstr "E596: Las fuente/s de impresión no son válidas"
-
-#: option.c:6139
-msgid "E597: can't select fontset"
-msgstr "E597: No se pudo seleccionar ese \"fontset\""
-
-#: option.c:6141
-msgid "E598: Invalid fontset"
-msgstr "E598: El conjunto de tipos de letra de impresión no es válido"
-
-#: option.c:6149
-msgid "E533: can't select wide font"
-msgstr ""
-"E533: No se pudo seleccionar el tipo de letra de impresión \"ancho\" (de "
-"\"byte\" doble)"
-
-#: option.c:6151
-msgid "E534: Invalid wide font"
-msgstr "E534: Tipo de letra de impresión \"ancho\" inválida"
-
-#: option.c:6477
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Carácter ilegal después de <%c>"
 
-#: option.c:6597
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: necesita una coma"
 
-#: option.c:6607
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' debe estar vacío o contener %s"
 
-#: option.c:6688
-msgid "E538: No mouse support"
-msgstr "E538: No hay soporte para el ratón"
-
-#: option.c:7007
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Secuencia de expresión sin cerrar"
 
-#: option.c:7011
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Demasiados elementos"
 
-#: option.c:7013
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Grupos sin equilibrar"
 
-#: option.c:7349
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Ya existe una ventana de visualización previa"
 
-#: option.c:7605
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: La opción árabe necesita de UTF-8, use \":set encoding=utf-8\""
 
-#: option.c:8028
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Necesita al menos %d líneas"
 
-#: option.c:8038
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Necesita al menos %d columnas"
 
-#: option.c:8357
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Opción desconocida: %s"
@@ -5635,12 +4810,12 @@ msgstr "E355: Opción desconocida: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
-#: option.c:8389
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Debe introducir un número: &%s = '%s'"
 
-#: option.c:8513
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -5648,7 +4823,7 @@ msgstr ""
 "\n"
 "--- Códigos de terminal ---"
 
-#: option.c:8515
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -5656,7 +4831,7 @@ msgstr ""
 "\n"
 "--- Valores de las opciones globales ---"
 
-#: option.c:8517
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -5664,7 +4839,7 @@ msgstr ""
 "\n"
 "--- Valores de las opciones locales ---"
 
-#: option.c:8519
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -5672,182 +4847,21 @@ msgstr ""
 "\n"
 "--- Opciones ---"
 
-#: option.c:9332
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ERROR en \"get_varp\""
 
-#: option.c:10431
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: \"langmap\": falta carácter coincidente para %s"
 
-#: option.c:10463
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: \"langmap\": caracteres extra después del punto y coma: %s"
 
-#: os_amiga.c:278
-msgid "cannot open "
-msgstr "No se pudo abrir"
-
-#: os_amiga.c:313
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: ¡No se pudo abrir la ventana!\n"
-
-#: os_amiga.c:340
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Necesito Amigados 2.04 o una versión posterior\n"
-
-#: os_amiga.c:346
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Necesito %s versión %<PRId64>\n"
-
-#: os_amiga.c:419
-msgid "Cannot open NIL:\n"
-msgstr "No se pudo abrir NIL:\n"
-
-#: os_amiga.c:437
-msgid "Cannot create "
-msgstr "No se pudo crear "
-
-#: os_amiga.c:943
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Saliendo de Vim con %d\n"
-
-#: os_amiga.c:979
-msgid "cannot change console mode ?!\n"
-msgstr "¡¿No se pudo cambiar el modo de la consola?!\n"
-
-#: os_amiga.c:1057
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "\"mch_get_shellsize\": ¿No es una consola?\n"
-
-# if Vim opened a window: Executing a shell may cause crashes
-#. if Vim opened a window: Executing a shell may cause crashes
-#: os_amiga.c:1212
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: No se pudo ejecutar el intérprete de órdenes con la opción -f"
-
-#: os_amiga.c:1253 os_amiga.c:1343
-msgid "Cannot execute "
-msgstr "No se puede ejecutar "
-
-#: os_amiga.c:1256 os_amiga.c:1353
-msgid "shell "
-msgstr "shell "
-
-#: os_amiga.c:1276 os_amiga.c:1378
-msgid " returned\n"
-msgstr " devolvió\n"
-
-#: os_amiga.c:1540
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "\"ANCHOR_BUF_SIZE\" demasiado pequeño."
-
-#: os_amiga.c:1544
-msgid "I/O ERROR"
-msgstr "ERROR I/O"
-
-#: os_mswin.c:595
-msgid "Message"
-msgstr "Mensaje"
-
-#: os_mswin.c:710
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "\"columns\" no es 80, no puede ejecutar órdenes externas"
-
-#: os_mswin.c:2143
-msgid "E237: Printer selection failed"
-msgstr "E237: Falló la selección de impresora"
-
-#: os_mswin.c:2183
-#, c-format
-msgid "to %s on %s"
-msgstr "para %s en %s"
-
-#: os_mswin.c:2198
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Tipo de letra de impresión desconocida en la impresora: %s"
-
-#: os_mswin.c:2247 os_mswin.c:2257
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Error de impresión: %s"
-
-#: os_mswin.c:2285
-#, c-format
-msgid "Printing '%s'"
-msgstr "Imprimiendo %s"
-
-#: os_mswin.c:3461
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr ""
-"E244: El nombre del conjunto de caracteres \"%s\" no es válido en el\n"
-"nombre del tipo de letra de impresión \"%s\""
-
-#: os_mswin.c:3471
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr ""
-"E245: Carácter '%c' ilegal en el nombre del tipo de letra de\n"
-"impresión %s"
-
-#: os_unix.c:1065
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Señal doble, saliendo\n"
-
-#: os_unix.c:1071
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Capté una señal mortal %s\n"
-
-#: os_unix.c:1074
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Capté una señal mortal\n"
-
-#: os_unix.c:1412
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Abrir la pantalla X tomó %<PRId64> mseg"
-
-#: os_unix.c:1439
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Hay un error de X\n"
-
-#: os_unix.c:1544
-msgid "Testing the X display failed"
-msgstr "Falló la prueba del sistema X"
-
-#: os_unix.c:1684
-msgid "Opening the X display timed out"
-msgstr "El \"display\" de X tardó demasiado en abrirse"
-
-#: os_unix.c:2658 os_unix.c:2665
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"No se pudo obtener el contexto de seguridad para "
-
-#: os_unix.c:2675
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"No se pudo definir el contexto de seguridad para "
-
-#: os_unix.c:3695 os_unix.c:4620
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -5855,15 +4869,7 @@ msgstr ""
 "\n"
 "No se pudo ejecutar el intérprete de órdenes "
 
-#: os_unix.c:3743
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"No se pudo ejecutar el intérprete de órdenes \"sh\"\n"
-
-#: os_unix.c:3747 os_unix.c:4626
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -5871,469 +4877,473 @@ msgstr ""
 "\n"
 "El intérprete de órdenes devolvió "
 
-#: os_unix.c:3891
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"No se pudo crear \"pipes\"\n"
+"No se pudo obtener el contexto de seguridad para "
 
-#: os_unix.c:3905 os_unix.c:4169
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"No se pudo crear proceso secundario \"fork\"\n"
+"No se pudo definir el contexto de seguridad para "
 
-#: os_unix.c:4633
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"La orden fue terminada\n"
-
-#: os_unix.c:4919 os_unix.c:5069 os_unix.c:6792
-msgid "XSMP lost ICE connection"
-msgstr "XSMP perdió la conexión ICE"
-
-#: os_unix.c:6192 os_unix.c:6295
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-#: os_unix.c:6377
-msgid "Opening the X display failed"
-msgstr "Falló la apertura de la pantalla de X"
-
-#: os_unix.c:6701
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP está manejando una solicitud de \"guardelo usted mismo\""
-
-#: os_unix.c:6815
-msgid "XSMP opening connection"
-msgstr "XSMP está abriendo una conexión"
-
-#: os_unix.c:6834
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP Falló el supervisión de la conexión ICE"
-
-#: os_unix.c:6858
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection falló: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: No se pudo encontrar el archivo \"%s\" en la ruta"
 
-#: os_vms_mms.c:60
-msgid "At line"
-msgstr "En la línea"
-
-#: os_w32exe.c:89
-msgid "Could not load vim32.dll!"
-msgstr "¡No se pudo cargar \"vim32.dll\"!"
-
-#: os_w32exe.c:89 os_w32exe.c:100
-msgid "VIM Error"
-msgstr "Error de Vim"
-
-#: os_w32exe.c:99
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "¡No se pudo conectar los punteros de la función a la DLL!"
-
-#: os_win16.c:342 os_win32.c:3399
-#, c-format
-msgid "shell returned %d"
-msgstr "El intérprete de órdenes ha devuelto %d"
-
-#: os_win32.c:2856
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Capté el evento %s\n"
-
-#: os_win32.c:2858
-msgid "close"
-msgstr "cerrar"
-
-#: os_win32.c:2860
-msgid "logoff"
-msgstr "cerrar la sesión"
-
-#: os_win32.c:2861
-msgid "shutdown"
-msgstr "apagar"
-
-#: os_win32.c:3351
-msgid "E371: Command not found"
-msgstr "E371: No se encontró la orden"
-
-#: os_win32.c:3364
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE no se encuentra en su $PATH.\n"
-"Las órdenes externas no harán una pausa al finalizar.\n"
-"Véase \":help win32-vimrun\"  para más información"
-
-#: os_win32.c:3367
-msgid "Vim Warning"
-msgstr "Advertencia de Vim"
-
-#: quickfix.c:330
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Demasiados %%%c en la cadena de formato"
 
-#: quickfix.c:343
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: %%%c inesperado en la cadena de formato"
 
-#: quickfix.c:405
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Falta ] en la cadena de formato"
 
-#: quickfix.c:419
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c no admitido en cadena de formato"
 
-#: quickfix.c:439
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: %%%c no es válido en el prefijo de una cadena de formato"
 
-#: quickfix.c:447
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: %%%c no es válido en una cadena de formato"
 
-#: quickfix.c:473
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' no contiene un patrón"
 
-#: quickfix.c:706
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Hace falta el nombre del directorio"
 
-#: quickfix.c:1408
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: No hay más elementos"
 
-#: quickfix.c:1830
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d de %d)%s%s: "
 
-#: quickfix.c:1832
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (línea borrada)"
 
-#: quickfix.c:2061
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Al final de la pila de corrección rápida"
 
-#: quickfix.c:2070
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Al principio de la pila de corrección rápida"
 
-#: quickfix.c:2084
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "lista de errores %d de %d: %d errores"
 
-#: quickfix.c:2670
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: No se pudo escribir, la opción \"buftype\" está activa"
 
-#: quickfix.c:3074
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Falta el nombre del archivo o el patrón no es válido"
 
-#: quickfix.c:3172
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "No se pudo abrir el archivo %s"
 
-#: quickfix.c:3705
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: El búfer no está cargado"
 
-#: quickfix.c:3766
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Se esperaba una lista o una cadena de caracteres"
 
-#: regexp.c:331
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: El elemento en %s%%[] no es válido"
 
-#: regexp.c:1017
-msgid "E339: Pattern too long"
-msgstr "E339: Patrón demasiado largo"
-
-#: regexp.c:1189
-msgid "E50: Too many \\z("
-msgstr "E50: Demasiados \\z("
-
-#: regexp.c:1200
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Hay demasiados %s("
-
-#: regexp.c:1257
-msgid "E52: Unmatched \\z("
-msgstr "E52: \\z( sin complemento"
-
-#: regexp.c:1261
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: %s%%( sin complemento"
-
-#: regexp.c:1263
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: %s( sin complemento"
-
-#: regexp.c:1268
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: %s) sin complemento"
-
-#: regexp.c:1484
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Carácter inválido después de %s@"
-
-#: regexp.c:1518
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Hay demasiados %s{...}s complejos"
-
-#: regexp.c:1534
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Anidado %s*"
-
-#: regexp.c:1537
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Anidado %s%c"
-
-#: regexp.c:1657
-msgid "E63: invalid use of \\_"
-msgstr "E63: Uso inválido de \\_"
-
-#: regexp.c:1713
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c no sigue a nada"
-
-#: regexp.c:1769
-msgid "E65: Illegal back reference"
-msgstr "E65: Referencia inversa ilegal"
-
-#: regexp.c:1782
-msgid "E66: \\z( not allowed here"
-msgstr "E66: No se permite \\z( aquí"
-
-#: regexp.c:1801
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 et al. no se permiten aquí"
-
-# Es preferible traducir "invalid" por "no [es] válido" pues "inválido" no es lo suficientemente claro. Además, no es políticamente correcto :-) ALV
-#: regexp.c:1813
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Hay un carácter no válido después de \\z"
-
-#: regexp.c:1865
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Falta ] después de %s%%["
-
-#: regexp.c:1881
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: %s%%[] vacío"
-
-#: regexp.c:1926
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Carácter no válido después de %s%%[dxouU]"
-
-#: regexp.c:1997
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Carácter ilegal después de %s%%"
-
-#: regexp.c:2290
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Falta ] después de %s["
 
-#: regexp.c:2978
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: %s%%( sin complemento"
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: %s( sin complemento"
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: %s) sin complemento"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: No se permite \\z( aquí"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 et al. no se permiten aquí"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Falta ] después de %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: %s%%[] vacío"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Patrón demasiado largo"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Demasiados \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Hay demasiados %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: \\z( sin complemento"
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: Carácter inválido después de %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Hay demasiados %s{...}s complejos"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Anidado %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Anidado %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Uso inválido de \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c no sigue a nada"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Referencia inversa ilegal"
+
+# Es preferible traducir "invalid" por "no [es] válido" pues "inválido" no es lo suficientemente claro. Además, no es políticamente correcto :-) ALV
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Hay un carácter no válido después de \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Carácter no válido después de %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Carácter ilegal después de %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Error de sintaxis en %s{...}"
 
-#: regexp.c:3821
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Sub-coincidencias externas:\n"
 
-#: screen.c:9072
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Demasiados \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: No se pudo encontrar el archivo temporal para escribir en él"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " REEMPLAZO VIRTUAL"
 
-#: screen.c:9076
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " REEMPLAZAR"
 
-#: screen.c:9081
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " INVERTIR"
 
-#: screen.c:9083
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERTAR"
 
-#: screen.c:9086
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (insertar)"
 
-#: screen.c:9088
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (reemplazar)"
 
-#: screen.c:9090
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (reemplazo virtual)"
 
-#: screen.c:9093
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hebreo"
 
-#: screen.c:9104
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " árabe"
 
-#: screen.c:9107
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (idioma)"
 
-#: screen.c:9111
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (pegar)"
 
-#: screen.c:9124
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUAL"
 
-#: screen.c:9125
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " LÍNEA VISUAL"
 
-#: screen.c:9126
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " BLOQUE VISUAL"
 
-#: screen.c:9127
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " SELECCIONAR"
 
-#: screen.c:9128
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " SELECCIONAR LÍNEA"
 
-#: screen.c:9129
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " SELECCIONAR BLOQUE"
 
-#: screen.c:9145 screen.c:9211
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "grabando"
 
-#: search.c:562
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: La cadena de búsqueda no es válida: %s"
 
-#: search.c:983
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: La búsqueda ha llegado al PRINCIPIO sin coincidir con: %s"
 
-#: search.c:986
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: La búsqueda ha llegado al FINAL sin coincidir con: %s"
 
-#: search.c:1415
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Esperaba \"?\" o \"/\" después de \";\""
 
-#: search.c:4681
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (incluye la coincidencia mostrada previamente)"
 
 # cursor at status line
 #. cursor at status line
-#: search.c:4701
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Archivos incluidos "
 
-#: search.c:4703
+#: ../search.c:4106
 msgid "not found "
 msgstr "no se encontrṕ"
 
-#: search.c:4704
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "en la ruta ---\n"
 
-#: search.c:4761
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Ya está listado)"
 
-#: search.c:4763
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NO SE ENCONTRÓ"
 
-#: search.c:4817
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Explorando el archivo incluido: %s"
 
-#: search.c:4826
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Buscando en el archivo incluido: %s"
 
-#: search.c:5049
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: La coincidencia está en la línea bajo el cursor"
 
-#: search.c:5193
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Se han encontrado todos los archivos incluidos"
 
-#: search.c:5195
+#: ../search.c:4519
 msgid "No included files"
 msgstr "No hay archivos incluidos"
 
-#: search.c:5211
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: La definición no se encontró"
 
-#: search.c:5213
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: El patrón no se encontró"
 
-#: search.c:5391
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Sustitución"
 
-#: search.c:5404
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -6344,104 +5354,99 @@ msgstr ""
 "# Último %sPatrón de búsqueda:\n"
 "~"
 
-#: spell.c:989
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Error de formato en el archivo de ortografía"
 
-#: spell.c:990
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Archivo de ortografía truncado"
 
-#: spell.c:991
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Texto sobrante en %s línea %d: %s"
 
-#: spell.c:992
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Nombre de afijo demasiado largo en %s línea %d: %s"
 
-#: spell.c:993
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Error de formato en el archivo de afijos FOL, LOW o UPP"
 
-#: spell.c:994
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: El carácter en FOL, LOW o UPP está fuera de rango"
 
-#: spell.c:995
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Comprimiendo el árbol de palabras..."
 
-#: spell.c:2149
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: La corrección ortográfica está desactivada"
 
-#: spell.c:2502
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Advertencia: No se pudo hallar la lista de palabras \"%s.%s.spl\" \n"
 "or \"%s.ascii.spl\""
 
-#: spell.c:2776
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Leyendo archivo de ortografía \"%s\""
 
-#: spell.c:2808
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Esto no parece un archivo de ortografía"
 
-#: spell.c:2814
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Archivo de ortografía obsoleto, debe actualizarlo"
 
-#: spell.c:2819
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: El archivo de ortografía es para una versión de Vim más reciente"
 
-#: spell.c:2922
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Sección no compatible en el archivo de ortografía"
 
-#: spell.c:4417
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Advertencia: la región %s no es compatible"
 
-#: spell.c:5307
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Leyendo el archivo de afijos \"%s\"..."
 
-#: spell.c:5355 spell.c:6699 spell.c:7278
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "La conversión falló para la palabra en %s línea %d: %s"
 
-#: spell.c:5403 spell.c:7313
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "La conversión en %s no es posible: de %s a %s"
 
-#: spell.c:5407 spell.c:7318
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "La conversión a %s no es posible en esta versión"
-
-#: spell.c:5420
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "El valor para \"FLAG\" no es válido en la %s línea %d: %s"
 
-#: spell.c:5433
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "\"FLAG\" después de usar parámetros en %s línea %d: %s"
 
-#: spell.c:5524
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -6451,7 +5456,7 @@ msgstr ""
 "erróneos\n"
 "en %s línea %d"
 
-#: spell.c:5533
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -6461,44 +5466,44 @@ msgstr ""
 "erróneos\n"
 "en %s línea %d"
 
-#: spell.c:5554
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Valor equivocado de COMPOUNDRULES %s línea %d: %s"
 
-#: spell.c:5581
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Valor equivocado de COMPOUNDWORDMAX en %s línea %d: %s"
 
-#: spell.c:5589
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Valor equivocado de COMPOUNDMIN en %s línea %d: %s"
 
-#: spell.c:5597
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Valor equivocado de COMPOUNDSYLMAX en %s línea %d: %s"
 
-#: spell.c:5619
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Valor equivocado de CHECKCOMPOUNDPATTERN en %s línea %d: %s"
 
-#: spell.c:5685
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Marca de combinación diferente en el bloque de afijos continuo\n"
 "en %s línea %d: %s"
 
-#: spell.c:5688
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Afijo duplicado en %s línea %d: %s"
 
-#: spell.c:5710
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -6508,338 +5513,336 @@ msgstr ""
 "en\n"
 "%s línea %d: %s"
 
-#: spell.c:5734
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Esperaba Y o N en %s línea %d: %s"
 
-#: spell.c:5818
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Condición inválida en %s línea %d: %s"
 
-#: spell.c:5966
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Esperaba conteo REP(SAL) en %s línea %d"
 
-#: spell.c:6001
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Esperaba conteo MAP en %s línea %d"
 
-#: spell.c:6020
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Carácter duplicado en MAP en %s línea %d"
 
-#: spell.c:6077
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Elemento no reconocido o duplicado en %s línea %d: %s"
 
-#: spell.c:6105
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Falta una línea FOL/LOW/UPP en %s"
 
-#: spell.c:6131
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX usado sin SYLLABLE"
 
-#: spell.c:6149
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Hay demasiados prefijos postpuestos"
 
-#: spell.c:6151
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Demasiados parámetros compuestos"
 
-#: spell.c:6153
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Demasiados prefijos postpuestos y/o \"flags\" compuestos"
 
-#: spell.c:6165
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Falta una línea SOFO%s en %s"
 
-#: spell.c:6168
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Líneas SAL y SOFO en %s"
 
-#: spell.c:6275
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "La marca no es un número en %s línea %d: %s"
 
-#: spell.c:6278
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Marca ilegal en %s line %d: %s"
 
-#: spell.c:6495 spell.c:6508
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "El valor %s difiere de los que se usa en otro archivo .aff"
 
-#: spell.c:6660
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Leyendo el archivo de diccionario %s ..."
 
-#: spell.c:6669
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: No hay cuenta de palabras en %s"
 
-#: spell.c:6740
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "línea %6d, palabra %6d - %s"
 
-#: spell.c:6764
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Palabra duplicada en %s línea %d: %s"
 
-#: spell.c:6767
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Primera palabra duplicada en %s line %d: %s"
 
-#: spell.c:6822
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d palabra(s) duplicada(s) en %s"
 
-#: spell.c:6824
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ignorando %d palabra(s) con caracteres no-ASCII en %s"
 
-#: spell.c:7247
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Leyendo archivo de palabras \"%s\" ..."
 
-#: spell.c:7297
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Ignorando línea /encoding= duplicada en %s line %d: %s"
 
-#: spell.c:7300
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Ignorando línea /encoding= después de palabra en %s línea %d: %s"
 
-#: spell.c:7327
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Ignorando línea /regions= en %s línea %d: %s"
 
-#: spell.c:7333
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Demasiadas regiones en %s línea %d: %s"
 
-#: spell.c:7347
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Ignorando línea / en %s línea %d: %s"
 
-#: spell.c:7377
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Región nr no válida en %s línea %d: %s"
 
-#: spell.c:7385
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Parámetros no reconocidos en %s línea %d: %s"
 
-#: spell.c:7415
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignorando %d palabras con caracteres no-ASCII"
 
-#: spell.c:7876
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Comprimiendo %d de %d nodos; faltan %d (%d%%)"
 
-#: spell.c:8720
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Releyendo el archivo de ortografía ..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
-#: spell.c:8741
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Ejecutando compresión fonética"
 
-#: spell.c:8754
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Número de palabras después de la compresión fonética: %<PRId64>"
 
-#: spell.c:8879
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Número total de palabras: %d"
 
-#: spell.c:9096
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Escribiendo el archivo de sugerencias %s ..."
 
-#: spell.c:9157 spell.c:9418
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Uso de memoria estimado al usar: %d bytes"
 
-#: spell.c:9289
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr ""
 "E751: El nombre del archivo de salida no debe contener un nombre de región"
 
-#: spell.c:9291
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Solo se pueden usar hasta 8 regiones"
 
-#: spell.c:9321
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Región no válida en %s"
 
-#: spell.c:9392
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Advertencia: Se especificó \"compounding\" y NOBREAK"
 
-#: spell.c:9411
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Escribiendo archivo de ortografía \"%s\" ..."
 
-#: spell.c:9416
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "¡Listo!"
 
-#: spell.c:9543
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' no tiene entradas %<PRId64>"
 
-#: spell.c:9588
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Eliminando palabra de %s"
 
-#: spell.c:9633
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Añadiendo palabra en \"%s\""
 
-#: spell.c:9946
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr ""
 "E763: Los caracteres de la palabra difieren entre archivos de ortografía"
 
-#: spell.c:10321
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Lo siento, no hay sugerencias"
 
-#: spell.c:10325
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Lo siento, solo hay %<PRId64> sugerencias"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
-#: spell.c:10346
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "\"%.*s\" cambió a:"
 
-#: spell.c:10386
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
-#: spell.c:10562
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: No hay un reemplazo de ortografía previo"
 
-#: spell.c:10612
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: No se encontró: %s"
 
-#: spell.c:11032
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Esto no se parece a un archivo .sug: %s"
 
-#: spell.c:11039
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Archivo .sug obsoleto, necesita una actualización: %s"
 
-#: spell.c:11045
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: El archivo .sug es para una versión más reciente de Vim: %s"
 
-#: spell.c:11055
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: El archivo .sug no corresponde al archivo .spl: %s"
 
-#: spell.c:11068
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Error al leer archivo .sig: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
-#: spell.c:13765
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: carácter duplicado en entrada MAP"
 
-#: syntax.c:3245 syntax.c:3271
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "No hay elementos sintácticos definidos para este búfer"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Argumento ilegal: %s"
 
-#: syntax.c:3453
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: No existe tal agrupamiento sintáctico: %s"
 
-#: syntax.c:3612
-msgid "No Syntax items defined for this buffer"
-msgstr "No hay elementos sintácticos definidos para este búfer"
-
-#: syntax.c:3620
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "Sincronizando con los comentarios de estilo \"C\""
 
-#: syntax.c:3628
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "no hay sincronización"
 
-#: syntax.c:3631
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "Comenzando sincronización"
 
-#: syntax.c:3633 syntax.c:3708
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " líneas antes de la línea superior"
 
-#: syntax.c:3638
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -6847,7 +5850,7 @@ msgstr ""
 "\n"
 "--- Elementos de sincronización de sintaxis ---"
 
-#: syntax.c:3643
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -6855,7 +5858,7 @@ msgstr ""
 "\n"
 "sincronizando con los elementos"
 
-#: syntax.c:3649
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -6863,260 +5866,281 @@ msgstr ""
 "\n"
 "--- Elementos sintácticos ---"
 
-#: syntax.c:3672
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: No existe tal agrupamiento sintáctico: %s"
 
-#: syntax.c:3698
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "mínimo"
 
-#: syntax.c:3705
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "máximo"
 
-#: syntax.c:3717
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; coincide"
 
-#: syntax.c:3719
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " líneas de quiebre"
 
-#: syntax.c:4347
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: el contenido del argumento no se acepta aquí"
 
-#: syntax.c:4358
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: el argumento \"containedin\" no se acepta aquí"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: El argumento no es válido"
 
-#: syntax.c:4380
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: \"grouphere\" y \"groupthere\" no son válidos aquí"
 
-#: syntax.c:4404
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: No se encuentra el elemento de la región para %s"
 
-#: syntax.c:4481
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Debe proporcionar un nombre de archivo"
 
-#: syntax.c:4603
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Hay demasiados nombres de archivos"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Falta un ']': %s"
 
-#: syntax.c:4843
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Falta un '=': %s"
 
-#: syntax.c:5002
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Argumentos insuficientes: región de sintaxis %s"
 
-#: syntax.c:5336
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: No existe tal agrupamiento sintáctico: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: No se ha especificado una agrupación"
 
-#: syntax.c:5373
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: No hay un delimitador de patrón: %s"
 
-#: syntax.c:5448
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Basura después del patrón: %s"
 
-#: syntax.c:5537
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: Sincronización de sintaxis: Se especificó dos veces un\n"
 "patrón de continuación de línea"
 
-#: syntax.c:5594
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Argumentos ilegales: %s"
 
-#: syntax.c:5644
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Falta el signo igual: %s"
 
-#: syntax.c:5650
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Argumento vacío: %s"
 
-#: syntax.c:5676
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s no se permite aquí"
 
-#: syntax.c:5683
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s debe ser el primero en la lista de contenido"
 
-#: syntax.c:5753
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nombre de grupo desconocido: %s"
 
-#: syntax.c:5988
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Suborden \":syntax\" no válido: %s"
 
-#: syntax.c:6475
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: bucle recursivo al cargar \"syncolor.vim\""
 
-#: syntax.c:6602
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: grupo de resaltado no encontrado: %s"
 
-#: syntax.c:6626
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Argumentos insuficientes: \":highlight link %s\""
 
-#: syntax.c:6633
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Demasiados argumentos: \":highlight link %s\""
 
-#: syntax.c:6653
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Esta grupo está configurado, se ignora el enlace resaltado"
 
-#: syntax.c:6785
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Signo \"=\" inesperado: %s"
 
-#: syntax.c:6821
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Falta el signo \"=\": %s"
 
-#: syntax.c:6849
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Falta el argumento: %s"
 
-#: syntax.c:6886
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Valor ilegal: %s"
 
-#: syntax.c:7005
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Color en primer plano desconocido"
 
-#: syntax.c:7016
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Color de fondo desconocido"
 
-#: syntax.c:7077
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nombre o número de color desconocido: %s"
 
-#: syntax.c:7304
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Código de terminal demasiado largo: %s"
 
-#: syntax.c:7351
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Argumento ilegal: %s"
 
-#: syntax.c:7912
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Hay demasiados atributos de resaltado sintáctico en uso"
 
-#: syntax.c:8649
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Carácter no imprimible en el nombre del grupo"
 
 # This is an error, but since there previously was no check only
 # * give a warning.
-#: syntax.c:8657
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Hay un carácter no válido en el nombre del grupo"
 
-#: tag.c:85
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: En el final de la pila de etiquetas"
 
-#: tag.c:86
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: En el principio de la pila de etiquetas"
 
-#: tag.c:434
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: No se pudo ir antes de la primer etiqueta coincidente"
 
-#: tag.c:583
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: No se encontró la etiqueta: %s"
 
-#: tag.c:616
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # etiqueta tipo \"pri\""
 
-#: tag.c:619
+#: ../tag.c:531
 msgid "file\n"
 msgstr "archivo\n"
 
-#: tag.c:953
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Sólo coincide una etiqueta"
 
-#: tag.c:955
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: No se pudo ir más allá de la última etiqueta coincidente"
 
-#: tag.c:979
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "No existe el archivo \"%s\""
 
 # Give an indication of the number of matching tags
 #. Give an indication of the number of matching tags
-#: tag.c:991
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "etiqueta %d de %d%s"
 
-#: tag.c:994
+#: ../tag.c:862
 msgid " or more"
 msgstr " o más"
 
-#: tag.c:996
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr ""
 "  ¡Está usando una etiqueta con mayúsculas y minúsculas que no coinciden!"
 
-#: tag.c:1051
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: El archivo \"%s\" no existe"
 
 # Highlight title
 #. Highlight title
-#: tag.c:1119
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -7124,81 +6148,81 @@ msgstr ""
 "\n"
 "  # A etiqueta        DESDE la línea   en el archivo/texto"
 
-#: tag.c:1546
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Buscando el archivo de etiquetas %s"
 
-#: tag.c:1737
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: La ruta del archivo de etiquetas %s está truncada\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr "Ignorando la línea larga en el archivo de etiquetas"
 
-#: tag.c:2388
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Error de formato en el archivo de etiquetas \"%s\""
 
-#: tag.c:2392
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Adelante del byte %<PRId64>"
 
-#: tag.c:2425
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Archivo de etiquetas sin ordenar: %s"
 
 # never opened any tags file
 #. never opened any tags file
-#: tag.c:2469
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: No hay archivo de etiquetas"
 
-#: tag.c:2748
-msgid "Ignoring long line in tags file"
-msgstr "Ignorando la línea larga en el archivo de etiquetas"
-
-#: tag.c:3257
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: No se pudo encontrar el patrón de la etiqueta"
 
-#: tag.c:3268
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: No se pudo encontrar la etiqueta. ¡Estoy adivinando!"
 
-#: term.c:1793
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Afijo duplicado en %s línea %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' desconocido. Los terminales incorporados disponibles son:"
 
-#: term.c:1817
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "Usando ' por defecto"
 
-#: term.c:2172
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: No se pudo abrir el archivo \"termcap\""
 
-#: term.c:2176
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: No he encontrado la definición del terminal en \"terminfo\""
 
-#: term.c:2178
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: No he encontrado la definición del terminal en \"termcap\""
 
-#: term.c:2337
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: la entrada %s no existe en el archivo \"termcap\""
 
-#: term.c:2811
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Se necesita la capacidad \"cm\" en el terminal"
 
 # Highlight title
 #. Highlight title
-#: term.c:5280
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -7206,218 +6230,169 @@ msgstr ""
 "\n"
 "--- Teclas de la terminal ---"
 
-#: ui.c:284
-msgid "new shell started\n"
-msgstr "Iniciado nuevo intérprete de órdenes\n"
-
-#: ui.c:1886
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: error al leer la entrada, saliendo...\n"
 
-#: ui.c:2409
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Se ha usado \"CUT_BUFFER0\" en vez de una selección vacía"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: El búfer cambió inesperadamente"
 
-# must display the prompt
-#. must display the prompt
-#: undo.c:645
-msgid "No undo possible; continue anyway"
-msgstr "No es posible deshacer; continuando de todos modos"
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: No se pudo abrir el archivo para escribir en él"
 
-#: undo.c:727 undo.c:937
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Escribiendo archivo \"viminfo\" \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Error de escritura en el archivo de intercambio"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Leyendo archivo de palabras \"%s\" ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: No se pudo abrir el archivo \"viminfo\" para lectura"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: No se encontró: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: No se pudo abrir el archivo \"%s\""
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "La ejecución de %s ha terminado"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Este es el cambio más antiguo"
 
-#: undo.c:742 undo.c:939
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Este es el cambio más nuevo"
 
-#: undo.c:930
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "No se encontró el número de \"deshacer\" %<PRId64>"
 
-#: undo.c:1100
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: \"u_undo\": números de línea erróneos"
 
-#: undo.c:1338
+#: ../undo.c:2183
 msgid "more line"
 msgstr "Una línea más"
 
-#: undo.c:1340
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "líneas más"
 
-#: undo.c:1342
+#: ../undo.c:2187
 msgid "line less"
 msgstr "una línea menos"
 
-#: undo.c:1344
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "líneas menos"
 
-#: undo.c:1349
+#: ../undo.c:2193
 msgid "change"
 msgstr "cambio"
 
-#: undo.c:1351
+#: ../undo.c:2195
 msgid "changes"
 msgstr "cambios"
 
-#: undo.c:1375
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
-#: undo.c:1378
+#: ../undo.c:2228
 msgid "before"
 msgstr "antes"
 
-#: undo.c:1378
+#: ../undo.c:2228
 msgid "after"
 msgstr "después"
 
-#: undo.c:1486
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nada que hacer"
 
-#: undo.c:1492
-msgid "number changes  time"
-msgstr "el número modifica el tiempo"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
-#: undo.c:1525
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "hace %<PRId64> segundos"
 
-#: undo.c:1541
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: \"undojoin\" no está permitido después de \"undo\""
 
-#: undo.c:1591
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: la lista de deshacer se ha dañado"
 
-#: undo.c:1623
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: falta la línea deshacer"
 
-# Only MS VC 4.1 and earlier can do Win32s
-#. Only MS VC 4.1 and earlier can do Win32s
-#: version.c:1366
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Versión de interfaz gráfica de 16/32 bits para MS-Windows"
-
-#: version.c:1369
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Versión de interfaz gráfica de 64 bits para MS-Windows"
-
-#: version.c:1371
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Versión de interfaz gráfica de 32 bits para MS-Windows"
-
-#: version.c:1375
-msgid " in Win32s mode"
-msgstr " en modo Win32s"
-
-#: version.c:1377
-msgid " with OLE support"
-msgstr " con compatibilidad con OLE"
-
-#: version.c:1381
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Versión de 64 bits para consola de MS-Windows"
-
-#: version.c:1383
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Versión de 32 bits para consola de MS-Windows"
-
-#: version.c:1388
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Versión de 16 bits para MS-Windows"
-
-#: version.c:1392
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versión de 32 bits para MS-DOS"
-
-#: version.c:1394
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versión de 16 bits para MS-DOS"
-
-#: version.c:1400
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Versión para X (Unix) para MacOS"
-
-#: version.c:1402
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Versión para MacOS X"
-
-#: version.c:1405
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Versión para MacOS"
-
-#: version.c:1410
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"Versión para RISC OS"
-
-#: version.c:1413
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Versión para OpenVMS"
-
-#: version.c:1428
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -7425,7 +6400,7 @@ msgstr ""
 "\n"
 "Parches incluidos: "
 
-#: version.c:1455
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -7433,11 +6408,11 @@ msgstr ""
 "\n"
 "Parches adicionales: "
 
-#: version.c:1467 version.c:1831
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modificado por "
 
-#: version.c:1474
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -7445,11 +6420,11 @@ msgstr ""
 "\n"
 "Compilado "
 
-#: version.c:1477
+#: ../version.c:649
 msgid "by "
 msgstr "por "
 
-#: version.c:1489
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -7457,817 +6432,1736 @@ msgstr ""
 "\n"
 "Versión \"enorme\" "
 
-#: version.c:1492
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Versión \"grande\" "
-
-#: version.c:1495
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Versión \"normal\" "
-
-#: version.c:1498
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Versión \"pequeña\" "
-
-#: version.c:1500
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Versión \"diminuta\" "
-
-#: version.c:1506
+#: ../version.c:661
 msgid "without GUI."
 msgstr "sin interfaz gráfica (GUI)."
 
-#: version.c:1511
-msgid "with GTK2-GNOME GUI."
-msgstr "con interfaz gráfica para GTK2-GNOME."
-
-#: version.c:1513
-msgid "with GTK-GNOME GUI."
-msgstr "con interfaz gráfica para GTK-GNOME."
-
-#: version.c:1517
-msgid "with GTK2 GUI."
-msgstr "con interfaz gráfica de GTK2."
-
-#: version.c:1519
-msgid "with GTK GUI."
-msgstr "con interfaz gráfica de GTK."
-
-#: version.c:1524
-msgid "with X11-Motif GUI."
-msgstr "con interfaz gráfica para X11-Motif."
-
-#: version.c:1528
-msgid "with X11-neXtaw GUI."
-msgstr "con interfaz gráfica de X11-neXtaw."
-
-#: version.c:1530
-msgid "with X11-Athena GUI."
-msgstr "con interfaz gráfica de X11-Athena."
-
-#: version.c:1534
-msgid "with Photon GUI."
-msgstr "con interfaz gráfica para Photon."
-
-#: version.c:1537
-msgid "with GUI."
-msgstr "con interfaz gráfica de usuario."
-
-#: version.c:1540
-msgid "with Carbon GUI."
-msgstr "con GUI Carbon."
-
-#: version.c:1543
-msgid "with Cocoa GUI."
-msgstr "con interfaz gráfica para Cocoa."
-
-#: version.c:1546
-msgid "with (classic) GUI."
-msgstr "con interfaz gráfica (clásica)."
-
-#: version.c:1556
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Aspectos incluidos (+) o no (-):\n"
 
-#: version.c:1568
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "     archivo \"vimrc\" del sistema: \""
 
-#: version.c:1573
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     archivo \"vimrc\" del usuario: \""
 
-#: version.c:1578
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  2º archivo \"vimrc\" del usuario: \""
 
-#: version.c:1583
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3er archivo \"vimrc\" del usuario: \""
 
-#: version.c:1588
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      archivo \"exrc\" del usuario: \""
 
-#: version.c:1593
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   2º archivo \"exrc\" del usuario: \""
 
-#: version.c:1599
-msgid "  system gvimrc file: \""
-msgstr "    archivo \"gvimrc\" del sistema: \""
-
-#: version.c:1603
-msgid "    user gvimrc file: \""
-msgstr "    archivo \"gvimrc\" del usuario: \""
-
-#: version.c:1607
-msgid "2nd user gvimrc file: \""
-msgstr " 2º archivo \"gvimrc\" del usuario: \""
-
-#: version.c:1612
-msgid "3rd user gvimrc file: \""
-msgstr "3er archivo \"gvimrc\" del usuario: \""
-
-#: version.c:1619
-msgid "    system menu file: \""
-msgstr "     archivo de menú del sistema: \""
-
-#: version.c:1627
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "            predefinido para $VIM: \""
 
-#: version.c:1633
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "     predefinido para $VIMRUNTIME: \""
 
-#: version.c:1637
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Compilación: "
 
-#: version.c:1643
-msgid "Compiler: "
-msgstr "Compilador: "
-
-#: version.c:1648
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Enlazado: "
 
-#: version.c:1653
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  COMPILACIÓN CON SÍMBOLOS DE DEPURACIÓN"
 
-#: version.c:1692
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - VI Mejorado"
 
-#: version.c:1694
+#: ../version.c:769
 msgid "version "
 msgstr "versión "
 
-#: version.c:1695
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "por Bram Moolenaar et al."
 
-#: version.c:1699
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim es código abierto y se puede distribuir libremente"
 
-#: version.c:1701
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "¡Ayude a los niños pobres de Uganda!"
 
-#: version.c:1702
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "escriba  «:help iccf<Intro>»    para más información  "
 
-#: version.c:1704
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "escriba  «:q<Intro>»            para salir             "
 
-#: version.c:1705
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "escriba  «:help<Intro>» o <F1>  para obtener ayuda     "
 
-#: version.c:1706
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "escriba «:help version7<Intro>» para información de la versión"
 
-#: version.c:1709
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Ejecutando en modo compatible con Vi"
 
-#: version.c:1710
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "escriba  «:set nocp<Intro>»  para los valores predefinidos de Vim"
 
-#: version.c:1711
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "escriba «:help cp-default<Intro>»        para más información"
 
-#: version.c:1726
-msgid "menu  Help->Orphans           for information    "
-msgstr "menú  Ayuda->Ayude a los niños huérfanos      para más información "
-
-#: version.c:1728
-msgid "Running modeless, typed text is inserted"
-msgstr "Ejecución no modal, el texto escrito se inserta directamente"
-
-#: version.c:1729
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menú Editar->Opciones globales->Activar/Desactivar modo de inserción"
-
-#: version.c:1730
-msgid "                              for two modes      "
-msgstr "                                                 para dos modos     "
-
-#: version.c:1734
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr ""
-"menú Editar->Opciones globales->Activar/Desactivar compatibilidad con Vi"
-
-#: version.c:1735
-msgid "                              for Vim defaults   "
-msgstr ""
-"                                 para los valores predeterminados de Vim"
-
-#: version.c:1782
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "¡Patrocine el desarrollo de Vim!"
 
-#: version.c:1783
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "¡Conviértase en un usuario registrado de Vim!"
 
-#: version.c:1786
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "escriba  «:help sponsor<Intro>»     para más información  "
 
-#: version.c:1787
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "escriba «:help register<Intro>»    para más información  "
 
-#: version.c:1789
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menú  Ayuda->Benefactor/Regístrese  para más información"
 
-#: version.c:1799
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ADVERTENCIA: se ha detectado Windows 95/98/ME"
-
-#: version.c:1802
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "escriba «:help windows95<Intro>» para más información"
-
-#: window.c:88
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Solo hay una ventana"
 
-#: window.c:237
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: No hay una ventana de vista previa"
 
-#: window.c:672
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: No se puede dividir arriba izq. y abajo der. al mismo tiempo"
 
-#: window.c:1484
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: No se puede rotar cuando otra ventana está dividida"
 
-#: window.c:2113
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: No se puede cerrar la última ventana"
 
-#: window.c:2120
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: No se puede cerrar la ventana de autocmd"
 
-#: window.c:2125
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr ""
 "E814: No se pudo cerrar la última ventana, solo quedará\n"
 "la ventana de autocmd"
 
-#: window.c:3188
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Otra ventana contiene cambios"
 
-#: window.c:5868
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: No hay un nombre de archivo bajo el cursor"
 
-#: window.c:6005
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: No se pudo encontrar el archivo \"%s\" en la ruta"
+#~ msgid "Patch file"
+#~ msgstr "Archivo de parches"
 
-#: if_perl.xs:420 globals.h:1420
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: No se pudo cargar la biblioteca dinámica %s"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&Aceptar\n"
+#~ "&Cancelar"
 
-#: if_perl.xs:671
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Esta orden está desactivada, no se pudo cargar la biblioteca de Perl"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: No hay conexión al servidor Vim"
 
-#: if_perl.xs:726
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: No se permite la evaluación de código Perl en la caja de\n"
-"arena sin el uso del módulo \"Safe\""
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Incapaz de enviar a %s"
 
-#: GvimExt/gvimext.cpp:587
-msgid "Edit with &multiple Vims"
-msgstr "Editar con &múltiples Vims"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Incapaz de leer una respuesta del servidor"
 
-#: GvimExt/gvimext.cpp:593
-msgid "Edit with single &Vim"
-msgstr "Editar con un solo &Vim"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Incapaz de enviar al cliente"
 
-#: GvimExt/gvimext.cpp:602
-msgid "Diff with Vim"
-msgstr "Diff con Vim"
+#~ msgid "Save As"
+#~ msgstr "Guardar como"
 
-#: GvimExt/gvimext.cpp:615
-msgid "Edit with &Vim"
-msgstr "Editar con &Vim"
+#~ msgid "Edit File"
+#~ msgstr "Editar archivo"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NO ENCONTRADO)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "Ejecute archivo de órdenes de Vim"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "Editar archivo en una ventana nueva"
+
+#~ msgid "Append File"
+#~ msgstr "Añadir archivo"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Posición de la ventana: X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "Guardar redirección"
+
+#~ msgid "Save View"
+#~ msgstr "Guardar vista"
+
+#~ msgid "Save Session"
+#~ msgstr "Guardar sesión"
+
+#~ msgid "Save Setup"
+#~ msgstr "Guardar configuración"
+
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< no está disponible sin la característica \"+eval\""
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: No hay dígrafos en esta versión"
+
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "es un dispositivo (desactivado con la opción 'opendevice')"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "Leyendo la entrada estándar..."
+
+#~ msgid "[crypted]"
+#~ msgstr "[cifrado]"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans no permite que se escriba sobre búfers sin modificar"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "No se permite la escritura parcial de los búfers de NetBeans"
+
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr ""
+#~ "se ha desactivado la escritura en dispositivo con la opción 'opendevice'"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Se perdería el segmento (\"fork\") de recursos (añada ! para forzar "
+#~ "la orden)"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: No se pudo iniciar la interfaz gráfica"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: No se pudo leer desde \"%s\""
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: No se pudo iniciar la interfaz gráfica (GUI), no se encontró "
+#~ "ninguna tipografía de impresión válida"
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: El valor de 'guifontwide' no es válido"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: El valor de 'imactivatekey' no es válido"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: No se pudo asignar el color %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr ""
+#~ "No hay correspondencia en la posición del cursor, buscando la siguiente"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<no se puede abrir> "
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr ""
+#~ "E616: \"vim_SelFile\": No se puede hallar la tipografía de impresión %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: \"vim_SelFile\": no puedo regresar al directorio actual"
+
+#~ msgid "Pathname:"
+#~ msgstr "Nombre de la ruta:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr ""
+#~ "E615: \"vim_SelFile\": No se pudo obtener la ubicación del directorio "
+#~ "actual"
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "Cancel"
+#~ msgstr "Cancelar"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Scrollbar Widget: No pude obtener la geometría de la miniatura \"pixmap\""
+
+#~ msgid "Vim dialog"
+#~ msgstr "Diálogo de Vim"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: No se pudo crear un \"BalloonEval\" que contenga tanto el mensaje "
+#~ "como la llamada de retorno"
+
+#~ msgid "Vim dialog..."
+#~ msgstr "Diálogo de Vim..."
+
+#~ msgid "Input _Methods"
+#~ msgstr "Métodos de Entrada (\"Input Methods\")"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Buscar y reemplazar..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Buscar..."
+
+#~ msgid "Find what:"
+#~ msgstr "¿Encontrar qué?:"
+
+#~ msgid "Replace with:"
+#~ msgstr "Reemplazar con:"
+
+# whole word only button
+#~ msgid "Match whole word only"
+#~ msgstr "Encontrar solo palabras completas"
+
+# match case button
+#~ msgid "Match case"
+#~ msgstr "La única coincidencia"
+
+#~ msgid "Direction"
+#~ msgstr "Dirección"
+
+# 'Up' and 'Down' buttons
+#~ msgid "Up"
+#~ msgstr "Hacia arriba"
+
+#~ msgid "Down"
+#~ msgstr "Hacia abajo"
+
+#~ msgid "Find Next"
+#~ msgstr "Encontrar siguiente"
+
+#~ msgid "Replace"
+#~ msgstr "Reemplazar"
+
+#~ msgid "Replace All"
+#~ msgstr "Reemplazar todos"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Recibí una solicitud \"die\" del administrador de sesiones.\n"
+
+#~ msgid "Close"
+#~ msgstr "Cerrar"
+
+#~ msgid "New tab"
+#~ msgstr "Pestaña nueva"
+
+#~ msgid "Open Tab..."
+#~ msgstr "Abrir pestaña..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: La ventana principal fue destruida inesperadamente.\n"
+
+#~ msgid "Font Selection"
+#~ msgstr "Selección de tipos de letra"
+
+#~ msgid "&Filter"
+#~ msgstr "&Filtro"
+
+#~ msgid "&Cancel"
+#~ msgstr "&Cancelar"
+
+#~ msgid "Directories"
+#~ msgstr "Directorios"
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "&Help"
+#~ msgstr "&Ayuda"
+
+#~ msgid "Files"
+#~ msgstr "Archivos"
+
+#~ msgid "&OK"
+#~ msgstr "&OK"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
+
+#~ msgid "Find &Next"
+#~ msgstr "Encontrar &Siguiente"
+
+#~ msgid "&Replace"
+#~ msgstr "&Reemplazar"
+
+#~ msgid "Replace &All"
+#~ msgstr "Reemplazar &Todos"
+
+#~ msgid "&Undo"
+#~ msgstr "&Deshacer"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: No se pudo encontrar el título de la ventana \"%s\""
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argumento no admitido: \"-%s\"; use la versión OLE."
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Incapaz de abrir ventana dentro de la aplicación MDI"
+
+#~ msgid "Close tab"
+#~ msgstr "Cerrar Ventana"
+
+#~ msgid "Open tab..."
+#~ msgstr "Abrir pestaña..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Buscar cadena (use '\\\\' para encontrar un '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Buscar y reemplazar (use '\\\\' para encontrar un '\\')"
+
+#~ msgid "Not Used"
+#~ msgstr "Sin usar"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Directorio\t*.nada\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: no se puede asignar una entrada al mapa de colores; algunos "
+#~ "colores tal vez no sean correctos"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Faltan los tipos de letras para los siguientes conjuntos de "
+#~ "caracteres en el conjunto de fuentes %s:"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nombre del conjunto de tipos de letra: %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "La tipografía de impresión '%s' no es de ancho fijo"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Nombre del conjunto de tipografías de impresión: %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "Tipo de letra de impresión 0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "Tipo de letra de impresión 1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr ""
+#~ "La anchura del tipo de letra de impresión %<PRId64> no es el doble de "
+#~ "la \n"
+#~ "de la tipografía de impresión 0\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Anchura del tipo de letra de impresión 0: %<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Anchura del tipo de letra de impresión 1: %<PRId64>\n"
+#~ "\n"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "La especificación de tipo de letra no es válida"
+
+#~ msgid "&Dismiss"
+#~ msgstr "&Cerrar"
+
+#~ msgid "no specific match"
+#~ msgstr "no hay una coincidencia especifica"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Selector de tipos de letra"
+
+#~ msgid "Name:"
+#~ msgstr "Nombre:"
+
+#~ msgid "Show size in Points"
+#~ msgstr "Mostrar tamaño en puntos"
+
+#~ msgid "Encoding:"
+#~ msgstr "Codificando:"
+
+#~ msgid "Font:"
+#~ msgstr "Tipo de letra:"
+
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
+
+#~ msgid "Size:"
+#~ msgstr "Tamaño:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ERROR del autómata Hangul"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: error en la función \"stat\""
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: No se pudo abrir la base de datos \"cscope\": %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr ""
+#~ "E626: No se pudo obtener información acerca de la base de datos \"cscope\""
+
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Lo siento, esta orden está desactivada, no se pudo cargar las "
+#~ "bibliotecas de MzScheme"
+
+#~ msgid "invalid expression"
+#~ msgstr "expresión no válida"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "expresiones desactivadas al compilar"
+
+#~ msgid "hidden option"
+#~ msgstr "opción oculta"
+
+#~ msgid "unknown option"
+#~ msgstr "opción desconocida"
+
+#~ msgid "window index is out of range"
+#~ msgstr "indice de ventana fuera del rango"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "No se pudo abrir el búfer"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "No se pudo guardar la información para deshacer"
+
+#~ msgid "cannot delete line"
+#~ msgstr "no puedo suprimir la línea"
+
+#~ msgid "cannot replace line"
+#~ msgstr "no se pudo reemplazar la línea"
+
+#~ msgid "cannot insert line"
+#~ msgstr "no se pudo insertar la línea"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "La cadena no puede contener quiebres de línea"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Error de Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Error de Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "El búfer no es valido"
+
+#~ msgid "window is invalid"
+#~ msgstr "La ventana no es válida"
+
+#~ msgid "linenr out of range"
+#~ msgstr "El número de la línea está fuera del rango"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "No permitido en la \"sandbox\" de vim"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Lo siento, esta orden está desactivada, no se pudo cargar la \n"
+#~ "biblioteca de Python"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: No se pudo invocar a Python recursivamente"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "No se pueden borrar los atributos de \"OutputObject\""
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "\"softspace\" debe ser un entero"
+
+#~ msgid "invalid attribute"
+#~ msgstr "Atributo no válido"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "\"writelines()\" requiere una lista de cadenas"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: error de iniciación de los objetos de I/O"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "Intento de referirse a un búfer suprimido"
+
+#~ msgid "line number out of range"
+#~ msgstr "El número de la línea está fuera del rango"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<objeto de búfer (suprimido) en %p>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "Nombre de marca no válido"
+
+#~ msgid "no such buffer"
+#~ msgstr "No existe tal búfer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "Intento de referirse a una ventana suprimida"
+
+#~ msgid "readonly attribute"
+#~ msgstr "Atributo de solo lectura"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "Posición del cursor fuera del búfer"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<objeto ventana (suprimido) en %p>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<objeto ventana (desconocido) en %p>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<ventana %d>"
+
+#~ msgid "no such window"
+#~ msgstr "No existe tal ventana"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ debe ser una instancia de \"String\""
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Lo siento, esta orden está desactivada, no se pudo cargar\n"
+#~ "la biblioteca de Ruby"
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: \"return\" inesperado"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: \"next\" inesperado"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: \"break\" inesperado"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: \"redo\" inesperado"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: \"retry\" fuera de una cláusula \"rescue\""
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: excepción sin manejar"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: El estado %d de \"longjmp\" es desconocido"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Intercambiar implementación/definición"
+
+#~ msgid "Show base class of"
+#~ msgstr "Mostrar la clase base de"
+
+#~ msgid "Show overridden member function"
+#~ msgstr ""
+#~ "Mostrar la función miembro que se ha sobrepasado con el código nuevo"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Restaurar del archivo"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Restaurar del proyecto"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Restaurar de todos los proyectos"
+
+#~ msgid "Retrieve"
+#~ msgstr "Restaurar"
+
+#~ msgid "Show source of"
+#~ msgstr "Mostrar el origen de "
+
+#~ msgid "Find symbol"
+#~ msgstr "Buscar símbolo"
+
+#~ msgid "Browse class"
+#~ msgstr "Navegador de Clases"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Mostrar la clase en su jerarquía"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Mostrar la clase en jerarquía restringida"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref se refiere a"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref referida por"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref tiene un"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref usada por"
+
+#~ msgid "Show docu of"
+#~ msgstr "Mostrar \"docu\" de"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generar \"docu\" de"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "No se pudo conectar a SNiFF+. Verifique el entorno (\"sniffemacs\" debe\n"
+#~ "estar en \"$PATH\").\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Error al leer. Desconectado"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ está actualmente "
+
+#~ msgid "not "
+#~ msgstr "no "
+
+#~ msgid "connected"
+#~ msgstr "conectado"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Petición de SNiFF+ desconocida: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Error al conectarme a SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ no está conectado"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: No es un búfer de SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: error al escribir. Desconectado"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "Número de búfer no válido"
+
+#~ msgid "not implemented yet"
+#~ msgstr "Aún no implementado"
+
+# ???
+#~ msgid "cannot set line(s)"
+#~ msgstr "No se puede(n) definir la/s línea/s"
+
+#~ msgid "mark not set"
+#~ msgstr "Marca sin definir"
+
+#~ msgid "row %d column %d"
+#~ msgstr "fila %d columna %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "No se puede insertar/añadir línea"
+
+#~ msgid "unknown flag: "
+#~ msgstr "Indicador desconocido: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "\"vimOption\" desconocida"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "Interrupción desde el teclado"
+
+#~ msgid "vim error"
+#~ msgstr "Error de Vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "No se pudo crear la orden de búfer/ventana: el objeto se suprimirá"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "No se pudo registrar el orden \"callback\": El búfer o la ventana ya se \n"
+#~ "eliminó"
+
+# This should never happen.  Famous last word?
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ERROR FATAL DE TCL: ¿¡\"reflist\" dañada!? Por favor, informe de \n"
+#~ "esto a vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "No se pudo registrar la orden de retorno de llamada: No se pudo "
+#~ "encontrar\n"
+#~ "la referencia al búfer o la ventana"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Lo siento, esta orden está desactivada pues no se pudo\n"
+#~ "cargar la biblioteca de Tcl"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: ERROR DE TCL: ¿¡el código de salida no es \"int\"!? Por favor\n"
+#~ "informe a vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: código de salida %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "No puedo obtener la línea"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Incapaz de registrar un nombre de servidor de órdenes"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: No pude enviar la orden al programa de destino"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: El ID de usuario no es válido en el servidor: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: La propiedad de registro de VIM es incorrecta. ¡Eliminada!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Este Vim no se ha compilado con la opción \"diff\""
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' no se puede usar: no se ha activado al compilar\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Error: Imposible iniciar gvim para NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Cuando mayúscula y minúscula son ignoradas añada \"/\" para \n"
+#~ "cambiar la marca (\"flag\") a mayúscula"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistrar este \"gvim\" para \"OLE\""
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tSuprimir el registro de \"gvim\" para \"OLE\""
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tEjecutar usando el GUI (como \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  o  --nofork\tPrimer plano: No separarse (\"fork\") cuando se\n"
+#~ "                      \tinicia la interfaz gráfica (GUI)"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNo usar \"newcli\" para abrir ventanas"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <dispositivo>\t\tUsar <dispositivo> para I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tUsar <gvimrc> en lugar de otro \".gvimrc\""
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEditar archivos cifrados"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <pantalla>\tConectar vim a este servidor X en particular"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tEvitar la conexión al servidor X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <archivos>\tEditar <archivos> en un servidor Vim si es posible"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent \"archivos\"\tLo mismo pero no se queja si no existe un\n"
+#~ "                                   \tservidor disponible"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait \"archivos\"\tComo --remote pero espera a que los archivos\n"
+#~ "                                 \tterminen de editarse"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent \"archivos\"\tLo mismo pero no se queja si no hay "
+#~ "un\n"
+#~ "                                        \tservidor disponible"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <archivos>  Como \"--remote\" pero usa una "
+#~ "pestaña por página"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <teclas>\tEnvíar <teclas> a un servidor Vim y cerrar"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <expr>\tEvaluar <expr> en un servidor Vim e imprimir el "
+#~ "resultado"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr ""
+#~ "--serverlist\t\tEmitir una lista de los servidores Vim disponibles y "
+#~ "cerrar"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr ""
+#~ "--servername \"nombre\"\tEnvíar a/se convierte en el servidor Vim con "
+#~ "<nombre>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconocidos por gvim (versión Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconocidos por gvim (versión neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconocidos por gvim (versión Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <pantalla>\tEjecuta vim en <pantalla>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tArranca vim \"iconizado\""
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <nombre>\t\tUsa un recurso como si vim fuese <nombre>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Sin implementar)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\tUsa <color> para el fondo (también: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <color>\tUsa <color> para el texto normal (también: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <tipo>\t\tUse <tipo de letra de impresión> para el texto normal\n"
+#~ "(también: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr ""
+#~ "-boldfont <tipo>\tUsa <tipo de letra de impresión> para texto en\n"
+#~ "negrita"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr ""
+#~ "-italicfont <tipo>\tUse <tipo de letra de impresión> para texto\n"
+#~ "en cursiva"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tUse <geom> para la geometría inicial (también: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <ancho>\tUsa un ancho de borde de <ancho> (también: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <ancho>\tUsa una barra de desplazamiento de ancho "
+#~ "<ancho>\n"
+#~ "                              \t(también: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <alt>\tUsa una barra de menú de altura <alt> (también: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tUsar vídeo inverso (también: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNo usar vídeo inverso (también: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <recurso>\tEstablece el recurso especificado"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconocidos por gvim (versión para RISC OS):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <número>\tAnchura inicial de la ventana, en columnas"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <número>\tAltura inicial de la ventana, en filas"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconocidos por gvim (versión GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <pantalla>\tEjecuta vim en <pantalla> (también: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <role>\tDefine un rol único para identificar la ventana principal"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tAbre a Vim dentro de otro \"widget\" GTK"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr ""
+#~ "-P <título ventana padre>\tAbrir a Vim dentro de la aplicación padre"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tAbrir Vim dentro de otro objeto de win32"
+
+#~ msgid "No display"
+#~ msgstr "No hay una ventana"
+
+# Failed to send, abort.
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Falló el envío.\n"
+
+# Let vim start normally.
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ""
+#~ ": Falló el inicio de sesión remota (\"send\"). Intentado una\n"
+#~ "ejecución local\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d de %d editados"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "No hay una ventana en el destino: El envío de la expresión falló.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Falló el envío de la expresión.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: No es una página de código válida"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Falló la creación del contexto de entrada"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Falló la apertura del método de entrada"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Advertencia: No pude crear una llamada de retorno\n"
+#~ "de destrucción al IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: el método de entrada no admite ningún estilo"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: El método de entrada no soporta mi tipo de pre-edición"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr ""
+#~ "E290: El estilo \"sobre el punto\" requiere del uso de un \"fontset\""
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr ""
+#~ "E291: Su versión de GTK+ es anterior a 1.2.3. Área de estado\n"
+#~ "desactivada"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: El servidor de método de entrada (IME) no está funcionando"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [no se puede usar con esta versión de Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Desprender y flotar este menú"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Diálogo: Selección de directorio"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Diálogo: Guardar Archivos"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Diálogo: Abrir Archivos"
+
+# TODO: non-GUI file selector here
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Lo siento, no hay navegador de archivos en el modo de consola"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: preservando archivos...\n"
+
+# close all memfiles, without deleting
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Finalizado.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ERROR: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] total liberados por alloc: %<PRIu64>-%<PRIu64>, en uso: "
+#~ "%<PRIu64>, uso máximo: %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[llamadas] total re/malloc(): %<PRIu64>, total free(): %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: La línea se está haciendo demasiado larga"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Error interno: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: El \"mouseshape\" no es válido"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Introduzca la clave de cifrado: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Introduzca la misma clave de cifrado otra vez: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "¡Las claves de cifrado no coinciden!"
+
+# Get here when the server can't be found.
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "No se pudo conectar a NetBeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "No se pudo conectar a NetBeans"
+
+# c-format
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: El dueño/a del archivo de conexión NetBeans no es válido: %s"
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "leído del socket NetBeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Se perdió la conexión NetBeans para el búfer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: La característica \"eval\" no está disponible"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "liberando %<PRId64> líneas"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: No se pudo cambiar \"term\" en la interfaz gráfica"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Use \":gui\" para iniciar la interfaz gráfica"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: No puede cambiarse en la interfaz gráfica de GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Las fuente/s de impresión no son válidas"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: No se pudo seleccionar ese \"fontset\""
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: El conjunto de tipos de letra de impresión no es válido"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr ""
+#~ "E533: No se pudo seleccionar el tipo de letra de impresión \"ancho\" (de "
+#~ "\"byte\" doble)"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Tipo de letra de impresión \"ancho\" inválida"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: No hay soporte para el ratón"
+
+#~ msgid "cannot open "
+#~ msgstr "No se pudo abrir"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: ¡No se pudo abrir la ventana!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Necesito Amigados 2.04 o una versión posterior\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Necesito %s versión %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "No se pudo abrir NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "No se pudo crear "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Saliendo de Vim con %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "¡¿No se pudo cambiar el modo de la consola?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "\"mch_get_shellsize\": ¿No es una consola?\n"
+
+# if Vim opened a window: Executing a shell may cause crashes
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: No se pudo ejecutar el intérprete de órdenes con la opción -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "No se puede ejecutar "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " devolvió\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "\"ANCHOR_BUF_SIZE\" demasiado pequeño."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ERROR I/O"
+
+#~ msgid "Message"
+#~ msgstr "Mensaje"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "\"columns\" no es 80, no puede ejecutar órdenes externas"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Falló la selección de impresora"
+
+#~ msgid "to %s on %s"
+#~ msgstr "para %s en %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Tipo de letra de impresión desconocida en la impresora: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Error de impresión: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Imprimiendo %s"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: El nombre del conjunto de caracteres \"%s\" no es válido en el\n"
+#~ "nombre del tipo de letra de impresión \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr ""
+#~ "E245: Carácter '%c' ilegal en el nombre del tipo de letra de\n"
+#~ "impresión %s"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Señal doble, saliendo\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Capté una señal mortal %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Capté una señal mortal\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Abrir la pantalla X tomó %<PRId64> mseg"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Hay un error de X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Falló la prueba del sistema X"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "El \"display\" de X tardó demasiado en abrirse"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "No se pudo ejecutar el intérprete de órdenes \"sh\"\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "No se pudo crear \"pipes\"\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "No se pudo crear proceso secundario \"fork\"\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "La orden fue terminada\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP perdió la conexión ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Falló la apertura de la pantalla de X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP está manejando una solicitud de \"guardelo usted mismo\""
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP está abriendo una conexión"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP Falló el supervisión de la conexión ICE"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection falló: %s"
+
+#~ msgid "At line"
+#~ msgstr "En la línea"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "¡No se pudo cargar \"vim32.dll\"!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Error de Vim"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "¡No se pudo conectar los punteros de la función a la DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "El intérprete de órdenes ha devuelto %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Capté el evento %s\n"
+
+#~ msgid "close"
+#~ msgstr "cerrar"
+
+#~ msgid "logoff"
+#~ msgstr "cerrar la sesión"
+
+#~ msgid "shutdown"
+#~ msgstr "apagar"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: No se encontró la orden"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE no se encuentra en su $PATH.\n"
+#~ "Las órdenes externas no harán una pausa al finalizar.\n"
+#~ "Véase \":help win32-vimrun\"  para más información"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Advertencia de Vim"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "La conversión a %s no es posible en esta versión"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: el argumento \"containedin\" no se acepta aquí"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: La ruta del archivo de etiquetas %s está truncada\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "Iniciado nuevo intérprete de órdenes\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Se ha usado \"CUT_BUFFER0\" en vez de una selección vacía"
+
+# must display the prompt
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "No es posible deshacer; continuando de todos modos"
+
+#~ msgid "number changes  time"
+#~ msgstr "el número modifica el tiempo"
+
+# Only MS VC 4.1 and earlier can do Win32s
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de interfaz gráfica de 16/32 bits para MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de interfaz gráfica de 64 bits para MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de interfaz gráfica de 32 bits para MS-Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " en modo Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " con compatibilidad con OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de 64 bits para consola de MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de 32 bits para consola de MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de 16 bits para MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de 32 bits para MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión de 16 bits para MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión para X (Unix) para MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión para MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión para MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión para RISC OS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versión para OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versión \"grande\" "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versión \"normal\" "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versión \"pequeña\" "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versión \"diminuta\" "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "con interfaz gráfica para GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "con interfaz gráfica para GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "con interfaz gráfica de GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "con interfaz gráfica de GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "con interfaz gráfica para X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "con interfaz gráfica de X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "con interfaz gráfica de X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "con interfaz gráfica para Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "con interfaz gráfica de usuario."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "con GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "con interfaz gráfica para Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "con interfaz gráfica (clásica)."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "    archivo \"gvimrc\" del sistema: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    archivo \"gvimrc\" del usuario: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr " 2º archivo \"gvimrc\" del usuario: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3er archivo \"gvimrc\" del usuario: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "     archivo de menú del sistema: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Compilador: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menú  Ayuda->Ayude a los niños huérfanos      para más información "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Ejecución no modal, el texto escrito se inserta directamente"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr ""
+#~ "menú Editar->Opciones globales->Activar/Desactivar modo de inserción"
+
+#~ msgid "                              for two modes      "
+#~ msgstr ""
+#~ "                                                 para dos modos     "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr ""
+#~ "menú Editar->Opciones globales->Activar/Desactivar compatibilidad con Vi"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr ""
+#~ "                                 para los valores predeterminados de Vim"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ADVERTENCIA: se ha detectado Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "escriba «:help windows95<Intro>» para más información"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: No se pudo cargar la biblioteca dinámica %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Esta orden está desactivada, no se pudo cargar la biblioteca de Perl"
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: No se permite la evaluación de código Perl en la caja de\n"
+#~ "arena sin el uso del módulo \"Safe\""
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Editar con &múltiples Vims"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Editar con un solo &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diff con Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Editar con &Vim"
 
 # Now concatenate
-#. Now concatenate
-#: GvimExt/gvimext.cpp:637
-msgid "Edit with existing Vim - "
-msgstr "Editar con un Vim en ejecución -"
-
-#: GvimExt/gvimext.cpp:752
-msgid "Edits the selected file(s) with Vim"
-msgstr "Editar el(los) archivos seleccionado/s con Vim"
-
-#: GvimExt/gvimext.cpp:891 GvimExt/gvimext.cpp:972
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr ""
-"Error al crear el proceso: ¡Asegúrese de que gvim esta en su ruta de acceso!"
-
-#: GvimExt/gvimext.cpp:892 GvimExt/gvimext.cpp:906 GvimExt/gvimext.cpp:973
-msgid "gvimext.dll error"
-msgstr "error de \"gvimext.dll\""
-
-#: GvimExt/gvimext.cpp:905
-msgid "Path length too long!"
-msgstr "¡La ruta de acceso es demasiado larga!"
-
-#: globals.h:1174
-msgid "--No lines in buffer--"
-msgstr "--No hay líneas en el búfer--"
-
-#
-# * The error messages that can be shared are included here.
-# * Excluded are errors that are only used once and debugging messages.
-#
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-#: globals.h:1374
-msgid "E470: Command aborted"
-msgstr "E470: La orden se ha interrumpido"
-
-#: globals.h:1375
-msgid "E471: Argument required"
-msgstr "E471: Es necesario un argumento"
-
-#: globals.h:1376
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ debería ir seguido de \"/\", \"?\" o \"&\""
-
-#: globals.h:1378
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Inválido en la ventana de la línea de órdenes: <CR> ejecuta, CTRL-C "
-"cierra"
-
-#: globals.h:1380
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Orden no permitida desde exrc/vimrc en el directorio \n"
-"en uso o al buscar etiquetas"
-
-#: globals.h:1382
-msgid "E171: Missing :endif"
-msgstr "E171: Falta \":endif\""
-
-#: globals.h:1383
-msgid "E600: Missing :endtry"
-msgstr "E600: Falta \":endtry\""
-
-#: globals.h:1384
-msgid "E170: Missing :endwhile"
-msgstr "E170: Falta \":endwhile\""
-
-#: globals.h:1385
-msgid "E170: Missing :endfor"
-msgstr "E170: Falta \":endfor\""
-
-#: globals.h:1386
-msgid "E588: :endwhile without :while"
-msgstr "E588: \":endwhile\" sin \":while\""
-
-#: globals.h:1387
-msgid "E588: :endfor without :for"
-msgstr "E588: \":endfor\" sin un \":for\""
-
-#: globals.h:1389
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: El archivo ya existe (use \"!\" para sobreescribir)"
-
-#: globals.h:1390
-msgid "E472: Command failed"
-msgstr "E472: La orden falló"
-
-#: globals.h:1392
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Conjunto de tipos de letra de impresión desconocido: %s"
-
-#: globals.h:1396
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Tipo de letra de impresión desconocida: %s"
-
-#: globals.h:1399
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: El tipo de letra de impresión \"%s\" no es de ancho fijo"
-
-#: globals.h:1401
-msgid "E473: Internal error"
-msgstr "E473: Error interno"
-
-#: globals.h:1402
-msgid "Interrupted"
-msgstr "Interrumpido"
-
-#: globals.h:1403
-msgid "E14: Invalid address"
-msgstr "E14: La dirección no es válida"
-
-#: globals.h:1404
-msgid "E474: Invalid argument"
-msgstr "E474: El argumento no es válido"
-
-#: globals.h:1405
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: El argumento no es válido: %s"
-
-#: globals.h:1407
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: La expresión no es válida: %s"
-
-#: globals.h:1409
-msgid "E16: Invalid range"
-msgstr "E16: El rango no es válido"
-
-#: globals.h:1410
-msgid "E476: Invalid command"
-msgstr "E476: La orden no es válida"
-
-#: globals.h:1412
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" es un directorio"
-
-#: globals.h:1415
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Falló la llamada a la biblioteca para \"%s()\""
-
-#: globals.h:1421
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: No pude cargar la biblioteca de funciones %s"
-
-#: globals.h:1423
-msgid "E19: Mark has invalid line number"
-msgstr "E19: El número de línea de la marca no es válido"
-
-#: globals.h:1424
-msgid "E20: Mark not set"
-msgstr "E20: No se ha colocado una marca"
-
-#: globals.h:1425
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: No se pudo modificar, 'modifiable' está desactivado"
-
-#: globals.h:1426
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Demasiados archivos de órdenes anidados"
-
-#: globals.h:1427
-msgid "E23: No alternate file"
-msgstr "E23: No hay un archivo alterno"
-
-#: globals.h:1428
-msgid "E24: No such abbreviation"
-msgstr "E24: No existe esa abreviatura"
-
-#: globals.h:1429
-msgid "E477: No ! allowed"
-msgstr "E477: \"!\" no está permitido"
-
-#: globals.h:1431
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr ""
-"E25: No se puede usar la interfaz gráfica de usuario: No se activó al "
-"compilar"
-
-#: globals.h:1434
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: No se pudo usar el hebreo: no se activó al compilar\n"
-
-#: globals.h:1437
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: No se pudo usar el persa (farsi): no se activó al compilar\n"
-
-#: globals.h:1440
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: No se pudo usar el árabe: no se activó al compilar\n"
-
-#: globals.h:1443
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: No existe un grupo de resaltado de nombre: %s"
-
-#: globals.h:1445
-msgid "E29: No inserted text yet"
-msgstr "E29: Aún no ha insertado texto"
-
-#: globals.h:1446
-msgid "E30: No previous command line"
-msgstr "E30: No hay una línea de órdenes previa"
-
-#: globals.h:1447
-msgid "E31: No such mapping"
-msgstr "E31: No existe tal asociación"
-
-#: globals.h:1448
-msgid "E479: No match"
-msgstr "E479: No hay coincidencia"
-
-#: globals.h:1449
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: No coincide: %s"
-
-#: globals.h:1450
-msgid "E32: No file name"
-msgstr "E32: No hay un nombre de archivo"
-
-#: globals.h:1451
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: No existe una expresión regular de sustitución previa"
-
-#: globals.h:1452
-msgid "E34: No previous command"
-msgstr "E34: No existe una orden previa"
-
-#: globals.h:1453
-msgid "E35: No previous regular expression"
-msgstr "E35: No existe una expresión regular previa"
-
-#: globals.h:1454
-msgid "E481: No range allowed"
-msgstr "E481: El rango no está permitido"
-
-#: globals.h:1456
-msgid "E36: Not enough room"
-msgstr "E36: No hay espacio suficiente"
-
-#: globals.h:1459
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: El servidor llamado \"%s\" no está registrado"
-
-#: globals.h:1461
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: No se pudo crear el archivo \"%s\""
-
-#: globals.h:1462
-msgid "E483: Can't get temp file name"
-msgstr "E483: No se pudo obtener el nombre del archivo temporal"
-
-#: globals.h:1463
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: No se pudo abrir el archivo \"%s\""
-
-#: globals.h:1464
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: No se pudo leer el archivo \"%s\""
-
-#: globals.h:1465
-msgid "E37: No write since last change (add ! to override)"
-msgstr ""
-"E37: No guardó el archivo desde el último cambio (añada \"!\" para forzar)"
-
-#: globals.h:1466
-msgid "E38: Null argument"
-msgstr "E38: Argumento nulo"
-
-#: globals.h:1468
-msgid "E39: Number expected"
-msgstr "E39: Se esperaba un número"
-
-#: globals.h:1471
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: No se pudo abrir el archivo de errores \"%s\""
-
-#: globals.h:1474
-msgid "E233: cannot open display"
-msgstr "E233: No se pudo abrir la pantalla"
-
-#: globals.h:1476
-msgid "E41: Out of memory!"
-msgstr "E41: ¡Memoria agotada!"
-
-#: globals.h:1478
-msgid "Pattern not found"
-msgstr "No se encontró el patrón de búsqueda"
-
-#: globals.h:1480
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: No se encontró el patrón de búsqueda: %s"
-
-#: globals.h:1481
-msgid "E487: Argument must be positive"
-msgstr "E487: El argumento debe ser positivo"
-
-#: globals.h:1483
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: No se pudo regresar al directorio previo"
-
-#: globals.h:1487
-msgid "E42: No Errors"
-msgstr "E42: No hay errores"
-
-#: globals.h:1488
-msgid "E776: No location list"
-msgstr "E776: No hay una lista de posiciones"
-
-#: globals.h:1490
-msgid "E43: Damaged match string"
-msgstr "E43: Cadena de coincidencia dañada"
-
-#: globals.h:1491
-msgid "E44: Corrupted regexp program"
-msgstr "E44: El programa \"regexp\" está corrupto"
-
-#: globals.h:1492
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: La opción 'readonly' está activada (añada \"!\" para forzar)"
-
-#: globals.h:1494
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: No puede cambiar la variable de solo lectura \"%s\""
-
-#: globals.h:1495
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: No se puede definir la variable en el \"sandbox\": \"%s\""
-
-#: globals.h:1498
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Error al leer el archivo de errores"
-
-#: globals.h:1501
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: No se permite en el ambiente protegido"
-
-#: globals.h:1503
-msgid "E523: Not allowed here"
-msgstr "E523: No se permite aquí"
-
-#: globals.h:1506
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: La configuración de la pantalla no es válida"
-
-#: globals.h:1508
-msgid "E49: Invalid scroll size"
-msgstr "E49: La longitud de desplazamiento no es válida"
-
-#: globals.h:1509
-msgid "E91: 'shell' option is empty"
-msgstr "E91: La opción 'shell' (intérprete de órdenes) está vacía"
-
-#: globals.h:1511
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: ¡No se pudo cargar los signos!"
-
-#: globals.h:1513
-msgid "E72: Close error on swap file"
-msgstr "E72: Error de cierre en el archivo de intercambio"
-
-#: globals.h:1514
-msgid "E73: tag stack empty"
-msgstr "E73: La pila de etiquetas ('tagstack') está vacía"
-
-#: globals.h:1515
-msgid "E74: Command too complex"
-msgstr "E74: La orden es demasiado compleja"
-
-#: globals.h:1516
-msgid "E75: Name too long"
-msgstr "E75: El nombre es demasiado largo"
-
-#: globals.h:1517
-msgid "E76: Too many ["
-msgstr "E76: Hay demasiados ["
-
-#: globals.h:1518
-msgid "E77: Too many file names"
-msgstr "E77: Hay demasiados nombres de archivos"
-
-#: globals.h:1519
-msgid "E488: Trailing characters"
-msgstr "E488: Caracteres en exceso al final de la línea"
-
-#: globals.h:1520
-msgid "E78: Unknown mark"
-msgstr "E78: Marca desconocida"
-
-#: globals.h:1521
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: No se pudo expandir los comodines"
-
-#: globals.h:1523
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: \"winheight\" no puede ser más pequeño que \"winminheight\""
-
-#: globals.h:1525
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: \"winwidth\" no puede ser más pequeño que \"winminwidth\""
-
-#: globals.h:1528
-msgid "E80: Error while writing"
-msgstr "E80: Error al escribir el archivo"
-
-#: globals.h:1529
-msgid "Zero count"
-msgstr "El recuento es cero"
-
-#: globals.h:1531
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Usando <SID> en un contexto que no es de archivo de órdenes"
-
-#: globals.h:1534
-msgid "E449: Invalid expression received"
-msgstr "E449: Se recibió una expresión inválida"
-
-#: globals.h:1537
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: La región está protegida, no se puede modificar"
-
-#: globals.h:1538
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans no permite cambios a archivos de sólo lectura"
-
-#: globals.h:1540
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Error interno: %s"
-
-#: globals.h:1541
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: El patrón usa más memoria que 'maxmempattern'"
-
-#: globals.h:1542
-msgid "E749: empty buffer"
-msgstr "E749: Búfer vacío"
-
-#: globals.h:1545
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Patrón de búsqueda o delimitador no válido"
-
-# Overwriting a file that is loaded in another buffer is not a
-# * good idea.
-#: globals.h:1547
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: El archivo ya se ha cargado en otro búfer"
-
-#: globals.h:1550
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: No se ha definido la opción '%s'"
-
-#: globals.h:1557
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "La búsqueda ha llegado al PRINCIPIO, continuando desde el FINAL"
-
-#: globals.h:1558
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "La búsqueda ha llegado al FINAL, continuando desde el PRINCIPIO"
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Editar con un Vim en ejecución -"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Editar el(los) archivos seleccionado/s con Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr ""
+#~ "Error al crear el proceso: ¡Asegúrese de que gvim esta en su ruta de "
+#~ "acceso!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "error de \"gvimext.dll\""
+
+#~ msgid "Path length too long!"
+#~ msgstr "¡La ruta de acceso es demasiado larga!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Conjunto de tipos de letra de impresión desconocido: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Tipo de letra de impresión desconocida: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: El tipo de letra de impresión \"%s\" no es de ancho fijo"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: No pude cargar la biblioteca de funciones %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: No se pudo usar el hebreo: no se activó al compilar\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: No se pudo usar el persa (farsi): no se activó al compilar\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: No se pudo usar el árabe: no se activó al compilar\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: El servidor llamado \"%s\" no está registrado"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: No se pudo abrir la pantalla"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Se recibió una expresión inválida"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: La región está protegida, no se puede modificar"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans no permite cambios a archivos de sólo lectura"
 
 #~ msgid "[NL found]"
 #~ msgstr "[NL encontrado]"

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -18,171 +18,218 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-08-09 02:00+0300\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-08-09 02:35+0300\n"
 "Last-Translator: Flammie Pirinen <flammie@iki.fi>\n"
 "Language-Team: Finnish <laatu@lokalisointi.org>\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() tyhjällä salasanalla"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Roskaa argumentin perässä"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfishin tavujärjestys väärä"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256-testi epäonnistui failed"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish-testi epäonnistui"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Sijaintiluettelo]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Pikakorjausluettelo]"
 
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: Autocommands muutti puskurin tai sen nimen"
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Mitään puskuria ei voitu varata, lopetetaan..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Puskuria ei voitu varata, käytetään toista..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Puskureita ei vapautettu"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Puskureita ei poistettu"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Puskureita ei pyyhitty"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 puskuri vapautettiin"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d puskuria vapautettiin"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 puskuri poistettu"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d puskuria poistettu"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 puskuri pyyhitty"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d puskuria pyyhitty"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Ei voi vapauttaa viimeistä puskuria"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Ei muokattuja puskureita"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Luetteloitua puskuria ei ole"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Puskuria %<PRId64> ei ole"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Viimeisen puskurin ohi ei voi edetä"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ensimmäisen puskurin ohi ei voi edetä"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
 "E89: Puskurin %<PRId64> muutoksia ei ole tallennettu (lisää komentoon ! "
 "ohittaaksesi)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Ei voi vapauttaa viimeistä puskuria"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varoitus: Tiedostonimiluettelon ylivuoto"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Puskuria %<PRId64> ei löydy"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s täsmää useampaan kuin yhteen puskuriin"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: %s ei täsmää yhteenkään puskuriin"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "rivi %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Samanniminen puskuri on jo olemassa"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Muokattu]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Muokkaamaton]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Uusi tiedosto]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Lukuvirheitä]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[Luku]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[kirjoitussuojattu]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 rivi --%d %%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> riviä --%d %%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "rivi %<PRId64>/%<PRId64> --%d %%-- sarake "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Nimetön]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ohje"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Ohje]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Esikatselu]"
 
 # sijainti tiedostossa -indikaattoreja:
 # 4 merkkiä sais riittää
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Kaik"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Loppu"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Alku"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -190,9 +237,11 @@ msgstr ""
 "\n"
 "# Puskuriluettelo:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Raapust]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -200,137 +249,200 @@ msgstr ""
 "\n"
 "--- Merkit ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Merkit kohteelle %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    rivi=%<PRId64>  id=%d  nimi=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Kaksoispiste puuttuu"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Virheellinen tila"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: pitää olla numero"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Virheellinen prosenttiluku"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Ei voi diffata enempää kuin %<PRId64> puskuria"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Ei voi lukea tai kirjoittaa väliaikaistiedostoja"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Ei voi luoda diffejä"
 
-msgid "Patch file"
-msgstr "Patch-tiedosto"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Ei voi lukea patchin tulostetta"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Ei voi lukea diffin tulostetta"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Tämä puskuri ei ole diff-tilassa"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Yksikään muu diff-tilan puskurit ei ole muokattavissa"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Yksikään muu puskuri ei ole diff-tilassa"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Monta puskuria on diff-tilassa, käytettävän valinta ei onnistu"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Puskuria %s ei löydy"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Puskuri %s ei ole diff-tilassa"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Puskuri vaihtui odottamatta"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escapea ei voi käyttää digraafissa"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Näppäinkarttaa ei löydy"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Käytetään :loadkeymapia ladatun tiedoston ulkopuolella"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Tyhjä keymap-kenttä"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Avainsanatäydennys (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X-tila (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Täysrivitäydennys (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Tiedostonimitäydennys (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Tägitäydennys (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Polkukuviotäydennys (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Määritelmätäydennys (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Sanakirjatäydennys (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus-täydennys (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Komentorivitäydennys (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Käyttäjän määrittelemä täydennys (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omnitäydennys (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Oikaisulukuehdotus (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Avainsanan paikallinen täydennys (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Kappaleen loppu tuli vastaan"
 
+#: ../edit.c:101
+#, fuzzy
+msgid "E839: Completion function changed window"
+msgstr "E813: Ei voi sulkea autocmd-ikkunaa"
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "dictionary-asetus on tyhjä"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "thesaurus-asetus on tyhjä"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Luetaan sanakirjaa: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (syöttö) Vieritys (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (korvaus) Vieritys (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Luetaan: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Luetaan tägejä."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Lisätään"
 
@@ -338,429 +450,586 @@ msgstr " Lisätään"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Haetaan..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Takaisin lähtöpisteessä"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Sana toisella rivillä"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Ainoa täsmäys"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "täsmäys %d/%d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "täsmäys %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Odottamattomia merkkejä komennossa :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Indeksi %<PRId64> luettelon rajojen ulkopuolella"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Määrittelemätön muuttuja: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ] puuttuu"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argumentin %s pitää olla lista"
 
 # datarakenteita
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argumentin %s pitää olla lista tai sanakirja"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Sanakirjassa ei voi olla tyhjiä avaimia"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Lista tarvitaan"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Sanakirja tarvitaan"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Liikaa argumentteja funktiolle: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Avainta %s ei ole sanakirjassa"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funktio %s on jo olemassa, lisää ! korvataksesi"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Sanakirja-alkio on jo olemassa"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref tarvitaan"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Sanakirjassa ei voi käyttää merkintää [:]"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Väärä muuttujatyyppi muuttujalle %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Tuntematon funktio: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Virheellinen muuttujanimi: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Float ei käy merkkijonosta"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Kohteita on vähemmän kuin listan alkioita"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Kohteita on enemmän kuin listan alkioita"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Kaksi ;:ttä listan muuttujissa"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Kohteen %s muuttujia ei voi listata"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Vain listalla ja sanakirjalla voi olla indeksejä"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:]:n pitää olla viimeisenä"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] toimii vain listalla"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Listalla on enemmän alkioita kuin kohteella"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Listalla ei ole tarpeeksi alkioita"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for-kommenolta puuttuu in"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Sulkeita puuttuu: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Muuttujaa %s ei ole"
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: muuttujassa liian monta tasoa lukituksen käsittelyyn"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: ?:n jälkeen puuttuu :"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Listaa voi verrata vain listaan"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Virheellinen toiminto listalle"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Sanakirjaa voi verrata vain sanakirjaan"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Virheellinen toiminto sanakirjalle"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcrefiä voi verrata vain funcrefiin"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Virheellinen toiminto funcrefille"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Ei voi käyttää '%':a Floatin kanssa"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ) puuttuu"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Funcrefiä ei voi indeksoida"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Asetuksen nimi puuttuu: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Tuntematon asetus: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Puuttuva lainausmerkki: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Puuttuva lainausmerkki: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Listasta puuttuu pilkku: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Listan lopusta puuttuu ]: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Sanakirjasta puuttuu kaksoispiste: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Kaksi samaa avainta sanakirjassa: %s"
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Sanakirjasta puuttuu pilkku: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Sanakirjan lopusta puuttuu }: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: muuttuja on upotettu liian syvälle näytettäväksi"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Liikaa argumentteja funktiolle %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Vääriä argumentteja funktiolle %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Tuntematon funktio: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Liikaa argumentteja funktiolle %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> skriptin ulkopuolella: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: dict-funktio ilman sanakirjaa: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Number tai Float vaaditaan"
 
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c-argumentti"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Liikaa argumentteja"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() toimii vain syöttötilassa"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Avain on jo olemassa: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd-argumentti"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c-argumentti"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c-argumentti"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld riviä: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Tuntematon funktio: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Peru"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() suoritettu useammin kuin inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c-argumentti"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Aluetta ei voi käyttää"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Virheellinen tyyppi funktiolle len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Stride on nolla"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Alku on lopun jälkeen"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<tyhjä>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Ei yhteyttä vim-palvelimeen"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd-argumentti"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Kohteeseen %s lähettäminen ei onnistunut"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Palvelimen vastauksen lukeminen ei onnistunut"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Liikaa symbolisia linkkejä (mahdollinen sykli)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Asiakkaalle lähetys ei onnistunut"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c-argumentti"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c-argumentti"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c-argumentti"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Lajittelun vertausfunktio ei onnistunut"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Lajittelun vertausfunktio ei onnistunut"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Virheellinen)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Väliaikaistiedostoon kirjoittaminen ei onnistunut"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float ei käy Numberista"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref ei käy Numberista"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Lista ei käy Numberista"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Sanakirja ei käy Numberista"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref ei käy merkkijonosta"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Lista ei käy merkkijonosta"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Sanakirja ei käy merkkijonosta"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Float ei käy merkkijonosta"
-
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funcrefin muuttujanimen pitää alkaa suuraakkosella: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Muuttujanimi on sama kuin olemassaolevan funktion: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Muuttujatyyppi ei täsmää: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Muuttujaa %s ei voi poistaa"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funcrefin muuttujanimen pitää alkaa suuraakkosella: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Muuttujanimi on sama kuin olemassaolevan funktion: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Arvo on lukittu: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Tuntematon"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Ei voi muuttaa muuttujan %s arvoa"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: muuttuja on upotettu liian syvälle kopioitavaksi"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Tuntematon funktio: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: ( puuttuu: %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Ei voi asettaa IC-arvoja"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Virheellinen argumentti: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "Kaksoiskappale kentän nimestä: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction puuttuu"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Funktion nimi on ristiriidassa muuttujan kanssa: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Funktiota %s ei voi määritellä uudestaan, koska se on käytössä"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Funktion nimi ei ole sama kuin skriptin tiedostonnimi: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Funktion nimi puuttuu"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Funktion nimen pitää alkaa suuraakkosella tai sisältää kaksoispisteen: "
 "%s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Funktion nimen pitää alkaa suuraakkosella tai sisältää kaksoispisteen: "
+"%s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Funktiota %s ei voi poistaa"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Funktiokutsujen syvyys on enemmän kuin maxfuncdepth"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "kutsutaan funktiota %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s keskeytettiin"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s palaa kohdassa #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s palaa kohdassa %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "jatkaa kohdassa %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return ei ole funktion sisällä"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -768,6 +1037,7 @@ msgstr ""
 "\n"
 "# globaalit muuttujat:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -775,214 +1045,105 @@ msgstr ""
 "\n"
 "\tViimeksi asetettu kohteesta "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Ei vanhoja tiedostoja"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Siirrytään vianetsintätilaan, kirjoita cont jatkaaksesi."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "rivi %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "kmnt: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Katkaisukohta %s%s rivillä %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Katkaisukohta puuttuu: %s"
-
-msgid "No breakpoints defined"
-msgstr "Ei katkaisukohtia"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  rivi %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Aloita käskyllä :profile start {fname}"
-
-msgid "Save As"
-msgstr "Tallenna nimellä"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Tallennetaanko muutokset tiedostoon %s?"
-
-msgid "Untitled"
-msgstr "Nimetön"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Muutoksia ei ole kirjoitettu puskurin %s viime muutoksen jälkeen"
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Varoitus: Puskuri vaihtui odottamatta (tarkista autocommands)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Vain yksi tiedosto muokattavana"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Ensimmäisen tiedoston ohi ei voi mennä"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Viimeisen tiedoston ohi ei voi mennä"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: kääntäjää ei tueta: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Etsitään ilmausta %s kohteesta %s"
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Etsitään ilmausta %s"
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "ei löydy runtimepathista: %s"
-
-msgid "Source Vim script"
-msgstr "Lataa vim-skripti"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Hakemistoa ei voi ladata: %s"
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "ei voitu ladata %s"
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "rivi %<PRId64>: ei voitu ladata %s"
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "ladataan %s"
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "rivi %<PRId64>: ladataan %s"
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "ladattu %s"
-
-msgid "modeline"
-msgstr "mode-rivi"
-
-msgid "--cmd argument"
-msgstr "--cmd-argumentti"
-
-msgid "-c argument"
-msgstr "-c-argumentti"
-
-msgid "environment variable"
-msgstr "ympäristömuuttuja"
-
-msgid "error handler"
-msgstr "virhekäsittelin"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Varoitus: Väärä rivierotin, ^M saattaa puuttua"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: :scriptencoding ladatun tiedoston ulkopuolella"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: :finish ladatun tiedoston ulkopuolella"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Käytössä oleva %skieli: %s"
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Kieleksi ei voitu asettaa kieltä %s"
-
 # puhutaan merkin ulkoasusta snprintf(..., c, c, c, c)
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d, heksana %02x, oktaalina %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, heksana %04x, oktaalina %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, hekdana %08x, oktaalina %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Rivien siirto itsejensä päälle"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 rivi siirretty"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> riviä siirretty"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> riviä suodatettu"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-autocommand ei voi vaihtaa puskuria"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Viimeisintä muutosta ei ole kirjoitettu]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s rivillä: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: liikaa virheitä, ohitetaan lopputiedosto"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Luetaan viminfo-tiedostoa \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " merkit"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " vanhaatiedostoa"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " EPÄONNISTUI"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo-tiedostoon ei voitu kirjoittaa: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Viminfo-tiedoston kirjoittaminen ei onnistu %s"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Kirjoitetaan viminfo-tiedostoa %s"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Vimin %s generoima viminfo-tiedosto.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -990,39 +1151,48 @@ msgstr ""
 "# Muokkaa varovasti!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# encoding-muuttujan arvo tiedostoa kirjoitettaessa\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Virheellinen aloitusmerkki"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Kirjoita osittainen tiedosto"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Käytä !-komentoa osittaisen puskurin kirjoittamiseen"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Ylikirjoitetaanko olemassaoleva tiedosto %s?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Swap-tiedosto %s on olemassa, ylikirjoitetaanko?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Swap-tiedosto on jo olemassa: %s (komento :silent! ohittaa)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Ei tiedostonimeä puskurille %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr ""
 "E142: Tiedostoa ei kirjoitettu; write-asetus poistaa kirjoituksen käytöstä"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1031,6 +1201,7 @@ msgstr ""
 "readonly asetettu tiedostolle \"%s\".\n"
 "Kirjoitetaanko?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1041,65 +1212,83 @@ msgstr ""
 "Siihen saattaa voida silti kirjoittaa.\n"
 "Yritetäänkö?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: %s on kirjoitussuojattu (lisää komentoon ! ohittaaksesi)"
 
-msgid "Edit File"
-msgstr "Muokkaa tiedostoa"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autocommand poisti uuden puskurin odotuksen vastaisesti %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z:n argumentti ei ole numero"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Kuoren komennot eivät toimi rvimissä"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Säännöllistä ilmausta ei voi rajata kirjaimilla"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "korvaa kohteella %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Keskeytetty)"
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 täsmäys"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 korvaus"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> täsmäystä"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> korvausta"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " 1 rivillä"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " %<PRId64> rivillä"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :globalia ei voi suorittaa rekursiivisesti"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Säännöllinen ilmaus puuttuu globaalista"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Kuvio löytyi joka riviltä: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Kuviota ei löydy"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1109,136 +1298,334 @@ msgstr ""
 "# Viimeisin korvausmerkkijono:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Älä panikoi."
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Sori, ei löydy %s-ohjetta kohteelle %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Sori, ei löydy ohjetta kohteelle %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Sori, ohjetiedostoa %s ei löydy"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Ei ole hakemisto: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Ei voi avata tiedostoa %s kirjoittamista varten"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Ei voi avata tiedostoa %s lukemista varten"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Monia ohjetiedostokoodauksia kielessä: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Kaksoiskappale tägistä %s tiedostossa %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Tuntematon merkkikomento: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Merkki puuttuu"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Liikaa merkkejä määritelty"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Virheellinen merkkiteksti: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Tuntematon merkki: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Merkin numero puuttuu"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Virheellinen puskurin nimi: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Virheellinen merkin tunnus: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (EI LÖYTYNYT)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (ei tuettu)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Poistettu]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Siirrytään vianetsintätilaan, kirjoita cont jatkaaksesi."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "rivi %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "kmnt: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Katkaisukohta %s%s rivillä %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Katkaisukohta puuttuu: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Ei katkaisukohtia"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  rivi %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Aloita käskyllä :profile start {fname}"
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Tallennetaanko muutokset tiedostoon %s?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Nimetön"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Muutoksia ei ole kirjoitettu puskurin %s viime muutoksen jälkeen"
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "Varoitus: Puskuri vaihtui odottamatta (tarkista autocommands)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Vain yksi tiedosto muokattavana"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Ensimmäisen tiedoston ohi ei voi mennä"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Viimeisen tiedoston ohi ei voi mennä"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: kääntäjää ei tueta: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Etsitään ilmausta %s kohteesta %s"
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Etsitään ilmausta %s"
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "ei löydy runtimepathista: %s"
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Hakemistoa ei voi ladata: %s"
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "ei voitu ladata %s"
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "rivi %<PRId64>: ei voitu ladata %s"
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "ladataan %s"
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "rivi %<PRId64>: ladataan %s"
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "ladattu %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "mode-rivi"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd-argumentti"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c-argumentti"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "ympäristömuuttuja"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "virhekäsittelin"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Varoitus: Väärä rivierotin, ^M saattaa puuttua"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: :scriptencoding ladatun tiedoston ulkopuolella"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: :finish ladatun tiedoston ulkopuolella"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Käytössä oleva %skieli: %s"
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Kieleksi ei voitu asettaa kieltä %s"
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Siirrytään Ex-tilaan, kirjoita visual palataksesi normaaliin tilaan."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Tiedoston lopussa"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Liian rekursiivinen komento"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Kiinniottamaton poikkeus: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Ladatun tiedoston loppu"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Funktion loppu"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Käyttäjän määrittelemän komennon monimerkityksinen käyttö"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Ei ole editorikomento"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Takaperoinen arvoalue annettu"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Takaperoinen arvoalue annettu, OK kääntää"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Käytä w:tä tai w>>:aa"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Komento ei ole käytettävissä tässä versiossa"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Vain yksi tiedostonimi sallitaan"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "vielä 1 tiedosto muokattavana, lopetaanko silti?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "vielä %d tiedostoa muokattavana, lopetetaanko silti?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: vielä 1 tiedosto muokattavana"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: vielä %<PRId64> tiedostoa muokattavana"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komento on jo olemassa, käytä !:ä korvataksesi"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1246,285 +1633,339 @@ msgstr ""
 "\n"
 "    Nimi        Arg  Arvot Valmis    Määritelmä"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Ei käyttäjän määrittelemiä komentoja"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Ei attribuutteja määriteltynä"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Väärä määrä attribuutteja"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Lukumäärää ei voi määritellä kahdesti"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Lukumäärän oletusarvo on väärä"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete vaatii argumentin"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Virheellinen attribuutti: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Virheellinen komennon nimi"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Käyttäjän määrittelemän komennon pitää alkaa suuraakkosella"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Käyttäjän määrittelemän komennon monimerkityksinen käyttö"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Käyttäjän komentoa ei ole olemassa: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Virheellinen täydennysarvo: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Täydennysargumentti sopii vain itse määriteltyyn täydennykseen"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Itse määritelty täydennys vaatii funktioargumentin"
 
-msgid "unknown"
-msgstr "tuntematon"
-
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Väriteemaa %s ei löydy"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Tervehdys, Vimin käyttäjä."
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Viimeistä välilehteä ei voi sulkea"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Vain yksi välilehti jäljellä enää"
 
-msgid "Edit File in new window"
-msgstr "Muokkaa uudessa ikkunassa"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Tabisivu %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Ei swap-tiedostoa"
 
-msgid "Append File"
-msgstr "Lisää tiedostoon"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Hakemistoa ei voida muuttaa, puskuria on muokattu (lisää komentoon ! "
 "ohittaaksesi"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Ei edellistä hakemistoa"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Tuntematon"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize vaatii kaksi numeroargumenttia"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Ikkunan sijainti: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Ikkunan sijainnin selvitys ei toimi tällä alustalla"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos vaatii kaksi lukuargumenttia"
 
-msgid "Save Redirection"
-msgstr "Tallenna uudelleenosoitus"
-
-msgid "Save View"
-msgstr "Tallenna näkymä"
-
-msgid "Save Session"
-msgstr "Tallenna sessio"
-
-msgid "Save Setup"
-msgstr "Tallenna asetukset"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: hakemistoa ei voi luoda: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: %s on jo olemassa (lisää komentoon ! ohittaaksesi)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Tiedostoa %s ei voitu avata kirjoittamista varten"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumentin eteen- tai taaksepäin lainaukseen pitää olla kirjain"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normalin liian syvä rekursio"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< ei ole käytössä jollei +eval ole päällä"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Ei vaihtoehtoista tiedostonimeä #:lle"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: ei autocommand-tiedostoa kohteelle <afile>"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: ei autocommand-puskurinumeroa kohteelle <abuf>"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: ei autocommand-täsmäysnimeä kohteella <amatch>"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: ei :source-tiedostonimeä kohteelle <sfile>"
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: ei :source-tiedostonimeä kohteelle <sfile>"
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Tyhjä tiedostonimi kohteissa % tai #  toimii vain :p:h"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Loppuarvo on tyhjä merkkijono"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Viminfoa ei voi avata lukemista varten"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Digraafeja ei ole tässä versiossa"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Vim-alkuisia poikkeuksia ei voi heittää :throw-komennolla"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Poikkeus heitetty: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Poikkeus lopeteltu: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Poikkeus poistettu: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, rivi %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Poikkeus otettu kiinni: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s odotutettu"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s palautettu"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s poistettu"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Poikkeus"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Virhe ja keskeytys"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Virhe"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Keskeytys"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: liian monta kerrosta :if-komennossa"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif ilman komentoa :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else ilman komentoa :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif ilman komentoa :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: :else monta kertaa"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif komennon :else jälkeen"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: liian monta tasoa :while- tai :for-komennoissa"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue ilman komentoa :while tai :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break ilman komentoa :while tai :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :endfor ilman komentoa :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :endwhile ilman komentoa :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: liian monta tasoa :try-komennossa"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch ilman komentoa :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch ilman komentoa :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally ilman komentoa :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: :finally monta kertaa"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry ilman komentoa :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction funktion ulkopuolella"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Puskuria ei voi muokata nyt"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Puskuria ei voi vaihtaa nyt"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "täginimi"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " -tiedostotyyppi\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "history-asetus on nolla"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1533,240 +1974,314 @@ msgstr ""
 "\n"
 "# %s Historia (uusimmasta alkaen):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Komentorivi"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Hakujono"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Ilmaus"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Syöterivi"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar komennon pituuden ulkopuolella"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktiivinen ikkuna tai puskuri poistettu"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Virheellinen polku: '**[numero]' kuuluu polun loppuun tai ennen kohtaa "
+"%s."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Hakemistoa %s ei löydy cdpathista"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Tiedostoa %s ei löydy polulta"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Hakemisto %s ei ole enää cdpathissa"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Tiedosto %s ei ole enää polulla"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autocommands muutti puskurin tai sen nimen"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Virheellinen tiedostonimi"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "on hakemisto"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "ei ole tiedosto"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "on laite (ei käytössä opendevice-asetuksen takia)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Uusi tiedosto]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[uusi HAKEMISTO]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Liian iso tiedosto]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Lupa kielletty]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr ""
 "E200: *ReadPre-autocommand-komennot tekivät tiedostosta lukukelvottoman"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre-autocommand-komennot eivät saa muuttaa puskuria"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Luetaan vakiosyötteestä...\n"
 
-msgid "Reading from stdin..."
-msgstr "Luetaan vakiosyötteestä"
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Muunnos teki tiedostosta lukukelvottoman."
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo t. soketti]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[soketti]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[merkki erikoinen]"
 
-msgid "[RO]"
-msgstr "[Luku]"
-
 # Carriage Return elikkä rivinvaihtomerkin eräs muoto/osa (vrt. LF)
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR puuttuu]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[pitkät rivit hajotettu]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[EI muunnettu]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[muunnettu]"
 
-msgid "[crypted]"
-msgstr "[salattu]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[MUUNNOSVIRHE rivillä %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[VIRHEELLINEN OKTETTI rivillä %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LUKUVIRHEITÄ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Ei voi löytää väliaikaistiedstoa muuntamiseksi"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Muunnos charconvert epäonnistui"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "charconvertin tulostetta ei voida lukea"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Tiedoston salaus on tuntematon"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Ei autocommand-komentoa acwrite-puskurille"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Autocommand-komennot poistivat tai vapauttivat puskurin, johon piti "
 "kirjoittaa"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autocommand-komento muutti rivien määrä odottamatta"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans ei salli kirjoittaa muokkaamattomiin puskureihin"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Osittaiset kirjoitukset kielletty NetBeans-puskureissa"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "ei ole tiedosto tai kirjoitettava laite"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "laitteeseen kirjoittaminen pois käytöstä opendevice-asetuksella"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "on kirjoitussuojattu (lisää komentoon ! ohittaaksesi)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Ei voi kirjoittaa varmuuskopiotiedostoon (lisää komentoon ! "
 "ohittaaksesi)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: Varmuuskopiotiedoston sulkeminen ei onnistu (lisää komentoon ! "
 "ohittaaksesi)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Varmuuskopiotiedostoa ei voi lukea (lisää komentoon ! ohittaaksesi)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Ei voi luoda varmuuskopiotiedostoa (lisää komentoon ! ohittaaksesi)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Ei voi tehdä varmuuskopiotiedostoa (lisää komentoon ! ohittaaksesi)"
 
-# tietääkseni resurssiforkki on applen tiedostojärjestelmän tunnistejuttujuttu
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: resurssiosa häviäisi (lisää komentoon ! ohittaaksesi)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Ei voi löytää väliaikaistiedostoa kirjoitettavaksi"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Muunnos ei onnistu (lisää komentoon ! kirjoittaaksesi muuntamatta)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Linkitetyn tiedoston avaus kirjoittamista varten ei onnistu"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Tiedoston avaus kirjoittamista varten ei onnistu"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync ei onnistunut"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Sulkeminen ei onnistunut"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: kirjoitusvirhe, muunnos epäonnistui (tyhjää fenc ohittaaksesi)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
-msgstr "E513: kirjoitusvirhe, muunnos epäonnistui rivillä %<PRId64>"
-"(tyhjää fenc ohittaaksesi)"
+msgstr ""
+"E513: kirjoitusvirhe, muunnos epäonnistui rivillä %<PRId64>(tyhjää fenc "
+"ohittaaksesi)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: kirjoitusvirhe (tiedostojärjestelmä täysi)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " MUUNNOSVIRHE"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " rivillä %<PRId64>"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Laite]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Uusi]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " lisätty"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " kirjoitettu"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patch-tilassa ei voi tallentaa alkuperäistiedostoa"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patch-tilassa ei voi muuttaa tyhjää alkuperäistiedostoa"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Ei voi poistaa varmuuskopiota"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1774,46 +2289,58 @@ msgstr ""
 "\n"
 "VAROITUS: Alkuperäistiedosto voi hävitä tai vahingoittua\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "älä lopeta editoria kesken tallentamisen."
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos-muoto]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac-muoto]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix-muoto]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 rivi, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> riviä, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 merkki"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> merkkiä"
 
 # ei rivinvaihtoja
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[eiriviv.]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Vajaa viimeinen rivi]"
 
@@ -1821,31 +2348,39 @@ msgstr "[Vajaa viimeinen rivi]"
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "VAROITUS: tiedosto on muuttunut viime lukukerran jälkeen!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Kirjoitetaanko"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Virhe kirjoitettaessa tiedostoon %s"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Virhe suljettaessa tiedostoa %s"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Virhe luettaessa tiedostoa %s"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell-autocommand poisti puskurin"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Tiedostoa %s ei ole enää"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1854,33 +2389,41 @@ msgstr ""
 "W12: Varoitus: Tiedostoa %s on muutettu ja Vimin puskurissa on muutoksia "
 "tiedostoon"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr ":help W12 kertoo lisätietoja."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Varoitus: Tiedostoa %s on muutettu muokkauksen aloituksen jälkeen"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr ":help W11 kertoo lisätietoja."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Varoitus: Tiedoston %s oikeuksia on muutettu muokkauksen aloituksen "
 "jälkeen"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr ":help W16 kertoo lisätietoja."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Varoitus: Tiedosto %s on luotu muokkauksen aloituksen jälkeen"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Varoitus"
 
 # yllä olevien varoitusten ratkaisut
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1888,39 +2431,48 @@ msgstr ""
 "&OK\n"
 "&Avaa tiedosto uudelleen"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Ei voitu valmistella uudelleen avausta %s"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Ei voitu uudelleenavata %s"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Poistettu--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "poistetaan autocommand automaattisesti: %s <puskuri=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Ryhmää ei ole: %s"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Virheellinen merkki *:n jälkeen: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Eventtiä ei ole: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Ryhmää tai eventtiä ei ole: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1928,532 +2480,765 @@ msgstr ""
 "\n"
 "--- Autocommandit ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <puskuri=%d>: virheellinen puskurinumero"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Ei voi suorittaa autocommandsia kaikille eventeille"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Ei täsmääviä autocommandsia"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: liian monta tasoa autocommandissa"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autocommands kohteelle %s"
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Suoritetaan %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { puuttuu."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } puuttuu."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: taitos puuttuu"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Taitoksia ei voi tehdä tällä foldmethodilla"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Taitosta ei voi poistaa tällä foldmethodilla"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld riviä taitettu pois "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Lisää lukupuskuriin"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursiivinen kuvaus"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: globaali lyhenne merkinnälle %s on jo olemassa"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: globaali kuvaus merkinnälle %s on jo olemassa"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: lyhenne on jo olemassa %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: kuvaus on jo olemassa %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Lyhennettä ei löydy"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Kuvausta ei löydy"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Virheellinen tila"
 
-msgid "<cannot open> "
-msgstr "<ei voi avata> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Ei rivejä puskurissa--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: ei saada fonttia %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Komento peruttu"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: nykyiseen hakemistoon ei voi palata"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argumentti puuttuu"
 
-msgid "Pathname:"
-msgstr "Polku:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\:n jälkeen pitää tulla /, ? tai &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: nykyistä hakemistoa ei saada selville"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Virheellinen komentorivi-ikkuna, <CR> suorittaa, Ctrl C lopettaa"
 
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Peru"
-
-msgid "Vim dialog"
-msgstr "Vim-ikkuna"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Vierityspalkki: Pixmapin geometria ei selviä"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Ei voi luoda BalloonEvalia viestille ja callbackille"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUIn käynnistys ei onnistu"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Ei voi lukea kohteesta %s"
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Ei voi avata GUIta, sopivaa fonttia ei löydy"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: guifontwide virheellinen"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: imactivatekeyn arvo on virheellinen"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Väriä %s ei voi määritellä"
-
-msgid "No match at cursor, finding next"
-msgstr "Ei täsmäystä kursorin alla, etsitään seuraava"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Kyllä\n"
-"&Ei\n"
-"&Peru"
+"E12: Komentoa ei tueta exrc:ssä tai vimrc:ssä tässä hakemistossa tai "
+"tägihaussa"
 
-msgid "Input _Methods"
-msgstr "Syöte_menetelmät"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif puuttuu"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Etsi ja korvaa..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry puuttuu"
 
-msgid "VIM - Search..."
-msgstr "VIM - Etsi..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile puuttuu"
 
-msgid "Find what:"
-msgstr "Etsi:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor puuttuu"
 
-msgid "Replace with:"
-msgstr "Korvaa:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile ilman komentoa :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Korvaa kokonaisia sanoja"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor ilman komentoa :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Kirjaintaso"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Tiedosto on jo olemassa (lisää ! ohittaaksesi)"
 
-msgid "Direction"
-msgstr "Suunta"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Komento epäonnistui"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Ylös"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Sisäinen virhe"
 
-msgid "Down"
-msgstr "Alas"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Keskeytetty"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Etsi seuraava"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Virheellinen osoite"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "Korvaa"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Virheellinen argumentti"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Korvaa kaikki"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: sessiomanageri lähetti die-pyynnön\n"
-
-msgid "Close"
-msgstr "Sulje"
-
-msgid "New tab"
-msgstr "Uusi välilehti"
-
-msgid "Open Tab..."
-msgstr "Avaa välilehti..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Pääikkuna tuhoutui odottamatta\n"
-
-msgid "&Filter"
-msgstr "&Suodata"
-
-msgid "&Cancel"
-msgstr "&Peru"
-
-msgid "Directories"
-msgstr "Hakemistot"
-
-msgid "Filter"
-msgstr "Suodatus"
-
-msgid "&Help"
-msgstr "O&hje"
-
-msgid "Files"
-msgstr "Tiedostot"
-
-msgid "&OK"
-msgstr "&Ok"
-
-msgid "Selection"
-msgstr "Valinta"
-
-msgid "Find &Next"
-msgstr "Hae &seuraava"
-
-msgid "&Replace"
-msgstr "Ko&rvaa"
-
-msgid "Replace &All"
-msgstr "Korvaa k&aikki"
-
-msgid "&Undo"
-msgstr "&Kumoa"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Ikkunan otsikkoa ei löydy %s"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Virheellinen argumentti: %s"
 
-# OLE on object linking and embedding på windowska
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argumenttia ei tueta: -%s, käytä OLE-versiota"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Virheellinen ilmaus: %s"
 
-# MDI eli windowsin moni-ikkunasovellus
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Ikkunaa ei voitu avata MDI-sovellukseen"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Virheellinen arvoalue"
 
-msgid "Close tab"
-msgstr "Sulje välilehti"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Virheellinen komento"
 
-msgid "Open tab..."
-msgstr "Avaa välilehti..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Etsi merkkijonoa (\\\\:llä löytää \\:t)"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Etsi ja korvaa (\\\\:llä löytää \\:t)"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Ei käytössä"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Hakemisto\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: Ei voi varata värikartan alkiota, värit voivat mennä väärin"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Seuraavien merkistöjoukkojen fontit puuttuvat fontsetistä %s:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: %s on hakemisto"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Fontsetin nimi: %s"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Virheellinen vierityskoko"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Fontti %s ei ole tasavälinen"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Fontsetin nimi: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Fontti0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Fontti1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Fontti%<PRId64>:n leveys ei ole kaksi kertaa fontti0:n\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Fontti0:n leveys: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Fontti1:n leveys: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Virheellinen fonttimääritys"
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
-msgid "&Dismiss"
-msgstr "&Ohita"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Kirjastukutsu %s() epäonnistui"
 
-msgid "no specific match"
-msgstr "ei tarkkaa täsmäystä"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Merkillä on virheellinen rivinumero"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - fonttivalitsin"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Merkkiä ei asetettu"
 
-msgid "Name:"
-msgstr "Nimi:"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Ei voi tehdä muutoksia, modifiable on pois päältä"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Näytä koko pisteinä"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Liian monta tasoa skripteissä"
 
-msgid "Encoding:"
-msgstr "Koodaus:"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Eo vaihtoehtoista tiedostoa"
 
-msgid "Font:"
-msgstr "Fontti:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Lyhennettä ei ole"
 
-msgid "Style:"
-msgstr "Tyyli:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! ei sallittu"
 
-msgid "Size:"
-msgstr "Koko:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUIta ei voi käyttää, koska sitä ei käännetty mukaan"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangu-automaattivirhe"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Korostusryhmää ei ole nimellä: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Tekstiä ei ole syötetty vielä"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Ei edellistä komentoriviä"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Kuvausta ei ole"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Ei täsmää"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Ei tsämää: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Ei tiedostonimeä"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Ei edellistä korvausta säännölliselle ilmaukselle"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Ei edellistä komentoa"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Ei edellistä säännöllistä ilmausta"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Arvoalue ei sallittu"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Tila ei riitä"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Tiedostoa %s ei voi luoda"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: väliaikaistiedoston nimeä ei saada selville"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Ei voi avata tiedostoa %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Ei voi lukea tiedostoa %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr ""
+"E37: Viimeisen muutoksen jälkeen ei ole kirjoitettu (lisää ! ohittaaksesi)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Viimeisintä muutosta ei ole kirjoitettu]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Null-argumentti"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Pitää olla numero"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: virhetiedostoa %s ei voi avata"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Muisti loppui"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Kuviota ei löydy"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Kuviota ei löydy: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argumentin pitää olla positiivinen"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Ei voi siirtyä edelliseen hakemistoon"
+
+# ;-)
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Ei virheitä"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Ei sijaintilistaa"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Viallinen täsmäysmerkkijono"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Viallinen regexp-ohjelma"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: readonly asetettu (lisää ! ohittaaksesi)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Kirjoitussuojattua muuttujaa %s ei voi muuttaa"
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Muuttujaa ei voi asettaa hiekkalaatikossa: %s"
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Virhe virhetiedostoa luettaessa"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Ei sallittu hiekkalaatikossa"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Ei sallittu täällä"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Näyttötila-asetus ei tuettu"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Virheellinen vierityskoko"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: shell-asetus on tyhjä"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Merkkidatan luku ei onnistu"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Swap-tiedoston sulkemisvirhe"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tägipino tyhjä"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Liian monimutkainen komento"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Liian pitkä nimi"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Liian monta [:a"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Liikaa tiedostonimiä"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Ylimääräisiä merkkejä perässä"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Tuntematon merkki"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Jokerimerkkien avaus ei onnistu"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: winheight ei voi olla pienempi kuin winminheight"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: winwidth ei voi olla pienempi kuin winminwidth"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Kirjoitusvirhe"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nollalaskuri"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> skriptin ulkopuolella"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Sisäinen virhe: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: kuvio käyttää enemmän muistia kuin maxmempattern on"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: tyhjä puskuri"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Virheellinen hakulauseke tai erotin"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Tiedosto on ladattu toiseen puskuriin"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Asetus %s on asettamatta"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Virheellinen rekisterin nimi: %s"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "haku pääsi ALKUUN, jatketaan LOPUSTA"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "haku pääsi LOPPUUN, jatketaan ALUSTA"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: kaksoispiste puuttuu"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Virheellinen komponentti"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: pitäisi olla numero"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Sivu %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Ei tekstiä tulostettavaksi"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Tulostetaan sivua %d (%d %%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopio %d/%d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Tulostettu: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Tulostus peruttu"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Virhe kirjoitettaessa PostScriptiä tiedostoon"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Ei voi avata tiedostoa %s"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Ei voi lukea PostScript-resurssitiedostoa %s"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: tiedosto %s ei ole PostScript-resurssitiedosto"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: tiedosto %s ei ole tuettu PostScript-resurssitiedosto"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: resurssitiedoston %s versio on väärä"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Tukematon monitvauinen merkistökoodaus ja merkistö."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset ei voi olla tyhjä monitavuiselle koodaukselle."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Ei oletusfonttia monitavuiseen tulostukseen"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript-tulostetiedoston avaus ei onnistu"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Tiedoston %s avaus ei onnistu"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: PostScript-resurssitiedostoa prolog.ps ei löydy"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: PostScript-resurssitiedostoa cidfont.ps ei löydy"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Postscript-resurssitiedosta %s.ps ei löydy"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Tulostuskoodaukseen %s muunto ei onnistu"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Lähetetään tulostimelle..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScript-tiedoston tulostus epäonnistui"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Tulostustyö lähetetty."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Lisää uusi tietokanta"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Hae kuviota"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Näytä tämä viesti"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Tapa yhteys"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Alusta uudelleen yhteydet"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Näytä yhteydet"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Käyttö: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Tämä cscope-komento ei tue ikkunan jakamista.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Käyttö: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tägia ei löydy"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s)-virhe: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat-virhe"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s ei ole hakemisto eikä cscope-tietokanta"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Lisätty cscope-tietokanta %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Virhe luettaessa cscope-yhteyttä %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: tuntematon cscope-hakutyyppi"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Ei voitu luoda cscope-putkia"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Ei voitu haarauttaa cscopea"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection epäonnistui"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection epäonnistui"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen to_fp epäonnistui"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen fr_fp epäonnistui"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Cscope-prosessin luonti epäonnistui"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: ei cscope-yhteyksiä"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: virheellinen cscopequickfix-asetus %c kohteelle %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: ei täsmäyksiä cscope-hakuun %s/%s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope-komennot:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Käyttö: %s)"
 
+#: ../if_cscope.c:1155
+#, fuzzy
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2463,7 +3248,7 @@ msgid ""
 "       g: Find this definition\n"
 "       i: Find files #including this file\n"
 "       s: Find this C symbol\n"
-"       t: Find assignments to\n"
+"       t: Find this text string\n"
 msgstr ""
 "\n"
 "       c: Etsi tätä funktiota kutsuvat funktiot\n"
@@ -2475,32 +3260,31 @@ msgstr ""
 "       s: Etsi tämä C-symboli\n"
 "       t: Etsi sijoitukset muuttujaan \n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: ei voi avata cscope-tietokantaa: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: ei voi hakea cscope-tietokannan tietoja"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: kaksoiskappaletta cscope-tietokannasta ei lisätty"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope-yhteys %s puuttuu"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope-yhteys %s on katkaistu"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: kriittinen virhe cs_manage_matches-funktiossa"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope-tägi: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2508,370 +3292,87 @@ msgstr ""
 "\n"
 "   #   rivi"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "tiedosto / konteksti / rivi\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope-virhe: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Kaikki cscope-tietokannat nollattu"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "ei cscope-yhteyksiä\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    tietokanta                          lisäyspolku\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Luan kirjastoa ei voitu ladata."
-
-msgid "cannot save undo information"
-msgstr "ei voitu tallentaa kumoustietoja"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr "E815: Sori, komento ei toimi, MzScheme-kirjastoa ei voitu ladata."
-
-msgid "invalid expression"
-msgstr "virheellinen ilmaus"
-
-msgid "expressions disabled at compile time"
-msgstr "ilmaukset poistettu käytöstä käännösaikana"
-
-msgid "hidden option"
-msgstr "piilotettu asetus"
-
-msgid "unknown option"
-msgstr "tuntematon asetus"
-
-msgid "window index is out of range"
-msgstr "ikkunan indeksi alueen ulkopuolella"
-
-msgid "couldn't open buffer"
-msgstr "ei voitu avata puskuria"
-
-msgid "cannot delete line"
-msgstr "ei voitu poistaa riviä"
-
-msgid "cannot replace line"
-msgstr "ei voitu korvata riviä"
-
-msgid "cannot insert line"
-msgstr "ei voitu lisätä riviä"
-
-msgid "string cannot contain newlines"
-msgstr "merkkijono ei saa sisältää rivinvaihtoja"
-
-msgid "Vim error: ~a"
-msgstr "Vim-virhe: ~a"
-
-msgid "Vim error"
-msgstr "Vim-virhe"
-
-msgid "buffer is invalid"
-msgstr "puskuri on virheellinen"
-
-msgid "window is invalid"
-msgstr "ikkuna on virheellinen"
-
-msgid "linenr out of range"
-msgstr "rivinumero arvoalueen ulkopuolelta"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "ei sallittu Vimin hiekkalaatikossa"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: Ei voi käyttää komentoja :py ja :py3 samassa istunnossa"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Python: Ei voi käyttää komentoja :py ja :py3 samassa istunnossa"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Sori, komento ei toimi, Python-kirjaston lataaminen ei onnistunut."
-
-msgid "can't delete OutputObject attributes"
-msgstr "ei voi poistaa OutputObject-attribuutteja"
-
-msgid "softspace must be an integer"
-msgstr "softspacen pitää olla kokonaisluku"
-
-msgid "invalid attribute"
-msgstr "virheellinen attribuutti"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<puskuriolio (poistettu) kohdassa %p>"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Pythonia ei voi kutsua rekursiivisesti"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: muuttujan $_ pitää olla Stringin instanssi"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: Sori, komento ei toimi, Ruby-kirjastoa ei voitu ladata."
-
-msgid "E267: unexpected return"
-msgstr "E267: odotuksenvastainen return"
-
-msgid "E268: unexpected next"
-msgstr "E268: Odotuksenvastainen next"
-
-msgid "E269: unexpected break"
-msgstr "E269: Odotuksenvastainen break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: odotuksenvastainen redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry rescuen ulkopuolella"
-
-msgid "E272: unhandled exception"
-msgstr "E272: käsittelemätön poikkeus"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: tuntematon longjmp-tila %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Vaihda toteutuksen ja määritelmän välillä"
-
-msgid "Show base class of"
-msgstr "Näytä kantaluokka kohteelle"
-
-msgid "Show overridden member function"
-msgstr "Näytä korvattu jäsenfunktio"
-
-msgid "Retrieve from file"
-msgstr "Jäljitä tiedostosta"
-
-msgid "Retrieve from project"
-msgstr "Jäljitä projektista"
-
-msgid "Retrieve from all projects"
-msgstr "Jäljitä kaikista projekteista"
-
-msgid "Retrieve"
-msgstr "Jäljitä"
-
-msgid "Show source of"
-msgstr "Näytä lähdekoodi kohteelle"
-
-msgid "Find symbol"
-msgstr "Etsi symboli"
-
-msgid "Browse class"
-msgstr "Selaa luokkaa"
-
-msgid "Show class in hierarchy"
-msgstr "Näytä luokka hierarkiassa"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Näytä luokka rajoitetussa hierarkiassa"
-
-msgid "Xref refers to"
-msgstr "Xref viittaa kohteeseen"
-
-msgid "Xref referred by"
-msgstr "Xref viitattu kohteesta"
-
-msgid "Xref has a"
-msgstr "Xref sisältää kohteen"
-
-msgid "Xref used by"
-msgstr "Xrefiä käyttää"
-
-msgid "Show docu of"
-msgstr "Näytä dokumentti kohteelle"
-
-msgid "Generate docu for"
-msgstr "Luo dokumentti kohteelle"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Ei voida yhdistää SNiFF+:aan. Tarkista ympäristömuuttujat (sniffemacsin "
-"löytyä polkumuuttujasta $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Virhe luettaessa, yhteys katkaistu"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ "
-
-msgid "not "
-msgstr "ei ole "
-
-msgid "connected"
-msgstr "yhdistetty"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Tuntematon SNiFF+-pyyntö: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Virhe yhdistettäessä SNiFF+:aan"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ ei ole yhdistetty"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ei ole SNiFF+-puskuri"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Virhe kirjoituksessa, yhteys katkaistu"
-
-msgid "invalid buffer number"
-msgstr "virheellinen puskurinumero"
-
-msgid "not implemented yet"
-msgstr "ei toteutettu"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "ei voi asettaa rivejä"
-
-msgid "invalid mark name"
-msgstr "virheellinen merkin nimi"
-
-msgid "mark not set"
-msgstr "merkko ei ole asetettu"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "rivi %d sarake %d"
-
-msgid "cannot insert/append line"
-msgstr "rivin lisäys ei onnistu"
-
-msgid "line number out of range"
-msgstr "rivinumero arvoalueen ulkopuolella"
-
-msgid "unknown flag: "
-msgstr "tuntematon asetus: "
-
-msgid "unknown vimOption"
-msgstr "tuntematon vimOption"
-
-msgid "keyboard interrupt"
-msgstr "näppäimistökeskeytys"
-
-msgid "vim error"
-msgstr "vim-virhe"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "ei voi luoda puskuri- tai ikkunakomentoa, olio on poistumassa"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "callbackia ei voi rekisteröidä: puskuri tai ikkuna on poistettu"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: kriittinen TCL-virhe: reflist hajalla? Ilmoita asiasta "
-"postituslistalle vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "callbackia ei voi rekisteröidä: puskurin tai ikkunan viitettä ei löydy"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: Sori, komento ei toimi, Tcl-kirjastoa ei voitu ladata."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL-virhe: lopetuskoodi ei ole kokonaisluku? Ilmoita asiasta "
-"postituslistalle vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: palautusarvo %d"
-
-msgid "cannot get line"
-msgstr "ei voida hakea riviä"
-
-msgid "Unable to register a command server name"
-msgstr "Komentopalvelimen nimen rekisteröinti ei onnistu"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Komennon lähetys kohdeohjelmalle ei onnistu"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Virheellinen palvelimen tunniste: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIMin instanssin rekisteriarvo on virheellinen, poistettiin."
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Tuntematon asetusargumentti"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Liikaa muokkausargumentteja"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argumentti puuttuu kohdasta"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Roskaa argumentin perässä"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Liikaa +komentoja, -c-komentoja tai --cmd-komentoja"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Väärä argumentti valitsimelle"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d tiedostoa muokattavana\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans ei toimi tässä käyttöliittymässä\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Tähän Vimiin ei ole käännetty diff-toimintoja mukaan."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "-nb:tä ei voi käyttää, koska sitä ei käännetty mukaan\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Yritettiin avata skriptitiedostoa uudestaan:"
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Ei voi avata luettavaksi: "
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Ei voi avata skriptin tulostetta varten: "
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Virhe: Gvimin käynnistys NetBeansistä ei onnistu\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Varoitus: Tuloste ei mene terminaalille\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Varoitus: Syöte ei tule terminaalilta\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "esi-vimrc-komentorivi"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Ei voida lukea kohteesta %s"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2879,18 +3380,23 @@ msgstr ""
 "\n"
 "Lisätietoja: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[tiedosto ..]       muokkaa tiedostoja"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                   lue vakiosyötteestä"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tägi             muokkaa tiedostoa tägistä"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [virhetiedosto]  muokkaa tiedostoa ensimmäisestä virheestä"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2900,9 +3406,11 @@ msgstr ""
 "\n"
 "käyttö:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumentit] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2910,14 +3418,7 @@ msgstr ""
 "\n"
 "   tai:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Jos aakkoslaji on ohitettu, lisää alkuun / tehdäksesi asetuksesta "
-"suuraakkosia"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2927,335 +3428,190 @@ msgstr ""
 "\n"
 "Argumentit:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tvain tiedostonimiä tämän jälkeen"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tÄlä käsittele jokerimerkkejä "
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\trekisteröi gvim OLEa varten"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tPoista gvim OLE-rekisteristä"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tAvaa GUI (kuten gvimillä)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f tai --nofork\tEdustalle: Älä haarauta GUIn käynnistyksessä"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi-tila (kuten villä)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx-tila (kute exillä)"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tHiljainen (eräajo)tila (vain exillä)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff-tila (kuten vimdiffillä)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tHelppokäyttötila (kuten evimissä, ilman tiloja)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tKirjoitussuojattu tila (kuten view'lla)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tRajoitettu tila (kuten rvimillä)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tMuokkaukset (kirjoittaminen tiedostoon) pois käytöstä"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tTekstin muokkaus pois käytöstä"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinääritila"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp-tila"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVi-yhteensopivuustila: compatible"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tEi Vi-yhteensopivuutta: nocompatible"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 "-V[N][tnimi]\t\tMonisanainen tuloste [Taso N] [kirjoita tuloste tnimeen] "
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tVianetsintätila"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tEi swap-tiedostoja, käytä muistia"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tLuetteloi swap-tiedostot ja poistu"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (tiedostonimi)\tPalauta kaatunut sessio"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tkuten -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tÄlä käytä newcli:tä ikkunan avaamiseen"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <laite>\t\tKäytä <laitetta> IO:hon"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tkäynnistä arabia-tilassa"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tkäynnistä heprea-tilassa"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tkäynnistä farsi-tilassa"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminaali>\tAseta terminaalin tyypiksi <terminaali>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tKäytä <vimrc>-tiedostoa .vimrc:iden sijasta"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tKäytä <gvimrc>-tiedostoa .gvimrc:iden sijasta"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tÄlä lataa liitännäisiä"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tAvaa N välilehteä (oletus: yksi per tiedosto)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tAvaa N ikkunaa (oletus: yksi per tiedosto)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tKuten -o, mutta jaa pystysuunnassa"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tAloita tiedoston lopusta"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<rivi>\t\t\tAloita riviltä <rivi>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <komento>\tSuorita <komento> ennen vimrc:iden latausta"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <komento>\t\tSuorita <komento> ensimmäisen tiedoston latauduttua"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <sessio>\t\tLataa <sessio> ensimmäisen tiedoston latauduttua"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skripti>\tLue normaalitilan komentoja <skripti>-tiedostosta"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <skripti>\tLisää kirjoitetut komennot <skripti>-tiedostoon"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <skripti>\tKirjoita komennot <skripti>-tiedostoon"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tMuokkaa salattua tiedostoa"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <näyttö>\tYhdistä vim tiettyyn X-palvelimeen"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tÄlä yhdistä X-palvelimeen"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr ""
-"--remote <tiedostoja>\tMuokkaa <tiedostoja> Vim-palvelimessa, jos mahdollista"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-silent <tiedostoja>\tSama, mutta älä ilmoita puuttuvasta "
-"palvelimesta"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <tiedostoja>  kuten --remote, mutta odota tiedostojen "
-"muokkaamista"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <tiedostoja>  sama, mutta älä ilmoita puuttuvasta "
-"palvelimesta"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <tiedostoja>  kuten --remote, mutta avaa "
-"välilehti joka tiedostolle"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr ""
-"--remote-send <näppäimiä>\tLähetä <näppäimiä> painalluksina Vimille ja lopeta"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <ilmaus>\tKäsittele <ilmaus> Vim-palvelimella ja tulosta tulos"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tLuettele Vim-palvelinten nimet ja lopeta"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nimi>\tLähetä Vim-palvelimelle <nimi> tai luo se"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <file>\tKirjoita käynnistysaikaviestit tiedostoon <file>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tKäytä <viminfo>-tiedostoa .viminfon sijaan"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h tai --help\tTulosta ohje (tämä viesti) ja lopeta"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t\tTulosta versiotiedot ja lopeta"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Gvimin (Motif-version) tuntemat argumentit:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Gvimin (neXtaw-version) tuntemat argumentit:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Gvimin (Athena-version) tuntemat argumentit:\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <näyttö>\tSuorita vim <näytössä>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tKäynnistä pienennettynä"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <väri>\tKäytä <väriä> taustavärinä (myös: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <väri>\tKäytä <väriä> tekstin värinä (myös: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <fontti>\t\tKäytä <fonttia> tekstissä (myös: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <fontti>\tKäytä <fonttia> lihavoidussa tekstissä"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <fontti>\tKäytä <fonttia> kursivoidussa tekstissä"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tKäytä mittoja <geom> ikkunan asetteluun (myös: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidt <leveys>\tKäytä <leveyttä> reunuksissa (myös: -bw) "
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <leveys>  Käytä <leveyttä> vierityspalkissa (myös: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <korkeus>\tKäytä <korkeutta> valikossa (myös: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tKäytä käänteisvärejä (myös: -rv) "
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tÄlä käytä käänteisvärejä (myös: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resurssi>\tAseta resurssi"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Gvimin (RISC OS -version) tuntemat argumentit:\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <luku>\tIkkunan alkuleveys sarakkeina"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <luku>\tIkkunan alkukorkeus riveinä"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Gvimin (GTK+-version) tuntemat argumentit:\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <näyttö>\tSuorita vim näytöllä <näyttö> (myös: --display)"
-
-# X-ikkunointijärjestelmässä saman sovelluksen saman luokan ikkunat
-# tunnistetaan rooliresursseista
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <rooli>\tAseta pääikkunalle ainutlaatuinen rooli tunnisteeksi"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tAvaa Vim annettuun GTK-olioon "
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <otsikko>\tAvaa Vim isäntäohjelman sisään"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tAvaa Vim annettuun win32-olioon "
-
-msgid "No display"
-msgstr "Ei näyttöä"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Lähetys epäonnistui.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Lähetys epäonnistui. Yritetään suorittaa paikallisena\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d/%d muokattu"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Ei näyttöä: Ilmauksen lähetys epäonnistui.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Ilmauksen lähetys epäonnistui.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Ei asetettuja merkkejä"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Mikään merkki ei täsmää ilmaukseen \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3264,6 +3620,7 @@ msgstr ""
 "merkki rivi sarake tiedosto/teksti"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3272,6 +3629,7 @@ msgstr ""
 "hyppy rivi sarake tiedosto/teksti"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3279,7 +3637,7 @@ msgstr ""
 "\n"
 "muutos rivi sarake teksti"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3288,7 +3646,7 @@ msgstr ""
 "# Tiedoston merkit:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3296,7 +3654,7 @@ msgstr ""
 "\n"
 "# Hyppylista (uusin ensiksi):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3304,86 +3662,84 @@ msgstr ""
 "\n"
 "# Tiedostojen merkkien historia (uusimmasta vanhimpaan):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "> puuttuu"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Koodisivu ei ole käypä"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Ei voi asettaa IC-arvoja"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Syötekontekstin luonti ei onnistu"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Syötemetodin avaus ei onnistu"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Varoitus: Ei voitu asettaa destroy-kutsua syötemetodipalvelimelle"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: syötemetodi ei tue tyylejä"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: syötemetodi ei tue tätä preedit-tyyppiä"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: lohkoa ei ole lukittu"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Hakuvirhe swap-tiedostoa luettaessa"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Lukuvirhe swap-tiedostossa"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Hakuvirhe swap-tiedostoa kirjoitettaessa"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Kirjoitusvirhe swap-tiedostossa"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Swaptiedosto on jo olemassa (symlink-hyökkäys?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Lohko 0:aa ei saatu?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Lohko 1:tä ei saatu?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Lohko 2:ta ei saatu?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Hups, swap-tiedosto hävisi!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Swap-tiedoston uudellennimeys ei onnistu"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Swap-tiedostoa %s ei voi avata, palautus ei onnistu"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Lohko 0:aa ei saatu?"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Ei swap-tiedostoa tiedostolle %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Anna swap-tiedoston numero tai 0 lopettaaksesi: "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Ei voi avata tiedostoa %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Ei voi lukea lohkoa 0 kohteesta "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3391,22 +3747,28 @@ msgstr ""
 "\n"
 "Muutoksia ei tehty, tai Vim ei päivittänyt swap-tiedostoa."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " ei toimi tämän version Vimin kanssa.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Käytä Vimin versiota 3.0\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ei ole Vimin swap-tiedosto"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " ei toimi tällä koneella.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Tiedosto luotiin "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3414,98 +3776,84 @@ msgstr ""
 ",\n"
 "tai tiedosto on vahingoittunut."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s on salattu eikä tämä Vim tue salausta"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " on vioittunut (sivun koko on vähimmäisarvoa pienempi).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Käytetään swap-tiedostoa %s"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Alkuperäinen tiedosto %s"
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Varoitus: Alkuperäistä tiedostoa saattaa olla muutettu"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Swap-tiedosto on salattu: %s"
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr "\n"
-"Jos käytit uutta salausavainta muttet kirjoittanut tekstitiedostoa,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr "\n"
-"anna uusi salausavain."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr "\n"
-"Jos kirjoitit tekstitiedoston salausavaimen vaihdon jälkeen paina enteriä"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr "\n"
-"käyttääksesi samaa avainta teksti- ja swäppitiedostoille"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Ei voitu lukea lohkoa 1 tiedostosta %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???PALJON RIVEJÄ PUUTTUU"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???RIVIMÄÄRÄ PIELESSÄ"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???TYHJÄ LOHKO"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???RIVEJÄ PUUTTUU"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Lohon 1 tunniste väärä (%s ei ole .swp-tiedosto?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???LOHKO PUUTTUU"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? tästä kohtaan ???LOPPU rivejä sekaisin"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? tästä kohtaan ???LOPPU rivejä saattaa olla lisätty tai poistettu"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???LOPPU"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Palautus keskeytetty"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Palautuksessa oli virheitä, etsi rivejä, jotka alkavat ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr ":help E312 kertoo lisätietoja"
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Palautus onnistui. Tarkista, että kaikki on kunnossa."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3513,57 +3861,70 @@ msgstr ""
 "\n"
 "(Saattaa kannattaa kirjoittaa tämä tiedosto toisella nimellä\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "ja katso diffillä muutokset alkuperäiseen tiedostoon)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Palautus onnistui. Puskurin ja tiedoston sisällöt täsmäävät."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
 "\n"
-msgstr "\n"
+msgstr ""
+"\n"
 "Voit poistaa .swp-tiedosto nyt.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Käytetään swäpin salausavainta tekstitiedostolle\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Swap-tiedostoja löytyi:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   Tässä hakemistossa:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Määritellyllä nimellä:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   Hakemistossa "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr " -- ei mitään --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          omistaja: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "  ajalta: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "            ajalta:"
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [Vimin 3.0-versiosta]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ei näytä Vimin swap-tiedostolta]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "      tiedostonimi: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3571,12 +3932,15 @@ msgstr ""
 "\n"
 "          muokattu: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "KYLLÄ"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ei"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3584,9 +3948,11 @@ msgstr ""
 "\n"
 "         käyttäjänimi: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   laitenimi: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3594,6 +3960,7 @@ msgstr ""
 "\n"
 "         laitenimi: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3601,16 +3968,11 @@ msgstr ""
 "\n"
 "        prosessin tunniste: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (käynnissä)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [ei toimi tämän Vim-version kanssa]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3618,75 +3980,97 @@ msgstr ""
 "\n"
 "         [ei toimi tällä koneella]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [ei voi lukea]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [ei voi avata]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Ei voi säilyttää, swap-tiedostoa ei ole"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Tiedosto säilytetty"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Säilyttäminen epäonnistui"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: virheellinen lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: riviä %<PRId64> ei löydy"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: osoitinlohkon tunnus väärä 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx pitää olla 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Päivitetty liikaa lohkoja"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: osoitinlohkon tunnus väärä 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "poistettu lohko 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Riviä %<PRId64> ei löydy"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: osoitinlohkon tunnus väärä"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count on nolla"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: rivinumero arvoalueen ulkopuoleta: %<PRId64> on loppua suurempi"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: rivimäärä väärin lohkossa %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Pinon koko kasvaa"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: osoitinlohon tunnus väärä 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Symlinkkisilmukka kohteelle %s"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: HUOMAA"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3694,38 +4078,44 @@ msgstr ""
 "\n"
 "Swap-tiedosto löytyi: \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Avattaessa tiedostoa "
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "   joka on UUDEMPI kuin swap-tiedosto!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Toinen ohjelma saattaa käyttää samaa tiedostoa.\n"
 "    Jos näin on, varo, ettet muokkaa saman tiedoston\n"
 "    kahta instanssia yhtä aikaa.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Lopeta, tai jatka.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Ohjelma on kaatunut muokatessa tiedostoa.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Jos näin on, käytä komentoa :recover tai vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3733,9 +4123,11 @@ msgstr ""
 "\"\n"
 "    palauttaaksesi muutokset (lisätietoja: \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Jos teit jo näin, poista swap-tiedosto "
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3743,18 +4135,23 @@ msgstr ""
 "\"\n"
 "    välttääksesi tämän viestin.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Swap-tiedosto "
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr " on jo olemassa"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - HUOMAUTUS"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Swap-tiedosto on jo olemassa"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3768,6 +4165,7 @@ msgstr ""
 "&Lopeta\n"
 "P&eru"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3783,34 +4181,56 @@ msgstr ""
 "&Lopeta\n"
 "P&eru"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Liian monta swap-tiedostoa"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Muisti loppui! (varattaessa %<PRIu64> tavua)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Valikkokohtapolun osa ei ole alivalikko"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Valikko on olemassa vain toisessa tilassa"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Ei valikkoa %s"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: tyhjä valikkonimi"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Valikkopolku ei saa johtaa alivalikkoon"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Valikkokohtia ei saa lisätä suoraan valikkopalkkiin"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Erotin ei voi olla valikkopolun osa"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3818,60 +4238,73 @@ msgstr ""
 "\n"
 "--- Valikot ---"
 
-msgid "Tear off this menu"
-msgstr "Repäise valikko irti"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Valikkopolun on johdettava valikkokohtaan"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Valikkoa ei löydy: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Valikkoa ei ole määritelty %s-tilassa"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Valikkopolun pitää johtaa alivalikkoon"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Valikkoa ei löytynyt - tarkista valikkojen nimet"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Virhe suoritettaessa komentoja %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "rivi %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Virheellinen rekisterin nimi: %s"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Käännöksen ylläpitäjä: Flammie Pirinen <flammie@iki.fi>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Keskeytys: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Paina enteriä tai kirjoita komento aloittaaksesi "
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s rivi %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Lisää --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: ruutu/sivu/rivi alas, b/u/k: ylös, q: lopeta "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Kysymys"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3879,6 +4312,17 @@ msgstr ""
 "&Kyllä\n"
 "&Ei"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Kyllä\n"
+"&Ei\n"
+"&Peru"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3892,264 +4336,174 @@ msgstr ""
 "T&uhoa kaikki\n"
 "&Peru"
 
-msgid "Select Directory dialog"
-msgstr "Hakemiston valintaikkuna"
-
-msgid "Save File dialog"
-msgstr "Tallennusikkuna"
-
-msgid "Open File dialog"
-msgstr "Avausikkuna"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Sori, tiedostonselain puuttuu konsolitilasta"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf():lle ei annettu tarpeeksi argumentteja"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Odotettiin Float-argumenttia printf():lle"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf():lle annettiin liikaa argumentteja"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Varoitus: Muutetaan kirjoitussuojattua tiedostoa"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Kirjoita numero ja <Enter> tai valitse hiirellä (tyhjä peruu): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Valitse numero ja <Enter> (tyhjä peruu): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 rivi lisää"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 rivi vähemmän"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> riviä lisää"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> riviä vähemmän"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Keskeytetty)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Piip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: säästetään tiedostoja...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Valmis.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "VIRHE: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[tavua] yht. alloc-free %<PRIu64>-%<PRIu64>, käytössä %<PRIu64>, käyttöhuippu %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[kutsut] yht. re/malloc() %<PRIu64>, yht. free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Rivistä tulee liian pitkä"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Sisäinen virhe: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Muisti loppui! (varattaessa %<PRIu64> tavua)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Kutsutaan kuorta suorittamaan: %s"
 
-msgid "E545: Missing colon"
-msgstr "E545: Kaksoispiste puuttuu"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Virheellinen tila"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Virheellinen hiiren muoto"
-
-msgid "E548: digit expected"
-msgstr "E548: pitää olla numero"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Virheellinen prosenttiluku"
-
-msgid "Enter encryption key: "
-msgstr "Anna salausavain: "
-
-msgid "Enter same key again: "
-msgstr "Anna sama avain uudestaan: "
-
-msgid "Keys don't match!"
-msgstr "Avaimet eivät täsmää!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Virheellinen polku: '**[numero]' kuuluu polun loppuun tai ennen kohtaa "
-"%s."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Hakemistoa %s ei löydy cdpathista"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Tiedostoa %s ei löydy polulta"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Hakemisto %s ei ole enää cdpathissa"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Tiedosto %s ei ole enää polulla"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Ei voi yhdistää Netbeans #2:een"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Ei voi yhdistää Netbeansiin"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Väärä avaustila NetBeans-yhteyden infotiedostolle: %s"
-
-msgid "read from Netbeans socket"
-msgstr "luettu Netbeans-soketista"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: NetBeans-yhteys katkesi puskurille %<PRId64>"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans on yhdistetty jo"
-
-msgid "E505: "
-msgstr "E505: "
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Ei tunnistetta osoittimen alla"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: operatorfunc on tyhjä"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval ei ole käytettävissä"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Varoitus: terminaalista puuttuu korostus"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Ei merkkijonoa kursorin alla"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: taitoksia ei voi poistaa tällä foldmethodilla"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: muutoslista on tyhjä"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Muutoslistan alussa"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Muutoslistan lopussa"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Komento :quit<Enter> lopettaa Vimin"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 riviä %s kerran"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 riviä %s %d kertaa"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> riviä %s kerran"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> riviä %s %d kertaa"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> riviä sisennettävänä..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 rivi sisennetty "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> riviä sisennetty "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Ei aiemmin käytettyjä rekisterejä"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "Ei voi kopioida; poista joka tapauksessa"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 rivi muuttui"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> riviä muuttui"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "vapautetaan %<PRId64> riviä"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "1 rivin lohko kopioitu"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 rivi kopioitu"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "lohko %<PRId64> riviltä kopioitu"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> riviä kopioitu"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Rekisterissä %s ei ole mitään"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4157,9 +4511,11 @@ msgstr ""
 "\n"
 "--- Rekisterit ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Virheellinen rekisterin nimi"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4167,156 +4523,182 @@ msgstr ""
 "\n"
 "# Rekisterit:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Tuntematon rekisterityyppi %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> saraketta, "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Valittu %s%<PRId64>/%<PRId64> riviä, %<PRId64>/%<PRId64> sanaa, %<PRId64>/%<PRId64> tavua"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "Valittu %s%<PRId64>/%<PRId64> riviä, %<PRId64>/%<PRId64> sanaa, %<PRId64>/%<PRId64> merkkiä, %<PRId64>/%<PRId64> tavua"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Valittu %s%<PRId64>/%<PRId64> riviä, %<PRId64>/%<PRId64> sanaa, %<PRId64>/"
+"%<PRId64> tavua"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Sarake %s/%s, Rivi %<PRId64>/%<PRId64>, sana %<PRId64>/%<PRId64>, tavu %<PRId64>/%<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
-msgstr "Sarake %s/%s, rivi %<PRId64>/%<PRId64>, sana %<PRId64>/%<PRId64>, merkki %<PRId64>/%<PRId64>, tavu %<PRId64>/%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Valittu %s%<PRId64>/%<PRId64> riviä, %<PRId64>/%<PRId64> sanaa, %<PRId64>/"
+"%<PRId64> merkkiä, %<PRId64>/%<PRId64> tavua"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Sarake %s/%s, Rivi %<PRId64>/%<PRId64>, sana %<PRId64>/%<PRId64>, tavu "
+"%<PRId64>/%<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Sarake %s/%s, rivi %<PRId64>/%<PRId64>, sana %<PRId64>/%<PRId64>, merkki "
+"%<PRId64>/%<PRId64>, tavu %<PRId64>/%<PRId64>"
 
 # Unicode Byte Order Mark
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> BOMista)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Sivu %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Kiitos että ajoit Vimiä"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Tuntematon asetus"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Asetusta ei tueta"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Ei sallitu modeline-rivillä"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: =:n jälkeen tarvitaan luku"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Puuttuu termcapista"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Virheellinen merkki <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Termiä ei voi asettaa tyhjäksi merkkijonoksi"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Ei voi vaihtaa termiä GUIssa"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Käytä komentoa :gui GUIn käynnistämiseen"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: backupext ja patchmod ovat samat"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: listcharsin arvoissa on ristiriitoja"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: fillcharsin arvossa on ristiriitoja"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Ei voi muuttaa GTK+2-GUIssa"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Kaksoispiste puuttuu"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Nollan pituinen merkkijono"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Lukuarvo puuttuu merkkijonon <%s> jälkeen"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Pilkku puuttuu"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: '-arvo pitää antaa"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Sisältää tulostumattomia tai leveitä merkkejä"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Viallisia fontteja"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Fontsetin valinta ei onnistu"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Viallinen fontset"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Leveän fontin valinta ei onnistu"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Viallinen leveä fontti"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Virheellinen merkki merkin <%c> jälkeen"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: pilkku puuttuu"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: commentstringin pitää olla tyhjä tai sisältää %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Hiirtä ei tueta"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Sulkematon lausekesarja"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: liikaa kohteita"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: epätasapainoisia ryhmiä"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Esikatseluikkuna on jo olemassa"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabialle pitää olla UTF-8:aa, aseta :set encoding=utf-8"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Tarvitaan ainakin %d riviä"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Tarvitaan ainakin %d saraketta"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Tuntematon asetus: %s"
@@ -4324,10 +4706,12 @@ msgstr "E355: Tuntematon asetus: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: tarvitaan luku: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4335,6 +4719,7 @@ msgstr ""
 "\n"
 "--- Terminaalikoodit ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4342,6 +4727,7 @@ msgstr ""
 "\n"
 "--- Globaalit asetukset ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4349,6 +4735,7 @@ msgstr ""
 "\n"
 "--- Paikalliset asetukset ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4356,141 +4743,21 @@ msgstr ""
 "\n"
 "--- Asetukset ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp-virhe"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: langmap: Merkkiin %s täsmäävä merkki puuttuu"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: langmap: ylimääräisiä merkkejä puolipisteen jälkeen: %s"
 
-msgid "cannot open "
-msgstr "ei voi avata "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Ei voi avata ikkunaa\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Amigados 2.04 tai uudempi tarvitaan\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Tarvitaan %s versio %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Ei voi avata NILiä:\n"
-
-msgid "Cannot create "
-msgstr "Ei voi luoda "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim sulkeutuu koodilla %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "ei voi vaihtaa konsolitilaa?\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: ei ole konsoli?\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Kuorta ei voi avata asetuksella -f"
-
-msgid "Cannot execute "
-msgstr "Ei voi suorittaa "
-
-msgid "shell "
-msgstr "kuori "
-
-msgid " returned\n"
-msgstr " palautti\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE liian pieni."
-
-msgid "I/O ERROR"
-msgstr "IO-virhe"
-
-msgid "Message"
-msgstr "Viesti"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "columns ei ole 80, ei voi suorittaa ulkoista komentoa"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Tulostimen valinta epäonnistui"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "tulostimelle %s kohteessa %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Tuntematon tulostimen fontti: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Tulostinvirhe: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Tulostetaan %s"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Virheellinen merkistön nimi %s fontin nimessä %s"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Virheellinen merkki %c fontin nimessä %s"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Kaksoissignaali, lopetetaan\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Tappava signaali %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Tappava signaali\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "X-näytön avaus vei %<PRId64> millisekuntia"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X-virhe\n"
-
-msgid "Testing the X display failed"
-msgstr "X-näytön testaus epäonnistui"
-
-msgid "Opening the X display timed out"
-msgstr "X-näytön avaus aikakatkaistiin"
-
-# mikä security context?
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Ei saatu turvallisuuskontekstia kohteelle "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Ei voitu asettaa turvallisuuskontekstia kohteelle "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4498,13 +4765,7 @@ msgstr ""
 "\n"
 "Kuoren suoritus ei onnistu "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Kuoren sh suoritus ei onnistu\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4512,368 +4773,473 @@ msgstr ""
 "\n"
 "kuoren palautusarvo "
 
+# mikä security context?
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Putkia ei voi tehdä\n"
+"Ei saatu turvallisuuskontekstia kohteelle "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Ei voi haarauttaa\n"
+"Ei voitu asettaa turvallisuuskontekstia kohteelle "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Komento loppui\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP kadotti ICE-yhteyden"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = %s"
 
-msgid "Opening the X display failed"
-msgstr "X-näytön avaus epäonnistui"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP käsittelee save-yourself-pyyntöä"
-
-msgid "XSMP opening connection"
-msgstr "XSMP avaa yhteyttä"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP:n ICE-yhteyden tarkkailu epäonnistui"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection epäonnistui: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Tiedosto %s ei löydy polulta"
 
-msgid "At line"
-msgstr "Rivillä"
-
-msgid "Could not load vim32.dll!"
-msgstr "Vim32.dll:ää ei voitu ladata"
-
-msgid "VIM Error"
-msgstr "VIM-virhe"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Ei voitu korjata funktio-osoittimia DLL:ssä"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "kuori palautti arvon %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Napattiin %s\n"
-
-msgid "close"
-msgstr "sulkeminen"
-
-msgid "logoff"
-msgstr "uloskirjautuminen"
-
-msgid "shutdown"
-msgstr "sammutus"
-
-msgid "E371: Command not found"
-msgstr "E371: Komentoa ei löydy"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXEä ei löydy muuttujasta $PATH.\n"
-"Ulkoiset komennot eivät pysähdy suorituksen lopussa.\n"
-"Lisätietoja komennolla  :help win32-vimrun"
-
-msgid "Vim Warning"
-msgstr "Vim-varoitus"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Liikaa %%%c-juttuja muotoilumerkkijonossa"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Odottamaton %%%c muotoilumerkkijonossa"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: ] puuttuu muotoilemerkkijonosta"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Tukematon %%%c muotoilumerkkijonossa"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Virheellinen %%%c muotoilumerkkijonon alussa"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Virheellinen %%%c muotoilumerkkijonossa"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: errorformatissa ei ole kuvioita"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Puuttuva tai tyhjä hakemiston nimi"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Ei enää kohteita"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d/%d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (rivi poistettu)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: quickfix-pinon pohjalla"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: quickfix-pinon huipulla"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "virhelista %d/%d, %d virhettä"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Ei voi kirjoittaa, buftype asetettu"
 
-msgid "Error file"
-msgstr "Virhetiedosto"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Tiedostonimi puuttuu tai kuvio on viallinen"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Tiedostoa %s ei voi avata"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Puskuria ei ole ladattu"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Pitää olla merkkijono tai lista"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: virheellinen olio kohdassa %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Liian pitkä kuvio"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Liikaa merkkejä \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Liikaa merkkejä %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Pariton \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Pariton %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Pariton %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Pariton %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: virheellinen merkki kohdan %s@ jälkeen"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Liikaa monimutkaisia ilmauksia %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Sisäkkäistetty %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Sisäkkäistetty %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: väärinkäytetty \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c jälkeen ei minkään"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Virheellinen täsmäysviittaus"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( ei ole sallittu tässä"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 jne. ei ole sallittu tässä"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Virheellinen merkki ilmauksen \\z jälkeen"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: ] puuttuu merkinnän %s%%[ jäljestä"
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Tyhjä %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Virheellinen merkki merkinnän %s%%[dxouU] jäljessä"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Virheellinen merkki merkinnän %s%% jäljessä"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: ] puuttuu merkinnän %s[ jäljestä"
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Pariton %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Pariton %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Pariton %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( ei ole sallittu tässä"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 jne. ei ole sallittu tässä"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: ] puuttuu merkinnän %s%%[ jäljestä"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Tyhjä %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Liian pitkä kuvio"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Liikaa merkkejä \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Liikaa merkkejä %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Pariton \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: virheellinen merkki kohdan %s@ jälkeen"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Liikaa monimutkaisia ilmauksia %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Sisäkkäistetty %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Sisäkkäistetty %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: väärinkäytetty \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c jälkeen ei minkään"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Virheellinen täsmäysviittaus"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Virheellinen merkki ilmauksen \\z jälkeen"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Virheellinen merkki merkinnän %s%%[dxouU] jäljessä"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Virheellinen merkki merkinnän %s%% jäljessä"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaksivirhe ilmauksessa %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Ulkoisia alitäsmäyksiä:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Liikaa merkkejä \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E828: Kumoustiedoston avaus kirjoittamista varten ei onnistu: %s"
+
 # tiloja
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " VKORVAUS"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " KORVAUS"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " KÄÄNTEIS"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " SYÖTTÖ"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (syöttö)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (korvaus)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (vkorvaus)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Heprea"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabia"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (kieli)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (liitos)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VALINTA"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VALINTARIVI"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VALINTALOHKO"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " WALINTA"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " WALINTARIVI"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " WALINTALOHKO"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "tallennetaan"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Viallinen hakujono: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Haku pääsi alkuun löytämättä jonoa: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Haku pääsi loppuun löytämättä jonoa: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ;:n jälkeen pitää olla ? tai /"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (sisältää viimeksi luetellun täsmäyksen)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Sisällytetyt tiedostot "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "ei löytynyt "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "polusta ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Jo lueteltu)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  EI LÖYTYNYT"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Haku sisälsi tiedoston: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Haku sisälsi tiedoston %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Täsmäys tällä rivillä"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Kaikki sisällytetyt rivit löytyivät"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Ei sisällytettyjä tiedostoja"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Määritelmä ei löydy"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: kuvio ei löydy"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Korvaa "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4884,80 +5250,97 @@ msgstr ""
 "# Edellinen %sHakulauseke:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Muotoiluvirhe oikolukutiedostossa"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Oikolukutiedosto katkaistu"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Tekstiä rivin perässä tiedostossa %s rivillä %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affiksin nimi on liian pitkä tiedostossa %s rivillä %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Affiksitiedoston FOL-, LOW- tai UPP-muotovirhe "
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Merkki FOL:ssä, LOW:ssä tai UPP:ssä ei kuulu arvoalueeseen"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Tiivistetään sanapuuta..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Oikaisuluku ei ole päällä"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Varoitus: Ei löydetty sanalistaa %s.%s.spl tai %s.ascii.spl"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Luetaan oikaisulukutiedosta %s"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Ei vaikuta oikaisulukutiedostolta"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Vanha oikaisulukutiedosto vaatii päivittämistä"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Oikaisulukutiedosto on uudemmalle Vimille"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Tukematon osio oikaisulukutiedostossa"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Varoitus: osaa %s ei tueta"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Luetaan affiksitiedostoa %s..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Muunnosvirhe sanalle %s rivillä %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Muunnosta kohteessa %s ei tueta: kohteesta %s kohteeseen %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Muutosta kohteessa %s ei tueta"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Tuntematon FLAG kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG kohteessa %s lippujen jälkeen rivillä %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -4966,6 +5349,7 @@ msgstr ""
 "COMPOUNDFORBIDFLAG PFX:n jälkeen voi antaa vääriä tuloksia kohteessa %s "
 "rivillä %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -4974,35 +5358,43 @@ msgstr ""
 "COMPOUNDPERMITFLAG PFX:n jälkeen voi antaa vääriä tuloksia kohteessa %s "
 "rivillä %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Väärä COMPOUNDRULES-arvo kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Väärä COMPOUNDWORDMAX-arvo kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Väärä COMPOUNDMIN-arvo kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Väärä COMPOUNDSYLMAX-arvo kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Väärä CHECKCOMPOUNDPATTERN-arvo kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Eri yhdistelmälippu jatketussa affiksilohkossa kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Kaksoiskappale affiksista kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5011,267 +5403,334 @@ msgstr ""
 "Affiksia käytetty myös BAD-, RARE-, KEEPCASE-, NEEDAFFIX-, NEEDCOMPOUND- tai "
 "NOSUGGEST-arvossa kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Odotettiin Y:tä tai N:ää kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Viallinen ehto kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Odotettiin REP(SAL)-arvoa kohteessa %s rivillä %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Odotettiin MAP-arvoa kohteessa %s rivillä %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Kaksoiskappale merkistä MAP:ssä kohteessa %s rivillä %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Tunnistamaton tai kaksoiskappale arvosta kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Puuttuva FOL, LOW tai UPP rivi kohteessa %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX ilman SYLLABLEa"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Liikaa jälkikäteistettyjä prefiksejä"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Liikaa yhdyssanalippuja"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Liikaa jälkikäteistettyjä prefiksejä tai yhdyssanalippuja"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Puuttuva SOFO%s-rivi kohteessa %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "SAL- ja SOFO-rivit kohteessa %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Lippu ei ole lukuarvo kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Tuntematon lippu kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s-arvo eroaa toisessa .aff-tiedostossa olevasta"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Luetaan sanakirjatiedostoa %s"
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Ei sanalaskuria kohteessa %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "rivi %6d, sana %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Toistettu sana kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Ensimmäinen kappale kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "toistettuja sanoja %d kohteessa %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ei-ASCII-merkkien takia ohitettuja sanoja %d kohteessa %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Luetaan sanatiedostoa %s..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Toistettu /encoding= ohitettu kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "/encoding= sanojen jälkeen ohitettu kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Toistettu /regions= ohitettu kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Liikaa regionseja kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "/ ohitettu kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Virheellinen region-luku kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Tunnistamaton lippu kohteessa %s rivillä %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ei-ASCIIn takia ohitettuja sanoja %d"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Tiivistetty %d/%d noodia. %d (%d %%) jäljellä"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Luetaan taas oikaisulukutiedostoa..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Ääntämyksen mukaan yhdistellään..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Sanoja ääntämysyhdistelyn jälkeen: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Sanoja yhteensä: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Kirjoitetaan ehdotustiedostoa %s..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Arvioitu käyttömuisti: %d tavua"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Tulostetiedostonimessä ei saa olla alueen nimeä"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Enintään 8 aluetta tuetaan"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Virheellinen alue kohteelle %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Varoitus: sekä yhdyssanamuodostus että NOBREAK käytössä"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Kirjoitetaan oikaisulukutiedostoa %s..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Valmista."
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: spellfile ei sisällä %<PRId64> kohtaa"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Sana poistettu kohteesta %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Sana lisätty kohteeseen %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Sanan merkit muuttuvat oikaisulukutiedostojen välillä"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Sori, ei ehdotuksia"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Sori, vain %<PRId64> ehdotusta"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Muuta %.*s:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < %.*s"
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Ei edellistä oikaisulukukorjausta"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Ei löytynyt: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Ei vaikuta .sug-tiedostolta: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Vanha .sug-tiedosto pitää päivittää: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug-tiedosto on uudemmalle Vimille: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug-tiedosto ei täsmää .spl-tiedostoon: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: virhe luettaessa .sug-tiedostoa: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: kaksoiskappale merkistä MAP-kohdassa"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Ei syntaksikohteita tälle puskurille"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Virheellinen argumentti: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaksiklusteri puuttuu: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Ei syntaksikohteita tälle puskurille"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synkkaa C-tyylin kommentteihin"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "ei synkkausta"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synkkaus aloitettu "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " riviä ennen alkua"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5279,6 +5738,7 @@ msgstr ""
 "\n"
 "--- Syntax sync -kohteet ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5286,6 +5746,7 @@ msgstr ""
 "\n"
 "synkataan kohteisiin"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5293,195 +5754,274 @@ msgstr ""
 "\n"
 "--- Syntax-kohteet ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: syntaksiklusteria ei ole: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "vähintään "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "enitntään "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; täsmää "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " rivinvaihdot"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: contains ei sovi tähän"
 
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Virheellinen argumentti"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here ei sovi tähän"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Aluetta nimelle %s ei löydy"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Tiedostonimi puuttuu"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Liikaa tiedostonimiä"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ] puuttuu: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: = puuttuu: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Argumentteja puuttuu: syntaksialue %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaksiklusteri puuttuu: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: klusteri määrittelemättä"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Kuvoin erotin puuttuu: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Roskia kuvion jäljessä: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: rivinjatkamiskuvio määritelty kahdesti"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Virheelliset argumentit: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: = puuttuu: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Tyhjä argumentti: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s ei sovi tähän"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s kuuluu contains-listan alkuun"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Tuntematon ryhmän nimi: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Virheelluinen :syntax-osakomento: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursiivinen silmukka syncolor.vimissä"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: korostusryhmää ei löytynyt: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Argumentteja puuttuu: :highlight link %s"
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Liikaa argumentteja: :highlight link %s"
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: ryhmällä on asetuksia, highlight link -komento ohitetaan"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: odotuksenvastainen =-merkki: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: puuttuva =-merkki: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: puuttuva argumentti: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Viallinen arvo: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: edustaväri tuntematon"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: taustaväri tuntematon"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Värin nimi tai numero tuntematon: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminaalikoodi liian pitkä: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Virheellinen argumentti: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Liikaa eri korostusattribuutteja"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Tulostuskelvoton merkki ryhmän nimessä"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Virheellinen merkki ryhmän nimessä"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: tägipinon pohja"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: tägipinon huippu"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Ei voida mennä ensimmäistä täsmäävää tägiä alummaksi"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tägi puuttuu: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # arvo tyyppi tägi"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "tiedosto\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Vain yksi tägi täsmää"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Ei voida edetä viimeisen täsmäävän tägin ohi"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Tiedostoa %s ei ole"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tägi %d/%d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " tai useammasta"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Tägissä eri kirjaintaso"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Tiedostoa %s ei ole"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5489,66 +6029,79 @@ msgstr ""
 "\n"
 "  # TILL tagg          FRÅN LINJE  i fil/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Etsitään tägitiedostoa %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tägitiedoston polku katkaistu kohdassa %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr "Ohitetaan pitkä rivi tägitiedostossa"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Muotovirh tägitiedostossa %s"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Ennen tavua %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tägitiedosto ei ole järjestetty: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Ei tägitiedostoja"
 
-msgid "Ignoring long line in tags file"
-msgstr "Ohitetaan pitkä rivi tägitiedostossa"
-
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Tägikuviota ei löydy"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Tägiä ei löydy, arvataan."
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Kaksoiskappale kentän nimestä: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr " ei tunnettu. Tuetut terminaalit:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "oletusarvona "
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Ei voi avata termcap-tiedostoa"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Terminaalia ei löytynyt terminfosta"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Terminaalia ei löytynyt termcapista"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: %s ei löytynyt termcapista"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: terminaalilla pitää olla cm kyvyissään"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5556,253 +6109,172 @@ msgstr ""
 "\n"
 "--- Terminaalinäppäimet ---"
 
-msgid "new shell started\n"
-msgstr "uusi kuori avattu\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Virhe luettaessa syötettä, poistutaan...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Käytettiin CUT_BUFFER0:aa tyhjän valinnan sijaan"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Rivimäärä vaihtui odottamatta"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Ei voi kumota, jatketaan silti"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Kumoustiedoston avaus kirjoittamista varten ei onnistu: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Pilaanntunut kumoustiedosto (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Ei voitu lukea kumoustiedostoa mistään undodir-muuttujan hakemistosta"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Ei ylikirjoitetat kumoustiedostolla, koska ei voida lukea: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Ei ylikirjoiteta, koska tämä ei ole kumoustiedosto: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Ohitetaan kumoustiedoston kirjoitus, koska ei ole peruutettavia"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Kirjoitetaan kumoustiedostoa: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Kirjoitusvirhe kumoustiedostossa: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Ei lueta kumoustiedosto jonka omistaja on eri: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Luetaan kumoustiedostoa: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Kumoustiedostoa ei voi avata lukemista varten: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Ei ole kumoustiedosto: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Salaamattomalla tiedostolla on salattu kumoustiedosto: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Kumoustiedoston purku epäonnistui: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Kumoustiedosto on salattu: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Epäyhteensopiva kumoustiedosto: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
-msgstr "Tiedoston sisältö on muuttunut, joen kumoustiedot ovat "
-"käyttökelvottomia"
+msgstr ""
+"Tiedoston sisältö on muuttunut, joen kumoustiedot ovat käyttökelvottomia"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Ladattu kumoustiedoto %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Vanhimmassa muutoksessa"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Nuorimmassa muutoksessa"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Kumouslukua %<PRId64> ei löydy"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: väärät rivinumerot"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "rivi lisää"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "riviä lisää"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "rivi vähemmän"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "riviä vähemmän"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "muutos"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "muutosta"
 
 # eka %s yläpuolelta, toka %s alapuolelta, kolmas %s aika
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s, %s #%<PRId64> %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "ennen muutosta"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "jälkeen muutoksen"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Ei kumottavaa"
 
-msgid "number changes  time            saved"
+#: ../undo.c:2330
+#, fuzzy
+msgid "number changes  when               saved"
 msgstr "muutoksia       aika            tallennettu"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekuntia sitten"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin ei toimi undon jälkeen"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: kumouslista rikki"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: kumousrivi puuttuu"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16- t. 32-bittinen GUI-versio"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64-bittinen GUI-versio"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32-bittinen GUI-version"
-
-msgid " in Win32s mode"
-msgstr " Win32s-tilassa"
-
-msgid " with OLE support"
-msgstr " OLE-tuella"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bittinen konsoliversio"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bittinen konsoliversio"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16-bittinen versio"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32-bittinen MS-DOS-versio"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16-bittinen MS-DOS-versio"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X-version (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X-version"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS-version"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS-version"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS-version"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5810,15 +6282,19 @@ msgstr ""
 "\n"
 "Pätsit: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
-msgstr "\n"
+msgstr ""
+"\n"
 "Muita pätsejä: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Muokannut "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5826,9 +6302,11 @@ msgstr ""
 "\n"
 "Kääntänyt "
 
+#: ../version.c:649
 msgid "by "
 msgstr ": "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5836,647 +6314,1714 @@ msgstr ""
 "\n"
 "Huge-versio "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Big-version "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normal-versio "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Small-versio "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Tiny-versio "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "ilman GUIta."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "GTK2-Gnome-GUIlla."
-
-msgid "with GTK2 GUI."
-msgstr "GTK2-GUIlla."
-
-msgid "with X11-Motif GUI."
-msgstr "X11-Motif-GUIlla."
-
-msgid "with X11-neXtaw GUI."
-msgstr "X11-neXtaw-GUIlla."
-
-msgid "with X11-Athena GUI."
-msgstr "X11-Athena-GUIlla."
-
-msgid "with Photon GUI."
-msgstr "Photon-GUIlla."
-
-msgid "with GUI."
-msgstr "GUIlla."
-
-msgid "with Carbon GUI."
-msgstr "Carbon-GUIlla."
-
-msgid "with Cocoa GUI."
-msgstr "Cocoa-GUIlla."
-
-msgid "with (classic) GUI."
-msgstr "perinteisellä GUIlla."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr " Ominaisuudet mukana (+) ja poissa (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   järjestelmän vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     käyttäjän vimrc: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2. käyttäjän vimrc: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3. käyttäjän vimrc: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      käyttäjän exrc: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2. käyttäjän exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  järjestelmän gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    käyttäjän gvimrc: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2. käyttäjän gvimrc: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3. käyttäjän gvimrc: \""
-
-msgid "    system menu file: \""
-msgstr "    järjestelmävalikko: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  $VIMin fallback: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " $VIMRUNTIMEn f-b: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Käännös: "
 
-msgid "Compiler: "
-msgstr "Käännin: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Linkitys: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  DEBUG-versio"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versio "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "tekijät Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim on avointa lähdekoodia ja vapaasti jaossa"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Auta Ugandan köyhiä lapsia"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "kirjoita :help iccf<Enter>    lisätietoa varten            "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "kirjoita :q<Enter>            lopettaaksesi                "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "kirjoita :help<Enter> tai <F1> ohjetta varten              "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "kirjoita :help version7<Enter> versiotietoja varten        "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Suoritetaan Vi-yhteensopivuustilaa"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "kirjoita :set nocp<Enter>      Vimin oletuksiin            "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "kirjoita :help cp-default<Enter> ohjetta oletuksista varten"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "valikko Ohje->Orvot            lisätietoja varten          "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Suoritetaan tilattomana, kirjoitettu teksti syötetään"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda syötetilaa"
-
-msgid "                              for two modes      "
-msgstr "                              kahta tilaa varten "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda Vi-yhteensopivuutta"
-
-msgid "                              for Vim defaults   "
-msgstr "                              Vim-oletuksia varten"
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Tue Vimin kehitystä"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Rekisteröidy Vim-käyttäjäksi."
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "kirjoita :help sponsor<Enter>  lisätietoja varten"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "kirjoita :help register<Enter> lisätietoja varten"
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "valikko Ohje->Sponsoroi/Rekisteröi lisätietoja varten"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "VAROITUS: Window 95/98/ME havaittu"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "kirjoita :help windows95<Enter> lisätietoja varten"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Enää yksi ikkuna jäljellä"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Ei esikatseluikkunaa"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Ei voi jakaa vasenta ylänurkkaa ja oikeaa alanurkkaa yhtäaikaa"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Ei voi kiertää kun toinen ikkuna on jaettu"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Ei voi sulkea viimeistä ikkunaa"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Ei voi sulkea autocmd-ikkunaa"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Ei voi sulkea viimeistä ikkunaa, joka ei ole autocmd-ikkuna"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Toinen ikkuna sisältää muutoksia"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Ei tiedostonimeä kursorin alla"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Tiedosto %s ei löydy polulta"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() tyhjällä salasanalla"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Kirjaston %s lataaminen ei onnistu"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Sori, komento ei toimi, Perl kirjastoa ei voinut ladata."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfishin tavujärjestys väärä"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Perl-suoritus kielletty hiekkalaatikossa ilman Safe-moduulia"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256-testi epäonnistui failed"
 
-msgid "Edit with &multiple Vims"
-msgstr "&Muokkaa usealla Vimillä"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish-testi epäonnistui"
 
-msgid "Edit with single &Vim"
-msgstr "Muokkaa yhdellä &Vimillä"
+#~ msgid "Patch file"
+#~ msgstr "Patch-tiedosto"
 
-msgid "Diff with Vim"
-msgstr "Diffi Vimillä"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Peru"
 
-msgid "Edit with &Vim"
-msgstr "Muokkaa &Vimillä"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Ei yhteyttä vim-palvelimeen"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Muokkaa olemassaolevalla Vimillä - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Kohteeseen %s lähettäminen ei onnistunut"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Muokkaa valittuja tiedostoja Vimillä"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Palvelimen vastauksen lukeminen ei onnistunut"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Virhe prosessin käynnistämisessä, varmista että gvim on polulla"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Asiakkaalle lähetys ei onnistunut"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll-virhe"
+#~ msgid "Save As"
+#~ msgstr "Tallenna nimellä"
 
-msgid "Path length too long!"
-msgstr "Liian pitkä polku"
+#~ msgid "Source Vim script"
+#~ msgstr "Lataa vim-skripti"
 
-msgid "--No lines in buffer--"
-msgstr "--Ei rivejä puskurissa--"
+#~ msgid "Edit File"
+#~ msgstr "Muokkaa tiedostoa"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Komento peruttu"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (EI LÖYTYNYT)"
 
-msgid "E471: Argument required"
-msgstr "E471: Argumentti puuttuu"
+#~ msgid "unknown"
+#~ msgstr "tuntematon"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\:n jälkeen pitää tulla /, ? tai &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Muokkaa uudessa ikkunassa"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Virheellinen komentorivi-ikkuna, <CR> suorittaa, Ctrl C lopettaa"
+#~ msgid "Append File"
+#~ msgstr "Lisää tiedostoon"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Komentoa ei tueta exrc:ssä tai vimrc:ssä tässä hakemistossa tai "
-"tägihaussa"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Ikkunan sijainti: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif puuttuu"
+#~ msgid "Save Redirection"
+#~ msgstr "Tallenna uudelleenosoitus"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry puuttuu"
+#~ msgid "Save View"
+#~ msgstr "Tallenna näkymä"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile puuttuu"
+#~ msgid "Save Session"
+#~ msgstr "Tallenna sessio"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor puuttuu"
+#~ msgid "Save Setup"
+#~ msgstr "Tallenna asetukset"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile ilman komentoa :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< ei ole käytössä jollei +eval ole päällä"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor ilman komentoa :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Digraafeja ei ole tässä versiossa"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Tiedosto on jo olemassa (lisää ! ohittaaksesi)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "on laite (ei käytössä opendevice-asetuksen takia)"
 
-msgid "E472: Command failed"
-msgstr "E472: Komento epäonnistui"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Luetaan vakiosyötteestä"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Tuntematon fontset: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[salattu]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Tuntematon fontti: %s"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Tiedoston salaus on tuntematon"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Fontti %s ei ole tasavälinen"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans ei salli kirjoittaa muokkaamattomiin puskureihin"
 
-msgid "E473: Internal error"
-msgstr "E473: Sisäinen virhe"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Osittaiset kirjoitukset kielletty NetBeans-puskureissa"
 
-msgid "Interrupted"
-msgstr "Keskeytetty"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "laitteeseen kirjoittaminen pois käytöstä opendevice-asetuksella"
 
-msgid "E14: Invalid address"
-msgstr "E14: Virheellinen osoite"
+# tietääkseni resurssiforkki on applen tiedostojärjestelmän tunnistejuttujuttu
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: resurssiosa häviäisi (lisää komentoon ! ohittaaksesi)"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Virheellinen argumentti"
+#~ msgid "<cannot open> "
+#~ msgstr "<ei voi avata> "
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Virheellinen argumentti: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: ei saada fonttia %s"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Virheellinen ilmaus: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: nykyiseen hakemistoon ei voi palata"
 
-msgid "E16: Invalid range"
-msgstr "E16: Virheellinen arvoalue"
+#~ msgid "Pathname:"
+#~ msgstr "Polku:"
 
-msgid "E476: Invalid command"
-msgstr "E476: Virheellinen komento"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: nykyistä hakemistoa ei saada selville"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: %s on hakemisto"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Kirjastukutsu %s() epäonnistui"
+#~ msgid "Cancel"
+#~ msgstr "Peru"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Ei voitu ladta kirjastofunktiota %s"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim-ikkuna"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Merkillä on virheellinen rivinumero"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Vierityspalkki: Pixmapin geometria ei selviä"
 
-msgid "E20: Mark not set"
-msgstr "E20: Merkkiä ei asetettu"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Ei voi luoda BalloonEvalia viestille ja callbackille"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Ei voi tehdä muutoksia, modifiable on pois päältä"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUIn käynnistys ei onnistu"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Liian monta tasoa skripteissä"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Ei voi lukea kohteesta %s"
 
-msgid "E23: No alternate file"
-msgstr "E23: Eo vaihtoehtoista tiedostoa"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Ei voi avata GUIta, sopivaa fonttia ei löydy"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Lyhennettä ei ole"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: guifontwide virheellinen"
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! ei sallittu"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: imactivatekeyn arvo on virheellinen"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUIta ei voi käyttää, koska sitä ei käännetty mukaan"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Väriä %s ei voi määritellä"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hepreaa ei voi käyttää, koska sitä ei käännetty mukaan\n"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Ei täsmäystä kursorin alla, etsitään seuraava"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsia ei voi käyttää, koska sitä ei käännetty mukaan\n"
+#~ msgid "Input _Methods"
+#~ msgstr "Syöte_menetelmät"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabiaa ei voi käyttää, koska sitä ei käännetty mukaan\n"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Etsi ja korvaa..."
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Korostusryhmää ei ole nimellä: %s"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Etsi..."
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Tekstiä ei ole syötetty vielä"
+#~ msgid "Find what:"
+#~ msgstr "Etsi:"
 
-msgid "E30: No previous command line"
-msgstr "E30: Ei edellistä komentoriviä"
+#~ msgid "Replace with:"
+#~ msgstr "Korvaa:"
 
-msgid "E31: No such mapping"
-msgstr "E31: Kuvausta ei ole"
+#~ msgid "Match whole word only"
+#~ msgstr "Korvaa kokonaisia sanoja"
 
-msgid "E479: No match"
-msgstr "E479: Ei täsmää"
+#~ msgid "Match case"
+#~ msgstr "Kirjaintaso"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Ei tsämää: %s"
+#~ msgid "Direction"
+#~ msgstr "Suunta"
 
-msgid "E32: No file name"
-msgstr "E32: Ei tiedostonimeä"
+#~ msgid "Up"
+#~ msgstr "Ylös"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Ei edellistä korvausta säännölliselle ilmaukselle"
+#~ msgid "Down"
+#~ msgstr "Alas"
 
-msgid "E34: No previous command"
-msgstr "E34: Ei edellistä komentoa"
+#~ msgid "Find Next"
+#~ msgstr "Etsi seuraava"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Ei edellistä säännöllistä ilmausta"
+#~ msgid "Replace"
+#~ msgstr "Korvaa"
 
-msgid "E481: No range allowed"
-msgstr "E481: Arvoalue ei sallittu"
+#~ msgid "Replace All"
+#~ msgstr "Korvaa kaikki"
 
-msgid "E36: Not enough room"
-msgstr "E36: Tila ei riitä"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: sessiomanageri lähetti die-pyynnön\n"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: palvelinta %s ei ole rekisteröitynä"
+#~ msgid "Close"
+#~ msgstr "Sulje"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Tiedostoa %s ei voi luoda"
+#~ msgid "New tab"
+#~ msgstr "Uusi välilehti"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: väliaikaistiedoston nimeä ei saada selville"
+#~ msgid "Open Tab..."
+#~ msgstr "Avaa välilehti..."
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Ei voi avata tiedostoa %s"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Pääikkuna tuhoutui odottamatta\n"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Ei voi lukea tiedostoa %s"
+#~ msgid "&Filter"
+#~ msgstr "&Suodata"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr ""
-"E37: Viimeisen muutoksen jälkeen ei ole kirjoitettu (lisää ! ohittaaksesi)"
+#~ msgid "&Cancel"
+#~ msgstr "&Peru"
 
-msgid "E38: Null argument"
-msgstr "E38: Null-argumentti"
+#~ msgid "Directories"
+#~ msgstr "Hakemistot"
 
-msgid "E39: Number expected"
-msgstr "E39: Pitää olla numero"
+#~ msgid "Filter"
+#~ msgstr "Suodatus"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: virhetiedostoa %s ei voi avata"
+#~ msgid "&Help"
+#~ msgstr "O&hje"
 
-msgid "E233: cannot open display"
-msgstr "E233: näyttöä ei voi avata"
+#~ msgid "Files"
+#~ msgstr "Tiedostot"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Muisti loppui"
+#~ msgid "&OK"
+#~ msgstr "&Ok"
 
-msgid "Pattern not found"
-msgstr "Kuviota ei löydy"
+#~ msgid "Selection"
+#~ msgstr "Valinta"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Kuviota ei löydy: %s"
+#~ msgid "Find &Next"
+#~ msgstr "Hae &seuraava"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argumentin pitää olla positiivinen"
+#~ msgid "&Replace"
+#~ msgstr "Ko&rvaa"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Ei voi siirtyä edelliseen hakemistoon"
+#~ msgid "Replace &All"
+#~ msgstr "Korvaa k&aikki"
 
-# ;-)
-msgid "E42: No Errors"
-msgstr "E42: Ei virheitä"
+#~ msgid "&Undo"
+#~ msgstr "&Kumoa"
 
-msgid "E776: No location list"
-msgstr "E776: Ei sijaintilistaa"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Ikkunan otsikkoa ei löydy %s"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Viallinen täsmäysmerkkijono"
+# OLE on object linking and embedding på windowska
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argumenttia ei tueta: -%s, käytä OLE-versiota"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Viallinen regexp-ohjelma"
+# MDI eli windowsin moni-ikkunasovellus
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Ikkunaa ei voitu avata MDI-sovellukseen"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: readonly asetettu (lisää ! ohittaaksesi)"
+#~ msgid "Close tab"
+#~ msgstr "Sulje välilehti"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Kirjoitussuojattua muuttujaa %s ei voi muuttaa"
+#~ msgid "Open tab..."
+#~ msgstr "Avaa välilehti..."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Muuttujaa ei voi asettaa hiekkalaatikossa: %s"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Etsi merkkijonoa (\\\\:llä löytää \\:t)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Virhe virhetiedostoa luettaessa"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Etsi ja korvaa (\\\\:llä löytää \\:t)"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Ei sallittu hiekkalaatikossa"
+#~ msgid "Not Used"
+#~ msgstr "Ei käytössä"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Ei sallittu täällä"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Hakemisto\t*.nothing\n"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Näyttötila-asetus ei tuettu"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Ei voi varata värikartan alkiota, värit voivat mennä väärin"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Virheellinen vierityskoko"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Seuraavien merkistöjoukkojen fontit puuttuvat fontsetistä %s:"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: shell-asetus on tyhjä"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Fontsetin nimi: %s"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Merkkidatan luku ei onnistu"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Fontti %s ei ole tasavälinen"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Swap-tiedoston sulkemisvirhe"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Fontsetin nimi: %s\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: tägipino tyhjä"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Fontti0: %s\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: Liian monimutkainen komento"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Fontti1: %s\n"
 
-msgid "E75: Name too long"
-msgstr "E75: Liian pitkä nimi"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Fontti%<PRId64>:n leveys ei ole kaksi kertaa fontti0:n\n"
 
-msgid "E76: Too many ["
-msgstr "E76: Liian monta [:a"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Fontti0:n leveys: %<PRId64>\n"
 
-msgid "E77: Too many file names"
-msgstr "E77: Liikaa tiedostonimiä"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Fontti1:n leveys: %<PRId64>\n"
+#~ "\n"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Ylimääräisiä merkkejä perässä"
+#~ msgid "Invalid font specification"
+#~ msgstr "Virheellinen fonttimääritys"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Tuntematon merkki"
+#~ msgid "&Dismiss"
+#~ msgstr "&Ohita"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Jokerimerkkien avaus ei onnistu"
+#~ msgid "no specific match"
+#~ msgstr "ei tarkkaa täsmäystä"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: winheight ei voi olla pienempi kuin winminheight"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - fonttivalitsin"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: winwidth ei voi olla pienempi kuin winminwidth"
+#~ msgid "Name:"
+#~ msgstr "Nimi:"
 
-msgid "E80: Error while writing"
-msgstr "E80: Kirjoitusvirhe"
+#~ msgid "Show size in Points"
+#~ msgstr "Näytä koko pisteinä"
 
-msgid "Zero count"
-msgstr "Nollalaskuri"
+#~ msgid "Encoding:"
+#~ msgstr "Koodaus:"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> skriptin ulkopuolella"
+#~ msgid "Font:"
+#~ msgstr "Fontti:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Virheellinen ilmaus saatu"
+#~ msgid "Style:"
+#~ msgstr "Tyyli:"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Alue on suojattu, muuttaminen ei onnistu"
+#~ msgid "Size:"
+#~ msgstr "Koko:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans ei tue muutoksia kirjoitussuojattuihin tiedostoihin"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangu-automaattivirhe"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Sisäinen virhe: %s"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat-virhe"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: kuvio käyttää enemmän muistia kuin maxmempattern on"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: ei voi avata cscope-tietokantaa: %s"
 
-msgid "E749: empty buffer"
-msgstr "E749: tyhjä puskuri"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: ei voi hakea cscope-tietokannan tietoja"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Virheellinen hakulauseke tai erotin"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Luan kirjastoa ei voitu ladata."
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Tiedosto on ladattu toiseen puskuriin"
+#~ msgid "cannot save undo information"
+#~ msgstr "ei voitu tallentaa kumoustietoja"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Asetus %s on asettamatta"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr "E815: Sori, komento ei toimi, MzScheme-kirjastoa ei voitu ladata."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "haku pääsi ALKUUN, jatketaan LOPUSTA"
+#~ msgid "invalid expression"
+#~ msgstr "virheellinen ilmaus"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "haku pääsi LOPPUUN, jatketaan ALUSTA"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "ilmaukset poistettu käytöstä käännösaikana"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Tarvitaan salausavain kohteelle %s "
+#~ msgid "hidden option"
+#~ msgstr "piilotettu asetus"
 
-msgid "writelines() requires list of strings"
-msgstr "writelines()-komennolle pitää antaa merkkijonolista"
+#~ msgid "unknown option"
+#~ msgstr "tuntematon asetus"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Virhe IO-olioiden alustuksessa"
+#~ msgid "window index is out of range"
+#~ msgstr "ikkunan indeksi alueen ulkopuolella"
 
-msgid "no such buffer"
-msgstr "puskuria ei ole"
+#~ msgid "couldn't open buffer"
+#~ msgstr "ei voitu avata puskuria"
 
-msgid "attempt to refer to deleted window"
-msgstr "yritettiin viitata poistettuun ikkunaan"
+#~ msgid "cannot delete line"
+#~ msgstr "ei voitu poistaa riviä"
 
-msgid "readonly attribute"
-msgstr "kirjoitussuojattu attribuutti"
+#~ msgid "cannot replace line"
+#~ msgstr "ei voitu korvata riviä"
 
-msgid "cursor position outside buffer"
-msgstr "kursorin sijainti puskurin ulkopuolella"
+#~ msgid "cannot insert line"
+#~ msgstr "ei voitu lisätä riviä"
 
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<ikkunaolio (poistettu) kohdassa %p>"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "merkkijono ei saa sisältää rivinvaihtoja"
 
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<ikkunaolio (tuntematon) kohdassa %p>"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim-virhe: ~a"
 
-#, c-format
-msgid "<window %d>"
-msgstr "<ikkuna %d>"
+#~ msgid "Vim error"
+#~ msgstr "Vim-virhe"
 
-msgid "no such window"
-msgstr "ikkunaa ei ole"
+#~ msgid "buffer is invalid"
+#~ msgstr "puskuri on virheellinen"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "yritettiin viitata poistettuun puskuriin"
+#~ msgid "window is invalid"
+#~ msgstr "ikkuna on virheellinen"
+
+#~ msgid "linenr out of range"
+#~ msgstr "rivinumero arvoalueen ulkopuolelta"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "ei sallittu Vimin hiekkalaatikossa"
+
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr ""
+#~ "E836: Python: Ei voi käyttää komentoja :py ja :py3 samassa istunnossa"
+
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr ""
+#~ "E837: Python: Ei voi käyttää komentoja :py ja :py3 samassa istunnossa"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Sori, komento ei toimi, Python-kirjaston lataaminen ei onnistunut."
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "ei voi poistaa OutputObject-attribuutteja"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspacen pitää olla kokonaisluku"
+
+#~ msgid "invalid attribute"
+#~ msgstr "virheellinen attribuutti"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<puskuriolio (poistettu) kohdassa %p>"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Pythonia ei voi kutsua rekursiivisesti"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: muuttujan $_ pitää olla Stringin instanssi"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: Sori, komento ei toimi, Ruby-kirjastoa ei voitu ladata."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: odotuksenvastainen return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: Odotuksenvastainen next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: Odotuksenvastainen break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: odotuksenvastainen redo"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry rescuen ulkopuolella"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: käsittelemätön poikkeus"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: tuntematon longjmp-tila %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Vaihda toteutuksen ja määritelmän välillä"
+
+#~ msgid "Show base class of"
+#~ msgstr "Näytä kantaluokka kohteelle"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Näytä korvattu jäsenfunktio"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Jäljitä tiedostosta"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Jäljitä projektista"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Jäljitä kaikista projekteista"
+
+#~ msgid "Retrieve"
+#~ msgstr "Jäljitä"
+
+#~ msgid "Show source of"
+#~ msgstr "Näytä lähdekoodi kohteelle"
+
+#~ msgid "Find symbol"
+#~ msgstr "Etsi symboli"
+
+#~ msgid "Browse class"
+#~ msgstr "Selaa luokkaa"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Näytä luokka hierarkiassa"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Näytä luokka rajoitetussa hierarkiassa"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref viittaa kohteeseen"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref viitattu kohteesta"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref sisältää kohteen"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xrefiä käyttää"
+
+#~ msgid "Show docu of"
+#~ msgstr "Näytä dokumentti kohteelle"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Luo dokumentti kohteelle"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Ei voida yhdistää SNiFF+:aan. Tarkista ympäristömuuttujat (sniffemacsin "
+#~ "löytyä polkumuuttujasta $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Virhe luettaessa, yhteys katkaistu"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ "
+
+#~ msgid "not "
+#~ msgstr "ei ole "
+
+#~ msgid "connected"
+#~ msgstr "yhdistetty"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Tuntematon SNiFF+-pyyntö: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Virhe yhdistettäessä SNiFF+:aan"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ ei ole yhdistetty"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ei ole SNiFF+-puskuri"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Virhe kirjoituksessa, yhteys katkaistu"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "virheellinen puskurinumero"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ei toteutettu"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "ei voi asettaa rivejä"
+
+#~ msgid "invalid mark name"
+#~ msgstr "virheellinen merkin nimi"
+
+#~ msgid "mark not set"
+#~ msgstr "merkko ei ole asetettu"
+
+#~ msgid "row %d column %d"
+#~ msgstr "rivi %d sarake %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "rivin lisäys ei onnistu"
+
+#~ msgid "line number out of range"
+#~ msgstr "rivinumero arvoalueen ulkopuolella"
+
+#~ msgid "unknown flag: "
+#~ msgstr "tuntematon asetus: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "tuntematon vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "näppäimistökeskeytys"
+
+#~ msgid "vim error"
+#~ msgstr "vim-virhe"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "ei voi luoda puskuri- tai ikkunakomentoa, olio on poistumassa"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "callbackia ei voi rekisteröidä: puskuri tai ikkuna on poistettu"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: kriittinen TCL-virhe: reflist hajalla? Ilmoita asiasta "
+#~ "postituslistalle vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "callbackia ei voi rekisteröidä: puskurin tai ikkunan viitettä ei löydy"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: Sori, komento ei toimi, Tcl-kirjastoa ei voitu ladata."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL-virhe: lopetuskoodi ei ole kokonaisluku? Ilmoita asiasta "
+#~ "postituslistalle vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: palautusarvo %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "ei voida hakea riviä"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Komentopalvelimen nimen rekisteröinti ei onnistu"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Komennon lähetys kohdeohjelmalle ei onnistu"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Virheellinen palvelimen tunniste: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIMin instanssin rekisteriarvo on virheellinen, poistettiin."
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans ei toimi tässä käyttöliittymässä\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Tähän Vimiin ei ole käännetty diff-toimintoja mukaan."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "-nb:tä ei voi käyttää, koska sitä ei käännetty mukaan\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Virhe: Gvimin käynnistys NetBeansistä ei onnistu\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Jos aakkoslaji on ohitettu, lisää alkuun / tehdäksesi asetuksesta "
+#~ "suuraakkosia"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\trekisteröi gvim OLEa varten"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tPoista gvim OLE-rekisteristä"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tAvaa GUI (kuten gvimillä)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f tai --nofork\tEdustalle: Älä haarauta GUIn käynnistyksessä"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tÄlä käytä newcli:tä ikkunan avaamiseen"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <laite>\t\tKäytä <laitetta> IO:hon"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tKäytä <gvimrc>-tiedostoa .gvimrc:iden sijasta"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tMuokkaa salattua tiedostoa"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <näyttö>\tYhdistä vim tiettyyn X-palvelimeen"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tÄlä yhdistä X-palvelimeen"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <tiedostoja>\tMuokkaa <tiedostoja> Vim-palvelimessa, jos "
+#~ "mahdollista"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <tiedostoja>\tSama, mutta älä ilmoita puuttuvasta "
+#~ "palvelimesta"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <tiedostoja>  kuten --remote, mutta odota tiedostojen "
+#~ "muokkaamista"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <tiedostoja>  sama, mutta älä ilmoita puuttuvasta "
+#~ "palvelimesta"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <tiedostoja>  kuten --remote, mutta avaa "
+#~ "välilehti joka tiedostolle"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <näppäimiä>\tLähetä <näppäimiä> painalluksina Vimille ja "
+#~ "lopeta"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <ilmaus>\tKäsittele <ilmaus> Vim-palvelimella ja tulosta "
+#~ "tulos"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tLuettele Vim-palvelinten nimet ja lopeta"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nimi>\tLähetä Vim-palvelimelle <nimi> tai luo se"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Gvimin (Motif-version) tuntemat argumentit:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Gvimin (neXtaw-version) tuntemat argumentit:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Gvimin (Athena-version) tuntemat argumentit:\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <näyttö>\tSuorita vim <näytössä>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tKäynnistä pienennettynä"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <väri>\tKäytä <väriä> taustavärinä (myös: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <väri>\tKäytä <väriä> tekstin värinä (myös: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <fontti>\t\tKäytä <fonttia> tekstissä (myös: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <fontti>\tKäytä <fonttia> lihavoidussa tekstissä"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <fontti>\tKäytä <fonttia> kursivoidussa tekstissä"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tKäytä mittoja <geom> ikkunan asetteluun (myös: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidt <leveys>\tKäytä <leveyttä> reunuksissa (myös: -bw) "
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <leveys>  Käytä <leveyttä> vierityspalkissa (myös: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <korkeus>\tKäytä <korkeutta> valikossa (myös: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tKäytä käänteisvärejä (myös: -rv) "
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tÄlä käytä käänteisvärejä (myös: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resurssi>\tAseta resurssi"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Gvimin (RISC OS -version) tuntemat argumentit:\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <luku>\tIkkunan alkuleveys sarakkeina"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <luku>\tIkkunan alkukorkeus riveinä"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Gvimin (GTK+-version) tuntemat argumentit:\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <näyttö>\tSuorita vim näytöllä <näyttö> (myös: --display)"
+
+# X-ikkunointijärjestelmässä saman sovelluksen saman luokan ikkunat
+# tunnistetaan rooliresursseista
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <rooli>\tAseta pääikkunalle ainutlaatuinen rooli tunnisteeksi"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tAvaa Vim annettuun GTK-olioon "
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <otsikko>\tAvaa Vim isäntäohjelman sisään"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tAvaa Vim annettuun win32-olioon "
+
+#~ msgid "No display"
+#~ msgstr "Ei näyttöä"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Lähetys epäonnistui.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Lähetys epäonnistui. Yritetään suorittaa paikallisena\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d/%d muokattu"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Ei näyttöä: Ilmauksen lähetys epäonnistui.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Ilmauksen lähetys epäonnistui.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Koodisivu ei ole käypä"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Syötekontekstin luonti ei onnistu"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Syötemetodin avaus ei onnistu"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Varoitus: Ei voitu asettaa destroy-kutsua syötemetodipalvelimelle"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: syötemetodi ei tue tyylejä"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: syötemetodi ei tue tätä preedit-tyyppiä"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s on salattu eikä tämä Vim tue salausta"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Swap-tiedosto on salattu: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Jos käytit uutta salausavainta muttet kirjoittanut tekstitiedostoa,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "anna uusi salausavain."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Jos kirjoitit tekstitiedoston salausavaimen vaihdon jälkeen paina enteriä"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "käyttääksesi samaa avainta teksti- ja swäppitiedostoille"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "Käytetään swäpin salausavainta tekstitiedostolle\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [ei toimi tämän Vim-version kanssa]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Repäise valikko irti"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Hakemiston valintaikkuna"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Tallennusikkuna"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Avausikkuna"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Sori, tiedostonselain puuttuu konsolitilasta"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: säästetään tiedostoja...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Valmis.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "VIRHE: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[tavua] yht. alloc-free %<PRIu64>-%<PRIu64>, käytössä %<PRIu64>, "
+#~ "käyttöhuippu %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[kutsut] yht. re/malloc() %<PRIu64>, yht. free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Rivistä tulee liian pitkä"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Sisäinen virhe: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Virheellinen hiiren muoto"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Anna salausavain: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Anna sama avain uudestaan: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Avaimet eivät täsmää!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Ei voi yhdistää Netbeans #2:een"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Ei voi yhdistää Netbeansiin"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: Väärä avaustila NetBeans-yhteyden infotiedostolle: %s"
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "luettu Netbeans-soketista"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: NetBeans-yhteys katkesi puskurille %<PRId64>"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans on yhdistetty jo"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval ei ole käytettävissä"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "vapautetaan %<PRId64> riviä"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Ei voi vaihtaa termiä GUIssa"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Käytä komentoa :gui GUIn käynnistämiseen"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Ei voi muuttaa GTK+2-GUIssa"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Viallisia fontteja"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Fontsetin valinta ei onnistu"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Viallinen fontset"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Leveän fontin valinta ei onnistu"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Viallinen leveä fontti"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Hiirtä ei tueta"
+
+#~ msgid "cannot open "
+#~ msgstr "ei voi avata "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Ei voi avata ikkunaa\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Amigados 2.04 tai uudempi tarvitaan\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Tarvitaan %s versio %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Ei voi avata NILiä:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Ei voi luoda "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim sulkeutuu koodilla %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "ei voi vaihtaa konsolitilaa?\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: ei ole konsoli?\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Kuorta ei voi avata asetuksella -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Ei voi suorittaa "
+
+#~ msgid "shell "
+#~ msgstr "kuori "
+
+#~ msgid " returned\n"
+#~ msgstr " palautti\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE liian pieni."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "IO-virhe"
+
+#~ msgid "Message"
+#~ msgstr "Viesti"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "columns ei ole 80, ei voi suorittaa ulkoista komentoa"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Tulostimen valinta epäonnistui"
+
+#~ msgid "to %s on %s"
+#~ msgstr "tulostimelle %s kohteessa %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Tuntematon tulostimen fontti: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Tulostinvirhe: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Tulostetaan %s"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Virheellinen merkistön nimi %s fontin nimessä %s"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Virheellinen merkki %c fontin nimessä %s"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Kaksoissignaali, lopetetaan\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Tappava signaali %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Tappava signaali\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "X-näytön avaus vei %<PRId64> millisekuntia"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X-virhe\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "X-näytön testaus epäonnistui"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "X-näytön avaus aikakatkaistiin"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kuoren sh suoritus ei onnistu\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Putkia ei voi tehdä\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ei voi haarauttaa\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Komento loppui\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP kadotti ICE-yhteyden"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "X-näytön avaus epäonnistui"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP käsittelee save-yourself-pyyntöä"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP avaa yhteyttä"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP:n ICE-yhteyden tarkkailu epäonnistui"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection epäonnistui: %s"
+
+#~ msgid "At line"
+#~ msgstr "Rivillä"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Vim32.dll:ää ei voitu ladata"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM-virhe"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Ei voitu korjata funktio-osoittimia DLL:ssä"
+
+#~ msgid "shell returned %d"
+#~ msgstr "kuori palautti arvon %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Napattiin %s\n"
+
+#~ msgid "close"
+#~ msgstr "sulkeminen"
+
+#~ msgid "logoff"
+#~ msgstr "uloskirjautuminen"
+
+#~ msgid "shutdown"
+#~ msgstr "sammutus"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Komentoa ei löydy"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXEä ei löydy muuttujasta $PATH.\n"
+#~ "Ulkoiset komennot eivät pysähdy suorituksen lopussa.\n"
+#~ "Lisätietoja komennolla  :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim-varoitus"
+
+#~ msgid "Error file"
+#~ msgstr "Virhetiedosto"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Muutosta kohteessa %s ei tueta"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tägitiedoston polku katkaistu kohdassa %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "uusi kuori avattu\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Käytettiin CUT_BUFFER0:aa tyhjän valinnan sijaan"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Ei voi kumota, jatketaan silti"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Salaamattomalla tiedostolla on salattu kumoustiedosto: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Kumoustiedoston purku epäonnistui: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Kumoustiedosto on salattu: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16- t. 32-bittinen GUI-versio"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64-bittinen GUI-versio"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bittinen GUI-version"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " Win32s-tilassa"
+
+#~ msgid " with OLE support"
+#~ msgstr " OLE-tuella"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bittinen konsoliversio"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bittinen konsoliversio"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16-bittinen versio"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32-bittinen MS-DOS-versio"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16-bittinen MS-DOS-versio"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X-version (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "OpenVMS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Big-version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normal-versio "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Small-versio "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Tiny-versio "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "GTK2-Gnome-GUIlla."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "GTK2-GUIlla."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "X11-Motif-GUIlla."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "X11-neXtaw-GUIlla."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "X11-Athena-GUIlla."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "Photon-GUIlla."
+
+#~ msgid "with GUI."
+#~ msgstr "GUIlla."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "Carbon-GUIlla."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "Cocoa-GUIlla."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "perinteisellä GUIlla."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  järjestelmän gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    käyttäjän gvimrc: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2. käyttäjän gvimrc: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3. käyttäjän gvimrc: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    järjestelmävalikko: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Käännin: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "valikko Ohje->Orvot            lisätietoja varten          "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Suoritetaan tilattomana, kirjoitettu teksti syötetään"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda syötetilaa"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              kahta tilaa varten "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda Vi-yhteensopivuutta"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              Vim-oletuksia varten"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "VAROITUS: Window 95/98/ME havaittu"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "kirjoita :help windows95<Enter> lisätietoja varten"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Kirjaston %s lataaminen ei onnistu"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "Sori, komento ei toimi, Perl kirjastoa ei voinut ladata."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: Perl-suoritus kielletty hiekkalaatikossa ilman Safe-moduulia"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "&Muokkaa usealla Vimillä"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Muokkaa yhdellä &Vimillä"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diffi Vimillä"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Muokkaa &Vimillä"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Muokkaa olemassaolevalla Vimillä - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Muokkaa valittuja tiedostoja Vimillä"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Virhe prosessin käynnistämisessä, varmista että gvim on polulla"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll-virhe"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Liian pitkä polku"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Tuntematon fontset: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Tuntematon fontti: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Fontti %s ei ole tasavälinen"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Ei voitu ladta kirjastofunktiota %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hepreaa ei voi käyttää, koska sitä ei käännetty mukaan\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsia ei voi käyttää, koska sitä ei käännetty mukaan\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabiaa ei voi käyttää, koska sitä ei käännetty mukaan\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: palvelinta %s ei ole rekisteröitynä"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: näyttöä ei voi avata"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Virheellinen ilmaus saatu"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Alue on suojattu, muuttaminen ei onnistu"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans ei tue muutoksia kirjoitussuojattuihin tiedostoihin"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Tarvitaan salausavain kohteelle %s "
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines()-komennolle pitää antaa merkkijonolista"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Virhe IO-olioiden alustuksessa"
+
+#~ msgid "no such buffer"
+#~ msgstr "puskuria ei ole"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "yritettiin viitata poistettuun ikkunaan"
+
+#~ msgid "readonly attribute"
+#~ msgstr "kirjoitussuojattu attribuutti"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "kursorin sijainti puskurin ulkopuolella"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<ikkunaolio (poistettu) kohdassa %p>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<ikkunaolio (tuntematon) kohdassa %p>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<ikkuna %d>"
+
+#~ msgid "no such window"
+#~ msgstr "ikkunaa ei ole"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "yritettiin viitata poistettuun puskuriin"
 
 # New Line eli uusi rivinvaihtomerkki (ei CR, LF tai CR LF)
 #~ msgid "[NL found]"

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -1805,10 +1805,6 @@ msgstr "%<PRId64> riviä, "
 msgid "1 character"
 msgstr "1 merkki"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> merkkiä"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -2057,10 +2057,6 @@ msgstr "%<PRId64> lignes, "
 msgid "1 character"
 msgstr "1 caractère"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> caractères"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Français)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-05-27 04:55+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-05-27 10:22+0200\n"
 "Last-Translator: Dominique Pellé <dominique.pelle@gmail.com>\n"
 "Language-Team: \n"
@@ -24,153 +24,189 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO_8859-15\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() appelée avec un mot de passe vide"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "impossible d'obtenir la valeur d'une option"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
-
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: petit/gros boutisme incorrect dans blowfish"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: le test de sha256 a échoué"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: le test de blowfish a échoué"
+#: ../api/private/helpers.c:204
+#, fuzzy
+msgid "internal error: unknown option type"
+msgstr "erreur interne : pas d'élément de liste vim"
 
 # DB - TODO : Trouver une traduction valable et attestée pour "location".
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Liste des emplacements]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Liste Quickfix]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Des autocommandes ont causé la terminaison de la commande"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Aucun tampon ne peut être alloué, Vim doit s'arrêter"
 
 # AB - La situation est probablement plus grave que la version anglaise ne le
 #      laisse entendre (voir l'aide en ligne). La version française est plus
 #      explicite.
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr ""
 "E83: L'allocation du tampon a échoué : arrêtez Vim, libérez de la mémoire"
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Aucun tampon n'a été déchargé"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Aucun tampon n'a été effacé"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Aucun tampon n'a été détruit"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 tampon a été déchargé"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d tampons ont été déchargés"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 tampon a été effacé"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d tampons ont été effacés"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 tampon a été détruit"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d tampons ont été détruits"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Impossible de décharger le dernier tampon"
+
 # AB - La version française est meilleure que la version anglaise.
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Aucun tampon n'est modifié"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Aucun tampon n'est listé"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Le tampon %<PRId64> n'existe pas"
 
 # AB - Je ne suis pas sûr que l'on puisse obtenir ce message.
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Impossible d'aller après le dernier tampon"
 
 # AB - Je ne suis pas sûr que l'on puisse obtenir ce message.
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Impossible d'aller avant le premier tampon"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
 "E89: Le tampon %<PRId64> n'a pas été enregistré (ajoutez ! pour passer outre)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Impossible de décharger le dernier tampon"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Alerte : La liste des noms de fichier déborde"
 
 # AB - Vu le code source, la version française est meilleure que la
 #      version anglaise. Ce message est similaire au message E86.
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Le tampon %<PRId64> n'existe pas"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Plusieurs tampons correspondent à %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Aucun tampon ne correspond à %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "ligne %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Un tampon porte déjà ce nom"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr "[Modifié]"
 
 # AB - "[Inédité]" est plus correct, mais sonne faux.
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Non édité]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nouveau fichier]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Erreurs de lecture]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
 # AB - La version courte, "[RO]", devrait-elle être traduite par "[LS]" ?
 #      Il faudrait faire un sondage auprès des utilisateurs francophones.
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[lecture-seule]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 ligne --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> lignes --%d%%--"
 
 # AB - Faut-il remplacer "sur" par "de" ?
 # DB - Mon avis : oui.
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "ligne %<PRId64> sur %<PRId64> --%d%%-- col "
@@ -178,13 +214,16 @@ msgstr "ligne %<PRId64> sur %<PRId64> --%d%%-- col "
 # DB - Je trouvais [Aucun fichier] (VO : [No file]) plus naturel
 #      lors du lancement de Vim en mode graphique (ce message
 #      apparaît notamment dans le titre de la fenêtre).
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Aucun nom]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "aide"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Aide]"
 
@@ -192,19 +231,24 @@ msgstr "[Aide]"
 #      traduction littérale et brève, mais qui risque fort d'être mal comprise.
 #      J'ai finalement choisi d'utiliser une abréviation, mais cela ne me
 #      satisfait pas.
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Prévisu]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Tout"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Bas"
 
 # AB - Attention, on passe de trois à quatre lettres.
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Haut"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -212,9 +256,11 @@ msgstr ""
 "\n"
 "# Liste des tampons :\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Brouillon]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -222,130 +268,175 @@ msgstr ""
 "\n"
 "--- Symboles ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Symboles dans %s :"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    ligne=%<PRId64>  id=%d  nom=%s"
+
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: ':' manquant"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Mode non autorisé"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: chiffre attendu"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Pourcentage non autorisé"
 
 # AB - Je n'ai pas trouvé de traduction satisfaisante au verbe "diff". Comme
 #      Vim fait en pratique appel au programme "diff" pour evaluer les
 #      différences entre fichiers, "to diff" a été traduit par "utiliser diff"
 #      et d'autres expressions appropriées.
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Impossible d'utiliser diff sur plus de %<PRId64> tampons"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Impossible de lire ou écrire des fichiers temporaires"
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: diff ne fonctionne pas"
 
-msgid "Patch file"
-msgstr "Fichier rustine"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Le fichier intermédiaire produit par patch n'a pu être lu"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Le fichier intermédiaire produit par diff n'a pu être lu"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Le tampon courant n'est pas en mode diff"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Aucun autre tampon en mode diff n'est modifiable"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Aucun autre tampon n'est en mode diff"
 
 # AB - La version française est meilleure que la version anglaise, mais elle
 #      peut être améliorée.
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Plus de deux tampons sont en mode diff, soyez plus précis"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Le tampon %s est introuvable"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Le tampon %s n'est pas en mode diff"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Le tampon a été modifié inopinément"
 
 # AB - Je cherche une traduction plus concise pour "escape".
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Un digraphe ne peut contenir le caractère d'échappement"
 
 # AB - La version française est trop verbeuse.
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Le fichier descripteur de clavier est introuvable"
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap ne peut être utilisé que dans un script Vim"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Entrée du descripteur de clavier (keymap) vide"
 
 # AB - Remplacer "complétion" par "complètement" ? Voir l'éthymologie
 #      d'"accrétion".
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Complètement de mot-clé (^N^P)"
 
 # DB - todo : Faut-il une majuscule à "mode" ?
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " mode ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Complètement de ligne entière (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Complètement de nom de fichier (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Complètement de marqueur (^]^N^P)"
 
 # AB - J'ai dû avoir une bonne raison de faire une version française aussi
 #      différente de la version anglaise. Il me faut la retrouver.
 # DB - TODO
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Complètement global de mot-clé (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Complètement de définition (^D^N^P)"
 
 # AB - Trouver une meilleure formulation que "selon le".
 # DB : proposition : "avec"
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Complètement avec le dictionnaire (^K^N^P)"
 
 # AB - Trouver une meilleure formulation que "selon le".
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Complètement avec le thésaurus (^T^N^P)"
 
 # AB - La version française est meilleure que la version anglaise.
 # DB : Suggestion.
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Complètement de ligne de commande (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Complètement défini par l'utilisateur (^U^N^P)"
 
 # DB : On doit pouvoir trouver nettement mieux que ça.
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Complètement selon le type de fichier (Omni) (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Suggestion d'orthographe (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Complètement local de mot-clé (^N/^P)"
 
@@ -353,35 +444,45 @@ msgstr " Complètement local de mot-clé (^N/^P)"
 #      Il faut éviter de le faire trop long. Je pense que la version française
 #      est suffisamment compréhensible dans le contexte dans lequel elle est
 #      affichée.
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Fin du paragraphe"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: La fonction de complètement a changé la fenêtre"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: La fonction de complètement a effacé du texte"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "L'option 'dictionary' est vide"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "L'option 'thesaurus' est vide"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Examen du dictionnaire : %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (insertion) Défilement (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (remplacement) Défilement (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Examen : %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Examen des marqueurs."
 
@@ -389,6 +490,7 @@ msgstr "Examen des marqueurs."
 #      opération de complétion est répétée (typiquement avec CTRL-X CTRL-N).
 #      Que ce soit en anglais ou en français, il y a un problème de majuscules.
 #      Bien qu'insatisfaisante, cette traduction semble optimale.
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Ajout"
 
@@ -396,183 +498,236 @@ msgstr " Ajout"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Recherche en cours..."
 
 # AB - Ce texte s'ajoute à la fin d'un des messages de complétion ci-dessus.
 # AB - Faut-il utiliser "origine" ou "originel" au lieu d'"original" ?
 # DB : Suggestion.
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Retour au point de départ"
 
 # AB - Ce texte s'ajoute à la fin d'un des messages de complétion ci-dessus.
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Mot d'une autre ligne"
 
 # AB - Ce texte s'ajoute à la fin d'un des messages de complétion ci-dessus.
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "La seule correspondance"
 
 # AB - Ce texte s'ajoute à la fin d'un des messages de complétion ci-dessus.
 # AB - Faut-il remplacer "sur" par "de" ?
 # DB : Pour moi, non.
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "Correspondance %d sur %d"
 
 # AB - Ce texte s'ajoute à la fin d'un des messages de complétion ci-dessus.
 # DB - todo : la VO n'a pas de majuscule.
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "Correspondance %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caractères inattendus avant '='"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: index de Liste hors limites : %<PRId64> au-delà de la fin"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Variable non définie : %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']' manquant"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: L'argument de %s doit être une Liste"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: L'argument de %s doit être une Liste ou un Dictionnaire"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Impossible d'utiliser une clé vide dans un Dictionnaire"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Liste requise"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Dictionnaire requis"
 
 # DB : Suggestion
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: La fonction %s a reçu trop d'arguments"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: La clé %s n'existe pas dans le Dictionnaire"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: La fonction %s existe déjà (ajoutez ! pour la remplacer)"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Une entrée du Dictionnaire porte déjà ce nom"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Référence de fonction (Funcref) requise"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Utilisation de [:] impossible avec un Dictionnaire"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Type de variable erroné avec %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Fonction inconnue : %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Nom de variable invalide : %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Utilisation d'un Flottant comme une Chaîne"
+
 # DB - todo : trouver mieux que "destinations".
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Moins de destinations que d'éléments dans la Liste"
 
 # DB - todo : trouver mieux que "destinations".
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Plus de destinations que d'éléments dans la Liste"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Double ; dans une liste de variables"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Impossible de lister les variables de %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Seul une Liste ou un Dictionnaire peut être indexé"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] ne peut être spécifié qu'en dernier"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] requiert une Liste"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: La Liste a plus d'éléments que la destination"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: La Liste n'a pas assez d'éléments"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: \"in\" manquant après :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Parenthèses manquantes : %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Variable inexistante : %s"
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variable trop imbriquée pour la (dé)verrouiller"
 
 # AB - Je suis partagé entre la concision d'une traduction assez littérale et
 #      la lourdeur d'une traduction plus correcte.
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Il manque ':' après '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Une Liste ne peut être comparée qu'avec une Liste"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Opération invalide avec les Listes"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Un Dictionnaire ne peut être comparé qu'avec un Dictionnaire"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Opération invalide avec les Dictionnaires"
 
 # DB - todo : Traduction valable (et courte) pour Funcref ?
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Une Funcref ne peut être comparée qu'à une Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Opération invalide avec les Funcrefs"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Impossible d'utiliser '%' avec un Flottant"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' manquant"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Impossible d'indexer une Funcref"
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Il manque un nom d'option après %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Option inconnue : %s"
@@ -580,232 +735,265 @@ msgstr "E113: Option inconnue : %s"
 # AB - La version française est meilleure que la version anglaise, qui est
 #      erronée, d'ailleurs : il s'agit d'une "double quote" et non d'une
 #      "quote".
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Il manque \" à la fin de %s"
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Il manque ' à la fin de %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Il manque une virgule dans la Liste %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Il manque ']' à la fin de la Liste %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Il manque ':' dans le Dictionnaire %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Clé \"%s\" dupliquée dans le Dictionnaire"
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Il manque une virgule dans le Dictionnaire %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Il manque '}' à la fin du Dictionnaire %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variable trop imbriquée pour être affichée"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Trop d'arguments pour la fonction %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Arguments invalides pour la fonction %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Fonction inconnue : %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: La fonction %s n'a pas reçu assez d'arguments"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> utilisé en dehors d'un script : %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Appel d'une fonction « dict » sans Dictionnaire : %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Nombre ou Flottant requis"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "argument de add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Trop d'arguments"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() n'est utilisable que dans le mode Insertion"
 
 # AB - Texte par défaut du bouton de la boîte de dialogue affichée par la
 #      fonction confirm().
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
-msgid "extend() argument"
-msgstr "argument de extend()"
-
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: un mappage existe déjà pour %s"
 
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr "argument de extend()"
+
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "argument de map()"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "argument de filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld lignes : "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Fonction inconnue : %s"
 
-# AB - Textes des boutons de la boîte de dialogue affichée par inputdialog().
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&Ok\n"
-"&Annuler"
-
 # AB - La version française est meilleure que la version anglaise.
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() a été appelé plus de fois qu'inputsave()"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "argument de insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Les plages ne sont pas autorisées"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Type invalide avec len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Le pas est nul"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Début au-delà de la fin"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<vide>"
 
-# AB - À mon avis, la version anglaise est erronée.
-# DB : Vérifier
-msgid "E240: No connection to Vim server"
-msgstr "E240: Pas de connexion au serveur X"
-
-# AB - La version française est meilleure que la version anglaise.
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: L'envoi au serveur %s à échoué"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Impossible de lire la réponse du serveur"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "argument de remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Trop de liens symboliques (cycle ?)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "argument de reverse()"
 
-# AB - La version française est meilleure que la version anglaise.
-msgid "E258: Unable to send to client"
-msgstr "E258: La réponse n'a pas pu être envoyée au client"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "argument de sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argument de add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: La fonction de comparaison de sort() a échoué"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: La fonction de comparaison de sort() a échoué"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Invalide)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Erreur lors de l'écriture du fichier temporaire"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Utilisation d'un Flottant comme un Nombre"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Utilisation d'une Funcref comme un Nombre"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Utilisation d'une Liste comme un Nombre"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Utilisation d'un Dictionnaire comme un Nombre"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Utilisation d'une Funcref comme une Chaîne"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Utilisation d'une Liste comme une Chaîne"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Utilisation d'un Dictionnaire comme une Chaîne"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Utilisation d'un Flottant comme une Chaîne"
-
 # DB : On doit pouvoir trouver nettement mieux que ça.
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Type de variable incohérent pour %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Impossible de supprimer la variable %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Le nom d'une Funcref doit commencer par une majuscule : %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Le nom d'une variable entre en conflit avec la fonction %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: La valeur de %s est verrouillée"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Inconnu"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Impossible de modifier la valeur de %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: variable trop imbriquée pour en faire une copie"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Fonction non définie : %s"
@@ -813,88 +1001,112 @@ msgstr "E123: Fonction non définie : %s"
 # AB - La version française est plus consistante que la version anglaise.
 # AB - Je suis partagé entre la concision d'une traduction assez littérale et
 #      la lourdeur d'une traduction plus correcte.
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Il manque '(' après %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Impossible d'utiliser g: ici"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Argument invalide : %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Nom d'argument dupliqué : %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Il manque :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Le nom de fonction entre en conflit avec la variable : %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Impossible de redéfinir fonction %s : déjà utilisée"
 
 # DB - Le contenu du "c-format" est le nom de la fonction.
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Le nom de la fonction %s ne correspond pas le nom du script"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Nom de fonction requis"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr "E128: La fonction %s ne commence pas par une majuscule ou contient ':'"
+
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
 msgstr "E128: La fonction %s ne commence pas par une majuscule ou contient ':'"
 
 # AB - Il est difficile de créer une version française qui fasse moins de 80
 #      caractères de long, nom de la fonction compris : "It is in use" est une
 #      expression très dense. Traductions possibles : "elle est utilisée",
 #      "elle s'exécute" ou "elle est occupée".
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Impossible d'effacer %s : cette fonction est utilisée"
 
 # AB - Vérifier dans la littérature technique s'il n'existe pas une meilleure
 #      traduction pour "function call depth".
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr ""
 "E132: La profondeur d'appel de fonction est supérieure à 'maxfuncdepth'"
 
 # AB - Ce texte fait partie d'un message de débogage.
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "appel de %s"
 
 # AB - Vérifier.
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s annulée"
 
 # AB - Ce texte fait partie d'un message de débogage.
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s a retourné #%<PRId64>"
 
 # AB - Ce texte fait partie d'un message de débogage.
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s a retourné \"%s\""
 
 # AB - Ce texte fait partie d'un message de débogage.
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "de retour dans %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return en dehors d'une fonction"
 
 # AB - La version française est capitalisée pour être en accord avec les autres
 #      commentaires enregistrés dans le fichier viminfo.
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -903,6 +1115,7 @@ msgstr ""
 "# Variables globales:\n"
 
 # DB - Plus précis ("la dernière fois") ?
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -910,33 +1123,41 @@ msgstr ""
 "\n"
 "\tModifié la dernière fois dans "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Aucun vieux fichier"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hexa %02x,  Octal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hexa %04x, Octal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hexa %08x, Octal %o"
 
 # AB - La version anglaise est très mauvaise, ce qui m'oblige a inventer une
 #      version française.
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: La destination est dans la plage d'origine"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 ligne déplacée"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> lignes déplacées"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> lignes filtrées"
@@ -946,23 +1167,27 @@ msgstr "%<PRId64> lignes filtrées"
 #      au filtrage (FilterReadPre, FilterReadPost, FilterWritePre et
 #      FilterWritePost) que "*Filter*" que l'on confond avec une tentative de
 #      mise en valeur.
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr ""
 "E135: Les autocommandes Filter* ne doivent pas changer le tampon courant"
 
 # AB - Il faut respecter l'esprit plus que la lettre. Dans le cas présent,
 #      nettement plus.
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Attention : tout n'est pas enregistré]\n"
 
 # AB - Le numéro et le message d'erreur (%s ci-dessous) et le "numéro" de ligne
 #      sont des chaînes de caractères dont le contenu est à la discrétion de
 #      l'appelant de la fonction viminfo_error().
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo : %s à la ligne "
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr ""
 "E136: Il y a trop d'erreurs ; interruption de la lecture du fichier viminfo"
@@ -970,25 +1195,30 @@ msgstr ""
 # AB - Ce texte fait partie d'un message de débogage.
 # DB - ... dont les valeurs possibles sont les messages
 #      qui suivent.
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Lecture du fichier viminfo \"%s\"%s%s%s"
 
 # AB - Ce texte fait partie d'un message de débogage.
 # DB - Voir ci-dessus.
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
 # AB - Ce texte fait partie d'un message de débogage.
 # DB - Voir ci-dessus.
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " marques"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " vieux fichiers"
 
 # AB - Ce texte fait partie d'un message de débogage.
 # DB - Voir ci-dessus.
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " ÉCHEC"
 
@@ -997,6 +1227,7 @@ msgstr " ÉCHEC"
 # AB - Le mot "viminfo" a été retiré pour que le message ne dépasse pas 80
 #      caractères dans le cas courant où %s = /home/12345678/.viminfo
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: L'écriture dans le fichier %s est interdite"
@@ -1004,21 +1235,25 @@ msgstr "E137: L'écriture dans le fichier %s est interdite"
 # AB - Le point d'exclamation est superflu.
 # AB - Le mot "viminfo" a été retiré pour que le message ne dépasse pas 80
 #      caractères dans le cas courant où %s = /home/12345678/.viminfo
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Impossible d'écrire le fichier %s"
 
 # AB - Ce texte est un message de débogage.
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Écriture du fichier viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Ce fichier viminfo a été généré par Vim %s.\n"
 
 # AB - Les deux versions, bien que différentes, se valent.
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1026,54 +1261,58 @@ msgstr ""
 "# Vous pouvez l'éditer, mais soyez prudent.\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# 'encoding' dans lequel ce fichier a été écrit\n"
 
 # AB - Ce texte est passé en argument à la fonction viminfo_error().
 # AB - "illégal" est un terme trop fort à mon goût.
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Caractère initial non valide"
 
-# AB - Ceci est un titre de boîte de dialogue. Vérifier que la version
-#      française est correcte pour les trois références ; j'ai un doute quant
-#      à la troisième.
-msgid "Save As"
-msgstr "Enregistrer sous - Vim"
-
 # AB - Ceci est un contenu de boîte de dialogue (éventuellement en mode texte).
 # AB - La version française est meilleure que la version anglaise.
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Perdre une partie du fichier ?"
 
 # AB - La version française est nettement meilleure que la version anglaise.
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr ""
 "E140: Une partie du fichier serait perdue (ajoutez ! pour passer outre)"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Écraser le fichier %s existant ?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Le fichier d'échange \"%s\" existe déjà, l'écraser ?"
 
 # DB - Un peu long à mon avis.
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Le fichier d'échange %s existe déjà (:silent! pour passer outre)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Pas de nom de fichier pour le tampon %<PRId64>"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr ""
 "E142: L'option 'nowrite' est activée et empêche toute écriture du fichier"
 
 # AB - Ceci est un contenu de boîte de dialogue (éventuellement en mode texte).
 # AB - "activée pour" n'est pas une formulation très heureuse.
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1082,6 +1321,7 @@ msgstr ""
 "L'option 'readonly' est activée pour \"%s\".\n"
 "Voulez-vous tout de même enregistrer ?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1092,81 +1332,94 @@ msgstr ""
 "Il peut être possible de l'écrire tout de même.\n"
 "Tenter ?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" est en lecture seule (ajoutez ! pour passer outre)"
-
-# AB - Ceci est un titre de boîte de dialogue.
-msgid "Edit File"
-msgstr "Ouvrir un fichier - Vim"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
 # AB - J'hésite à ajouter "à sa création" après le nom du tampon. Ce message
 #      devrait n'être affiché qu'après une tentative d'ouverture de fichier,
 #      la version actuelle devrait donc suffire.
 # DB - Suggestion : "nouveau tampon" ?
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Une autocommande a effacé le nouveau tampon %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: L'argument de :z n'est pas numérique"
 
 # AB - La version française fera peut-être mieux passer l'amère pilule.
 #      La consultation de l'aide donnera l'explication complète à ceux qui
 #      ne comprendraient pas à quoi ce message est dû.
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Les commandes externes sont indisponibles dans rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr ""
 "E146: Les expressions régulières ne peuvent pas être délimitées par des "
 "lettres"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "remplacer par %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Interrompu) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 correspondance"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 substitution"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> correspondances"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> substitutions"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " sur 1 ligne"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " sur %<PRId64> lignes"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
 # AB - Ce message devrait contenir une référence à :vglobal.
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global ne peut pas exécuter :global"
 
 # AB - Ce message devrait contenir une référence à :vglobal.
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: :global doit être suivi par une expression régulière"
 
 # AB - Ce message est utilisé lorsque :vglobal ne trouve rien. Lorsque :global
 #      ne trouve rien, c'est "Pattern not found: %s" / "Motif introuvable: %s"
 #      qui est utilisé.
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Motif trouvé dans toutes les lignes : %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Motif introuvable: %s"
@@ -1177,6 +1430,7 @@ msgstr "Motif introuvable: %s"
 #      à internationalisation. J'attends que les deux autres messages soient
 #      traduisibles pour traduire celui-ci.
 # DB - TODO : Qu'en est-il à présent ?
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1187,35 +1441,43 @@ msgstr ""
 "$"
 
 # This message should *so* be E42!
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Pas de panique !"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Désolé, aucune aide en langue '%s' pour %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Désolé, aucune aide pour %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Désolé, le fichier d'aide \"%s\" est introuvable"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s n'est pas un répertoire"
 
 # AB - La version anglaise est plus précise, mais trop technique.
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Impossible d'écrire %s"
 
 # AB - La version anglaise est plus précise, mais trop technique.
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Impossible de lire %s"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Encodages différents dans les fichiers d'aide en langue %s"
@@ -1225,252 +1487,315 @@ msgstr "E670: Encodages différents dans les fichiers d'aide en langue %s"
 #      traduction de 40 caractères ou moins. Ce qui est loin d'être le cas
 #      présent.
 # DB - Suggestion.
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Marqueur \"%s\" dupliqué dans le fichier %s/%s"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Commande inconnue : :sign %s"
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Il manque le nom du symbole"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Trop de symboles sont définis"
 
 # AB - Cette traduction ne me satisfait pas.
 # DB - Suggestion.
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Le texte du symbole est invalide : %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Symbole inconnu : %s"
 
 # AB - La version française est meilleure que la version anglaise.
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Il manque l'ID du symbole"
 
 # AB - Vu le code source, la version française est meilleure que la
 #      version anglaise. Ce message est similaire au message E102.
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Le tampon %s est introuvable"
 
 # AB - Vu le code source, la version française est meilleure que la
 #      version anglaise.
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Le symbole %<PRId64> est introuvable"
 
-msgid " (NOT FOUND)"
-msgstr "  (INTROUVABLE)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (non supporté)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Effacé]"
 
 # AB - La version française de la première phrase ne me satisfait pas.
 # DB - Suggestion.
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Mode débogage activé. Tapez \"cont\" pour continuer."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "ligne %<PRId64> : %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "cmde : %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Point d'arrêt dans %s%s ligne %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Le point d'arrêt %s est introuvable"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Aucun point d'arrêt n'est défini"
 
 # AB - Le deuxième %s est remplacé par "func" ou "file" sans que l'on puisse
 #      traduire ces mots.
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  ligne %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Utilisez d'abord \":profile start {nomfichier}\""
 
 # AB - "changes to" est redondant et a été omis de la version française.
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Enregistrer \"%s\" ?"
 
 # AB - Si les parenthèses posent problème, il faudra remettre les guillemets
 #      ci-dessus.
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "(sans titre)"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
 # AB - Ce message est similaire au message E89.
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Le tampon %s n'a pas été enregistré"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "Alerte : Entrée inattendue dans un autre tampon (vérifier autocmdes)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Il n'y a qu'un seul fichier à éditer"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Impossible d'aller avant le premier fichier"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Impossible d'aller au-delà du dernier fichier"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Compilateur %s non supporté"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Recherche de \"%s\" dans \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Recherche de \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "introuvable dans 'runtimepath' : \"%s\""
 
-msgid "Source Vim script"
-msgstr "Sourcer un script - Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Impossible de sourcer un répertoire : \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "impossible de sourcer \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "ligne %<PRId64> : impossible de sourcer \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "sourcement \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "ligne %<PRId64> : sourcement de \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "fin du sourcement de %s"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "ligne de mode"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "argument --cmd"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "argument -c"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "variable d'environnement"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "gestionnaire d'erreur"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Alerte : Séparateur de ligne erroné, ^M possiblement manquant"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding utilisé en dehors d'un fichier sourcé"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish utilisé en dehors d'un fichier sourcé"
 
 # DB - Le premier %s est, au choix : "time ", "ctype " ou "messages ",
 #      sans qu'il soit possible de les traduire.
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Langue courante pour %s : \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Impossible de choisir la langue \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Mode Ex activé. Tapez \"visual\" pour passer en mode Normal."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: À la fin du fichier"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Commande trop récursive"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Exception non interceptée : %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Fin du fichier sourcé"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Fin de la fonction"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Utilisation ambiguë d'une commande définie par l'utilisateur"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Commande inconnue"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: La plage spécifiée est inversée"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "La plage spécifiée est inversée, OK pour l'inverser"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Utilisez w ou w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Désolé, cette commande n'est pas disponible dans cette version"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Un seul nom de fichier autorisé"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Encore 1 fichier à éditer. Quitter tout de même ?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Encore %d fichiers à éditer. Quitter tout de même ?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: encore 1 fichier à éditer"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: encore %<PRId64> fichiers à éditer"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: La commande existe déjà : ajoutez ! pour la redéfinir"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1478,301 +1803,347 @@ msgstr ""
 "\n"
 "    Nom         Args Plage Complet.  Définition"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Aucune commande définie par l'utilisateur trouvée"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Pas d'attribut spécifié"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Nombre d'arguments invalide"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Le quantificateur ne peut être spécifié deux fois"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: La valeur par défaut du quantificateur est invalide"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: argument requis avec -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Attribut invalide : %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Nom de commande invalide"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Les commandes utilisateur doivent commencer par une majuscule"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr ""
 "E841: Nom réservé, ne peux pas être utilisé pour une commande utilisateur"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Aucune commande %s définie par l'utilisateur"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Valeur invalide pour \"-complete=\" : %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Seul le complètement personnalisé accepte un argument"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Le complètement personnalisé requiert une fonction en argument"
 
-msgid "unknown"
-msgstr "inconnu"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Impossible de trouver le jeu de couleurs '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Bienvenue, utilisateur de Vim !"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Impossible de fermer le dernier onglet"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Il ne reste déjà plus qu'un seul onglet"
 
-msgid "Edit File in new window"
-msgstr "Ouvrir un fichier dans une nouvelle fenêtre - Vim"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Onglet %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Pas de fichier d'échange"
 
-msgid "Append File"
-msgstr "Ajouter fichier"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Tampon modifié : impossible de changer de répertoire (ajoutez ! pour "
 "passer outre)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Pas de répertoire précédent"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Inconnu"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize requiert deux arguments numériques"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Position de la fenêtre : X %d, Y %d"
-
 # DB : Suggestion, sans doute perfectible.
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Récupérer la position de la fenêtre non implémenté dans cette version"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos requiert deux arguments numériques"
 
-msgid "Save Redirection"
-msgstr "Enregistrer la redirection"
-
-msgid "Save View"
-msgstr "Enregistrer la vue - Vim"
-
-msgid "Save Session"
-msgstr "Enregistrer la session - Vim"
-
-msgid "Save Setup"
-msgstr "Enregistrer les réglages - Vim"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Impossible de créer le répertoire \"%s\""
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existe (ajoutez ! pour passer outre)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Impossible d'ouvrir \"%s\" pour y écrire"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: L'argument doit être une lettre ou une (contre-)apostrophe"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Appel récursif de :normal trop important"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< n'est pas disponible sans la fonctionnalité +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Aucun nom de fichier alternatif à substituer à '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Aucun nom de ficher d'autocommande à substituer à \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Aucun numéro de tampon d'autocommande à substituer à \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Aucune correspondance d'autocommande à substituer à \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: Aucun nom de fichier :source à substituer à \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: aucun numéro de ligne à utiliser pour \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Nom de fichier vide pour '%' ou '#', ne marche qu'avec \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Évalué en une chaîne vide"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Impossible d'ouvrir le viminfo en lecture"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Pas de digraphes dans cette version"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Impossible d'émettre des exceptions avec 'Vim' comme préfixe"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Exception émise : %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Exception terminée : %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Exception éliminée : %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, ligne %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Exception interceptée : %s"
 
 # DB - Le c-format est féminin, singulier ou pluriel (cf. 3 messages plus bas).
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s mise(s) en attente"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s ré-émise(s)"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s éliminée(s)"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Exception"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Erreur et interruption"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Erreur"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Interruption"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Imbrication de :if trop importante"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif sans :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else sans :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif sans :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Il ne peut y avoir qu'un seul :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif après :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Imbrication de :while ou :for trop importante"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue sans :while ou :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break sans :while ou :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Utilisation de :endfor avec :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Utilisation de :endwhile avec :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Imbrication de :try trop importante"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch sans :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch après :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally sans :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Il ne peut y avoir qu'un seul :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry sans :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction en dehors d'une fonction"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: L'édition d'un autre tampon n'est plus permise"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr ""
 "E811: Changement des informations du tampon n'est pas permise maintenant"
 
 # DB - TODO : Pas compris le message ni comment le déclencher malgré une visite
 #      dans le code.
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nom du marqueur"
 
 # DB - TODO : Idem précédent.
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " type de fichier\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "l'option 'history' vaut zéro"
 
 # DB - Messages et les suivants : fichier .viminfo.
 #      Pas de majuscule nécessaire pour les messages d'après.
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1781,241 +2152,311 @@ msgstr ""
 "\n"
 "# Historique %s (chronologie décroissante) :\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "ligne de commande"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "chaîne de recherche"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "expression"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "ligne de saisie"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar au-delà de la longueur de la commande"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Fenêtre ou tampon actif effacé"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: chemin trop long pour complètement"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Chemin invalide : '**[nombre]' doit être à la fin du chemin ou être "
+"suivi de '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Répertoire \"%s\" introuvable dans 'cdpath'"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Fichier \"%s\" introuvable dans 'path'"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Plus de répertoire \"%s\" dans 'cdpath'"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Plus de fichier \"%s\" dans 'path'"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Des autocommandes ont changé le tampon ou le nom du tampon"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Nom de fichier invalide"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "est un répertoire"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "n'est pas un fichier"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "est un périphérique (désactivé par l'option 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nouveau fichier]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nouveau RÉPERTOIRE]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Fichier trop volumineux]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Permission refusée]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Les autocommandes *ReadPre ont rendu le fichier illisible"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr ""
 "E201: Autocommandes *ReadPre ne doivent pas modifier le contenu du tampon "
 "courant"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim : Lecture de stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Lecture de stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: La conversion a rendu le fichier illisible !"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[caractère spécial]"
 
-msgid "[RO]"
-msgstr "[RO]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR manquant]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[lignes longues coupées]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NON converti]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[converti]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[chiffré]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ERREUR DE CONVERSION à la ligne %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[OCTET INVALIDE à la ligne %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ERREURS DE LECTURE]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Impossible de générer un fichier temporaire pour la conversion"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "La conversion avec 'charconvert' a échoué"
 
 # DB : Pas de majuscule ?
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "Impossible de lire la sortie de 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Le fichier est chiffré avec une méthode inconnue"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Pas d'autocommande correspondante pour le tampon acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Des autocommandes ont effacé ou déchargé le tampon à écrire"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr ""
 "E204: L'autocommande a modifié le nombre de lignes de manière inattendue"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans interdit l'écriture des tampons non modifiés"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Netbeans interdit l'écriture partielle de ses tampons"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "n'est pas un fichier ou un périphérique inscriptible"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "écriture vers un périphérique désactivé par l'option 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "est en lecture seule (ajoutez ! pour passer outre)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Impossible d'écrire la copie de secours (! pour passer outre)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Erreur de fermeture de la copie de secours (! pour passer outre)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Impossible de lire le fichier pour la copie de secours (ajoutez ! pour "
 "passer outre)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Impossible de créer la copie de secours (ajoutez ! pour passer outre)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Impossible de générer la copie de secours (ajoutez ! pour passer outre)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr ""
-"E460: Les ressources partagées seraient perdues (ajoutez ! pour passer outre)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Impossible de générer un fichier temporaire pour y écrire"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Impossible de convertir (ajoutez ! pour écrire sans convertir)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Impossible d'ouvrir le lien pour y écrire"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Impossible d'ouvrir le fichier pour y écrire"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsynch a échoué"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Erreur de fermeture de fichier"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Erreur d'écriture, échec de conversion (videz 'fenc' pour passer outre)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Erreur d'écriture, échec de conversion à la ligne %<PRId64> (videz 'fenc' "
-"pour passer outre)"
+"E513: Erreur d'écriture, échec de conversion à la ligne %<PRId64> (videz "
+"'fenc' pour passer outre)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: erreur d'écriture (système de fichiers plein ?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ERREUR DE CONVERSION"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " à la ligne %<PRId64>"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Périph.]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nouveau]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " ajouté(s)"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [e]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " écrit(s)"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode : impossible d'enregistrer le fichier original"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode : impossible de créer le fichier original vide"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Impossible d'effacer la copie de secours"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -2024,79 +2465,99 @@ msgstr ""
 "ALERTE: Le fichier original est peut-être perdu ou endommagé\n"
 
 # DB - todo : un peu long...
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr ""
 "ne quittez pas l'éditeur tant que le fichier n'est pas correctement "
 "enregistré !"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[format dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[format mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[format unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 ligne, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> lignes, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 caractère"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> caractères"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Dernière ligne incomplète]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ALERTE : Le fichier a été modifié depuis que Vim l'a lu !"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Voulez-vous vraiment écrire dedans"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Erreur lors de l'écriture dans \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Erreur lors de la fermeture de \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Erreur lors de la lecture de \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: L'autocommande FileChangedShell a effacé le tampon"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Le fichier \"%s\" n'est plus disponible"
 
 # DB - todo : Suggestion. Bof bof, à améliorer.
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -2104,32 +2565,40 @@ msgid ""
 msgstr ""
 "W12: Alerte : Le fichier \"%s\" a été modifié, ainsi que le tampon dans Vim"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Consultez \":help W12\" pour plus d'information."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Alerte : Le fichier \"%s\" a changé depuis le début de l'édition"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Consultez \":help W11\" pour plus d'information."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Alerte : Les permissions de \"%s\" ont changé depuis le début de "
 "l'édition"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Consultez \":help W16\" pour plus d'information."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Alerte : Le fichier \"%s\" a été créé après le début de l'édition"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Alerte"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -2137,39 +2606,48 @@ msgstr ""
 "&Ok\n"
 "&Charger le fichier"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Impossible de préparer le rechargement de \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Impossible de recharger \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Effacé--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "Autocommandes marquées pour auto-suppression : %s <tampon=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Aucun groupe \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Caractère non valide après * : %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Aucun événement %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Aucun événement ou groupe %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -2177,565 +2655,774 @@ msgstr ""
 "\n"
 "--- Auto-commandes ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d> : numéro de tampon invalide"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr ""
 "E217: Impossible d'exécuter les autocommandes pour TOUS les événements (ALL)"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Aucune autocommande correspondante"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocommandes trop imbriquées"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "Autocommandes %s pour \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Exécution de %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommande %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { manquant."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } manquant."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Aucun repli trouvé"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Impossible de créer un repli avec la 'foldmethod'e actuelle"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Impossible de supprimer un repli avec la 'foldmethod'e actuelle"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld lignes repliées "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Ajout au tampon de lecture"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: mappage récursif"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: une abréviation globale existe déjà pour %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: un mappage global existe déjà pour %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: une abréviation existe déjà pour %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: un mappage existe déjà pour %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Aucune abréviation trouvée"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Aucun mappage trouvé"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap : mode invalide"
 
-msgid "E851: Failed to create a new process for the GUI"
+# msgstr "--Pas de lignes dans le tampon--"
+# DB - todo : ou encore : msgstr "--Aucune ligne dans le tampon--"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Le tampon est vide--"
+
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Commande annulée"
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argument requis"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ devrait être suivi de /, ? ou &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E851: Échec lors de la création d'un nouveau processus pour l'interface "
-"graphique"
+"E11: Invalide dans la fenêtre ligne-de-commande ; <CR> exécute, CTRL-C quitte"
 
-msgid "E852: The child process failed to start the GUI"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E852: Le processus fils n'a pas réussi à démarrer l'interface graphique"
+"E12: commande non autorisée depuis un exrc/vimrc dans répertoire courant ou "
+"une recherche de marqueur"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Impossible de démarrer l'interface graphique"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif manquant"
 
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry manquant"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile manquant"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor manquant"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile sans :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor sans :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Le fichier existe déjà (ajoutez ! pour passer outre)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: La commande a échoué"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Erreur interne"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Interrompu"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Adresse invalide"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Argument invalide"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Impossible de lire \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Argument invalide : %s"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Expression invalide : %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Plage invalide"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Commande invalide"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" est un répertoire"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Valeur de défilement invalide"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"E665: Impossible de démarrer l'IHM graphique, aucune police valide trouvée"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' est invalide"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Valeur de 'imactivatekey' invalide"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Impossible d'allouer la couleur %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Aucune correspondance sous le curseur, recherche de la suivante"
-
-msgid "<cannot open> "
-msgstr "<impossible d'ouvrir> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile : impossible d'obtenir la police %s"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile : impossible de revenir dans le répertoire courant"
-
-msgid "Pathname:"
-msgstr "Chemin :"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile : impossible d'obtenir le répertoire courant"
-
-msgid "OK"
-msgstr "Ok"
-
-msgid "Cancel"
-msgstr "Annuler"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Widget scrollbar : Impossible d'obtenir la géométrie du pixmap 'thumb'"
-
-msgid "Vim dialog"
-msgstr "Vim"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Impossible de créer un BalloonEval avec message ET callback"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"&Oui\n"
-"&Non\n"
-"&Annuler"
 
-# todo '_' is for hotkey, i guess?
-msgid "Input _Methods"
-msgstr "_Méthodes de saisie"
-
-msgid "VIM - Search and Replace..."
-msgstr "Remplacer - Vim"
-
-msgid "VIM - Search..."
-msgstr "Rechercher - Vim"
-
-msgid "Find what:"
-msgstr "Rechercher :"
-
-msgid "Replace with:"
-msgstr "Remplacer par :"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Mots entiers seulement"
-
-#. match case button
-msgid "Match case"
-msgstr "Respecter la casse"
-
-msgid "Direction"
-msgstr "Direction"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Haut"
-
-msgid "Down"
-msgstr "Bas"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Suivant"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Remplacer"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Remplacer tout"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim : Une requête \"die\" a été reçue par le gestionnaire de session\n"
-
-msgid "Close"
-msgstr "Fermer"
-
-msgid "New tab"
-msgstr "Nouvel onglet"
-
-# DB - todo : un peu long. Cet entrée de menu permet d'ouvrir un fichier
-#      dans un nouvel onglet via le sélecteur de fichiers graphique.
-msgid "Open Tab..."
-msgstr "Ouvrir dans un onglet..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim : Fenêtre principale détruite inopinément\n"
-
-msgid "&Filter"
-msgstr "&Filtrer"
-
-msgid "&Cancel"
-msgstr "&Annuler"
-
-msgid "Directories"
-msgstr "Répertoires"
-
-msgid "Filter"
-msgstr "Filtre"
-
-msgid "&Help"
-msgstr "&Aide"
-
-msgid "Files"
-msgstr "Fichiers"
-
-msgid "&OK"
-msgstr "&Ok"
-
-msgid "Selection"
-msgstr "Sélection"
-
-msgid "Find &Next"
-msgstr "Suiva&nt"
-
-msgid "&Replace"
-msgstr "&Remplacer"
-
-msgid "Replace &All"
-msgstr "Rempl&acer tout"
-
-msgid "&Undo"
-msgstr "Ann&uler"
-
+#: ../globals.h:1024
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Titre de fenêtre \"%s\" introuvable"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: L'appel à la bibliothèque a échoué pour \"%s()\""
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: La marque a un numéro de ligne invalide"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Marque non positionnée"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Impossible de modifier, 'modifiable' est désactivé"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Trop de récursion dans les scripts"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Pas de fichier alternatif"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Cette abréviation n'existe pas"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Le ! n'est pas autorisé"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: L'interface graphique n'a pas été compilée dans cette version"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument non supporté : \"-%s\" ; Utilisez la version OLE."
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Aucun nom de groupe de surbrillance %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Impossible d'ouvrir une fenêtre dans une application MDI"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Pas encore de texte inséré"
 
-# DB - Les quelques messages qui suivent se retrouvent aussi ici :
-#      gui_gtk_x11.c:3170 et suivants.
-#      Les libellés changent un peu (majuscule par exemple).
-#      La VF tâche de les unifier.
-msgid "Close tab"
-msgstr "Fermer l'onglet"
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Aucune ligne de commande précédente"
 
-msgid "Open tab..."
-msgstr "Ouvrir dans un onglet..."
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Mappage inexistant"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Chercher une chaîne (utilisez '\\\\' pour chercher un '\\')"
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Aucune correspondance"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Chercher et remplacer (utilisez '\\\\' pour trouver un '\\')"
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Aucune correspondance : %s"
 
-# DB - Traduction non indispensable puisque le code indique qu'il s'agit d'un
-#      paramétrage bidon afin de sélectionner un répertoire plutôt qu'un
-#      fichier.
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Non utilisé"
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Aucun nom de fichier"
 
-# DB - Traduction non indispensable puisque le code indique qu'il s'agit d'un
-#      paramétrage bidon afin de sélectionner un répertoire plutôt qu'un
-#      fichier.
-msgid "Directory\t*.nothing\n"
-msgstr "Répertoire\t*.rien\n"
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Aucune expression régulière de substitution précédente"
 
-# DB - todo : perfectible.
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Aucune commande précédente"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Aucune expression régulière précédente"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Les plages ne sont pas autorisées"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Pas assez de place"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Impossible de créer le fichier %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Impossible d'obtenir un nom de fichier temporaire"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Impossible d'ouvrir le fichier \"%s\""
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Impossible de lire le fichier %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Modifications non enregistrées (ajoutez ! pour passer outre)"
+
+# AB - Il faut respecter l'esprit plus que la lettre. Dans le cas présent,
+#      nettement plus.
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Attention : tout n'est pas enregistré]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Argument null"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nombre attendu"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Impossible d'ouvrir le fichier d'erreurs %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Mémoire épuisée"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Motif introuvable"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Motif introuvable : %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: L'argument doit être positif"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Impossible de retourner au répertoire précédent"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Aucune erreur"
+
+# DB - TODO : trouver une traduction valable et attestée pour "location".
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Aucune liste d'emplacements"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: La chaîne de recherche est endommagée"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: L'automate de regexp est corrompu"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: L'option 'readonly' est activée (ajoutez ! pour passer outre)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: La variable \"%s\" est en lecture seule"
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
 msgstr ""
-"Vim E458: Erreur d'allocation de couleurs, couleurs possiblement incorrectes"
+"E794: Impossible de modifier une variable depuis le bac à sable : \"%s\""
 
-# DB - todo : La VF est-elle compréhensible ?
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Erreur lors de la lecture du fichier d'erreurs"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Opération interdite dans le bac à sable"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Interdit à cet endroit"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Choix du mode d'écran non supporté"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Valeur de défilement invalide"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: L'option 'shell' est vide"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Impossible de lire les données du symbole !"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Erreur lors de la fermeture du fichier d'échange"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: La pile des marqueurs est vide"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Commande trop complexe"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Nom trop long"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Trop de ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Trop de noms de fichiers"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Caractères surnuméraires"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Marque inconnue"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Impossible de développer les métacaractères"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' ne peut pas être plus petit que 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' ne peut pas être plus petit que 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Erreur lors de l'écriture"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Le quantificateur est nul"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> utilisé en dehors d'un script"
+
+#: ../globals.h:1102
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr ""
-"E250: Des polices manquent dans %s pour les jeux de caractères suivants :"
+msgid "E685: Internal error: %s"
+msgstr "E685: Erreur interne : %s"
 
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: le motif utilise plus de mémoire que 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: tampon vide"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Délimiteur ou motif de recherche invalide"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Le fichier est chargé dans un autre tampon"
+
+#: ../globals.h:1110
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nom du jeu de polices : %s"
+msgid "E764: Option '%s' is not set"
+msgstr "E764: L'option '%s' n'est pas activée"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "La police '%s' n'a pas une largeur fixe"
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Nom de registre invalide"
 
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Nom du jeu de polices : %s\n"
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "La recherche a atteint le HAUT, et continue en BAS"
 
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "La recherche a atteint le BAS, et continue en HAUT"
 
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "La largeur de Font%<PRId64> n'est pas le double de celle de Font0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Largeur de Font0 : %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
-msgstr ""
-"Largeur de Font1 : %<PRId64>\n"
-"\n"
-
-# DB - todo : Pas certain de mon coup, ici...
-msgid "Invalid font specification"
-msgstr "La spécification de la police est invalide"
-
-msgid "&Dismiss"
-msgstr "Aban&donner"
-
-# DB - todo : Pas certain de mon coup, ici...
-msgid "no specific match"
-msgstr "aucune correspondance particulière"
-
-msgid "Vim - Font Selector"
-msgstr "Choisir une police - Vim"
-
-msgid "Name:"
-msgstr "Nom :"
-
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Afficher la taille en Points"
-
-msgid "Encoding:"
-msgstr "Encodage :"
-
-msgid "Font:"
-msgstr "Police :"
-
-msgid "Style:"
-msgstr "Style :"
-
-msgid "Size:"
-msgstr "Taille :"
-
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ERREUR dans l'automate Hangul"
-
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: ':' manquant"
 
 # DB - Il s'agit ici d'un problème lors du parsing d'une option dont le contenu
 #      est une liste d'éléments séparés par des virgules.
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: élément invalide"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: chiffre attendu"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Page %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Aucun texte à imprimer"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Impression de la page %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Copie %d sur %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Imprimé : %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Impression interrompue"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Erreur lors de l'écriture du fichier PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Impossible d'ouvrir le fichier \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Impossible de lire le fichier de ressource PostScript \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: \"%s\" n'est pas un fichier de ressource PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: \"%s\" n'est pas un fichier de ressource PostScript supporté"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: La version du fichier de ressource \"%s\" est erronée"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Jeu de caractères et encodage multi-octets incompatibles"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr ""
 "E674: 'printmbcharset' ne peut pas être vide avec un encodage multi-octets"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Aucune police par défaut pour l'impression multi-octets"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Impossible d'ouvrir le fichier PostScript de sortie"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Impossible d'ouvrir le fichier \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Le fichier de ressource PostScript \"prolog.ps\" est introuvable"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr ""
 "E456: Le fichier de ressource PostScript \"cidfont.ps\" est introuvable"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Le fichier de ressource PostScript \"%s.ps\" est introuvable"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: La conversion pour imprimer dans l'encodage \"%s\" a échoué"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Envoi à l'imprimante..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: L'impression du fichier PostScript a échoué"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Tâche d'impression envoyée."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Ajouter une base de données"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Rechercher un motif"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Afficher ce message"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Fermer une connexion"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Réinitialiser toutes les connexions"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Afficher les connexions"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Utilisation : cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Cette commande cscope ne supporte pas le partage de la fenêtre.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Utilisation : cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag : marqueur introuvable"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: Erreur stat(%s) : %d"
 
-msgid "E563: stat error"
-msgstr "E563: Erreur stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s n'est pas un répertoire ou une base de données cscope valide"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Base de données cscope %s ajoutée"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: erreur lors de la lecture de la connexion cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: type de recherche cscope inconnu"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Impossible de créer les tuyaux (pipes) cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Impossible de forker pour cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "exec de cs_create_connection a échoué"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "exec de cs_create_connection a échoué"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection : fdopen pour to_fp a échoué"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection : fdopen pour fr_fp a échoué"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Impossible d'engendrer le processus cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: Aucune connexion cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Drapeau cscopequickfix %c invalide pour %c"
 
 # DB - todo
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: aucune correspondance trouvée pour la requête cscope %s de %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "commandes cscope :\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Utilisation : %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2757,33 +3444,31 @@ msgstr ""
 "       s: Trouver ce symbole C\n"
 "       t: Trouver cette chaîne\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: impossible d'ouvrir la base de données cscope %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr ""
-"E626: impossible d'obtenir des informations sur la base de données cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: base de données cscope redondante non ajoutée"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: Connexion cscope %s introuvable"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "connexion cscope %s fermée"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: erreur fatale dans cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Marqueur cscope : %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2792,373 +3477,87 @@ msgstr ""
 "   #   ligne"
 
 # DB - todo : Faut-il respecter l'alignement ici ?
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "nom      / contexte/ ligne\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Erreur cscope : %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Toutes les bases de données cscope ont été réinitialisées"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "aucune connexion cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    nom de la base de données           chemin\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "La bibliothèque Lua n'a pas pu être chargée."
-
-msgid "cannot save undo information"
-msgstr "impossible d'enregistrer les informations d'annulation"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Désolé, cette commande est désactivée : les bibliothèques MzScheme "
-"n'ont pas pu être chargées."
-
-msgid "invalid expression"
-msgstr "expression invalide"
-
-msgid "expressions disabled at compile time"
-msgstr "expressions désactivée lors de la compilation"
-
-msgid "hidden option"
-msgstr "option cachée"
-
-msgid "unknown option"
-msgstr "option inconnue"
-
-msgid "window index is out of range"
-msgstr "numéro de fenêtre hors limites"
-
-msgid "couldn't open buffer"
-msgstr "impossible d'ouvrir le tampon"
-
-msgid "cannot delete line"
-msgstr "impossible d'effacer la ligne"
-
-msgid "cannot replace line"
-msgstr "impossible de remplacer la ligne"
-
-msgid "cannot insert line"
-msgstr "impossible d'insérer la ligne"
-
-msgid "string cannot contain newlines"
-msgstr "une chaîne ne peut pas contenir de saut-de-ligne"
-
-msgid "error converting Scheme values to Vim"
-msgstr "erreur lors de la conversion d'une valeur de Scheme à Vim"
-
-msgid "Vim error: ~a"
-msgstr "Erreur Vim : ~a"
-
-msgid "Vim error"
-msgstr "Erreur Vim"
-
-msgid "buffer is invalid"
-msgstr "tampon invalide"
-
-msgid "window is invalid"
-msgstr "fenêtre invalide"
-
-msgid "linenr out of range"
-msgstr "numéro de ligne hors limites"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "non autorisé dans le bac à sable"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Vim ne peut pas exécuter :python après avoir utilisé :py3"
-
-msgid "only string keys are allowed"
-msgstr "seule une chaine est autorisée comme clé"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Désolé, commande désactivée : la bibliothèque Python n'a pas pu être "
-"chargée."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Impossible d'invoquer Python récursivement"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Vim ne peut pas exécuter :py3 après avoir utilisé :python"
-
-msgid "index must be int or slice"
-msgstr "index doit être int ou slice"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ doit être une instance de chaîne (String)"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Désolé, commande désactivée : la bibliothèque Ruby n'a pas pu être "
-"chargée."
-
-msgid "E267: unexpected return"
-msgstr "E267: « return » inattendu"
-
-msgid "E268: unexpected next"
-msgstr "E268: « next » inattendu"
-
-msgid "E269: unexpected break"
-msgstr "E269: « break » inattendu"
-
-msgid "E270: unexpected redo"
-msgstr "E270: « redo » inattendu"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: « retry » hors d'une clause « rescue »"
-
-msgid "E272: unhandled exception"
-msgstr "E272: Exception non prise en charge"
-
-# DB - todo
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: contexte de longjmp inconnu : %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Basculer implémentation/définition"
-
-msgid "Show base class of"
-msgstr "Montrer la classe de base de"
-
-msgid "Show overridden member function"
-msgstr "Montrer les fonctions membres surchargées"
-
-msgid "Retrieve from file"
-msgstr "Récupérer du fichier"
-
-msgid "Retrieve from project"
-msgstr "Récupérer du projet"
-
-msgid "Retrieve from all projects"
-msgstr "Récupérer de tous les projets"
-
-msgid "Retrieve"
-msgstr "Récupérer"
-
-msgid "Show source of"
-msgstr "Montrer source de"
-
-msgid "Find symbol"
-msgstr "Trouver symbole"
-
-msgid "Browse class"
-msgstr "Parcourir classe"
-
-msgid "Show class in hierarchy"
-msgstr "Montrer classe dans hiérarchie"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Montrer classe dans hiérarchie restreinte"
-
-# todo
-msgid "Xref refers to"
-msgstr "Xref référence"
-
-msgid "Xref referred by"
-msgstr "Xref est référencé par"
-
-msgid "Xref has a"
-msgstr "Xref a un(e)"
-
-msgid "Xref used by"
-msgstr "Xref utilisée par"
-
-msgid "Show docu of"
-msgstr "Montrer doc de"
-
-msgid "Generate docu for"
-msgstr "Générer la doc de"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Connexion à SNiFF+ impossible. Vérifiez l'environnement (sniffemacs doit "
-"être dans le $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff : Erreur de lecture. Déconnexion"
-
-# DB - Les trois messages suivants vont ensembles.
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ est actuellement "
-
-msgid "not "
-msgstr "dé"
-
-msgid "connected"
-msgstr "connecté"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Requête SNiFF+ inconnue : %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Erreur lors de la connexion à SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ n'est pas connecté"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ce tampon n'est pas un tampon SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff : Erreur lors d'une écriture. Déconnexion"
-
-msgid "invalid buffer number"
-msgstr "numéro de tampon invalide"
-
-msgid "not implemented yet"
-msgstr "pas encore implémenté"
-
-# DB - TODO : le contexte est celui d'une annulation.
-#. ???
-msgid "cannot set line(s)"
-msgstr "Impossible de remettre la/les ligne(s)"
-
-msgid "invalid mark name"
-msgstr "nom de marque invalide"
-
-msgid "mark not set"
-msgstr "marque non positionnée"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "ligne %d colonne %d"
-
-msgid "cannot insert/append line"
-msgstr "Impossible d'insérer/ajouter de lignes"
-
-msgid "line number out of range"
-msgstr "numéro de ligne hors limites"
-
-msgid "unknown flag: "
-msgstr "drapeau inconnu : "
-
-msgid "unknown vimOption"
-msgstr "vimOption inconnue"
-
-msgid "keyboard interrupt"
-msgstr "interruption clavier"
-
-msgid "vim error"
-msgstr "erreur Vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr ""
-"Impossible de créer commande de tampon/fenêtre : objet en cours d'effacement"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"Impossible d'inscrire la commande de rappel : tampon/fenêtre en effacement"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: ERREUR FATALE TCL: reflist corrompue ?! Contactez vim-dev@vim.org, SVP."
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"Impossible d'inscrire la commande de rappel : réf. tampon/fenêtre introuvable"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Désolé, commande désactivée: la bibliothèque Tcl n'a pas pu être "
-"chargée."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: code de sortie %d"
-
-msgid "cannot get line"
-msgstr "Impossible d'obtenir la ligne"
-
-msgid "Unable to register a command server name"
-msgstr "Impossible d'inscrire un nom de serveur de commande"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Échec de l'envoi de la commande au programme cible"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Id utilisé pour le serveur invalide : %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Entrée registre de l'instance de Vim mal formatée. Suppression !"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Option inconnue"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Trop d'arguments d'édition"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argument manquant après"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "arguments en trop après l'option"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Trop d'arguments \"+command\", \"-c command\" ou \"--cmd command\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Argument invalide pour"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d fichiers à éditer\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans n'est pas supporté avec cette interface graphique\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Ce Vim n'a pas été compilé avec la fonctionnalité diff"
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' ne peut pas être utilisé : désactivé à la compilation\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Nouvelle tentative pour ouvrir le script : \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Impossible d'ouvrir en lecture : \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Impossible d'ouvrir pour la sortie script : \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim : Erreur : Impossible de démarrer gvim depuis NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim : Alerte : La sortie ne s'effectue pas sur un terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim : Alerte : L'entrée ne se fait pas sur un terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "ligne de commande pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Impossible de lire \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -3166,18 +3565,23 @@ msgstr ""
 "\n"
 "Plus d'info avec : \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[fichier ...]  ouvrir le ou les fichiers spécifiés"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-              lire le texte à partir de stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t marqueur    ouvrir le fichier qui contient le marqueur"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [fichErr]   ouvrir à l'endroit de la première erreur"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -3187,9 +3591,11 @@ msgstr ""
 "\n"
 "utilisation :"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [args] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -3197,15 +3603,7 @@ msgstr ""
 "\n"
 "    ou :"
 
-# DB - todo (VMS uniquement).
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"pour lesquels la casse est indifférente (/ pour que le drapeau soit "
-"majuscule)"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -3215,330 +3613,192 @@ msgstr ""
 "\n"
 "Arguments :\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\tSeuls des noms de fichier sont spécifiés après ceci"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\tNe pas développer les métacaractères"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\tInscrire ce gvim pour OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\tDésinscrire gvim de OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\tLancer l'interface graphique (comme \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr ""
-"-f, --nofork\tPremier-plan : ne pas détacher l'interface graphique du "
-"terminal"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\tMode Vi (comme \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\tMode Ex (comme \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tMode Ex amélioré"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\tMode silencieux (batch) (seulement pour \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\tMode diff (comme \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\tMode facile (comme \"evim\", vim sans modes)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\tMode lecture seule (comme \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\tMode restreint (comme \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\tInterdire l'enregistrement des fichiers"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\tInterdire toute modification de texte"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\tMode binaire"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\tMode lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\tCompatible avec Vi : 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\tPas totalement compatible avec Vi : 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][<fichier>]\tMode verbeux [niveau N] [dans <fichier>]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\tMode débogage"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\tNe pas utiliser de fichier d'échange, seulement la mémoire"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\tLister les fichiers d'échange et quitter"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r <fichier>\tRécupérer une session plantée"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\tComme -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\tNe pas utiliser newcli pour l'ouverture des fenêtres"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <périph>\tUtiliser <périphérique> pour les E/S"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\tDémarrer en mode arabe"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\tDémarrer en mode hébreu"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\tDémarrer en mode farsi"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <term>\tRégler le type du terminal sur <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\tUtiliser <vimrc> au lieu du vimrc habituel"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\tUtiliser <gvimrc> au lieu du gvimrc habituel"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\tNe charger aucun greffon"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\tOuvrir N onglets (défaut : un pour chaque fichier)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\tOuvrir N fenêtres (défaut : une pour chaque fichier)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\tComme -o, mais partager verticalement"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\tOuvrir à la fin du fichier"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<numL>\tOuvrir le fichier à la ligne <numL>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <cmde>\tExécuter <commande> avant de charger les fichiers vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <cmde>\tExécuter <commande> une fois le 1er fichier chargé"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <session>\tSourcer le fichier <session> une fois le 1er fichier chargé"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <src>\tLire les commandes du mode Normal à partir du fichier <src>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <dest>\tAjouter toutes les commandes tapées dans le fichier <dest>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <dest>\tÉcrire toutes les commandes tapées dans le fichier <dest>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tÉditer des fichiers chiffrés"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tConnecter Vim au serveur X spécifié"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNe pas se connecter à un serveur X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <fich>\tÉditer les <fichiers> dans un serveur Vim si possible"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-silent ...\tPareil, mais pas d'erreur s'il n'y a aucun serveur"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <fich>\tComme --remote mais ne quitter qu'à la fin de l'édition"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent\tPareil, mais pas d'erreur s'il n'y a aucun serveur"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <fich>\tComme --remote mais ouvrir un onglet "
-"pour chaque fichier"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <tche>\tEnvoyer <touches> à un serveur Vim puis quitter"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <expr>\tÉvaluer <expr> dans un serveur Vim, afficher le "
-"résultat"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr ""
-"--serverlist\t\tLister les noms des serveurs Vim disponibles et quitter"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nom>\tEnvoyer au/devenir le serveur Vim nommé <nom>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <fich>\tÉcrire les messages d'horodatage au démarrage dans "
 "<fich>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUtiliser <viminfo> au lieu du viminfo habituel"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h ou --help\t\tAfficher l'aide (ce message) puis quitter"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tAfficher les informations de version et quitter"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Arguments reconnus par gvim (version Motif) :\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Arguments reconnus par gvim (version neXtaw) :\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Arguments reconnus par gvim (version Athena) :\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <écran>\tLancer Vim sur ce <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tIconifier Vim au démarrage"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr ""
-"-background <coul>\tUtiliser <couleur> pour l'arrière-plan\t   (abrv : -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <coul>\tUtiliser <couleur> pour le texte normal\t   (abrv : -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <fonte>\tUtiliser <fonte> pour le texte normal\t   (abrv : -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <fonte>\tUtiliser <fonte> pour le texte gras"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <fonte>\tUtiliser <fonte> pour le texte italique"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <géom>\tUtiliser cette <géométrie> initiale\t (abrv : -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr ""
-"-borderwidth <épais>\tUtiliser cette <épaisseur> de bordure\t   (abrv : -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <lg>\tUtiliser cette <largeur> de barre de défil. (abrv: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <haut>\tUtiliser cette <hauteur> de menu\t   (abrv : -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tUtiliser la vidéo inverse\t\t   (abrv : -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNe pas utiliser de vidéo inverse\t   (abrv : +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ressource>\tConfigurer la <ressource> spécifiée"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Arguments reconnus par gvim (version GTK+) :\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr ""
-"-display <display>\tLancer Vim sur ce <display>\t(également : --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <rôle>\tDonner un rôle pour identifier la fenêtre principale"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOuvrir Vim dans un autre widget GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tGvim affiche l'ID de la fenêtre sur stdout"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <titre parent>\tOuvrir Vim dans une application parente"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tOuvrir Vim dans un autre widget win32"
-
-msgid "No display"
-msgstr "Aucun display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr " : L'envoi a échoué.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr " : L'envoi a échoué. Tentative d'exécution locale\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d édités sur %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Aucun display : L'envoi de l'expression a échoué.\n"
-
-msgid ": Send expression failed.\n"
-msgstr " : L'envoi de l'expression a échoué.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Aucune marque positionnée"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Aucune marque ne correspond à \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3547,6 +3807,7 @@ msgstr ""
 "marq ligne col fichier/texte"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3555,6 +3816,7 @@ msgstr ""
 " saut ligne col fichier/texte"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3562,6 +3824,7 @@ msgstr ""
 "\n"
 "modif  ligne col fichier/texte"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3570,6 +3833,7 @@ msgstr ""
 "# Marques dans le fichier :\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3577,6 +3841,7 @@ msgstr ""
 "\n"
 "# Liste de sauts (le plus récent en premier) :\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3584,91 +3849,84 @@ msgstr ""
 "\n"
 "# Historique des marques dans les fichiers (les plus récentes en premier) :\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>' manquant"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Page de codes non valide"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Impossible de régler les valeurs IC"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Échec de la création du contexte de saisie"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Échec de l'ouverture de la méthode de saisie"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Alerte : Impossible d'inscrire la callback de destruction dans la MS"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: la méthode de saisie ne supporte aucun style"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr ""
-"E289: le type de préédition de Vim n'est pas supporté par la méthode de "
-"saisie"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: le bloc n'était pas verrouillé"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Erreur de positionnement lors de la lecture du fichier d'échange"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Erreur de lecture dans le fichier d'échange"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Erreur de positionnement lors de l'écriture du fichier d'échange"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Erreur d'écriture dans le fichier d'échange"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Le fichier d'échange existe déjà (attaque par symlink ?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Bloc n°0 non récupéré ?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Bloc n°1 non récupéré ?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Bloc n°2 non récupéré ?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Erreur lors de la mise à jour du fichier d'échange crypté"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Oups, le fichier d'échange a disparu !"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Impossible de renommer le fichier d'échange"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Impossible d'ouvrir fichier .swp pour \"%s\", récup. impossible"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0() : bloc 0 non récupéré ?!"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Aucun fichier d'échange trouvé pour %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Entrez le numéro du fichier d'échange à utiliser (0 pour quitter) : "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Impossible d'ouvrir %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Impossible de lire le bloc 0 de "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3677,22 +3935,28 @@ msgstr ""
 "Il est possible qu'aucune modification n'a été faite ou que Vim n'a pas mis "
 "à jour  le fichier d'échange."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " ne peut pas être utilisé avec cette version de Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Utilisez Vim version 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ne semble pas être un fichier d'échange de Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " ne peut pas être utilisé sur cet ordinateur.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Le fichier a été créé le "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3700,107 +3964,86 @@ msgstr ""
 ",\n"
 "ou le fichier a été endommagé."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr ""
-"E833: %s est chiffré et cette version de Vim ne supporte pas le chiffrement"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " a été endommagé (taille de page inférieure à la valeur minimale).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Utilisation du fichier d'échange \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Fichier original \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Alerte : Le fichier original a pu être modifié"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Fichier d'échange chiffré : \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Si vous avez tapé une nouvelle clé de chiffrement mais n'avez pas enregistré "
-"le fichier texte,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"tapez la nouvelle clé de chiffrement."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Si vous avez écrit le fichier texte après avoir changé la clé de "
-"chiffrement, appuyez sur entrée"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"afin d'utiliser la même clé pour le fichier texte et le fichier d'échange"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Impossible de lire le bloc 1 de %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???DE NOMBREUSES LIGNES MANQUENT"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???NOMBRE DE LIGNES ERRONÉ"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???BLOC VIDE"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LIGNES MANQUANTES"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID du bloc 1 erroné (%s n'est pas un fichier d'échange ?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOC MANQUANT"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? d'ici jusqu'à ???FIN des lignes peuvent être corrompues"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? d'ici jusqu'à ???FIN des lignes ont pu être insérées/effacées"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???FIN"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Récupération interrompue"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Erreurs lors de la récupération ; examinez les lignes commençant "
 "par ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Consultez \":help E312\" pour plus d'information."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Récupération achevée. Vérifiez que tout est correct."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3808,14 +4051,17 @@ msgstr ""
 "\n"
 "(Vous voudrez peut-être enregistrer ce fichier sous un autre nom\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "et lancer diff avec le fichier original pour repérer les changements)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr ""
 "Récupération achevée. Le contenu du tampon est identique au contenu du "
 "fichier."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3825,45 +4071,52 @@ msgstr ""
 "Il est conseillé d'effacer maintenant le fichier .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr ""
-"Utilisation de la clé de chiffrement du fichier d'échange pour le fichier "
-"texte.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Fichiers d'échange trouvés :"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   Dans le répertoire courant :\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "Utilisant le nom indiqué :\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   Dans le répertoire "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "     -- aucun --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "      propriété de : "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    daté : "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              daté : "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [de Vim version 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ne semble pas être un fichier d'échange Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "    nom de fichier : "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3871,12 +4124,15 @@ msgstr ""
 "\n"
 "           modifié : "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "OUI"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "non"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3884,9 +4140,11 @@ msgstr ""
 "\n"
 " nom d'utilisateur : "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   nom d'hôte : "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3894,6 +4152,7 @@ msgstr ""
 "\n"
 "        nom d'hôte : "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3901,16 +4160,11 @@ msgstr ""
 "\n"
 "      processus n° : "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (en cours d'exécution)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [inutilisable avec cette version de Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3918,75 +4172,97 @@ msgstr ""
 "\n"
 "         [inutilisable sur cet ordinateur]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [ne peut être lu]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [ne peut être ouvert]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Préservation impossible, il n'y a pas de fichier d'échange"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Fichier préservé"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Échec de la préservation"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get : numéro de ligne invalide : %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get : ligne %<PRId64> introuvable"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: mauvais id de pointeur de bloc 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx devrait être 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Trop de blocs mis à jour ?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: mauvais id de pointeur de bloc 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "bloc 1 effacé ?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Ligne %<PRId64> introuvable"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: mauvais id de pointeur de bloc"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count vaut zéro"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: numéro de ligne hors limites : %<PRId64> au-delà de la fin"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: nombre de lignes erroné dans le bloc %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "La taille de la pile s'accroît"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: mauvais id de pointeur de block 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: cycle de liens symboliques avec \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ATTENTION"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3994,14 +4270,15 @@ msgstr ""
 "\n"
 "Trouvé un fichier d'échange nommé \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Lors de l'ouverture du fichier \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      PLUS RÉCENT que le fichier d'échange !\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -4013,15 +4290,19 @@ msgstr ""
 "    Si c'est le cas, faites attention à ne pas vous retrouver avec\n"
 "    deux versions différentes du même fichier en faisant des modifications."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Quittez, ou continuez prudemment.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Une session d'édition de ce fichier a planté.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Si c'est le cas, utilisez \":recover\" ou \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -4029,9 +4310,11 @@ msgstr ""
 "\"\n"
 "    pour récupérer le fichier (voir \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Si vous l'avez déjà fait, effacez le fichier d'échange \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -4039,18 +4322,23 @@ msgstr ""
 "\"\n"
 "    pour éviter ce message.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Le fichier d'échange \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" existe déjà !"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ATTENTION"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Un fichier d'échange existe déjà !"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -4064,6 +4352,7 @@ msgstr ""
 "&Quitter\n"
 "&Abandonner"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -4079,36 +4368,58 @@ msgstr ""
 "&Quitter\n"
 "&Abandonner"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Trop de fichiers d'échange trouvés"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Mémoire épuisée ! (allocation de %<PRIu64> octets)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Une partie du chemin de l'élément de menu n'est pas un sous-menu"
 
 # DB - todo : J'hésite avec
 #      msgstr "E328: Le menu n'existe pas dans ce mode"
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Le menu n'existe que dans un autre mode"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Aucun menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Nom de menu vide"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Le chemin de menu ne doit pas conduire à un sous-menu"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Ajout d'éléments de menu directement dans barre de menu interdit"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Un séparateur ne peut faire partie d'un chemin de menu"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -4116,62 +4427,75 @@ msgstr ""
 "\n"
 "--- Menus ---"
 
-msgid "Tear off this menu"
-msgstr "Détacher ce menu"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Le chemin du menu doit conduire à un élément de menu"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Menu introuvable : %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Le menu n'est pas défini pour le mode %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Le chemin du menu doit conduire à un sous-menu"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Menu introuvable - vérifiez les noms des menus"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Erreur détectée en traitant %s :"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "ligne %4ld :"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nom de registre invalide : '%s'"
 
 # DB - todo : mettre à jour ?
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Maintenance des messages : Dominique Pellé <dominique.pelle@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Interruption : "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Appuyez sur ENTRÉE ou tapez une commande pour continuer"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s, ligne %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Plus --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr ""
 "ESPACE/d/j : écran/page/ligne vers le bas, b/u/k : vers le haut, q : quitter"
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Question"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -4179,6 +4503,17 @@ msgstr ""
 "&Oui\n"
 "&Non"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Oui\n"
+"&Non\n"
+"&Annuler"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4192,277 +4527,176 @@ msgstr ""
 "Tout aban&donner\n"
 "&Annuler"
 
-# DB : Les trois messages qui suivent sont des titres de boîtes
-#      de dialogue par défaut.
-msgid "Select Directory dialog"
-msgstr "Sélecteur de répertoire"
-
-msgid "Save File dialog"
-msgstr "Enregistrer un fichier"
-
-msgid "Open File dialog"
-msgstr "Ouvrir un fichier"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Désolé, pas de sélecteur de fichiers en mode console"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Pas assez d'arguments pour printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: printf() attend un argument de type Flottant"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Trop d'arguments pour printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Alerte : Modification d'un fichier en lecture seule"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Tapez un nombre et <Entrée> ou cliquez avec la souris (rien annule) :"
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Tapez un nombre et <Entrée> (rien annule) :"
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 ligne en plus"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 ligne en moins"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> lignes en plus"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> lignes en moins"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Interrompu)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Bip !"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim : préservation des fichiers...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim : Fini.\n"
-
-msgid "ERROR: "
-msgstr "ERREUR : "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[octets] total alloué-libéré %<PRIu64>-%<PRIu64>, utilisé %<PRIu64>, pic %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[appels] total re/malloc() %<PRIu64>, total free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: La ligne devient trop longue"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Erreur interne : lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Mémoire épuisée ! (allocation de %<PRIu64> octets)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Appel du shell pour exécuter : \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: ':' manquant"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Mode non autorisé"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Forme de curseur invalide"
-
-msgid "E548: digit expected"
-msgstr "E548: chiffre attendu"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Pourcentage non autorisé"
-
-msgid "Enter encryption key: "
-msgstr "Tapez la clé de chiffrement : "
-
-msgid "Enter same key again: "
-msgstr "Tapez la clé à nouveau : "
-
-msgid "Keys don't match!"
-msgstr "Les clés ne correspondent pas !"
-
-msgid "E854: path too long for completion"
-msgstr "E854: chemin trop long pour complètement"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Chemin invalide : '**[nombre]' doit être à la fin du chemin ou être "
-"suivi de '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Répertoire \"%s\" introuvable dans 'cdpath'"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Fichier \"%s\" introuvable dans 'path'"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Plus de répertoire \"%s\" dans 'cdpath'"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Plus de fichier \"%s\" dans 'path'"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Impossible de se connecter à Netbeans n°2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Impossible de se connecter à Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Mode d'accès incorrect au fichier d'infos de connexion NetBeans : \"%s"
-"\""
-
-# DB : message d'un appel à perror().
-msgid "read from Netbeans socket"
-msgstr "read sur la socket Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Connexion NetBeans perdue pour le tampon %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans n'est pas supporté avec cette interface graphique"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans déjà connecté"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s est en lecture seule (ajoutez ! pour passer outre)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Aucun identifiant sous le curseur"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' est vide"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: La fonctionnalité d'évaluation n'est pas disponible"
-
 # DB : Il est ici question du mode Visuel.
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Alerte : le terminal ne peut pas surligner"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Aucune chaîne sous le curseur"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Impossible d'effacer des replis avec la 'foldmethod'e actuelle"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: La liste des modifications (changelist) est vide"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Au début de la liste des modifications"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: À la fin de la liste des modifications"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "tapez  :q<Entrée>  pour quitter Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 ligne %sée 1 fois"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 ligne %sée %d fois"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> lignes %sées 1 fois"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> lignes %sées %d fois"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> lignes à indenter... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 ligne indentée "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> lignes indentées "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Aucun registre n'a été précédemment utilisé"
 
 # DB - Question O/N.
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "impossible de réaliser une copie ; effacer tout de même"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 ligne modifiée"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> lignes modifiées"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "libération de %<PRId64> lignes"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "bloc de 1 ligne copié"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 ligne copiée"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "bloc de %<PRId64> lignes copié"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> lignes copiées"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Le registre %s est vide"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4470,9 +4704,11 @@ msgstr ""
 "\n"
 "--- Registres ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Nom de registre invalide"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4480,167 +4716,184 @@ msgstr ""
 "\n"
 "# Registres :\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Type de registre %d inconnu"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Colonnes ; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr ""
-"%s%<PRId64> sur %<PRId64> Lignes ; %<PRId64> sur %<PRId64> Mots ; %<PRId64> sur %<PRId64> Octets sélectionnés"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"%s%<PRId64> sur %<PRId64> Lignes ; %<PRId64> sur %<PRId64> Mots ; %<PRId64> sur %<PRId64> Caractères ; %<PRId64> sur "
-"%<PRId64> octets sélectionnés"
+"%s%<PRId64> sur %<PRId64> Lignes ; %<PRId64> sur %<PRId64> Mots ; %<PRId64> "
+"sur %<PRId64> Octets sélectionnés"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr ""
-"Colonne %s sur %s ; Ligne %<PRId64> sur %<PRId64> ; Mot %<PRId64> sur %<PRId64> ; Octet %<PRId64> sur %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Colonne %s sur %s ; Ligne %<PRId64> sur %<PRId64> ; Mot %<PRId64> sur %<PRId64> ; Caractère %<PRId64> sur "
+"%s%<PRId64> sur %<PRId64> Lignes ; %<PRId64> sur %<PRId64> Mots ; %<PRId64> "
+"sur %<PRId64> Caractères ; %<PRId64> sur %<PRId64> octets sélectionnés"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Colonne %s sur %s ; Ligne %<PRId64> sur %<PRId64> ; Mot %<PRId64> sur "
 "%<PRId64> ; Octet %<PRId64> sur %<PRId64>"
 
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Colonne %s sur %s ; Ligne %<PRId64> sur %<PRId64> ; Mot %<PRId64> sur "
+"%<PRId64> ; Caractère %<PRId64> sur %<PRId64> ; Octet %<PRId64> sur %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> pour le BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Page %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Merci d'avoir choisi Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Option inconnue"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Option non supportée"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Non autorisé dans une ligne de mode"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Le code de touche n'est pas configuré"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Nombre requis après ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Introuvable dans termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Caractère <%s> invalide"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' ne doit pas être une chaîne vide"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Impossible de modifier term dans l'interface graphique"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Utilisez \":gui\" pour démarrer l'interface graphique"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' et 'patchmode' sont égaux"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Conflits avec la valeur de 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Conflits avec la valeur de 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Non modifiable dans l'interface graphique GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: ':' manquant"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Chaîne de longueur nulle"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Nombre manquant après <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Virgule manquante"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Une valeur ' doit être spécifiée"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: contient des caractères à largeur double non-imprimables"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Police(s) invalide(s)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Impossible de sélectionner un jeu de polices"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Jeu de polices invalide"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Impossible de sélectionner une police à largeur double"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Police à largeur double invalide"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Caractère invalide après <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: virgule requise"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' doit être vide ou contenir %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: La souris n'est pas supportée"
-
 # DB - Le code est sans ambiguïté sur le caractère manquant.
 #      À défaut d'une traduction valable, au moins comprend-on
 #      ce qui se passe.
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: '}' manquant"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: trop d'éléments"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: parenthèses non équilibrées"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Il existe déjà une fenêtre de prévisualisation"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: L'arabe requiert l'UTF-8, tapez ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Au moins %d lignes sont nécessaires"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Au moins %d colonnes sont nécessaires"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Option inconnue : %s"
@@ -4648,10 +4901,12 @@ msgstr "E355: Option inconnue : %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Nombre requis : &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4659,6 +4914,7 @@ msgstr ""
 "\n"
 "--- Codes de terminal ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4666,6 +4922,7 @@ msgstr ""
 "\n"
 "--- Valeur des options globales ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4673,6 +4930,7 @@ msgstr ""
 "\n"
 "--- Valeur des options locales ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4680,141 +4938,21 @@ msgstr ""
 "\n"
 "--- Options ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ERREUR get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap' : Aucun caractère correspondant pour %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap' : Caractères surnuméraires après point-virgule : %s"
 
-msgid "cannot open "
-msgstr "impossible d'ouvrir "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM : Impossible d'ouvrir la fenêtre !\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Amigados version 2.04 ou ultérieure est nécessaire\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "%s version %<PRId64> est nécessaire\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Impossible d'ouvrir NIL :\n"
-
-msgid "Cannot create "
-msgstr "Impossible de créer "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim quitte avec %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "Impossible de modifier le mode de la console ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize : pas une console ?!\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Impossible d'exécuter un shell avec l'option -f"
-
-msgid "Cannot execute "
-msgstr "Impossible d'exécuter "
-
-msgid "shell "
-msgstr "le shell "
-
-msgid " returned\n"
-msgstr " a été retourné\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE trop petit."
-
-msgid "I/O ERROR"
-msgstr "ERREUR d'E/S"
-
-msgid "Message"
-msgstr "Message"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' ne vaut pas 80, impossible d'exécuter des commandes externes"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: La sélection de l'imprimante a échoué"
-
-# DB - Contenu des c-formats : Imprimante puis Port.
-#, c-format
-msgid "to %s on %s"
-msgstr "vers %s sur %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Police d'imprimante inconnue : %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Erreur d'impression : %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Impression de '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Jeu de caractères \"%s\" invalide dans le nom de fonte \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Caractère '%c' invalide dans le nom de fonte \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim : Double signal, sortie\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim : Signal mortel %s intercepté\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim : Signal mortel intercepté\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "L'ouverture du display X a pris %<PRId64> ms"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim : Réception d'une erreur X\n"
-
-msgid "Testing the X display failed"
-msgstr "Le test du display X a échoué"
-
-msgid "Opening the X display timed out"
-msgstr "L'ouverture du display X a dépassé le délai d'attente"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Impossible d'obtenir le contexte de sécurité pour "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Impossible de modifier le contexte de sécurité pour "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4822,13 +4960,7 @@ msgstr ""
 "\n"
 "Impossible d'exécuter le shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Impossible d'exécuter le shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4836,254 +4968,234 @@ msgstr ""
 "\n"
 "le shell a retourné "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Impossible de créer des tuyaux (pipes)\n"
+"Impossible d'obtenir le contexte de sécurité pour "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Impossible de forker\n"
+"Impossible de modifier le contexte de sécurité pour "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Commande interrompue\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP a perdu la connexion ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "L'ouverture du display X a échoué"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP : prise en charge d'une requête save-yourself"
-
-msgid "XSMP opening connection"
-msgstr "XSMP : ouverture de la connexion"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP : échec de la surveillance de connexion ICE"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP : SmcOpenConnection a échoué : %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Le fichier \"%s\" est introuvable dans 'path'"
 
-msgid "At line"
-msgstr "À la ligne"
-
-msgid "Could not load vim32.dll!"
-msgstr "Impossible de charger vim32.dll !"
-
-msgid "VIM Error"
-msgstr "Erreur VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Impossible d'initialiser les pointeurs de fonction vers la DLL !"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "le shell a retourné %d"
-
-# DB - Les événements en question sont ceux des messages qui suivent.
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim : Événement %s intercepté\n"
-
-msgid "close"
-msgstr "de fermeture"
-
-msgid "logoff"
-msgstr "de déconnexion"
-
-msgid "shutdown"
-msgstr "d'arrêt"
-
-msgid "E371: Command not found"
-msgstr "E371: Commande introuvable"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE est introuvable votre $PATH.\n"
-"Les commandes externes ne feront pas de pause une fois terminées.\n"
-"Voir  :help win32-vimrun  pour plus d'informations."
-
-msgid "Vim Warning"
-msgstr "Alerte Vim"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Trop de %%%c dans la chaîne de format"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: %%%c inattendu dans la chaîne de format"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: ] manquant dans la chaîne de format"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c non supporté dans la chaîne de format"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: %%%c invalide dans le préfixe de la chaîne de format"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: %%%c invalide dans la chaîne de format"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' ne contient aucun motif"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Nom de répertoire vide ou absent"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Plus d'éléments"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d sur %d)%s%s : "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (ligne effacée)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: En bas de la pile quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Au sommet de la pile quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "liste d'erreurs %d sur %d ; %d erreurs"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Écriture impossible, l'option 'buftype' est activée"
 
-msgid "Error file"
-msgstr "Fichier d'erreurs"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Nom de fichier manquant ou motif invalide"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Impossible d'ouvrir le fichier \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: le tampon n'est pas chargé"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Chaîne ou Liste attendue"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: élément invalide dans %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: ']' manquant après %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Pas de correspondance pour %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: %s( ouvrante non fermée"
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: %s) fermante non ouverte"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Motif trop long"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Trop de \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Trop de %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Pas de correspondance pour \\z("
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: caractère invalide après %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Trop de %s{...}s complexes"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: %s* imbriqués"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: %s%c imbriqués"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: utilisation invalide de \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c ne suit aucun atome"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: post-référence invalide"
-
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( n'est pas autorisé ici"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 et co. ne sont pas autorisés ici"
 
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Caractère invalide après \\z"
-
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: ']' manquant après %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] vide"
 
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Motif trop long"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Trop de \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Trop de %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Pas de correspondance pour \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: caractère invalide après %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Trop de %s{...}s complexes"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: %s* imbriqués"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: %s%c imbriqués"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: utilisation invalide de \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c ne suit aucun atome"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: post-référence invalide"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Caractère invalide après \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Caractère invalide après %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Caractère invalide après %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Erreur de syntaxe dans %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Sous-correspondances externes :\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
@@ -5091,40 +5203,63 @@ msgstr ""
 "E864: \\%#= peut être suivi uniquement de 0, 1 ou 2. Le moteur automatique "
 "sera utilisé "
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) Fin de regexp rencontrée prématurément"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (regexp NFA) %c au mauvais endroit"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) Fin de regexp rencontrée prématurément"
+#: ../regexp_nfa.c:242
+#, fuzzy, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr "E877: (regexp NFA) Classe de caractère invalide "
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Opérateur inconnu '\\z%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Erreur lors de la construction du NFA avec classe d'équivalence"
+#: ../regexp_nfa.c:1387
+#, fuzzy, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr "E867: (NFA) Opérateur inconnu '\\z%c'"
 
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Opérateur inconnu '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (regexp NFA) Erreur à la lecture des limites de répétition"
 
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (regexp NFA) Un multi ne peut pas suivre un multi !"
 
+#. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (regexp NFA) Trop de '('"
 
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E872: (regexp NFA) Trop de '('"
+
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA regexp) erreur de terminaison"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Impossible de dépiler !"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
@@ -5132,150 +5267,178 @@ msgstr ""
 "E875: (regexp NFA) (lors de la conversion de postfix à NFA), il reste trop "
 "d'états sur la pile"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (regexp NFA) Pas assez de mémoire pour stocker le NFA"
 
-msgid "E999: (NFA regexp internal error) Should not process NOT node !"
-msgstr ""
-"E999: (erreur interne du regexp NFA) Un noeud 'NOT' ne devrait pas être "
-"traité !"
-
-#. should not be here :P
-msgid "E877: (NFA regexp) Invalid character class "
-msgstr "E877: (regexp NFA) Classe de caractère invalide "
-
-#, c-format
-msgid "(NFA) COULD NOT OPEN %s !"
-msgstr "(NFA) IMPOSSIBLE D'OUVRIR %s !"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
 "Impossible d'ouvrir le fichier de log temporaire en écriture, affichage sur "
 "stderr ... "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr ""
-"E878: (NFA) Impossible d'allouer la mémoire pour parcourir les branches!"
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr "(NFA) IMPOSSIBLE D'OUVRIR %s !"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Impossible d'ouvrir le fichier de log en écriture"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " VREMPLACEMENT"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " REMPLACEMENT"
 
 # DB - todo
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " REVERSE"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERTION"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (insertion)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (remplacement)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (vremplacement)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hébreu"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " arabe"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (langue)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (collage)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUEL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUEL LIGNE"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUEL BLOC"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " SÉLECTION"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " SÉLECTION LIGNE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " SÉLECTION BLOC"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "Enregistrement"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Chaîne de recherche invalide : %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: la recherche a atteint le HAUT sans trouver : %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: la recherche a atteint le BAS sans trouver : %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: '?' ou '/' attendu après ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (inclut des correspondances listées précédemment)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Fichiers inclus "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "introuvables "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "dans le chemin ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Déjà listé)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  INTROUVABLE"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Examen des fichiers inclus : %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Recherche du fichier inclus %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: La correspondance est sur la ligne courante"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Tous les fichiers inclus ont été trouvés"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Aucun fichier inclus"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Impossible de trouver la définition"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Impossible de trouver le motif"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Substitue "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5286,84 +5449,97 @@ msgstr ""
 "# Dernier motif de recherche %s :\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Erreur de format du fichier orthographique"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Fichier orthographique tronqué"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Texte en trop dans %s ligne %d : %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Nom d'affixe trop long dans %s ligne %d : %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Erreur de format dans le fichier d'affixe FOL, LOW et UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Un caractère dans FOL, LOW ou UPP est hors-limites"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Compression de l'arbre des mots"
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: La vérification orthographique n'est pas activée"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr "Alerte : Liste de mots \"%s_%s.spl\" ou \"%s_ascii.spl\" introuvable"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Alerte : Liste de mots \"%s.%s.spl\" ou \"%s.ascii.spl\" introuvable"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Lecture du fichier orthographique \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Le fichier ne ressemble pas à un fichier orthographique"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Fichier orthographique obsolète, sa mise à jour est nécessaire"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Le fichier est prévu pour une version de Vim plus récente"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Section non supportée dans le fichier orthographique"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Alerte : région %s non supportée"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Lecture du fichier d'affixes %s..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Échec de conversion du mot dans %s ligne %d : %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "La conversion dans %s non supportée : de %s vers %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "La conversion dans %s non supportée"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Valeur de FLAG invalide dans %s ligne %d : %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG trouvé après des drapeaux dans %s ligne %d : %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5372,6 +5548,7 @@ msgstr ""
 "Définir COMPOUNDFORBIDFLAG après des PFX peut donner des résultats erronés "
 "dans %s ligne %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5380,37 +5557,45 @@ msgstr ""
 "Définir COMPOUNDPERMITFLAG après des PFX peut donner des résultats erronés "
 "dans %s ligne %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Valeur de COMPOUNDRULES erronée dans %s ligne %d : %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Valeur de COMPOUNDWORDMAX erronée dans %s ligne %d : %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Valeur de COMPOUNDMIN erronée dans %s ligne %d : %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Valeur de COMPOUNDSYLMAX erronée dans %s ligne %d : %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Valeur de CHECKCOMPOUNDPATTERN erronée dans %s ligne %d : %s"
 
 # DB - TODO
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Drapeaux de composition différents dans un bloc d'affixes continu dans %s "
 "ligne %d : %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Affixe dupliqué dans %s ligne %d : %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5419,275 +5604,339 @@ msgstr ""
 "Affixe aussi utilisée pour BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
 "NOSUGGEST dans %s ligne %d : %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Y ou N attendu dans %s ligne %d : %s"
 
 # DB - todo (regexp impossible à compiler...)
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Condition non valide dans %s ligne %d : %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Nombre de REP(SAL) attendu dans %s ligne %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Nombre de MAP attendu dans %s ligne %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Caractère dupliqué dans MAP dans %s ligne %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Élément non reconnu ou dupliqué dans %s ligne %d : %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Ligne FOL/LOW/UPP manquante dans %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "Utilisation de COMPOUNDSYLMAX sans SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Trop de préfixes reportés (PFXPOSTPONE)"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Trop de drapeaux de composition"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Trop de préfixes reportés et/ou de drapeaux de composition"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Ligne SOFO%s manquante dans %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Lignes SAL et lignes SOFO présentes dans %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Le drapeau n'est pas un nombre dans %s ligne %d : %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Drapeau non autorisé dans %s ligne %d : %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "La valeur de %s est différente de celle d'un autre fichier .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Lecture du fichier orthographique %s..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Nombre de mots non indiqué dans %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "ligne %6d, mot %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Mot dupliqué dans %s ligne %d : %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Premier mot dupliqué dans %s ligne %d : %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d mot(s) dupliqué(s) dans %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "%d mot(s) ignoré(s) avec des caractères non-ASCII dans %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Lecture de la liste de mots %s..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Ligne /encoding= en double ignorée dans %s ligne %d : %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Ligne /encoding= après des mots ignorée dans %s ligne %d : %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Ligne /regions= en double ignorée dans %s ligne %d : %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Trop de régions dans %s ligne %d : %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Ligne / ignorée dans %s ligne %d : %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Numéro de région invalide dans %s ligne %d : %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Drapeaux non reconnus dans %s ligne %d : %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "%d mot(s) ignoré(s) avec des caractères non-ASCII"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: mémoire insuffisante, liste de mots peut-être incomplète"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "%d noeuds compressés sur %d ; %d (%d%%) restants "
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Relecture du fichier orthographique"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Analyse phonétique en cours..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Nombre de mots après l'analyse phonétique : %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Nombre total de mots : %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Écriture du fichier de suggestions %s..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Estimation de mémoire consommée : %d octets"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Le nom du fichier ne doit pas contenir de nom de région"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 8 régions au maximum sont supportées"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Région invalide dans %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Alerte : la composition et NOBREAK sont tous les deux spécifiés"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Écriture du fichier orthographique %s..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Terminé !"
 
 # DB - todo : perfectible.
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' n'a pas %<PRId64> entrées"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Mot retiré de %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Mot ajouté dans %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr ""
 "E763: Les caractères de mots diffèrent entre les fichiers orthographiques"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Désolé, aucune suggestion"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Désolé, seulement %<PRId64> suggestions"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Remplacer \"%.*s\" par :"
 
 # DB - todo : l'intérêt de traduire ce message m'échappe.
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Pas de suggestion orthographique précédente"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Introuvable : %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: %s ne semble pas être un fichier .sug"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Fichier de suggestions obsolète, mise à jour nécessaire : %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Fichier .sug prévu pour une version de Vim plus récente : %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Le fichier .sug ne correspond pas au fichier .spl : %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Erreur lors de la lecture de fichier de suggestions : %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: caractères dupliqué dans l'entrée MAP"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Aucun élément de syntaxe défini pour ce tampon"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Argument invalide : %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Aucune grappe de syntaxe %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Aucun élément de syntaxe défini pour ce tampon"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronisation sur les commentaires de type C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "Aucune synchronisation"
 
 # DB - Les deux messages qui suivent vont ensemble.
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "La synchronisation débute "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " lignes avant la ligne du haut"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5695,6 +5944,7 @@ msgstr ""
 "\n"
 "--- Éléments de synchronisation syntaxique ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5702,6 +5952,7 @@ msgstr ""
 "\n"
 "synchronisation sur éléments"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5709,211 +5960,275 @@ msgstr ""
 "\n"
 "--- Éléments de syntaxe ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Aucune grappe de syntaxe %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimum "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximum "
 
 # DB - todo
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; correspond avec "
 
 # DB - todo
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " coupures de ligne"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: L'argument « contains » n'est pas accepté ici"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: valeur de cchar invalide"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: L'argument « group[t]here » n'est pas accepté ici"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Aucun élément de type région trouvé pour %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Nom de fichier requis"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Trop d'inclusions de syntaxe"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' manquant : %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' manquant : %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Pas assez d'arguments : syntax region %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Trop de grappes de syntaxe"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Aucune grappe spécifiée"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Délimiteur de motif introuvable : %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: caractères en trop après le motif : %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: synchro syntax : motif de continuation de ligne présent deux fois"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Arguments invalides : %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: '=' manquant : %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Argument vide : %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s n'est pas autorisé ici"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s doit être le premier élément d'une liste « contains »"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nom de groupe inconnu : %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Sous-commande de :syntax invalide : %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: boucle récursive lors du chargement de syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: groupe de surbrillance introuvable : %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Trop peu d'arguments : \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Trop d'arguments : \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: le groupe a déjà des attributs, lien de surbrillance ignoré"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: signe égal inattendu : %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: '=' manquant : %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: argument manquant : %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Valeur invalide : %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Couleur de premier plan inconnue"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Couleur d'arrière-plan inconnue"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nom ou numéro de couleur non reconnu : %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: le code de terminal est trop long : %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Argument invalide : %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr ""
 "E424: Trop d'attributs de surbrillance différents en cours d'utilisation"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Caractère non-imprimable dans un nom de groupe"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Caractère invalide dans un nom de groupe"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Trop de groupes de surbrillance et de syntaxe"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: En bas de la pile de marqueurs"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: Au sommet de la pile de marqueurs"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Impossible d'aller avant le premier marqueur correspondant"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Marqueur introuvable : %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri type marqueur"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "fichier\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Il n'y a qu'un marqueur correspondant"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Impossible d'aller au-delà du dernier marqueur correspondant"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Le fichier \"%s\" n'existe pas"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "marqueur %d sur %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " ou plus"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Utilisation d'un marqueur avec une casse différente !"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Le fichier \"%s\" n'existe pas"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5921,67 +6236,80 @@ msgstr ""
 "\n"
 "  # VERS marqueur  DE ligne   dans le fichier/texte"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Examen du fichier de marqueurs %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Chemin de fichiers de marqueurs tronqué pour %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ignore longue ligne dans le fichier de marqueurs"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Erreur de format dans le fichier de marqueurs \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Avant l'octet %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Le fichier de marqueurs %s n'est pas ordonné"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Aucun fichier de marqueurs"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Le motif de marqueur est introuvable"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Marqueur introuvable, tentative pour deviner !"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Nom de champ dupliqué : %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' inconnu. Les terminaux intégrés sont :"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "utilisation par défaut de '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Impossible d'ouvrir le fichier termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: La description du terminal est introuvable dans terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: La description du terminal est introuvable dans termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Aucune entrée \"%s\" dans termcap"
 
 # DB - todo : Comment améliorer ?
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: capacité de terminal \"cm\" requise"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5989,251 +6317,174 @@ msgstr ""
 "\n"
 "--- Touches du terminal ---"
 
-msgid "new shell started\n"
-msgstr "nouveau shell démarré\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim : Erreur lors de la lecture de l'entrée, sortie...\n"
 
-# DB - Message de débogage.
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "CUT_BUFFER0 utilisé plutôt qu'une sélection vide"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Le nombre de lignes a été changé inopinément"
 
-# DB - Question O/N.
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Annulation impossible ; continuer"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Impossible d'ouvrir le fichier d'annulations en écriture : %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Fichier d'annulations corrompu (%s) : %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr ""
 "Impossible d'écrire le fichier d'annulations dans n'importe quel répertoire "
 "de 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Le fichier d'annulations ne sera pas écrasé, impossible de lire : %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Fichier ne sera pas écrasé, ce n'est pas un fichier d'annulations : %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Le fichier d'annulations n'est pas écrit, rien à annuler"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Écriture du fichier d'annulations : %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Erreur d'écriture dans le fichier d'annulations : %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Le fichier d'annulations n'est pas lu, propriétaire différent : %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Lecture du fichier d'annulations : %s..."
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Impossible d'ouvrir le fichier d'annulations en lecture : %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Ce n'est pas un fichier d'annulations : %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Fichier non-chiffré a un fichier d'annulations chiffré : %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Déchiffrage du fichier d'annulation a échoué : %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Le fichier d'annulations est chiffré : %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Fichier d'annulations incompatible : %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr ""
 "Le contenu du fichier a changé, impossible d'utiliser les informations "
 "d'annulation"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Fin de lecture du fichier d'annulations %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Déjà à la modification la plus ancienne"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Déjà à la modification la plus récente"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Annulation n° %<PRId64> introuvable"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo : numéros de ligne erronés"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "ligne en plus"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "lignes en plus"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "ligne en moins"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "lignes en moins"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "modification"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "modifications"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s ; %s #%<PRId64> ; %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "avant"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "après"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Rien à annuler"
 
 # DB - Les deux premières colonnes sont alignées à droite.
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "numéro modif.   instant            enregistré"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "il y a %<PRId64> secondes"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin n'est pas autorisé après une annulation"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: la liste d'annulation est corrompue"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: ligne d'annulation manquante"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Version graphique MS-Windows 16/32 bits"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Version graphique MS-Windows 64 bits"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Version graphique MS-Windows 32 bits"
-
-msgid " in Win32s mode"
-msgstr " lancée en mode Win32s"
-
-msgid " with OLE support"
-msgstr " supportant l'OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Version console MS-Windows 64 bits"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Version console MS-Windows 32 bits"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Version MS-Windows 16 bits"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Version MS-DOS 32 bits"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Version MS-DOS 16 bits"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Version MaxOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Version MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Version MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Version OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -6241,6 +6492,7 @@ msgstr ""
 "\n"
 "Rustines incluses : "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -6248,9 +6500,11 @@ msgstr ""
 "\n"
 "Rustines extra : "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modifié par "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -6258,9 +6512,11 @@ msgstr ""
 "\n"
 "Compilé "
 
+#: ../version.c:649
 msgid "by "
 msgstr "par "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6268,808 +6524,1949 @@ msgstr ""
 "\n"
 "Énorme version "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Grosse version "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Version normale "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Petite version "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Version minuscule "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "sans interface graphique."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "avec interface graphique GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "avec interface graphique GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "avec interface graphique X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "avec interface graphique X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "avec interface graphique X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "avec interface graphique Photon."
-
-msgid "with GUI."
-msgstr "avec une interface graphique."
-
-msgid "with Carbon GUI."
-msgstr "avec interface graphique Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "avec interface graphique Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "avec interface graphique (classic)."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Fonctionnalités incluses (+) ou non (-) :\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "         fichier vimrc système : \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     fichier vimrc utilisateur : \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2me fichier vimrc utilisateur : \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3me fichier vimrc utilisateur : \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      fichier exrc utilisateur : \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2me fichier exrc utilisateur : \""
 
-msgid "  system gvimrc file: \""
-msgstr "        fichier gvimrc système : \""
-
-msgid "    user gvimrc file: \""
-msgstr "    fichier gvimrc utilisateur : \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2me fichier gvimrc utilisateur : \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3me fichier gvimrc utilisateur : \""
-
-msgid "    system menu file: \""
-msgstr "          fichier menu système : \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "               $VIM par défaut : \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "        $VIMRUNTIME par défaut : \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Compilation : "
 
-msgid "Compiler: "
-msgstr "Compilateur : "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Édition de liens : "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  VERSION DE DÉBOGAGE"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi Amélioré"
 
+#: ../version.c:769
 msgid "version "
 msgstr "version "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "par Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim est un logiciel libre"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Aidez les enfants pauvres d'Ouganda !"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "tapez  :help iccf<Entrée>       pour plus d'informations          "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "tapez  :q<Entrée>               pour sortir du programme          "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "tapez  :help<Entrée>  ou  <F1>  pour accéder à l'aide en ligne    "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "tapez  :help version7<Entrée>   pour lire les notes de mise à jour"
 
 # DB - Pour les trois messages qui suivent :
 #        :set cp
 #        :intro
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Compatibilité avec Vi activée"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "tapez  :set nocp<Entrée>       pour la désactiver"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "tapez  :help cp-default<Entrée>  pour plus d'info"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu  Aide->Orphelins            pour plus d'info"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Les modes sont désactivés, le texte saisi est inséré"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menu  Édition->Réglages Globaux->Insertion Permanente"
-
-# DB - todo
-msgid "                              for two modes      "
-msgstr "                                  pour les modes     "
-
-# DB - todo
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menu  Édition->Réglages Globaux->Compatibilité Vi"
-
-# DB - todo
-msgid "                              for Vim defaults   "
-msgstr "                                pour déf. de Vim "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Sponsorisez le développement de Vim !"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Devenez un utilisateur de Vim enregistré !"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "tapez  :help sponsor<Entrée>    pour plus d'informations          "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "tapez  :help register<Entrée>   pour plus d'informations          "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu  Aide->Sponsor/Enregistrement pour plus d'info"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ALERTE: Windows 95/98/ME détecté"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "tapez  :help windows95<Entrée>  pour plus d'information"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Il n'y a déjà plus qu'une fenêtre"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Il n'y a pas de fenêtre de prévisualisation"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Impossible de partager topleft et botright en même temps"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Rotation impossible quand une autre fenêtre est partagée"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Impossible de fermer la dernière fenêtre"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Impossible de fermer la fenêtre des autocommandes"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr ""
 "E814: Impossible de fermer la fenêtre, seule la fenêtre des autocommandes "
 "resterait"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Les modifications de l'autre fenêtre n'ont pas été enregistrées"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Aucun nom de fichier sous le curseur"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Le fichier \"%s\" est introuvable dans 'path'"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() appelée avec un mot de passe vide"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Impossible de charger la bibliothèque %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Désolé, commande désactivée : la bibliothèque Perl n'a pas pu être chargée."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: petit/gros boutisme incorrect dans blowfish"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Évaluation Perl interdite dans bac à sable sans le module Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: le test de sha256 a échoué"
 
-msgid "Edit with &multiple Vims"
-msgstr "Éditer dans &plusieurs Vims"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: le test de blowfish a échoué"
 
-msgid "Edit with single &Vim"
-msgstr "Éditer dans un seul &Vim"
+#~ msgid "Patch file"
+#~ msgstr "Fichier rustine"
 
-msgid "Diff with Vim"
-msgstr "&Comparer avec Vim"
+# AB - Textes des boutons de la boîte de dialogue affichée par inputdialog().
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&Ok\n"
+#~ "&Annuler"
 
-msgid "Edit with &Vim"
-msgstr "Éditer dans &Vim"
+# AB - À mon avis, la version anglaise est erronée.
+# DB : Vérifier
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Pas de connexion au serveur X"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Éditer dans le Vim existant - "
+# AB - La version française est meilleure que la version anglaise.
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: L'envoi au serveur %s à échoué"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Édites le(s) fichier(s) sélectionné(s) avec Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Impossible de lire la réponse du serveur"
+
+# AB - La version française est meilleure que la version anglaise.
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: La réponse n'a pas pu être envoyée au client"
+
+# AB - Ceci est un titre de boîte de dialogue. Vérifier que la version
+#      française est correcte pour les trois références ; j'ai un doute quant
+#      à la troisième.
+#~ msgid "Save As"
+#~ msgstr "Enregistrer sous - Vim"
+
+# AB - Ceci est un titre de boîte de dialogue.
+#~ msgid "Edit File"
+#~ msgstr "Ouvrir un fichier - Vim"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr "  (INTROUVABLE)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "Sourcer un script - Vim"
+
+#~ msgid "unknown"
+#~ msgstr "inconnu"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "Ouvrir un fichier dans une nouvelle fenêtre - Vim"
+
+#~ msgid "Append File"
+#~ msgstr "Ajouter fichier"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Position de la fenêtre : X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "Enregistrer la redirection"
+
+#~ msgid "Save View"
+#~ msgstr "Enregistrer la vue - Vim"
+
+#~ msgid "Save Session"
+#~ msgstr "Enregistrer la session - Vim"
+
+#~ msgid "Save Setup"
+#~ msgstr "Enregistrer les réglages - Vim"
+
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< n'est pas disponible sans la fonctionnalité +eval"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Pas de digraphes dans cette version"
+
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "est un périphérique (désactivé par l'option 'opendevice')"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "Lecture de stdin..."
+
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[chiffré]"
+
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Le fichier est chiffré avec une méthode inconnue"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans interdit l'écriture des tampons non modifiés"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Netbeans interdit l'écriture partielle de ses tampons"
+
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "écriture vers un périphérique désactivé par l'option 'opendevice'"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Les ressources partagées seraient perdues (ajoutez ! pour passer "
+#~ "outre)"
+
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr ""
+#~ "E851: Échec lors de la création d'un nouveau processus pour l'interface "
+#~ "graphique"
+
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr ""
+#~ "E852: Le processus fils n'a pas réussi à démarrer l'interface graphique"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Impossible de démarrer l'interface graphique"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Impossible de lire \"%s\""
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Impossible de démarrer l'IHM graphique, aucune police valide trouvée"
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' est invalide"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Valeur de 'imactivatekey' invalide"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Impossible d'allouer la couleur %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Aucune correspondance sous le curseur, recherche de la suivante"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<impossible d'ouvrir> "
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile : impossible d'obtenir la police %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr ""
+#~ "E614: vim_SelFile : impossible de revenir dans le répertoire courant"
+
+#~ msgid "Pathname:"
+#~ msgstr "Chemin :"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile : impossible d'obtenir le répertoire courant"
+
+#~ msgid "OK"
+#~ msgstr "Ok"
+
+#~ msgid "Cancel"
+#~ msgstr "Annuler"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Widget scrollbar : Impossible d'obtenir la géométrie du pixmap 'thumb'"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Vim"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Impossible de créer un BalloonEval avec message ET callback"
+
+# todo '_' is for hotkey, i guess?
+#~ msgid "Input _Methods"
+#~ msgstr "_Méthodes de saisie"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "Remplacer - Vim"
+
+#~ msgid "VIM - Search..."
+#~ msgstr "Rechercher - Vim"
+
+#~ msgid "Find what:"
+#~ msgstr "Rechercher :"
+
+#~ msgid "Replace with:"
+#~ msgstr "Remplacer par :"
+
+#~ msgid "Match whole word only"
+#~ msgstr "Mots entiers seulement"
+
+#~ msgid "Match case"
+#~ msgstr "Respecter la casse"
+
+#~ msgid "Direction"
+#~ msgstr "Direction"
+
+#~ msgid "Up"
+#~ msgstr "Haut"
+
+#~ msgid "Down"
+#~ msgstr "Bas"
+
+#~ msgid "Find Next"
+#~ msgstr "Suivant"
+
+#~ msgid "Replace"
+#~ msgstr "Remplacer"
+
+#~ msgid "Replace All"
+#~ msgstr "Remplacer tout"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr ""
+#~ "Vim : Une requête \"die\" a été reçue par le gestionnaire de session\n"
+
+#~ msgid "Close"
+#~ msgstr "Fermer"
+
+#~ msgid "New tab"
+#~ msgstr "Nouvel onglet"
+
+# DB - todo : un peu long. Cet entrée de menu permet d'ouvrir un fichier
+#      dans un nouvel onglet via le sélecteur de fichiers graphique.
+#~ msgid "Open Tab..."
+#~ msgstr "Ouvrir dans un onglet..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim : Fenêtre principale détruite inopinément\n"
+
+#~ msgid "&Filter"
+#~ msgstr "&Filtrer"
+
+#~ msgid "&Cancel"
+#~ msgstr "&Annuler"
+
+#~ msgid "Directories"
+#~ msgstr "Répertoires"
+
+#~ msgid "Filter"
+#~ msgstr "Filtre"
+
+#~ msgid "&Help"
+#~ msgstr "&Aide"
+
+#~ msgid "Files"
+#~ msgstr "Fichiers"
+
+#~ msgid "&OK"
+#~ msgstr "&Ok"
+
+#~ msgid "Selection"
+#~ msgstr "Sélection"
+
+#~ msgid "Find &Next"
+#~ msgstr "Suiva&nt"
+
+#~ msgid "&Replace"
+#~ msgstr "&Remplacer"
+
+#~ msgid "Replace &All"
+#~ msgstr "Rempl&acer tout"
+
+#~ msgid "&Undo"
+#~ msgstr "Ann&uler"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Titre de fenêtre \"%s\" introuvable"
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument non supporté : \"-%s\" ; Utilisez la version OLE."
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Impossible d'ouvrir une fenêtre dans une application MDI"
+
+# DB - Les quelques messages qui suivent se retrouvent aussi ici :
+#      gui_gtk_x11.c:3170 et suivants.
+#      Les libellés changent un peu (majuscule par exemple).
+#      La VF tâche de les unifier.
+#~ msgid "Close tab"
+#~ msgstr "Fermer l'onglet"
+
+#~ msgid "Open tab..."
+#~ msgstr "Ouvrir dans un onglet..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Chercher une chaîne (utilisez '\\\\' pour chercher un '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Chercher et remplacer (utilisez '\\\\' pour trouver un '\\')"
+
+# DB - Traduction non indispensable puisque le code indique qu'il s'agit d'un
+#      paramétrage bidon afin de sélectionner un répertoire plutôt qu'un
+#      fichier.
+#~ msgid "Not Used"
+#~ msgstr "Non utilisé"
+
+# DB - Traduction non indispensable puisque le code indique qu'il s'agit d'un
+#      paramétrage bidon afin de sélectionner un répertoire plutôt qu'un
+#      fichier.
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Répertoire\t*.rien\n"
+
+# DB - todo : perfectible.
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Erreur d'allocation de couleurs, couleurs possiblement "
+#~ "incorrectes"
+
+# DB - todo : La VF est-elle compréhensible ?
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Des polices manquent dans %s pour les jeux de caractères suivants :"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nom du jeu de polices : %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "La police '%s' n'a pas une largeur fixe"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Nom du jeu de polices : %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "La largeur de Font%<PRId64> n'est pas le double de celle de Font0\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Largeur de Font0 : %<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Largeur de Font1 : %<PRId64>\n"
+#~ "\n"
+
+# DB - todo : Pas certain de mon coup, ici...
+#~ msgid "Invalid font specification"
+#~ msgstr "La spécification de la police est invalide"
+
+#~ msgid "&Dismiss"
+#~ msgstr "Aban&donner"
+
+# DB - todo : Pas certain de mon coup, ici...
+#~ msgid "no specific match"
+#~ msgstr "aucune correspondance particulière"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Choisir une police - Vim"
+
+#~ msgid "Name:"
+#~ msgstr "Nom :"
+
+#~ msgid "Show size in Points"
+#~ msgstr "Afficher la taille en Points"
+
+#~ msgid "Encoding:"
+#~ msgstr "Encodage :"
+
+#~ msgid "Font:"
+#~ msgstr "Police :"
+
+#~ msgid "Style:"
+#~ msgstr "Style :"
+
+#~ msgid "Size:"
+#~ msgstr "Taille :"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ERREUR dans l'automate Hangul"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: Erreur stat"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: impossible d'ouvrir la base de données cscope %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr ""
+#~ "E626: impossible d'obtenir des informations sur la base de données cscope"
+
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "La bibliothèque Lua n'a pas pu être chargée."
+
+#~ msgid "cannot save undo information"
+#~ msgstr "impossible d'enregistrer les informations d'annulation"
+
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Désolé, cette commande est désactivée : les bibliothèques MzScheme "
+#~ "n'ont pas pu être chargées."
+
+#~ msgid "invalid expression"
+#~ msgstr "expression invalide"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "expressions désactivée lors de la compilation"
+
+#~ msgid "hidden option"
+#~ msgstr "option cachée"
+
+#~ msgid "unknown option"
+#~ msgstr "option inconnue"
+
+#~ msgid "window index is out of range"
+#~ msgstr "numéro de fenêtre hors limites"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "impossible d'ouvrir le tampon"
+
+#~ msgid "cannot delete line"
+#~ msgstr "impossible d'effacer la ligne"
+
+#~ msgid "cannot replace line"
+#~ msgstr "impossible de remplacer la ligne"
+
+#~ msgid "cannot insert line"
+#~ msgstr "impossible d'insérer la ligne"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "une chaîne ne peut pas contenir de saut-de-ligne"
+
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "erreur lors de la conversion d'une valeur de Scheme à Vim"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Erreur Vim : ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Erreur Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "tampon invalide"
+
+#~ msgid "window is invalid"
+#~ msgstr "fenêtre invalide"
+
+#~ msgid "linenr out of range"
+#~ msgstr "numéro de ligne hors limites"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "non autorisé dans le bac à sable"
+
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Vim ne peut pas exécuter :python après avoir utilisé :py3"
+
+#~ msgid "only string keys are allowed"
+#~ msgstr "seule une chaine est autorisée comme clé"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Désolé, commande désactivée : la bibliothèque Python n'a pas pu "
+#~ "être chargée."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Impossible d'invoquer Python récursivement"
+
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Vim ne peut pas exécuter :py3 après avoir utilisé :python"
+
+#~ msgid "index must be int or slice"
+#~ msgstr "index doit être int ou slice"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ doit être une instance de chaîne (String)"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Désolé, commande désactivée : la bibliothèque Ruby n'a pas pu être "
+#~ "chargée."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: « return » inattendu"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: « next » inattendu"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: « break » inattendu"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: « redo » inattendu"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: « retry » hors d'une clause « rescue »"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Exception non prise en charge"
+
+# DB - todo
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: contexte de longjmp inconnu : %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Basculer implémentation/définition"
+
+#~ msgid "Show base class of"
+#~ msgstr "Montrer la classe de base de"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Montrer les fonctions membres surchargées"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Récupérer du fichier"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Récupérer du projet"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Récupérer de tous les projets"
+
+#~ msgid "Retrieve"
+#~ msgstr "Récupérer"
+
+#~ msgid "Show source of"
+#~ msgstr "Montrer source de"
+
+#~ msgid "Find symbol"
+#~ msgstr "Trouver symbole"
+
+#~ msgid "Browse class"
+#~ msgstr "Parcourir classe"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Montrer classe dans hiérarchie"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Montrer classe dans hiérarchie restreinte"
+
+# todo
+#~ msgid "Xref refers to"
+#~ msgstr "Xref référence"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref est référencé par"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref a un(e)"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref utilisée par"
+
+#~ msgid "Show docu of"
+#~ msgstr "Montrer doc de"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Générer la doc de"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Connexion à SNiFF+ impossible. Vérifiez l'environnement (sniffemacs doit "
+#~ "être dans le $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff : Erreur de lecture. Déconnexion"
+
+# DB - Les trois messages suivants vont ensembles.
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ est actuellement "
+
+#~ msgid "not "
+#~ msgstr "dé"
+
+#~ msgid "connected"
+#~ msgstr "connecté"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Requête SNiFF+ inconnue : %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Erreur lors de la connexion à SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ n'est pas connecté"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ce tampon n'est pas un tampon SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff : Erreur lors d'une écriture. Déconnexion"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "numéro de tampon invalide"
+
+#~ msgid "not implemented yet"
+#~ msgstr "pas encore implémenté"
+
+# DB - TODO : le contexte est celui d'une annulation.
+#~ msgid "cannot set line(s)"
+#~ msgstr "Impossible de remettre la/les ligne(s)"
+
+#~ msgid "invalid mark name"
+#~ msgstr "nom de marque invalide"
+
+#~ msgid "mark not set"
+#~ msgstr "marque non positionnée"
+
+#~ msgid "row %d column %d"
+#~ msgstr "ligne %d colonne %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "Impossible d'insérer/ajouter de lignes"
+
+#~ msgid "line number out of range"
+#~ msgstr "numéro de ligne hors limites"
+
+#~ msgid "unknown flag: "
+#~ msgstr "drapeau inconnu : "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "vimOption inconnue"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "interruption clavier"
+
+#~ msgid "vim error"
+#~ msgstr "erreur Vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "Impossible de créer commande de tampon/fenêtre : objet en cours "
+#~ "d'effacement"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "Impossible d'inscrire la commande de rappel : tampon/fenêtre en effacement"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ERREUR FATALE TCL: reflist corrompue ?! Contactez vim-dev@vim.org, "
+#~ "SVP."
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "Impossible d'inscrire la commande de rappel : réf. tampon/fenêtre "
+#~ "introuvable"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Désolé, commande désactivée: la bibliothèque Tcl n'a pas pu être "
+#~ "chargée."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: code de sortie %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "Impossible d'obtenir la ligne"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Impossible d'inscrire un nom de serveur de commande"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Échec de l'envoi de la commande au programme cible"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Id utilisé pour le serveur invalide : %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Entrée registre de l'instance de Vim mal formatée. Suppression !"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans n'est pas supporté avec cette interface graphique\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Ce Vim n'a pas été compilé avec la fonctionnalité diff"
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' ne peut pas être utilisé : désactivé à la compilation\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim : Erreur : Impossible de démarrer gvim depuis NetBeans\n"
+
+# DB - todo (VMS uniquement).
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "pour lesquels la casse est indifférente (/ pour que le drapeau soit "
+#~ "majuscule)"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\tInscrire ce gvim pour OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\tDésinscrire gvim de OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\tLancer l'interface graphique (comme \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f, --nofork\tPremier-plan : ne pas détacher l'interface graphique du "
+#~ "terminal"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\tNe pas utiliser newcli pour l'ouverture des fenêtres"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <périph>\tUtiliser <périphérique> pour les E/S"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\tUtiliser <gvimrc> au lieu du gvimrc habituel"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tÉditer des fichiers chiffrés"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tConnecter Vim au serveur X spécifié"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNe pas se connecter à un serveur X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <fich>\tÉditer les <fichiers> dans un serveur Vim si possible"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent ...\tPareil, mais pas d'erreur s'il n'y a aucun serveur"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <fich>\tComme --remote mais ne quitter qu'à la fin de "
+#~ "l'édition"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent\tPareil, mais pas d'erreur s'il n'y a aucun serveur"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <fich>\tComme --remote mais ouvrir un onglet "
+#~ "pour chaque fichier"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <tche>\tEnvoyer <touches> à un serveur Vim puis quitter"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <expr>\tÉvaluer <expr> dans un serveur Vim, afficher le "
+#~ "résultat"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr ""
+#~ "--serverlist\t\tLister les noms des serveurs Vim disponibles et quitter"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nom>\tEnvoyer au/devenir le serveur Vim nommé <nom>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconnus par gvim (version Motif) :\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconnus par gvim (version neXtaw) :\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconnus par gvim (version Athena) :\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <écran>\tLancer Vim sur ce <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tIconifier Vim au démarrage"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr ""
+#~ "-background <coul>\tUtiliser <couleur> pour l'arrière-plan\t   (abrv : -"
+#~ "bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <coul>\tUtiliser <couleur> pour le texte normal\t   (abrv : -"
+#~ "fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <fonte>\tUtiliser <fonte> pour le texte normal\t   (abrv : -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <fonte>\tUtiliser <fonte> pour le texte gras"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <fonte>\tUtiliser <fonte> pour le texte italique"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <géom>\tUtiliser cette <géométrie> initiale\t (abrv : -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <épais>\tUtiliser cette <épaisseur> de bordure\t   (abrv : -"
+#~ "bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <lg>\tUtiliser cette <largeur> de barre de défil. (abrv: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <haut>\tUtiliser cette <hauteur> de menu\t   (abrv : -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tUtiliser la vidéo inverse\t\t   (abrv : -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNe pas utiliser de vidéo inverse\t   (abrv : +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ressource>\tConfigurer la <ressource> spécifiée"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Arguments reconnus par gvim (version GTK+) :\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr ""
+#~ "-display <display>\tLancer Vim sur ce <display>\t(également : --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <rôle>\tDonner un rôle pour identifier la fenêtre principale"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOuvrir Vim dans un autre widget GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tGvim affiche l'ID de la fenêtre sur stdout"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <titre parent>\tOuvrir Vim dans une application parente"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tOuvrir Vim dans un autre widget win32"
+
+#~ msgid "No display"
+#~ msgstr "Aucun display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr " : L'envoi a échoué.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr " : L'envoi a échoué. Tentative d'exécution locale\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d édités sur %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Aucun display : L'envoi de l'expression a échoué.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr " : L'envoi de l'expression a échoué.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Page de codes non valide"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Impossible de régler les valeurs IC"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Échec de la création du contexte de saisie"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Échec de l'ouverture de la méthode de saisie"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Alerte : Impossible d'inscrire la callback de destruction dans la MS"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: la méthode de saisie ne supporte aucun style"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr ""
+#~ "E289: le type de préédition de Vim n'est pas supporté par la méthode de "
+#~ "saisie"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Erreur lors de la mise à jour du fichier d'échange crypté"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s est chiffré et cette version de Vim ne supporte pas le "
+#~ "chiffrement"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Fichier d'échange chiffré : \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Si vous avez tapé une nouvelle clé de chiffrement mais n'avez pas "
+#~ "enregistré le fichier texte,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "tapez la nouvelle clé de chiffrement."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Si vous avez écrit le fichier texte après avoir changé la clé de "
+#~ "chiffrement, appuyez sur entrée"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "afin d'utiliser la même clé pour le fichier texte et le fichier d'échange"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr ""
+#~ "Utilisation de la clé de chiffrement du fichier d'échange pour le fichier "
+#~ "texte.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [inutilisable avec cette version de Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Détacher ce menu"
+
+# DB : Les trois messages qui suivent sont des titres de boîtes
+#      de dialogue par défaut.
+#~ msgid "Select Directory dialog"
+#~ msgstr "Sélecteur de répertoire"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Enregistrer un fichier"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Ouvrir un fichier"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Désolé, pas de sélecteur de fichiers en mode console"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim : préservation des fichiers...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim : Fini.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ERREUR : "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[octets] total alloué-libéré %<PRIu64>-%<PRIu64>, utilisé %<PRIu64>, pic "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[appels] total re/malloc() %<PRIu64>, total free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: La ligne devient trop longue"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Erreur interne : lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Forme de curseur invalide"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Tapez la clé de chiffrement : "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Tapez la clé à nouveau : "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Les clés ne correspondent pas !"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Impossible de se connecter à Netbeans n°2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Impossible de se connecter à Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Mode d'accès incorrect au fichier d'infos de connexion NetBeans : "
+#~ "\"%s\""
+
+# DB : message d'un appel à perror().
+#~ msgid "read from Netbeans socket"
+#~ msgstr "read sur la socket Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Connexion NetBeans perdue pour le tampon %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans n'est pas supporté avec cette interface graphique"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans déjà connecté"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s est en lecture seule (ajoutez ! pour passer outre)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: La fonctionnalité d'évaluation n'est pas disponible"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "libération de %<PRId64> lignes"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Impossible de modifier term dans l'interface graphique"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Utilisez \":gui\" pour démarrer l'interface graphique"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Non modifiable dans l'interface graphique GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Police(s) invalide(s)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Impossible de sélectionner un jeu de polices"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Jeu de polices invalide"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Impossible de sélectionner une police à largeur double"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Police à largeur double invalide"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: La souris n'est pas supportée"
+
+#~ msgid "cannot open "
+#~ msgstr "impossible d'ouvrir "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM : Impossible d'ouvrir la fenêtre !\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Amigados version 2.04 ou ultérieure est nécessaire\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "%s version %<PRId64> est nécessaire\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Impossible d'ouvrir NIL :\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Impossible de créer "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim quitte avec %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "Impossible de modifier le mode de la console ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize : pas une console ?!\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Impossible d'exécuter un shell avec l'option -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Impossible d'exécuter "
+
+#~ msgid "shell "
+#~ msgstr "le shell "
+
+#~ msgid " returned\n"
+#~ msgstr " a été retourné\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE trop petit."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ERREUR d'E/S"
+
+#~ msgid "Message"
+#~ msgstr "Message"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr ""
+#~ "'columns' ne vaut pas 80, impossible d'exécuter des commandes externes"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: La sélection de l'imprimante a échoué"
+
+# DB - Contenu des c-formats : Imprimante puis Port.
+#~ msgid "to %s on %s"
+#~ msgstr "vers %s sur %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Police d'imprimante inconnue : %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Erreur d'impression : %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Impression de '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Jeu de caractères \"%s\" invalide dans le nom de fonte \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Caractère '%c' invalide dans le nom de fonte \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim : Double signal, sortie\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim : Signal mortel %s intercepté\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim : Signal mortel intercepté\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "L'ouverture du display X a pris %<PRId64> ms"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim : Réception d'une erreur X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Le test du display X a échoué"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "L'ouverture du display X a dépassé le délai d'attente"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Impossible d'exécuter le shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Impossible de créer des tuyaux (pipes)\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Impossible de forker\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Commande interrompue\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP a perdu la connexion ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "L'ouverture du display X a échoué"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP : prise en charge d'une requête save-yourself"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP : ouverture de la connexion"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP : échec de la surveillance de connexion ICE"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP : SmcOpenConnection a échoué : %s"
+
+#~ msgid "At line"
+#~ msgstr "À la ligne"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Impossible de charger vim32.dll !"
+
+#~ msgid "VIM Error"
+#~ msgstr "Erreur VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Impossible d'initialiser les pointeurs de fonction vers la DLL !"
+
+#~ msgid "shell returned %d"
+#~ msgstr "le shell a retourné %d"
+
+# DB - Les événements en question sont ceux des messages qui suivent.
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim : Événement %s intercepté\n"
+
+#~ msgid "close"
+#~ msgstr "de fermeture"
+
+#~ msgid "logoff"
+#~ msgstr "de déconnexion"
+
+#~ msgid "shutdown"
+#~ msgstr "d'arrêt"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Commande introuvable"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE est introuvable votre $PATH.\n"
+#~ "Les commandes externes ne feront pas de pause une fois terminées.\n"
+#~ "Voir  :help win32-vimrun  pour plus d'informations."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Alerte Vim"
+
+#~ msgid "Error file"
+#~ msgstr "Fichier d'erreurs"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr ""
+#~ "E868: Erreur lors de la construction du NFA avec classe d'équivalence"
+
+#~ msgid "E999: (NFA regexp internal error) Should not process NOT node !"
+#~ msgstr ""
+#~ "E999: (erreur interne du regexp NFA) Un noeud 'NOT' ne devrait pas être "
+#~ "traité !"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr ""
+#~ "E878: (NFA) Impossible d'allouer la mémoire pour parcourir les branches!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Alerte : Liste de mots \"%s_%s.spl\" ou \"%s_ascii.spl\" introuvable"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "La conversion dans %s non supportée"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: mémoire insuffisante, liste de mots peut-être incomplète"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Chemin de fichiers de marqueurs tronqué pour %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "nouveau shell démarré\n"
+
+# DB - Message de débogage.
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "CUT_BUFFER0 utilisé plutôt qu'une sélection vide"
+
+# DB - Question O/N.
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Annulation impossible ; continuer"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Fichier non-chiffré a un fichier d'annulations chiffré : %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Déchiffrage du fichier d'annulation a échoué : %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Le fichier d'annulations est chiffré : %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version graphique MS-Windows 16/32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version graphique MS-Windows 64 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version graphique MS-Windows 32 bits"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " lancée en mode Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " supportant l'OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version console MS-Windows 64 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version console MS-Windows 32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MS-Windows 16 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MS-DOS 32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MS-DOS 16 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MaxOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Grosse version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Version normale "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Petite version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Version minuscule "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "avec interface graphique GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "avec interface graphique GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "avec interface graphique X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "avec interface graphique X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "avec interface graphique X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "avec interface graphique Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "avec une interface graphique."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "avec interface graphique Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "avec interface graphique Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "avec interface graphique (classic)."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "        fichier gvimrc système : \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    fichier gvimrc utilisateur : \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2me fichier gvimrc utilisateur : \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3me fichier gvimrc utilisateur : \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "          fichier menu système : \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Compilateur : "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu  Aide->Orphelins            pour plus d'info"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Les modes sont désactivés, le texte saisi est inséré"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menu  Édition->Réglages Globaux->Insertion Permanente"
+
+# DB - todo
+#~ msgid "                              for two modes      "
+#~ msgstr "                                  pour les modes     "
+
+# DB - todo
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menu  Édition->Réglages Globaux->Compatibilité Vi"
+
+# DB - todo
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                pour déf. de Vim "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ALERTE: Windows 95/98/ME détecté"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "tapez  :help windows95<Entrée>  pour plus d'information"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Impossible de charger la bibliothèque %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Désolé, commande désactivée : la bibliothèque Perl n'a pas pu être "
+#~ "chargée."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Évaluation Perl interdite dans bac à sable sans le module Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Éditer dans &plusieurs Vims"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Éditer dans un seul &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "&Comparer avec Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Éditer dans &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Éditer dans le Vim existant - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Édites le(s) fichier(s) sélectionné(s) avec Vim"
 
 # DB - MessageBox win32, la longueur n'est pas un problème !
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr ""
-"Erreur de création du processus : vérifiez que gvim est bien dans votre "
-"chemin !"
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr ""
+#~ "Erreur de création du processus : vérifiez que gvim est bien dans votre "
+#~ "chemin !"
 
-msgid "gvimext.dll error"
-msgstr "Erreur de gvimext.dll"
+#~ msgid "gvimext.dll error"
+#~ msgstr "Erreur de gvimext.dll"
 
-msgid "Path length too long!"
-msgstr "Le chemin est trop long !"
+#~ msgid "Path length too long!"
+#~ msgstr "Le chemin est trop long !"
 
-# msgstr "--Pas de lignes dans le tampon--"
-# DB - todo : ou encore : msgstr "--Aucune ligne dans le tampon--"
-msgid "--No lines in buffer--"
-msgstr "--Le tampon est vide--"
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Jeu de police inconnu : %s"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Commande annulée"
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Police inconnue : %s"
 
-msgid "E471: Argument required"
-msgstr "E471: Argument requis"
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: La police \"%s\" n'a pas une chasse (largeur) fixe"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ devrait être suivi de /, ? ou &"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Impossible de charger la fonction %s de la bibliothèque"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Invalide dans la fenêtre ligne-de-commande ; <CR> exécute, CTRL-C quitte"
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Le support de l'hébreu n'a pas été compilé dans cette version\n"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: commande non autorisée depuis un exrc/vimrc dans répertoire courant ou "
-"une recherche de marqueur"
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Le support du farsi n'a pas été compilé dans cette version\n"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif manquant"
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Le support de l'arabe n'a pas été compilé dans cette version\n"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry manquant"
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: aucun serveur nommé \"%s\" n'est enregistré"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile manquant"
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: ouverture du display impossible"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor manquant"
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Expression invalide reçue"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile sans :while"
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Cette zone est verrouillée et ne peut pas être modifiée"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor sans :for"
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr ""
+#~ "E744: NetBeans n'autorise pas la modification des fichiers en lecture "
+#~ "seule"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Le fichier existe déjà (ajoutez ! pour passer outre)"
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Besoin de la clé de chiffrement pour \"%s\""
 
-msgid "E472: Command failed"
-msgstr "E472: La commande a échoué"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "impossible d'effacer les attributs d'OutputObject"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Jeu de police inconnu : %s"
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace doit être un nombre entier"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Police inconnue : %s"
+#~ msgid "invalid attribute"
+#~ msgstr "attribut invalide"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: La police \"%s\" n'a pas une chasse (largeur) fixe"
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() requiert une liste de chaînes"
 
-msgid "E473: Internal error"
-msgstr "E473: Erreur interne"
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python : Erreur d'initialisation des objets d'E/S"
 
-msgid "Interrupted"
-msgstr "Interrompu"
+#~ msgid "empty keys are not allowed"
+#~ msgstr "les clés vides ne sont pas autorisées"
 
-msgid "E14: Invalid address"
-msgstr "E14: Adresse invalide"
+#~ msgid "Cannot delete DictionaryObject attributes"
+#~ msgstr "Impossible d'effacer les attributs de DictionaryObject"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Argument invalide"
+#~ msgid "Cannot modify fixed dictionary"
+#~ msgstr "Impossible de modifier un dictionnaire fixe"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Argument invalide : %s"
+#~ msgid "Cannot set this attribute"
+#~ msgstr "Impossible d'initialiser cet attribut"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Expression invalide : %s"
+#~ msgid "dict is locked"
+#~ msgstr "dictionnaire est verrouillé"
 
-msgid "E16: Invalid range"
-msgstr "E16: Plage invalide"
+#~ msgid "failed to add key to dictionary"
+#~ msgstr "l'ajout de clé au dictionnaire a échoué"
 
-msgid "E476: Invalid command"
-msgstr "E476: Commande invalide"
+#~ msgid "list index out of range"
+#~ msgstr "index de liste hors limites"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" est un répertoire"
+#~ msgid "internal error: failed to get vim list item"
+#~ msgstr "erreur interne : accès à un élément de liste a échoué"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: L'appel à la bibliothèque a échoué pour \"%s()\""
+#~ msgid "list is locked"
+#~ msgstr "liste verrouillée"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Impossible de charger la fonction %s de la bibliothèque"
+#~ msgid "Failed to add item to list"
+#~ msgstr "Ajout à la liste a échoué"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: La marque a un numéro de ligne invalide"
+#~ msgid "can only assign lists to slice"
+#~ msgstr "seules des tranches peuvent être assignées aux listes"
 
-msgid "E20: Mark not set"
-msgstr "E20: Marque non positionnée"
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "erreur interne : ajout d'élément à la liste a échoué"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Impossible de modifier, 'modifiable' est désactivé"
+#~ msgid "can only concatenate with lists"
+#~ msgstr "on ne peut que concaténer avec des listes"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Trop de récursion dans les scripts"
+#~ msgid "cannot delete vim.dictionary attributes"
+#~ msgstr "impossible d'effacer les attributs de vim.dictionary"
 
-msgid "E23: No alternate file"
-msgstr "E23: Pas de fichier alternatif"
+#~ msgid "cannot modify fixed list"
+#~ msgstr "impossible de modifier une liste fixe"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Cette abréviation n'existe pas"
+#~ msgid "cannot set this attribute"
+#~ msgstr "impossible d'initialiser cet attribut"
 
-msgid "E477: No ! allowed"
-msgstr "E477: Le ! n'est pas autorisé"
+#~ msgid "'self' argument must be a dictionary"
+#~ msgstr "l'argument 'self' doit être un dictionnaire"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: L'interface graphique n'a pas été compilée dans cette version"
+#~ msgid "failed to run function"
+#~ msgstr "exécution de la fonction a échoué"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Le support de l'hébreu n'a pas été compilé dans cette version\n"
+#~ msgid "unable to unset global option"
+#~ msgstr "impossible de désactiver une option globale"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Le support du farsi n'a pas été compilé dans cette version\n"
+#~ msgid "unable to unset option without global value"
+#~ msgstr "impossible de désactiver une option sans une valeur globale"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Le support de l'arabe n'a pas été compilé dans cette version\n"
+#~ msgid "object must be integer"
+#~ msgstr "objet doit être un nombre entier"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Aucun nom de groupe de surbrillance %s"
+#~ msgid "object must be string"
+#~ msgstr "objet doit être de type string"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Pas encore de texte inséré"
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "tentative de référencer un onglet effacé"
 
-msgid "E30: No previous command line"
-msgstr "E30: Aucune ligne de commande précédente"
+#~ msgid "<tabpage object (deleted) at %p>"
+#~ msgstr "<objet onglet (effacé) à %p>"
 
-msgid "E31: No such mapping"
-msgstr "E31: Mappage inexistant"
+#~ msgid "<tabpage object (unknown) at %p>"
+#~ msgstr "<objet onglet (inconnu) à %p>"
 
-msgid "E479: No match"
-msgstr "E479: Aucune correspondance"
+#~ msgid "<tabpage %d>"
+#~ msgstr "<onglet %d>"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Aucune correspondance : %s"
+#~ msgid "no such tab page"
+#~ msgstr "cet onglet n'existe pas"
 
-msgid "E32: No file name"
-msgstr "E32: Aucun nom de fichier"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "tentative de référencer une fenêtre effacée"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Aucune expression régulière de substitution précédente"
+#~ msgid "readonly attribute"
+#~ msgstr "attribut en lecture seule"
 
-msgid "E34: No previous command"
-msgstr "E34: Aucune commande précédente"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "curseur positionné en dehors du tampon"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Aucune expression régulière précédente"
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<objet fenêtre (effacé) à %p>"
 
-msgid "E481: No range allowed"
-msgstr "E481: Les plages ne sont pas autorisées"
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<objet fenêtre (inconnu) à %p>"
 
-msgid "E36: Not enough room"
-msgstr "E36: Pas assez de place"
+#~ msgid "<window %d>"
+#~ msgstr "<fenêtre %d>"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: aucun serveur nommé \"%s\" n'est enregistré"
+#~ msgid "no such window"
+#~ msgstr "Cette fenêtre n'existe pas"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Impossible de créer le fichier %s"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "tentative de référencer un tampon effacé"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Impossible d'obtenir un nom de fichier temporaire"
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<objet tampon (effacé) à %p>"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Impossible d'ouvrir le fichier \"%s\""
+#~ msgid "key must be integer"
+#~ msgstr "la clé doit être un nombre entier"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Impossible de lire le fichier %s"
+#~ msgid "expected vim.buffer object"
+#~ msgstr "objet vim.buffer attendu"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Modifications non enregistrées (ajoutez ! pour passer outre)"
+#~ msgid "failed to switch to given buffer"
+#~ msgstr "impossible de se déplacer au tampon donné"
 
-msgid "E38: Null argument"
-msgstr "E38: Argument null"
+#~ msgid "expected vim.window object"
+#~ msgstr "objet vim.window attendu"
 
-msgid "E39: Number expected"
-msgstr "E39: Nombre attendu"
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "impossible de trouver une fenêtre dans l'onglet courant"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Impossible d'ouvrir le fichier d'erreurs %s"
+#~ msgid "did not switch to the specified window"
+#~ msgstr "ne s'est pas déplacé à la fenêtre spécifiée"
 
-msgid "E233: cannot open display"
-msgstr "E233: ouverture du display impossible"
+#~ msgid "expected vim.tabpage object"
+#~ msgstr "objet vim.tabpage attendu"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Mémoire épuisée"
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "impossible de se déplacer à l'onglet spécifié"
 
-msgid "Pattern not found"
-msgstr "Motif introuvable"
+#~ msgid "failed to run the code"
+#~ msgstr "exécution du code a échoué"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Motif introuvable : %s"
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval n'a pas retourné un objet python valide"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: L'argument doit être positif"
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Conversion d'objet python à une valeur de vim a échoué"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Impossible de retourner au répertoire précédent"
+#~ msgid "unable to convert to vim structure"
+#~ msgstr "conversion à une structure vim impossible"
 
-msgid "E42: No Errors"
-msgstr "E42: Aucune erreur"
+#~ msgid "NULL reference passed"
+#~ msgstr "référence NULL passée"
 
-# DB - TODO : trouver une traduction valable et attestée pour "location".
-msgid "E776: No location list"
-msgstr "E776: Aucune liste d'emplacements"
-
-msgid "E43: Damaged match string"
-msgstr "E43: La chaîne de recherche est endommagée"
-
-msgid "E44: Corrupted regexp program"
-msgstr "E44: L'automate de regexp est corrompu"
-
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: L'option 'readonly' est activée (ajoutez ! pour passer outre)"
-
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: La variable \"%s\" est en lecture seule"
-
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr ""
-"E794: Impossible de modifier une variable depuis le bac à sable : \"%s\""
-
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Erreur lors de la lecture du fichier d'erreurs"
-
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Opération interdite dans le bac à sable"
-
-msgid "E523: Not allowed here"
-msgstr "E523: Interdit à cet endroit"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Choix du mode d'écran non supporté"
-
-msgid "E49: Invalid scroll size"
-msgstr "E49: Valeur de défilement invalide"
-
-msgid "E91: 'shell' option is empty"
-msgstr "E91: L'option 'shell' est vide"
-
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Impossible de lire les données du symbole !"
-
-msgid "E72: Close error on swap file"
-msgstr "E72: Erreur lors de la fermeture du fichier d'échange"
-
-msgid "E73: tag stack empty"
-msgstr "E73: La pile des marqueurs est vide"
-
-msgid "E74: Command too complex"
-msgstr "E74: Commande trop complexe"
-
-msgid "E75: Name too long"
-msgstr "E75: Nom trop long"
-
-msgid "E76: Too many ["
-msgstr "E76: Trop de ["
-
-msgid "E77: Too many file names"
-msgstr "E77: Trop de noms de fichiers"
-
-msgid "E488: Trailing characters"
-msgstr "E488: Caractères surnuméraires"
-
-msgid "E78: Unknown mark"
-msgstr "E78: Marque inconnue"
-
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Impossible de développer les métacaractères"
-
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' ne peut pas être plus petit que 'winminheight'"
-
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' ne peut pas être plus petit que 'winminwidth'"
-
-msgid "E80: Error while writing"
-msgstr "E80: Erreur lors de l'écriture"
-
-msgid "Zero count"
-msgstr "Le quantificateur est nul"
-
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> utilisé en dehors d'un script"
-
-msgid "E449: Invalid expression received"
-msgstr "E449: Expression invalide reçue"
-
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Cette zone est verrouillée et ne peut pas être modifiée"
-
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr ""
-"E744: NetBeans n'autorise pas la modification des fichiers en lecture seule"
-
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Erreur interne : %s"
-
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: le motif utilise plus de mémoire que 'maxmempattern'"
-
-msgid "E749: empty buffer"
-msgstr "E749: tampon vide"
-
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Délimiteur ou motif de recherche invalide"
-
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Le fichier est chargé dans un autre tampon"
-
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: L'option '%s' n'est pas activée"
-
-msgid "E850: Invalid register name"
-msgstr "E850: Nom de registre invalide"
-
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "La recherche a atteint le HAUT, et continue en BAS"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "La recherche a atteint le BAS, et continue en HAUT"
-
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Besoin de la clé de chiffrement pour \"%s\""
-
-msgid "can't delete OutputObject attributes"
-msgstr "impossible d'effacer les attributs d'OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "softspace doit être un nombre entier"
-
-msgid "invalid attribute"
-msgstr "attribut invalide"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() requiert une liste de chaînes"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python : Erreur d'initialisation des objets d'E/S"
-
-msgid "empty keys are not allowed"
-msgstr "les clés vides ne sont pas autorisées"
-
-msgid "Cannot delete DictionaryObject attributes"
-msgstr "Impossible d'effacer les attributs de DictionaryObject"
-
-msgid "Cannot modify fixed dictionary"
-msgstr "Impossible de modifier un dictionnaire fixe"
-
-msgid "Cannot set this attribute"
-msgstr "Impossible d'initialiser cet attribut"
-
-msgid "dict is locked"
-msgstr "dictionnaire est verrouillé"
-
-msgid "failed to add key to dictionary"
-msgstr "l'ajout de clé au dictionnaire a échoué"
-
-msgid "list index out of range"
-msgstr "index de liste hors limites"
-
-msgid "internal error: failed to get vim list item"
-msgstr "erreur interne : accès à un élément de liste a échoué"
-
-msgid "list is locked"
-msgstr "liste verrouillée"
-
-msgid "Failed to add item to list"
-msgstr "Ajout à la liste a échoué"
-
-msgid "internal error: no vim list item"
-msgstr "erreur interne : pas d'élément de liste vim"
-
-msgid "can only assign lists to slice"
-msgstr "seules des tranches peuvent être assignées aux listes"
-
-msgid "internal error: failed to add item to list"
-msgstr "erreur interne : ajout d'élément à la liste a échoué"
-
-msgid "can only concatenate with lists"
-msgstr "on ne peut que concaténer avec des listes"
-
-msgid "cannot delete vim.dictionary attributes"
-msgstr "impossible d'effacer les attributs de vim.dictionary"
-
-msgid "cannot modify fixed list"
-msgstr "impossible de modifier une liste fixe"
-
-msgid "cannot set this attribute"
-msgstr "impossible d'initialiser cet attribut"
-
-msgid "'self' argument must be a dictionary"
-msgstr "l'argument 'self' doit être un dictionnaire"
-
-msgid "failed to run function"
-msgstr "exécution de la fonction a échoué"
-
-msgid "unable to get option value"
-msgstr "impossible d'obtenir la valeur d'une option"
-
-msgid "unable to unset global option"
-msgstr "impossible de désactiver une option globale"
-
-msgid "unable to unset option without global value"
-msgstr "impossible de désactiver une option sans une valeur globale"
-
-msgid "object must be integer"
-msgstr "objet doit être un nombre entier"
-
-msgid "object must be string"
-msgstr "objet doit être de type string"
-
-msgid "attempt to refer to deleted tab page"
-msgstr "tentative de référencer un onglet effacé"
-
-#, c-format
-msgid "<tabpage object (deleted) at %p>"
-msgstr "<objet onglet (effacé) à %p>"
-
-#, c-format
-msgid "<tabpage object (unknown) at %p>"
-msgstr "<objet onglet (inconnu) à %p>"
-
-#, c-format
-msgid "<tabpage %d>"
-msgstr "<onglet %d>"
-
-msgid "no such tab page"
-msgstr "cet onglet n'existe pas"
-
-msgid "attempt to refer to deleted window"
-msgstr "tentative de référencer une fenêtre effacée"
-
-msgid "readonly attribute"
-msgstr "attribut en lecture seule"
-
-msgid "cursor position outside buffer"
-msgstr "curseur positionné en dehors du tampon"
-
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<objet fenêtre (effacé) à %p>"
-
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<objet fenêtre (inconnu) à %p>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<fenêtre %d>"
-
-msgid "no such window"
-msgstr "Cette fenêtre n'existe pas"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "tentative de référencer un tampon effacé"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<objet tampon (effacé) à %p>"
-
-msgid "key must be integer"
-msgstr "la clé doit être un nombre entier"
-
-msgid "expected vim.buffer object"
-msgstr "objet vim.buffer attendu"
-
-msgid "failed to switch to given buffer"
-msgstr "impossible de se déplacer au tampon donné"
-
-msgid "expected vim.window object"
-msgstr "objet vim.window attendu"
-
-msgid "failed to find window in the current tab page"
-msgstr "impossible de trouver une fenêtre dans l'onglet courant"
-
-msgid "did not switch to the specified window"
-msgstr "ne s'est pas déplacé à la fenêtre spécifiée"
-
-msgid "expected vim.tabpage object"
-msgstr "objet vim.tabpage attendu"
-
-msgid "did not switch to the specified tab page"
-msgstr "impossible de se déplacer à l'onglet spécifié"
-
-msgid "failed to run the code"
-msgstr "exécution du code a échoué"
-
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval n'a pas retourné un objet python valide"
-
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Conversion d'objet python à une valeur de vim a échoué"
-
-msgid "unable to convert to vim structure"
-msgstr "conversion à une structure vim impossible"
-
-msgid "NULL reference passed"
-msgstr "référence NULL passée"
-
-msgid "internal error: invalid value type"
-msgstr "erreur interne : type de valeur invalide"
+#~ msgid "internal error: invalid value type"
+#~ msgstr "erreur interne : type de valeur invalide"
 
 #~ msgid "E860: Eval did not return a valid python 3 object"
 #~ msgstr "E860: Eval n'a pas retourné un object python 3 valid"

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -6,148 +6,216 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-04-14 09:44-0500\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-04-14 10:01-0500\n"
 "Last-Translator: Kevin Patrick Scannell <kscanne@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
+"Language: ga\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Dramhaíl i ndiaidh argóinte rogha"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Liosta Suíomh]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Liosta Ceartúchán Tapa]"
+
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: Bhí maolán nó ainm maoláin athraithe ag orduithe uathoibríocha"
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Ní féidir maolán a dháileadh, ag scor..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Ní féidir maolán a dháileadh, ag úsáid cinn eile..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Ní raibh aon mhaolán díluchtaithe"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Ní raibh aon mhaolán scriosta"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Ní raibh aon mhaolán bánaithe"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Bhí maolán amháin díluchtaithe"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d maolán folmhaithe"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Bhí maolán amháin scriosta"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d maolán scriosta"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Bhí maolán amháin bánaithe"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d maolán bánaithe"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Ní féidir an maolán deireanach a dhíluchtú"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Níor aimsíodh maolán mionathraithe"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Níl aon mhaolán liostaithe ann"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Níl a leithéid de mhaolán %<PRId64>"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Ní féidir a dhul thar an maolán deireanach"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ní féidir a dhul roimh an chéad mhaolán"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Athraíodh maolán %<PRId64> ach nach bhfuil sé sábháilte ó shin (cuir ! leis "
-"an ordú chun sárú)"
+"E89: Athraíodh maolán %<PRId64> ach nach bhfuil sé sábháilte ó shin (cuir ! "
+"leis an ordú chun sárú)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Ní féidir an maolán deireanach a dhíluchtú"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Rabhadh: Liosta ainmneacha comhaid thar maoil"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Maolán %<PRId64> gan aimsiú"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Níos mó ná teaghrán amháin comhoiriúnaithe le %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Níl aon mhaolán comhoiriúnaithe le %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "líne %<PRId64>:"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Tá maolán ann leis an ainm seo cheana"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Mionathraithe]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Gan eagrú]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Comhad nua]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Earráidí léimh]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[L-A]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[inléite amháin]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 líne --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> líne --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "líne %<PRId64> de %<PRId64> --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Gan Ainm]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "cabhair"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Cabhair]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Réamhamharc]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Uile"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Bun"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Barr"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -155,15 +223,11 @@ msgstr ""
 "\n"
 "# Liosta maoláin:\n"
 
-msgid "[Location List]"
-msgstr "[Liosta Suíomh]"
-
-msgid "[Quickfix List]"
-msgstr "[Liosta Ceartúchán Tapa]"
-
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Sealadach]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -171,139 +235,202 @@ msgstr ""
 "\n"
 "--- Comharthaí ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Comharthaí do %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    líne=%<PRId64>  id=%d  ainm=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Idirstad ar iarraidh"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Mód neamhcheadaithe"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: ag súil le digit"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Céatadán neamhcheadaithe"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Ní féidir diff a dhéanamh ar níos mó ná %<PRId64> maolán"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Ní féidir comhaid shealadacha a léamh nó a scríobh"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Ní féidir diffeanna a chruthú"
 
-msgid "Patch file"
-msgstr "Comhad paiste"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Ní féidir aschur ó 'patch' a léamh"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Ní féidir aschur ó 'diff' a léamh"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Níl an maolán reatha sa mhód diff"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Ní féidir aon mhaolán eile a athrú sa mhód diff"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Níl aon mhaolán eile sa mhód diff"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Tá níos mó ná dhá mhaolán sa mhód diff, níl fhios agam cé acu ba chóir "
 "a úsáid"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Tá maolán \"%s\" gan aimsiú"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Níl maolán \"%s\" i mód diff"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Athraíodh an maolán gan choinne"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Ní cheadaítear carachtair éalúcháin i ndéghraf"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Comhad eochairmhapála gan aimsiú"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Ag úsáid :loadkeymap ach ní comhad foinsithe é seo"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Iontráil fholamh eochairmhapála"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Comhlánú lorgfhocal (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " mód ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Comhlánú Línte Ina Iomlán (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Comhlánú de na hainmneacha comhaid (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Comhlánú clibeanna (^]/^N/^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Comhlánú Conaire (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Comhlánú de na sainmhínithe (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Comhlánú foclóra (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Comhlánú teasárais (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Comhlánú den líne ordaithe (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Comhlánú saincheaptha (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Comhlánú Omni (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Moladh litrithe (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Comhlánú logánta lorgfhocal (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Sroicheadh críoch an pharagraif"
 
+#: ../edit.c:101
+#, fuzzy
+msgid "E839: Completion function changed window"
+msgstr "E813: Ní féidir fuinneog autocmd a dhúnadh"
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "tá an rogha 'dictionary' folamh"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "tá an rogha 'thesaurus' folamh"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Foclóir á scanadh: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (ionsáigh) Scrollaigh (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (ionadaigh) Scrollaigh (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "%s á scanadh"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Clibeanna á scanadh."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Méadú"
 
@@ -311,430 +438,587 @@ msgstr " Méadú"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Ag Cuardach..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Ar ais ag an mbunáit"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Focal as líne eile"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "An t-aon teaghrán amháin comhoiriúnaithe"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "comhoiriúnú %d as %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "comhoiriúnú %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Carachtair gan choinne i :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: innéacs liosta as raon: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Athróg gan sainmhíniú: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: `]' ar iarraidh"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Caithfidh argóint de %s a bheith ina Liosta"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Caithfidh argóint de %s a bheith ina Liosta nó Foclóir"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Ní féidir eochair fholamh a úsáid le Foclóir"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Tá gá le liosta"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Tá gá le foclóir"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: An iomarca argóintí d'fheidhm: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Níl an eochair seo san Fhoclóir: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Tá feidhm %s ann cheana, cuir ! leis an ordú chun é a asáitiú"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Tá an iontráil foclóra seo ann cheana"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Tá gá le Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Ní féidir [:] a úsáid le foclóir"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Cineál mícheart athróige le haghaidh %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Feidhm anaithnid: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Ainm athróige neamhcheadaithe: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Snámhphointe á úsáid mar Theaghrán"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Níos lú spriocanna ná míreanna Liosta"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Níos mó spriocanna ná míreanna Liosta"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "; dúblach i liosta na n-athróg"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Ní féidir athróga do %s a thaispeáint"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Is féidir Liosta nó Foclóir amháin a innéacsú"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: caithfidh [:] a bheith ar deireadh"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: ní foláir Liosta a thabhairt le [:]"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Tá níos mó míreanna ag an Liosta ná an sprioc"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Níl go leor míreanna ag an Liosta"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: \"in\" ar iarraidh i ndiaidh :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Lúibíní ar iarraidh: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Níl a leithéid d'athróg: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: athróg neadaithe ródhomhain chun í a (dí)ghlasáil"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: ':' ar iarraidh i ndiaidh '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Is féidir Liosta a chur i gcomparáid le Liosta eile amháin"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Oibríocht neamhbhailí ar Liostaí"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Is féidir Foclóir a chur i gcomparáid le Foclóir eile amháin"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Oibríocht neamhbhailí ar Fhoclóir"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Is féidir Funcref a chur i gcomparáid le Funcref eile amháin"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Oibríocht neamhbhailí ar Funcref"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Ní féidir '%' a úsáid le Snámhphointe"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' ar iarraidh"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Ní féidir Funcref a innéacsú"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Ainm rogha ar iarraidh: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Rogha anaithnid: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Comhartha athfhriotail ar iarraidh: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Comhartha athfhriotail ar iarraidh: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Camóg ar iarraidh i Liosta: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: ']' ar iarraidh ag deireadh liosta: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Idirstad ar iarraidh i bhFoclóir: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Eochair dhúblach i bhFoclóir: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Camóg ar iarraidh i bhFoclóir: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: '}' ar iarraidh ag deireadh foclóra: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: athróg neadaithe ródhomhain chun í a thaispeáint"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: An iomarca argóintí d'fheidhm %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Argóintí neamhbhailí d'fheidhm %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Feidhm anaithnid: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Níl go leor feidhmeanna d'fheidhm: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> á úsáid ach gan a bheith i gcomhthéacs scripte: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Feidhm 'dict' á ghlao gan Foclóir: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Uimhir nó Snámhphointe de dhíth"
 
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "argóint -c"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: An iomarca argóintí"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: is féidir complete() a úsáid sa mhód Ionsáite amháin"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Tá eochair ann cheana: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "argóint --cmd"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "argóint -c"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "argóint -c"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld líne: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Feidhm anaithnid: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Cealaigh"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Glaodh inputrestore() níos minice ná inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "argóint -c"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Ní cheadaítear an raon"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Cineál neamhbhailí le haghaidh len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Is nialas í an chéim"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Tosach thar dheireadh"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<folamh>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Níl aon nasc le freastalaí Vim"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "argóint --cmd"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Ní féidir aon rud a sheoladh chuig %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Ní féidir freagra ón fhreastalaí a léamh"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: An iomarca naisc shiombalacha (ciogal?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Ní féidir aon rud a sheoladh chuig an chliant"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "argóint -c"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "argóint -c"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argóint -c"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Theip ar fheidhm chomparáide le linn sórtála"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Theip ar fheidhm chomparáide le linn sórtála"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Neamhbhailí)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Earráid agus comhad sealadach á scríobh"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Snámhphointe á úsáid mar Uimhir"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref á úsáid mar Uimhir"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Liosta á úsáid mar Uimhir"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Foclóir á úsáid mar Uimhir"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref á úsáid mar Theaghrán"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Liosta á úsáid mar Theaghrán"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Foclóir á úsáid mar Theaghrán"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Snámhphointe á úsáid mar Theaghrán"
-
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Caithfidh ceannlitir a bheith ar dtús ainm Funcref: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Tagann ainm athróige salach ar fheidhm atá ann cheana: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Mímheaitseáil idir cineálacha athróige: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Ní féidir athróg %s a scriosadh"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Caithfidh ceannlitir a bheith ar dtús ainm Funcref: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Tagann ainm athróige salach ar fheidhm atá ann cheana: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Tá an luach faoi ghlas: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Anaithnid"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Ní féidir an luach de %s a athrú"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: athróg neadaithe ródhomhain chun í a chóipeáil"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Feidhm gan sainmhíniú: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '(' ar iarraidh: %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Ní féidir luachanna IC a shocrú"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Argóint neamhcheadaithe: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Argóint neamhcheadaithe: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction ar iarraidh"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Tagann ainm na feidhme salach ar athróg: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
-msgstr "E127: Ní féidir sainmhíniú nua a dhéanamh ar fheidhm %s: In úsáid cheana"
+msgstr ""
+"E127: Ní féidir sainmhíniú nua a dhéanamh ar fheidhm %s: In úsáid cheana"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr ""
 "E746: Níl ainm na feidhme comhoiriúnach le hainm comhaid na scripte: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Tá gá le hainm feidhme"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Caithfidh ceannlitir a bheith ar dtús ainm feidhme, nó idirstad a "
 "bheith ann: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Caithfidh ceannlitir a bheith ar dtús ainm feidhme, nó idirstad a "
+"bheith ann: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Ní féidir feidhm %s a scriosadh: Tá sé in úsáid faoi láthair"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Doimhneacht na nglaonna níos mó ná 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s á glao"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s tobscortha"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s ag aisfhilleadh #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s ag aisfhilleadh %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "ag leanúint i %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: Caithfidh :return a bheith isteach i bhfeidhm"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -742,6 +1026,7 @@ msgstr ""
 "\n"
 "# athróga comhchoiteanna:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -749,85 +1034,106 @@ msgstr ""
 "\n"
 "\tSocraithe is déanaí ó "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Gan seanchomhaid"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Heics %02x,  Ocht %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Heics %04x, Ocht %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Heics %08x, Ocht %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Bog línte isteach iontu féin"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Bogadh líne amháin"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Bogadh %<PRId64> líne"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Scagadh %<PRId64> líne"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr ""
 "E135: Ní cheadaítear d'uathorduithe *scagaire* an maolán reatha a athrú"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Athraithe agus nach sábháilte ó shin]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s i líne: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr ""
 "E136: viminfo: An iomarca earráidí, ag scipeáil an chuid eile den chomhad"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Comhad viminfo \"%s\"%s%s%s á léamh"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " eolas"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " marcanna"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " seanchomhad"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " TEIPTHE"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Níl an comhad Viminfo inscríofa: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Ní féidir comhad viminfo %s a scríobh!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Comhad viminfo \"%s\" á scríobh"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Chruthaigh Vim an comhad viminfo seo %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -835,41 +1141,47 @@ msgstr ""
 "# Is féidir leat an comhad seo a chur in eagar ach bí cúramach!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Luach 'encoding' agus an comhad seo á scríobh\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Carachtar neamhcheadaithe tosaigh"
 
-msgid "Save As"
-msgstr "Sábháil Mar"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Scríobh comhad neamhiomlán?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Bain úsáid as ! chun maolán neamhiomlán a scríobh"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Forscríobh comhad \"%s\" atá ann cheana?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Tá comhad babhtála \"%s\" ann cheana; forscríobh mar sin féin?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Tá comhad babhtála ann cheana: %s (úsáid :silent! chun sárú)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Níl aon ainm ar mhaolán %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Níor scríobhadh an comhad: díchumasaithe leis an rogha 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -878,6 +1190,7 @@ msgstr ""
 "tá an rogha 'readonly' socraithe do \"%s\".\n"
 "Ar mhaith leat é a scríobh mar sin féin?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -888,67 +1201,85 @@ msgstr ""
 "Seans gurbh fhéidir scríobh ann mar sin féin.\n"
 "An bhfuil fonn ort triail a bhaint as?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: is inléite amháin é \"%s\" (cuir ! leis an ordú chun sárú)"
 
-msgid "Edit File"
-msgstr "Cuir Comhad in Eagar"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Scrios na huathorduithe maolán nua %s go tobann"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: argóint neamhuimhriúil chun :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Ní cheadaítear orduithe blaoisce i rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr ""
 "E146: Ní cheadaítear litreacha mar theormharcóirí ar shloinn ionadaíochta"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "cuir %s ina ionad (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Idirbhriste) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 rud comhoiriúnach"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 ionadaíocht"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> rud comhoiriúnach"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> ionadaíocht"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " ar líne amháin"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " ar %<PRId64> líne"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Ní cheadaítear :global go hathchúrsach"
 
 # should have ":"
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Slonn ionadaíochta ar iarraidh ó :global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Aimsíodh an patrún i ngach líne: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Patrún gan aimsiú"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -958,265 +1289,336 @@ msgstr ""
 "# Teaghrán Ionadach Is Déanaí:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Ná téigh i scaoll!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Tá brón orm, ní aon chabhair '%s' do %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Tá brón orm, níl aon chabhair do %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Tá brón orm, comhad cabhrach \"%s\" gan aimsiú"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Ní comhadlann é: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Ní féidir %s a oscailt chun scríobh ann"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Ní féidir %s a oscailt chun é a léamh"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Ionchóduithe éagsúla do chomhaid chabhracha i dteanga aonair: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Clib dhúblach \"%s\" i gcomhad %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Ordú anaithnid comhartha: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Ainm comhartha ar iarraidh"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: An iomarca comharthaí sainmhínithe"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Téacs neamhbhailí comhartha: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Comhartha anaithnid: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Uimhir chomhartha ar iarraidh"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ainm maoláin neamhbhailí: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: ID neamhbhailí comhartha: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (AR IARRAIDH)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (níl an rogha seo ar fáil)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Scriosta]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Mód dífhabhtaithe á thosú.  Clóscríobh \"cont\" chun leanúint."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "líne %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "ordú: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Brisphointe i \"%s%s\" líne %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Brisphointe gan aimsiú: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Níl aon bhrisphointe socraithe"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  líne %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Úsáid \":profile start {ainm}\" ar dtús"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Sábháil athruithe ar \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Gan Teideal"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Athraíodh maolán \"%s\" ach nach bhfuil sé sábháilte ó shin"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "Rabhadh: Chuathas i maolán eile go tobann (seiceáil na huathorduithe)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Níl ach aon chomhad amháin le cur in eagar"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Ní féidir a dhul roimh an chéad chomhad"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Ní féidir a dhul thar an gcomhad deireanach"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: ní ghlactar leis an tiomsaitheoir: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Ag déanamh cuardach ar \"%s\" i \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Ag déanamh cuardach ar \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "gan aimsiú i 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Foinsigh script Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Ní féidir comhadlann a léamh: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "níorbh fhéidir \"%s\" a léamh"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "líne %<PRId64>: níorbh fhéidir \"%s\" a fhoinsiú"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" á fhoinsiú"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "líne %<PRId64>: \"%s\" á fhoinsiú"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "deireadh ag foinsiú %s"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "módlíne"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "argóint --cmd"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "argóint -c"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "athróg thimpeallachta"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "láimhseálaí earráidí"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr ""
 "W15: Rabhadh: Deighilteoir línte mícheart, is féidir go bhfuil ^M ar iarraidh"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: ní úsáidtear :scriptencoding ach i gcomhad foinsithe"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: ní úsáidtear :finish ach i gcomhaid foinsithe"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "%sTeanga faoi láthair: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Ní féidir an teanga a shocrú mar \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Mód Ex á thosú.  Clóscríobh \"visual\" le haghaidh an ghnáthmhód."
 
 # in FARF -KPS
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Ag an chomhadchríoch"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Ordú ró-athchúrsach"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Eisceacht gan láimhseáil: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Críoch chomhaid foinsithe"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Críoch fheidhme"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Úsáid athbhríoch d'ordú saincheaptha"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Níl ina ordú eagarthóra"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Raon droim ar ais"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Raon droim ar ais, babhtáil"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Bain úsáid as w nó w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Tá brón orm, níl an t-ordú ar fáil sa leagan seo"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Ní cheadaítear ach aon ainm comhaid amháin"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 comhad le cur in eagar fós.  Scoir mar sin féin?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d comhad le cur in eagar fós.  Scoir mar sin féin?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 chomhad le heagrú fós"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> comhad le cur in eagar"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Tá an t-ordú ann cheana: cuir ! leis chun sárú"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1224,288 +1626,345 @@ msgstr ""
 "\n"
 "    Ainm        Arg  Raon  Iomlán    Sainmhíniú"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Níl aon ordú aimsithe atá sainithe ag an úsáideoir"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Níl aon aitreabúid sainithe"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Tá líon na n-argóintí mícheart"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Ní cheadaítear an t-áireamh a bheith tugtha faoi dhó"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Luach réamhshocraithe neamhbhailí ar áireamh"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: tá gá le hargóint i ndiaidh -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Aitreabúid neamhbhailí: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Ainm neamhbhailí ordaithe"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr ""
 "E183: Caithfidh ceannlitir a bheith ar dtús orduithe atá sainithe ag an "
 "úsáideoir"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Úsáid athbhríoch d'ordú saincheaptha"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Níl a leithéid d'ordú saincheaptha: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Luach iomlán neamhbhailí: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Ní cheadaítear argóint chomhlánaithe ach le comhlánú saincheaptha"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Tá gá le hargóint fheidhme le comhlánú saincheaptha"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Scéim dathanna %s gan aimsiú"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Dia duit, a úsáideoir Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Ní féidir an leathanach cluaisín deiridh a dhúnadh"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Níl ach leathanach cluaisín amháin cheana féin"
 
-msgid "Edit File in new window"
-msgstr "Cuir comhad in eagar i bhfuinneog nua"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Leathanach cluaisín %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Níl aon chomhad babhtála ann"
 
-msgid "Append File"
-msgstr "Cuir Comhad i nDeireadh"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Ní féidir an chomhadlann a athrú, mionathraíodh an maolán (cuir ! leis "
 "an ordú chun sárú)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Níl aon chomhadlann roimhe seo"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Anaithnid"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: ní foláir dhá argóint uimhriúla le :winsize"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Ionad na fuinneoige: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Ní féidir ionad na fuinneoige a fháil amach ar an chóras seo"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: ní foláir dhá argóint uimhriúla le :winpos"
 
-msgid "Save Redirection"
-msgstr "Sábháil Atreorú"
-
-msgid "Save View"
-msgstr "Sábháil an tAmharc"
-
-msgid "Save Session"
-msgstr "Sábháil an Seisiún"
-
-msgid "Save Setup"
-msgstr "Sábháil an Socrú"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Ní féidir comhadlann a chruthú: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: Tá \"%s\" ann cheana (cuir ! leis an ordú chun sárú)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Ní féidir \"%s\" a oscailt chun léamh"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Caithfidh an argóint a bheith litir nó comhartha athfhriotal"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: athchúrsáil :normal ródhomhain"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: níl #< ar fáil gan ghné +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Níl aon ainm comhaid a chur in ionad '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: níl aon ainm comhaid uathordaithe le cur in ionad \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: níl aon uimhir mhaolán uathordaithe le cur in ionad \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: níl aon ainm meaitseála uathordaithe le cur in ionad \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: níl aon ainm comhaid :source le cur in ionad \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: níl aon ainm comhaid :source le cur in ionad \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr ""
 "E499: Ainm comhaid folamh le haghaidh '%' nó '#', oibreoidh sé le \":p:h\" "
 "amháin"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Luacháiltear é seo mar theaghrán folamh"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Ní féidir an comhad viminfo a oscailt chun léamh"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Ní cheadaítear déghraif sa leagan seo"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Ní féidir eisceachtaí a :throw le réimír 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Gineadh eisceacht: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Eisceacht curtha i gcrích: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Eisceacht curtha i leataobh: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, líne %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Láimhseáladh eisceacht: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s ar feitheamh anois"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "atosaíodh %s"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s curtha i leataobh"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Eisceacht"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Earráid agus idirbhriseadh"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Earráid"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Idirbhriseadh"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if neadaithe ródhomhain"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif gan :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else gan :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif gan :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: :else iomadúla"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif i ndiaidh :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for neadaithe ródhomhain"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue gan :while ná :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break gan :while ná :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :endfor á úsáid le :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :endwhile á úsáid le :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try neadaithe ródhomhain"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch gan :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch i ndiaidh :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally gan :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: :finally iomadúla"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry gan :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: Caithfidh :endfunction a bheith isteach i bhfeidhm"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Níl cead agat maolán eile a chur in eagar anois"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Níl cead agat faisnéis an mhaoláin a athrú anois"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "clibainm"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " cineál comhaid\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "tá an rogha 'history' nialas"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1516,234 +1975,310 @@ msgstr ""
 
 # this gets plugged into the %s in the previous string,
 # hence the colon
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Líne na nOrduithe:"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Teaghrán Cuardaigh"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Sloinn:"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Líne an Ionchuir:"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar os cionn fad an ordaithe"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Scriosadh an fhuinneog reatha nó an maolán reatha"
 
-msgid "E812: Autocommands changed buffer or buffer name"
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
 msgstr ""
-"E812: Bhí maolán nó ainm maoláin athraithe ag orduithe uathoibríocha"
 
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Conair neamhbhailí: ní mór '**[uimhir]' a bheith ag deireadh na "
+"conaire, nó le '%s' ina dhiaidh."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Ní féidir comhadlann \"%s\" a aimsiú sa cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Ní féidir comhad \"%s\" a aimsiú sa chonair"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Níl comhadlann \"%s\" sa cdpath a thuilleadh"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Níl comhad \"%s\" sa chonair a thuilleadh"
+
+#: ../fileio.c:137
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E812: Bhí maolán nó ainm maoláin athraithe ag orduithe uathoibríocha"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Ainm comhaid neamhcheadaithe"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "is comhadlann é"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "ní comhad é"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "is gléas é seo (díchumasaithe le rogha 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Comhad Nua]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[COMHADLANN nua]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Comhad rómhór]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Cead Diúltaithe]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Rinne uathorduithe *ReadPre praiseach as an chomhad"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Ní cheadaítear d'uathorduithe *ReadPre an maolán reatha a athrú"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Ag léamh ón ionchur caighdeánach...\n"
 
-msgid "Reading from stdin..."
-msgstr "Ag léamh ón ionchur caighdeánach..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Comhad doléite i ndiaidh an tiontaithe!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/soicéad]"
 
 # `TITA' ?! -KPS
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[soicéad]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[comhad speisialta den chineál carachtar]"
 
-msgid "[RO]"
-msgstr "[L-A]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR ar iarraidh]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[línte fada deighilte]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NÍ tiontaithe]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[tiontaithe]"
 
-msgid "[crypted]"
-msgstr "[criptithe]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[EARRÁID TIONTAITHE i líne %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[BEART NEAMHCHEADAITHE i líne %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[EARRÁIDÍ LÉIMH]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Ní féidir comhad sealadach a aimsiú le haghaidh tiontaithe"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Theip ar thiontú le 'charconvert'"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "ní féidir an t-aschur ó 'charconvert' a léamh"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Níl aon uathordú comhoiriúnaithe le haghaidh maoláin acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Scrios nó dhíluchtaigh uathorduithe an maolán le scríobh"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: D'athraigh uathordú líon na línte gan choinne"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "Ní cheadaíonn NetBeans maoláin gan athrú a bheith scríofa"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Ní cheadaítear maoláin NetBeans a bheith scríofa go neamhiomlán"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "ní comhad ná gléas inscríofa á"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "díchumasaíodh scríobh chuig gléas le rogha 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "is inléite amháin é (cuir ! leis an ordú chun sárú)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Ní féidir scríobh a dhéanamh sa chomhad cúltaca (úsáid ! chun sárú)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: Earráid agus comhad cúltaca á dhúnadh (cuir ! leis an ordú chun sárú)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Ní féidir an comhad cúltaca a léamh (cuir ! leis an ordú chun sárú)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Ní féidir comhad cúltaca a chruthú (cuir ! leis an ordú chun sárú)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Ní féidir comhad cúltaca a chruthú (cuir ! leis an ordú chun sárú)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Chaillfí an forc acmhainne (cuir ! leis an ordú chun sárú)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Ní féidir comhad sealadach a aimsiú chun scríobh ann"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Ní féidir tiontú (cuir ! leis an ordú chun scríobh gan tiontú)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Ní féidir comhad nasctha a oscailt chun scríobh ann"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Ní féidir comhad a oscailt chun scríobh ann"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Theip ar fsync"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Theip ar dúnadh"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: earráid le linn scríobh, theip ar thiontú (úsáid 'fenc' folamh chun "
 "sárú)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: earráid le linn scríofa, theip ar thiontú ar líne %<PRId64> (úsáid 'fenc' folamh le "
-"sárú)"
+"E513: earráid le linn scríofa, theip ar thiontú ar líne %<PRId64> (úsáid "
+"'fenc' folamh le sárú)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: earráid le linn scríofa (an bhfuil an córas comhaid lán?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " EARRÁID TIONTAITHE"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " ar líne %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Gléas]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nua]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " iarcheangailte"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " scríofa"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: ní féidir an comhad bunúsach a shábháil"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: ní féidir an comhad bunúsach folamh a theagmháil"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Ní féidir an comhad cúltaca a scriosadh"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1751,75 +2286,96 @@ msgstr ""
 "\n"
 "RABHADH: Is féidir gur caillte nó loite an comhad bunúsach\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ná scoir go dtí go scríobhfaí an comhad!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[formáid dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[formáid mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[formáid unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 líne, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> líne, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 carachtar"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> carachtar"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[ganEOL]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Is neamhiomlán an líne dheireanach]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "RABHADH: Athraíodh an comhad ó léadh é!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "An bhfuil tú cinnte gur mhaith leat é a scríobh"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Earráid agus \"%s\" á scríobh"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Earráid agus \"%s\" á dhúnadh"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Earráid agus \"%s\" á léamh"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Scrios uathordú FileChangedShell an maolán"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Níl comhad \"%s\" ar fáil feasta"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1827,31 +2383,39 @@ msgid ""
 msgstr ""
 "W12: Rabhadh: Athraíodh comhad \"%s\" agus athraíodh an maolán i Vim fosta"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Bain triail as \":help W12\" chun tuilleadh eolais a fháil."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Rabhadh: Athraíodh comhad \"%s\" ó tosaíodh é a chur in eagar"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Bain triail as \":help W11\" chun tuilleadh eolais a fháil."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Rabhadh: Athraíodh mód an chomhaid \"%s\" ó tosaíodh é a chur in eagar"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Bain triail as \":help W16\" chun tuilleadh eolais a fháil."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Rabhadh: Cruthaíodh comhad \"%s\" ó tosaíodh é a chur in eagar"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Rabhadh"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1859,39 +2423,48 @@ msgstr ""
 "&OK\n"
 "&Luchtaigh Comhad"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Ní féidir \"%s\" a ullmhú le haghaidh athluchtaithe"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Ní féidir \"%s\" a athluchtú"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Scriosta--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "uathordú á bhaint go huathoibríoch: %s <maolán=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Níl a leithéid de ghrúpa: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Carachtar neamhcheadaithe i ndiaidh *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Níl a leithéid de theagmhas: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Níl a leithéid de ghrúpa nó theagmhas: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1899,542 +2472,768 @@ msgstr ""
 "\n"
 "--- Uathorduithe ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <maolán=%d>: uimhir neamhbhailí mhaoláin "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Ní féidir uathorduithe a rith i gcomhair teagmhas UILE"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Níl aon uathordú comhoiriúnaithe"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: uathordú neadaithe ródhomhain"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Uathorduithe do \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s á rith"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "uathordú %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { ar iarraidh."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } ar iarraidh."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Níor aimsíodh aon fhilleadh"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Ní féidir filleadh a chruthú leis an 'foldmethod' reatha"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Ní féidir filleadh a scriosadh leis an 'foldmethod' reatha"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld líne fillte "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Cuir leis an maolán léite"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: mapáil athchúrsach"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: tá giorrúchán comhchoiteann ann cheana le haghaidh %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: tá mapáil chomhchoiteann ann cheana le haghaidh %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: tá giorrúchán ann cheana le haghaidh %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: tá mapáil ann cheana le haghaidh %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Níor aimsíodh aon ghiorrúchán"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Níor aimsíodh aon mhapáil"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Mód neamhcheadaithe"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Ní féidir an GUI a chur ag obair"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Tá an maolán folamh--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Ní féidir léamh ó \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Ordú tobscortha"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Tá gá le hargóint"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: Ba chóir /, ? nó & a chur i ndiaidh \\"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E665: Ní féidir an GUI a chur ag obair, níl aon chlófhoireann bhailí ann"
+"E11: Neamhbhailí i bhfuinneog líne na n-orduithe; <CR>=rith, CTRL-C=scoir"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' neamhbhailí"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Luach neamhbhailí ar 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Ní féidir dath %s a dháileadh"
-
-msgid "No match at cursor, finding next"
-msgstr "Níl a leithéid ag an chúrsóir, ag cuardach ar an chéad cheann eile"
-
-msgid "<cannot open> "
-msgstr "<ní féidir a oscailt> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: níl aon fháil ar an chlófhoireann %s"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: ní féidir dul ar ais go dtí an chomhadlann reatha"
-
-msgid "Pathname:"
-msgstr "Conair:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: níl an chomhadlann reatha ar fáil"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Cealaigh"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Giuirléid Scrollbharra: Ní féidir céimseata an mhapa picteilíní a fháil."
+"E12: Ní cheadaítear ordú ó exrc/vimrc sa chomhadlann reatha ná ó chuardach "
+"clibe"
 
-msgid "Vim dialog"
-msgstr "Dialóg Vim"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif ar iarraidh"
 
-msgid "E232: Cannot create BalloonEval with both message and callback"
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry ar iarraidh"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile ar iarraidh"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor ar iarraidh"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile gan :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor gan :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Tá comhad ann cheana (cuir ! leis an ordú chun forscríobh)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Theip ar ordú"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Earráid inmheánach"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Idirbhriste"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Drochsheoladh"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Argóint neamhbhailí"
+
+#: ../globals.h:1015
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Argóint neamhbhailí: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Slonn neamhbhailí: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Raon neamhbhailí"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Ordú neamhbhailí"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: is comhadlann \"%s\""
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Méid neamhbhailí scrollaithe"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"E232: Ní féidir BalloonEval a chruthú le teachtaireacht agus aisghlaoch araon"
 
-msgid "Vim dialog..."
-msgstr "Dialóg Vim..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"&Tá\n"
-"&Níl\n"
-"&Cealaigh"
 
-msgid "Input _Methods"
-msgstr "_Modhanna ionchuir"
-
-# in OLT --KPS
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Cuardaigh agus Athchuir..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Cuardaigh..."
-
-msgid "Find what:"
-msgstr "Aimsigh:"
-
-msgid "Replace with:"
-msgstr "Le cur in ionad:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Focal iomlán amháin"
-
-#. match case button
-msgid "Match case"
-msgstr "Meaitseáil an cás"
-
-msgid "Direction"
-msgstr "Treo"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Suas"
-
-msgid "Down"
-msgstr "Síos"
-
-msgid "Find Next"
-msgstr "An Chéad Cheann Eile"
-
-msgid "Replace"
-msgstr "Ionadaigh"
-
-msgid "Replace All"
-msgstr "Ionadaigh Uile"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Fuarthas iarratas \"die\" ó bhainisteoir an tseisiúin\n"
-
-msgid "Close"
-msgstr "Dún"
-
-msgid "New tab"
-msgstr "Cluaisín nua"
-
-msgid "Open Tab..."
-msgstr "Oscail Cluaisín..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Milleadh an príomhfhuinneog gan choinne\n"
-
-msgid "Font Selection"
-msgstr "Roghnú Cló"
-
-msgid "&Filter"
-msgstr "&Scagaire"
-
-msgid "&Cancel"
-msgstr "&Cealaigh"
-
-msgid "Directories"
-msgstr "Comhadlanna"
-
-msgid "Filter"
-msgstr "Scagaire"
-
-msgid "&Help"
-msgstr "&Cabhair"
-
-msgid "Files"
-msgstr "Comhaid"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Roghnú"
-
-msgid "Find &Next"
-msgstr "An Chéad Chea&nn Eile"
-
-msgid "&Replace"
-msgstr "&Ionadaigh"
-
-msgid "Replace &All"
-msgstr "Ionadaigh &Uile"
-
-msgid "&Undo"
-msgstr "&Cealaigh"
-
+#: ../globals.h:1024
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Ní féidir teideal na fuinneoige \"%s\" a aimsiú"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Theip ar ghlao leabharlainne \"%s()\""
 
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argóint gan tacaíocht: \"-%s\"; Bain úsáid as an leagan OLE."
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Tá líne-uimhir neamhbhailí ag an mharc"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Ní féidir fuinneog a oscailt isteach i bhfeidhmchlár MDI"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Marc gan socrú"
 
-msgid "Close tab"
-msgstr "Dún cluaisín"
-
-msgid "Open tab..."
-msgstr "Oscail cluaisín..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Aimsigh teaghrán (bain úsáid as '\\\\' chun '\\' a aimsiú)"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Aimsigh & Athchuir (úsáid '\\\\' chun '\\' a aimsiú)"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Gan Úsáid"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Comhadlann\t*.neamhní\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
 msgstr ""
-"Vim E458: Ní féidir iontráil dathmhapála a dháileadh, is féidir go mbeidh "
-"dathanna míchearta ann"
+"E21: Ní féidir athruithe a chur i bhfeidhm, níl an bhratach 'modifiable' "
+"socraithe"
 
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: scripteanna neadaithe ródhomhain"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Níl aon chomhad malartach"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Níl a leithéid de ghiorrúchán ann"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Ní cheadaítear !"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Ní féidir an GUI a úsáid: Níor cumasaíodh é ag am tiomsaithe"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr ""
-"E250: Clónna ar iarraidh le haghaidh na dtacar carachtar i dtacar cló %s:"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Níl a leithéid d'ainm grúpa aibhsithe: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Níl aon téacs ionsáite go dtí seo"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Níl aon líne na n-orduithe roimhe seo"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Níl a leithéid de mhapáil"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Níl aon rud comhoiriúnach ann"
+
+#: ../globals.h:1041
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Ainm an tacar cló: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Níl aon rud comhoiriúnach ann: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Níl aon ainm comhaid"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Níl aon slonn ionadaíochta roimhe seo"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Níl aon ordú roimhe seo"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Níl aon slonn ionadaíochta roimhe seo"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Ní cheadaítear raon"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Níl slí a dhóthain ann"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Ní cló aonleithid é '%s'"
+msgid "E482: Can't create file %s"
+msgstr "E482: Ní féidir comhad %s a chruthú"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Níl aon fháil ar ainm comhaid sealadach"
+
+#: ../globals.h:1051
 #, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Ainm an tacar cló: %s\n"
+msgid "E484: Can't open file %s"
+msgstr "E484: Ní féidir comhad %s a oscailt"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0: %s\n"
-msgstr "Cló0: %s\n"
+msgid "E485: Can't read file %s"
+msgstr "E485: Ní féidir comhad %s a léamh"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Tá athruithe ann gan sábháil (cuir ! leis an ordú chun sárú)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Athraithe agus nach sábháilte ó shin]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Argóint nialasach"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Ag súil le huimhir"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1: %s\n"
-msgstr "Cló1: %s\n"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Ní féidir an comhad earráide %s a oscailt"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Cuimhne ídithe!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Patrún gan aimsiú"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Níl Cló%<PRId64> níos leithne faoi dhó ná cló0\n"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Patrún gan aimsiú: %s"
 
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Ní foláir argóint dheimhneach"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Ní féidir a fhilleadh ar an chomhadlann roimhe seo"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Níl Aon Earráid Ann"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Gan liosta suíomh"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Teaghrán cuardaigh loite"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Clár na sloinn ionadaíochta truaillithe"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: tá an rogha 'readonly' socraithe (cuir ! leis an ordú chun sárú)"
+
+#: ../globals.h:1073
 #, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Leithead Cló0: %<PRId64>\n"
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Ní féidir athróg inléite amháin \"%s\" a athrú"
 
+#: ../globals.h:1075
 #, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
-msgstr ""
-"Leithead Cló1: %<PRId64>\n"
-"\n"
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Ní féidir athróg a shocrú sa bhosca gainimh: \"%s\""
 
-msgid "Invalid font specification"
-msgstr "Sonrú neamhbhailí cló"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Earráid agus comhad earráide á léamh"
 
-msgid "&Dismiss"
-msgstr "&Ruaig"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Ní cheadaítear é seo i mbosca gainimh"
 
-msgid "no specific match"
-msgstr "níl a leithéid ann"
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Ní cheadaítear é anseo"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Roghnú Cló"
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Ní féidir an mód scáileáin a shocrú"
 
-msgid "Name:"
-msgstr "Ainm:"
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Méid neamhbhailí scrollaithe"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Taispeáin méid (Pointí)"
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: rogha 'shell' folamh"
 
-msgid "Encoding:"
-msgstr "Ionchódú:"
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Níorbh fhéidir na sonraí comhartha a léamh!"
 
-msgid "Font:"
-msgstr "Cló:"
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Earráid agus comhad babhtála á dhúnadh"
 
-msgid "Style:"
-msgstr "Stíl:"
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tá cruach na gclibeanna folamh"
 
-msgid "Size:"
-msgstr "Méid:"
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Ordú róchasta"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: EARRÁID leis na huathoibreáin Hangul"
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Ainm rófhada"
 
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: an iomarca ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: An iomarca ainmneacha comhaid"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Carachtair chun deiridh"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Marc anaithnid"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Ní féidir saoróga a leathnú"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: ní cheadaítear 'winheight' a bheith níos lú ná 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: ní cheadaítear 'winwidth' a bheith níos lú ná 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Earráid agus á scríobh"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nialas"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> á úsáid nach i gcomhthéacs scripte"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Earráid inmheánach: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: úsáideann an patrún níos mó cuimhne ná 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: maolán folamh"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Patrún nó teormharcóir neamhbhailí cuardaigh"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Tá an comhad luchtaithe i maolán eile"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Rogha '%s' gan socrú"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Ainm neamhbhailí tabhaill: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Buaileadh an BARR le linn an chuardaigh, ag leanúint ag an CHRÍOCH"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Buaileadh an BUN le linn an chuardaigh, ag leanúint ag an BHARR"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Idirstad ar iarraidh"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Comhpháirt neamhcheadaithe"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: ag súil le digit"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Leathanach %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Níl aon téacs le priontáil"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Leathanach %d (%d%%) á phriontáil"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Cóip %d de %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Priontáilte: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Priontáil tobscortha"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Earráid le linn scríobh chuig aschomhad PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Ní féidir an comhad \"%s\" a oscailt"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Ní féidir comhad acmhainne PostScript \"%s\" a léamh"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Níl comhad \"%s\" ina chomhad acmhainne PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Tá \"%s\" ina chomhad acmhainne PostScript gan tacú"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Tá an leagan mícheart ar an gcomhad acmhainne \"%s\""
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Ionchódú agus tacar carachtar ilbhirt neamh-chomhoiriúnach."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr ""
 "E674: ní cheadaítear printmbcharset a bheith folamh le hionchódú ilbhirt."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Níor réamhshocraíodh cló le haghaidh priontála ilbhirt."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Ní féidir aschomhad PostScript a oscailt"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Ní féidir an comhad \"%s\" a oscailt"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Comhad acmhainne PostScript \"prolog.ps\" gan aimsiú"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Comhad acmhainne PostScript \"cidfont.ps\" gan aimsiú"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Comhad acmhainne PostScript \"%s.ps\" gan aimsiú"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Ní féidir an t-ionchódú priontála \"%s\" a thiontú"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Á sheoladh chuig an phrintéir..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Theip ar phriontáil comhaid PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Seoladh jab priontála."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Bunachar sonraí nua"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Iarratas ar phatrún"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Taispeáin an teachtaireacht seo"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Maraigh nasc"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Atúsaigh gach nasc"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Taispeáin naisc"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Úsáid: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Ní féidir fuinneoga a scoilteadh leis an ordú seo `cscope'.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Úsáid: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: clib gan aimsiú"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: earráid stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: earráid stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: Níl %s ina comhadlann nó bunachar sonraí cscope bailí"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Bunachar sonraí nua cscope: %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: earráid agus an nasc cscope %<PRId64> á léamh"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: cineál anaithnid cuardaigh cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Níorbh fhéidir píopaí cscope a chruthú"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Níorbh fhéidir forc a dhéanamh le haghaidh cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "theip ar rith cs_create_connection"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "theip ar rith cs_create_connection"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: theip ar fdopen le haghaidh to_fp"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: theip ar fdopen le haghaidh fr_fp"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Níorbh fhéidir próiseas cscope a sceitheadh"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: níl aon nasc cscope ann"
 
+#: ../if_cscope.c:1009
+#, c-format
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr "E469: bratach neamhbhailí cscopequickfix %c le haghaidh %c"
+
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr ""
 "E259: níor aimsíodh aon rud comhoiriúnach leis an iarratas cscope %s de %s"
 
-#, c-format
-msgid "E469: invalid cscopequickfix flag %c for %c"
-msgstr "E469: bratach neamhbhailí cscopequickfix %c le haghaidh %c"
-
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "Orduithe cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Úsáid: %s)"
 
+#: ../if_cscope.c:1155
+#, fuzzy
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2444,7 +3243,7 @@ msgid ""
 "       g: Find this definition\n"
 "       i: Find files #including this file\n"
 "       s: Find this C symbol\n"
-"       t: Find assignments to\n"
+"       t: Find this text string\n"
 msgstr ""
 "\n"
 "       c: Aimsigh feidhmeanna a chuireann glaoch ar an bhfeidhm seo\n"
@@ -2456,32 +3255,31 @@ msgstr ""
 "       s: Aimsigh an tsiombail C seo\n"
 "       t: Aimsigh sanntaí do\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: ní féidir bunachar sonraí cscope a oscailt: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: ní féidir eolas a fháil faoin bhunachar sonraí cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: níor cuireadh bunachar sonraí dúblach cscope leis"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: nasc cscope %s gan aimsiú"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "Dúnadh nasc cscope %s"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: earráid mharfach i cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Clib cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2489,403 +3287,88 @@ msgstr ""
 "\n"
 "   #   líne"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "ainm comhaid / comhthéacs / líne\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Earráid cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Athshocraíodh gach bunachar sonraí cscope"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "níl aon nasc cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    ainm bunachair                       conair thosaigh\n"
 
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Tá brón orm, bhí an t-ordú seo díchumasaithe, níorbh fhéidir leabharlanna "
-"MzScheme a luchtú."
-
-msgid "invalid expression"
-msgstr "slonn neamhbhailí"
-
-msgid "expressions disabled at compile time"
-msgstr "díchumasaíodh sloinn ag am an tiomsaithe"
-
-msgid "hidden option"
-msgstr "rogha fholaithe"
-
-msgid "unknown option"
-msgstr "rogha anaithnid"
-
-msgid "window index is out of range"
-msgstr "innéacs fuinneoige as raon"
-
-msgid "couldn't open buffer"
-msgstr "ní féidir maolán a oscailt"
-
-msgid "cannot save undo information"
-msgstr "ní féidir eolas cealaithe a shábháil"
-
-msgid "cannot delete line"
-msgstr "ní féidir an líne a scriosadh"
-
-msgid "cannot replace line"
-msgstr "ní féidir an líne a athchur"
-
-msgid "cannot insert line"
-msgstr "ní féidir líne a ionsá"
-
-msgid "string cannot contain newlines"
-msgstr "ní cheadaítear carachtair líne nua sa teaghrán"
-
-msgid "Vim error: ~a"
-msgstr "earráid Vim: ~a"
-
-msgid "Vim error"
-msgstr "earráid Vim"
-
-msgid "buffer is invalid"
-msgstr "maolán neamhbhailí"
-
-msgid "window is invalid"
-msgstr "fuinneog neamhbhailí"
-
-msgid "linenr out of range"
-msgstr "líne-uimhir as raon"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "ní cheadaítear é seo i mbosca gainimh Vim"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Tá brón orm, níl an t-ordú seo le fáil, níorbh fhéidir an leabharlann "
-"Python a luchtú."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Ní féidir Python a rith go hathchúrsach"
-
-msgid "can't delete OutputObject attributes"
-msgstr "ní féidir tréithe OutputObject a scriosadh"
-
-msgid "softspace must be an integer"
-msgstr "caithfidh softspace a bheith ina shlánuimhir"
-
-msgid "invalid attribute"
-msgstr "aitreabúid neamhbhailí"
-
-msgid "writelines() requires list of strings"
-msgstr "liosta teaghrán ag teastáil ó writelines()"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Earráid agus réada I/A á dtúsú"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "rinneadh iarracht ar mhaolán scriosta a rochtain"
-
-msgid "line number out of range"
-msgstr "líne-uimhir as raon"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<réad maoláin (scriosta) ag %p>"
-
-msgid "invalid mark name"
-msgstr "ainm neamhbhailí mairc"
-
-msgid "no such buffer"
-msgstr "níl a leithéid de mhaolán ann"
-
-msgid "attempt to refer to deleted window"
-msgstr "rinneadh iarracht ar fhuinneog scriosta a rochtain"
-
-msgid "readonly attribute"
-msgstr "tréith inléite amháin"
-
-msgid "cursor position outside buffer"
-msgstr "cúrsóir taobh amuigh den mhaolán"
-
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<réad fuinneoige (scriosta) ag %p>"
-
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<réad fuinneoige (anaithnid) ag %p>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<fuinneog %d>"
-
-msgid "no such window"
-msgstr "níl a leithéid d'fhuinneog ann"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: caithfidh $_ a bheith cineál Teaghráin"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Tá brón orm, níl an t-ordú seo le fáil, níorbh fhéidir an leabharlann "
-"Ruby a luchtú."
-
-msgid "E267: unexpected return"
-msgstr "E267: \"return\" gan choinne"
-
-msgid "E268: unexpected next"
-msgstr "E268: \"next\" gan choinne"
-
-msgid "E269: unexpected break"
-msgstr "E269: \"break\" gan choinne"
-
-msgid "E270: unexpected redo"
-msgstr "E270: \"redo\" gan choinne"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: \"retry\" taobh amuigh de chlásal tarrthála"
-
-msgid "E272: unhandled exception"
-msgstr "E272: eisceacht gan láimhseáil"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: stádas anaithnid longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Scoránaigh feidhmiú/sainmhíniú"
-
-msgid "Show base class of"
-msgstr "Taispeáin an bunaicme de"
-
-msgid "Show overridden member function"
-msgstr "Taispeáin ballfheidhm sáraithe"
-
-msgid "Retrieve from file"
-msgstr "Aisghabh ó chomhad"
-
-msgid "Retrieve from project"
-msgstr "Aisghabh ó thionscadal"
-
-msgid "Retrieve from all projects"
-msgstr "Aisghabh ó gach tionscadal"
-
-msgid "Retrieve"
-msgstr "Aisghabh"
-
-msgid "Show source of"
-msgstr "Taispeáin foinse"
-
-msgid "Find symbol"
-msgstr "Aimsigh siombail"
-
-msgid "Browse class"
-msgstr "Brabhsáil aicme"
-
-msgid "Show class in hierarchy"
-msgstr "Taispeáin an aicme in ordlathas"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Taispeáin an aicme in ordlathas srianta"
-
-msgid "Xref refers to"
-msgstr "Tagraíonn Xref do"
-
-msgid "Xref referred by"
-msgstr "Xref tagartha ag"
-
-msgid "Xref has a"
-msgstr "Rud atá ag Xref:"
-
-msgid "Xref used by"
-msgstr "Xref á úsáid ag"
-
-msgid "Show docu of"
-msgstr "Taispeáin eolas faoi"
-
-msgid "Generate docu for"
-msgstr "Gin eolas faoi"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Ní féidir nasc a dhéanamh le SNiFF+. Seiceáil do chuid athróga "
-"thimpeallachta (caithfidh tú sniffemacs a chur i do $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Earráid sa léamh. Dínasctha"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ stádas faoi láthair: "
-
-msgid "not "
-msgstr "ní "
-
-msgid "connected"
-msgstr "nasctha"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Iarratas anaithnid SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Earráid ag nascadh le SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ gan nasc"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ní maolán SNiFF+ é"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Earráid sa scríobh. Dínasctha"
-
-msgid "invalid buffer number"
-msgstr "uimhir neamhbhailí mhaoláin"
-
-msgid "not implemented yet"
-msgstr "níl ar fáil"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "ní féidir lín(t)e a shocrú"
-
-msgid "mark not set"
-msgstr "marc gan socrú"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "líne %d colún %d"
-
-msgid "cannot insert/append line"
-msgstr "ní féidir líne a ionsá/iarcheangal"
-
-msgid "unknown flag: "
-msgstr "bratach anaithnid: "
-
-msgid "unknown vimOption"
-msgstr "vimOption anaithnid"
-
-msgid "keyboard interrupt"
-msgstr "idirbhriseadh méarchláir"
-
-msgid "vim error"
-msgstr "earráid vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "ní féidir ordú maoláin/fuinneoige a chruthú: réad á scriosadh"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "ní féidir ordú aisghlaoch a chlárú: maolán/fuinneog á scriosadh cheana"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: EARRÁID MHARFACH TCL: liosta truaillithe tagartha!? Seol tuairisc "
-"fhabht chuig <vim-dev@vim.org> le do thoil"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"ní féidir ordú aisghlaoch a chlárú: tagairt mhaolán/fhuinneoige gan aimsiú"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Tá brón orm, níl an t-ordú seo le fáil: níorbh fhéidir an leabharlann "
-"Tcl a luchtú."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: EARRÁID TCL: níl an cód scortha ina shlánuimhir!? Seol tuairisc fhabht "
-"chuig <vim-dev@vim.org> le do thoil"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: cód scortha %d"
-
-msgid "cannot get line"
-msgstr "ní féidir an líne a fháil"
-
-msgid "Unable to register a command server name"
-msgstr "Ní féidir ainm fhreastalaí ordaithe a chlárú"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Theip ar sheoladh ordú chuig an sprioc-chlár"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Aitheantas neamhbhailí freastalaí in úsáid: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Airí míchumtha sa chlárlann áisc VIM.  Scriosta!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Argóint anaithnid rogha"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "An iomarca argóintí eagarthóireachta"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argóint ar iarraidh i ndiaidh"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Dramhaíl i ndiaidh argóinte rogha"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "An iomarca argóintí den chineál \"+ordú\", \"-c ordú\" nó \"--cmd ordú\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Argóint neamhbhailí do"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d comhad le heagrú\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Níor tiomsaíodh an leagan Vim seo le `diff' ar fáil."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "Ní féidir '-nb' a úsáid: níor cumasaíodh é ag am tiomsaithe\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Déan iarracht ar oscailt na scripte arís: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Ní féidir é a oscailt chun léamh: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Ní féidir a oscailt le haghaidh an aschuir scripte: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Earráid: Theip ar thosú gvim ó NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Rabhadh: Níl an t-aschur ag dul chuig teirminéal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Rabhadh: Níl an t-ionchur ag teacht ó theirminéal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "líne na n-orduithe pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Ní féidir léamh ó \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2893,18 +3376,23 @@ msgstr ""
 "\n"
 "Tuilleadh eolais: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[comhad ..]       cuir na comhaid ceaptha in eagar"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               scríobh téacs ó stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          cuir an comhad ina bhfuil an chlib in eagar"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [comhadearr] cuir comhad leis an chéad earráid in eagar"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2914,9 +3402,11 @@ msgstr ""
 "\n"
 "úsáid:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argóintí] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2924,14 +3414,7 @@ msgstr ""
 "\n"
 "   nó:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Nuair nach cásíogair é, cuir '/' ag tosach na brataí chun í a chur sa chás "
-"uachtair"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2941,346 +3424,194 @@ msgstr ""
 "\n"
 "Argóintí:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tNí cheadaítear ach ainmneacha comhaid i ndiaidh é seo"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNá leathnaigh saoróga"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tCláraigh an gvim seo le haghaidh OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tDíchláraigh an gvim seo le haghaidh OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tRith agus úsáid an GUI (mar \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  nó  --nofork\tTulra: Ná déan forc agus an GUI á thosú"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tMód Vi (mar \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tMód Ex (mar \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tMód ciúin (baiscphróiseála) (do \"ex\" amháin)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tMód diff (mar \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tMód éasca (mar \"evim\", gan mhóid)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMód inléite amháin (mar \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tMód srianta (mar \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tNí cheadaítear athruithe (.i. scríobh na gcomhad)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tNí cheadaítear athruithe sa téacs"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tMód dénártha"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tMód Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tComhoiriúnach le Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNí comhoiriúnaithe le Vi go hiomlán: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 "-V[N][fname]\t\tBí foclach [leibhéal N] [logáil teachtaireachtaí i fname]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tMód dífhabhtaithe"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNá húsáid comhad babhtála .i. ná húsáid ach an chuimhne"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tTaispeáin comhaid bhabhtála agus scoir"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (le hainm comhaid)\tAthshlánaigh ó chliseadh"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tAr comhbhrí le -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNá húsáid newcli chun fuinneog a oscailt"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <gléas>\t\tBain úsáid as <gléas> do I/A"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\ttosaigh sa mhód Araibise"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tTosaigh sa mhód Eabhraise"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tTosaigh sa mhód Pheirsise"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <teirminéal>\tSocraigh cineál teirminéal"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tÚsáid <vimrc> in ionad aon .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tBain úsáid as <gvimrc> in ionad aon .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNá luchtaigh breiseáin"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tOscail N leathanach cluaisín (default: ceann do gach comhad)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOscail N fuinneog (réamhshocrú: ceann do gach comhad)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tMar -o, ach roinn go hingearach"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tTosaigh ag an chomhadchríoch"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tTosaigh ar líne <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <ordú>\tRith <ordú> roimh aon chomhad vimrc a luchtú"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <ordú>\t\tRith <ordú> i ndiaidh luchtú an chéad chomhad"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <seisiún>\t\tLéigh comhad <seisiún> i ndiaidh an chéad chomhad á léamh"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <script>\tLéigh orduithe gnáthmhóid ón chomhad <script>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr ""
 "-w <script>\tIarcheangail gach ordú iontráilte leis an gcomhad <script>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <aschur>\tScríobh gach ordú clóscríofa sa chomhad <aschur>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tCuir comhaid chriptithe in eagar"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <freastalaí>\tNasc vim leis an bhfreastalaí-X seo"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNá naisc leis an bhfreastalaí X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr ""
-"--remote <comhaid>\tCuir <comhaid> in eagar le freastalaí Vim más féidir"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-silent <comhaid> Mar an gcéanna, ná déan gearán mura bhfuil "
-"freastalaí ann"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <comhaid>  Mar --remote ach fan leis na comhaid a bheith "
-"curtha in eagar"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <comhaid>  Mar an gcéanna, ná déan gearán mura bhfuil "
-"freastalaí ann"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <comhaid>  Cosúil le --remote ach oscail "
-"cluaisín do gach comhad"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr ""
-"--remote-send <eochracha>\tSeol <eochracha> chuig freastalaí Vim agus scoir"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <slonn>\tLuacháil <slonn> le freastalaí Vim agus taispeáin an "
-"toradh"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tTaispeáin freastalaithe Vim atá ar fáil agus scoir"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <ainm>\tSeol chuig/Téigh i do fhreastalaí Vim <ainm>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
-msgstr "--startuptime <comhad>\tScríobh faisnéis maidir le tréimhse tosaithe i <comhad>"
+msgstr ""
+"--startuptime <comhad>\tScríobh faisnéis maidir le tréimhse tosaithe i "
+"<comhad>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tÚsáid <viminfo> in ionad .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  nó  --help\tTaispeáin an chabhair seo agus scoir"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tTaispeáin eolas faoin leagan agus scoir"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argóintí ar eolas do gvim (leagan Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argóintí ar eolas do gvim (leagan neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argóintí ar eolas do gvim (leagan Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <scáileán>\tRith vim ar <scáileán>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tTosaigh vim sa mhód íoslaghdaithe"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <ainm>\t\tÚsáid acmhainn mar a bheadh vim <ainm>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Níl ar fáil)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <dath>\tBain úsáid as <dath> don chúlra (-bg fosta)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <dath>\tÚsáid <dath> le haghaidh gnáth-théacs (fosta: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <cló>\t\tÚsáid <cló> le haghaidh gnáth-théacs (fosta: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <cló>\tBain úsáid as <cló> do chló trom"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <cló>\tÚsáid <cló> le haghaidh téacs iodálach"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geoim>\tÚsáid <geoim> le haghaidh na céimseatan tosaigh (fosta: -"
-"geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <leithead>\tSocraigh <leithead> na himlíne (-bw fosta)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <leithead> Socraigh leithead na scrollbharraí a bheith "
-"<leithead> (fosta: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <airde>\tSocraigh airde an bharra roghchláir a bheith <airde> "
-"(fosta: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tÚsáid fís aisiompaithe (fosta: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNá húsáid fís aisiompaithe (fosta: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <acmhainn>\tSocraigh an acmhainn sainithe"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argóintí ar eolas do gvim (leagan RISC OS):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <uimhir>\tLeithead fuinneoige i dtosach (colúin)"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <uimhir>\tAirde fhuinneoige i dtosach (rónna)"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argóintí ar eolas do gvim (leagan GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <scáileán>\tRith vim ar <scáileán> (fosta: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <ról>\tSocraigh ról sainiúil chun an phríomhfhuinneog a aithint"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOscail Vim isteach i ngiuirléid GTK eile"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <máthairchlár>\tOscail Vim isteach sa mháthairchlár"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tOscail Vim isteach i ngiuirléid win32 eile"
-
-msgid "No display"
-msgstr "Gan taispeáint"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Theip ar seoladh.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Theip ar seoladh. Ag baint triail as go logánta\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d as %d déanta"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Gan taispeáint: Theip ar sheoladh sloinn.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Theip ar sheoladh sloinn.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Níl aon mharc socraithe"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Níl aon mharc comhoiriúnaithe le \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3289,6 +3620,7 @@ msgstr ""
 "marc líne  col comhad/téacs"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3297,6 +3629,7 @@ msgstr ""
 " léim líne  col comhad/téacs"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3304,7 +3637,7 @@ msgstr ""
 "\n"
 "athrú  líne  col téacs"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3313,7 +3646,7 @@ msgstr ""
 "# Marcanna comhaid:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3321,7 +3654,7 @@ msgstr ""
 "\n"
 "# Liosta léimeanna (is nuaí i dtosach):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3329,98 +3662,86 @@ msgstr ""
 "\n"
 "# Stair na marcanna i gcomhaid (is nuaí ar dtús):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "`>' ar iarraidh"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Ní códleathanach bailí é"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Ní féidir luachanna IC a shocrú"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Theip ar chruthú comhthéacs ionchuir"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Theip ar oscailt mhodh ionchuir"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Rabhadh: Níorbh fhéidir aisghlaoch léirscriosta a shocrú le IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Ní thacaíonn an modh ionchuir aon stíl"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: ní thacaíonn an modh ionchuir mo chineál réamheagair"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: tacar cló ag teastáil ó stíl thar-an-spota"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr ""
-"E291: Tá an GTK+ atá agat níos sine ná leagan 1.2.3. Díchumasaítear an "
-"limistéar stádais"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Níl an Freastalaí Mhodh Ionchuir ag rith"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: ní raibh an bloc faoi ghlas"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Earráid chuardaigh agus comhad babhtála á léamh"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Earráid sa léamh i gcomhad babhtála"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Earráid chuardaigh agus comhad babhtála á scríobh"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Earráid sa scríobh i gcomhad babhtála"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Tá comhad babhtála ann cheana (ionsaí le naisc shiombalacha?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Ní bhfuarthas bloc 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Ní bhfuarthas bloc a haon?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Ní bhfuarthas bloc a dó?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Úps, cailleadh an comhad babhtála!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Níorbh fhéidir an comhad babhtála a athainmniú"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Ní féidir comhad babhtála le haghaidh \"%s\" a oscailt, ní féidir "
 "athshlánú"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Ní bhfuarthas bloc 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Níor aimsíodh comhad babhtála le haghaidh %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Iontráil uimhir an chomhaid babhtála le húsáid (0 = scoir): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Ní féidir %s a oscailt"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Ní féidir bloc 0 a léamh ó "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3429,22 +3750,28 @@ msgstr ""
 "B'fhéidir nach raibh aon athrú á dhéanamh, nó tá an comhad\n"
 "babhtála as dáta."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " níl ar fáil leis an leagan seo de Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Bain úsáid as Vim, leagan 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: Níl %s cosúil le comhad babhtála Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " níl ar fáil ar an ríomhaire seo.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Cruthaíodh an comhad seo ar "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3452,67 +3779,86 @@ msgstr ""
 ",\n"
 "is é sin nó rinneadh dochar don chomhad."
 
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " rinneadh dochar dó (méid an leathanaigh níos lú ná an íosmhéid).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Comhad babhtála \"%s\" á úsáid"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Comhad bunúsach \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Rabhadh: Is féidir gur athraíodh an comhad bunúsach"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Ní féidir bloc a haon a léamh ó %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???GO LEOR LÍNTE AR IARRAIDH"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???LÍON MÍCHEART NA LÍNTE"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???BLOC FOLAMH"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LÍNTE AR IARRAIDH"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Aitheantas mícheart ar bhloc a haon (níl %s ina chomhad .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOC AR IARRAIDH"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? is féidir go ndearnadh praiseach de línte ó anseo go ???END"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? is féidir go bhfuil línte ionsáite/scriosta ó anseo go ???END"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???DEIREADH"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Idirbhriseadh an t-athshlánú"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Braitheadh earráidí le linn athshlánaithe; féach ar na línte le ??? ar "
 "tosach"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Bain triail as \":help E312\" chun tuilleadh eolais a fháil."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Athshlánaíodh. Ba chóir duit gach rud a sheiceáil uair amháin eile."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3520,52 +3866,73 @@ msgstr ""
 "\n"
 "(B'fhéidir gur mian leat an comhad seo a shábháil de réir ainm eile\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr ""
 "agus déan comparáid leis an chomhad bhunúsach (m.sh. le `diff') chun "
 "athruithe a scrúdú)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Scrios an comhad .swp tar éis sin.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Comhaid bhabhtála aimsithe:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   Sa chomhadlann reatha:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Ag baint úsáid as ainm socraithe:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   Sa chomhadlann "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- neamhní --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          úinéir: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   dátaithe: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             dátaithe: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [ó leagan 3.0 Vim]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ní cosúil le comhad babhtála Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         ainm comhaid: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3573,12 +3940,15 @@ msgstr ""
 "\n"
 "          mionathraithe: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "IS SEA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ní hea"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3586,9 +3956,11 @@ msgstr ""
 "\n"
 "         úsáideoir: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   ainm an óstríomhaire: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3596,6 +3968,7 @@ msgstr ""
 "\n"
 "         óstainm: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3603,16 +3976,11 @@ msgstr ""
 "\n"
 "        PID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (ag rith fós)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [ní inúsáidte leis an leagan seo Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3620,75 +3988,97 @@ msgstr ""
 "\n"
 "         [ní inúsáidte ar an ríomhaire seo]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [ní féidir a léamh]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [ní féidir oscailt]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Ní féidir é a chaomhnú, níl aon chomhad babhtála ann"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Caomhnaíodh an comhad"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Theip ar chaomhnú"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: lnum neamhbhailí: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: líne %<PRId64> gan aimsiú"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: aitheantas mícheart ar an mbloc pointeora 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "ba chóir do stack_idx a bheith 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: An iomarca bloic nuashonraithe?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: aitheantas mícheart ar an mbloc pointeora 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "bloc a haon scriosta?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Líne %<PRId64> gan aimsiú"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: aitheantas mícheart ar an mbloc pointeora"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "is 0 pe_line_count\""
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: líne-uimhir as raon: %<PRId64> thar dheireadh"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: líon mícheart na línte i mbloc %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Méadaíonn an chruach"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: aitheantas mícheart ar an mbloc pointeora 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Ciogal i naisc shiombalacha le haghaidh \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: AIRE"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3696,39 +4086,45 @@ msgstr ""
 "\n"
 "Fuarthas comhad babhtála darbh ainm \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Agus an comhad seo á oscailt: \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NÍOS NUAÍ ná comhad babhtála!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Is féidir go bhfuil clár eile ag rochtain an comhad seo.\n"
 "    Más ea, bí cúramach nach bhfuil dhá leagan den chomhad\n"
 "    céanna.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Scoir, nó lean ar aghaidh go hairdeallach.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Rinne Vim thobscor agus an comhad seo\n"
 "    idir lámha agat.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Más amhlaidh, bain úsáid as \":recover\" nó \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3736,9 +4132,11 @@ msgstr ""
 "\"\n"
 "    chun na hathruithe a fháil ar ais (féach \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Má tá sé seo déanta cheana agat, scrios an comhad babhtála \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3746,18 +4144,23 @@ msgstr ""
 "\"\n"
 "   chun an teachtaireacht seo a sheachaint.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Comhad babhtála \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" tá sé ann cheana!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - AIRE"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Tá comhad babhtála ann cheana!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3771,6 +4174,7 @@ msgstr ""
 "&Scoir\n"
 "&Tobscoir"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3786,36 +4190,58 @@ msgstr ""
 "&Scoir\n"
 "&Tobscoir"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Aimsíodh an iomarca comhaid bhabhtála"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Cuimhne ídithe!  (%<PRIu64> beart á ndáileadh)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Ní fo-roghchlár í páirt de chonair roghchláir"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Níl an roghchlár ar fáil sa mhód seo"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Níl aon roghchlár darbh ainm \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Ainm folamh ar an roghchlár"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Ní cheadaítear conair roghchláir a threoraíonn go fo-roghchlár"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr ""
 "E331: Ní cheadaítear míreanna roghchláir a chur le barra roghchláir go "
 "díreach"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Ní cheadaítear deighilteoir mar pháirt de chonair roghchláir"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3823,61 +4249,74 @@ msgstr ""
 "\n"
 "--- Roghchláir ---"
 
-msgid "Tear off this menu"
-msgstr "Bain an roghchlár seo"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Ní mór conair roghchláir a threorú chun mír roghchláir"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Roghchlár gan aimsiú: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Níl an roghchlár ar fáil sa mhód %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Ní mór conair roghchláir a threorú chun fo-roghchlár"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Roghchlár gan aimsiú - deimhnigh ainmneacha na roghchlár"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Earráid agus %s á phróiseáil:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "líne %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ainm neamhbhailí tabhaill: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "Cothaitheoir na dteachtaireachtaí: Kevin P. Scannell <scannell@slu.edu>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Idirbhriseadh: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Brúigh ENTER nó iontráil ordú le leanúint"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s líne %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Tuilleadh --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPÁS/d/j: scáileán/leathanach/líne síos, b/u/k: suas, q: scoir "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Ceist"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3885,6 +4324,17 @@ msgstr ""
 "&Tá\n"
 "&Níl"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Tá\n"
+"&Níl\n"
+"&Cealaigh"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3898,267 +4348,180 @@ msgstr ""
 "&Dealaigh Uile\n"
 "&Cealaigh"
 
-msgid "Select Directory dialog"
-msgstr "Dialóg `Roghnaigh Comhadlann'"
-
-msgid "Save File dialog"
-msgstr "Dialóg `Sábháil Comhad'"
-
-msgid "Open File dialog"
-msgstr "Dialóg `Oscail Comhad'"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Níl brabhsálaí comhaid ar fáil sa mhód consóil"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Easpa argóintí d'fheidhm printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Bhíothas ag súil le hargóint Snámhphointe d'fheidhm printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: An iomarca argóintí d'fheidhm printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Rabhadh: Comhad inléite amháin á athrú"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "Clóscríobh uimhir agus <Enter> nó cliceáil leis an luch (fág folamh le "
 "cealú): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Clóscríobh uimhir agus <Enter> (fág folamh le cealú): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 líne eile"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 líne níos lú"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> líne eile"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> líne níos lú"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Idirbhriste)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Bíp!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: comhaid á gcaomhnú...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Críochnaithe.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "EARRÁID: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[beart] iomlán dáilte-saor %<PRIu64>-%<PRIu64>, in úsáid %<PRIu64>, buaic %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[glaonna] re/malloc(): %<PRIu64>, free(): %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Tá an líne ag éirí rófhada"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Earráid inmheánach: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Cuimhne ídithe!  (%<PRIu64> beart á ndáileadh)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "An t-ordú seo á rith leis an bhlaosc: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Idirstad ar iarraidh"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Mód neamhcheadaithe"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Cruth neamhcheadaithe luiche"
-
-msgid "E548: digit expected"
-msgstr "E548: ag súil le digit"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Céatadán neamhcheadaithe"
-
-msgid "Enter encryption key: "
-msgstr "Iontráil eochair chriptiúcháin: "
-
-msgid "Enter same key again: "
-msgstr "Iontráil an eochair arís: "
-
-msgid "Keys don't match!"
-msgstr "Níl na heochracha comhoiriúnach le chéile!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Conair neamhbhailí: ní mór '**[uimhir]' a bheith ag deireadh na "
-"conaire, nó le '%s' ina dhiaidh."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Ní féidir comhadlann \"%s\" a aimsiú sa cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Ní féidir comhad \"%s\" a aimsiú sa chonair"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Níl comhadlann \"%s\" sa cdpath a thuilleadh"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Níl comhad \"%s\" sa chonair a thuilleadh"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Ní féidir nascadh le Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Ní féidir nascadh le Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Mód mícheart rochtana ar an chomhad eolas naisc NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "léadh ó shoicéad Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Cailleadh nasc NetBeans le haghaidh maoláin %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Níl aitheantóir faoin chúrsóir"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' folamh"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Níl an ghné Eval le fáil"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Rabhadh: ní féidir leis an teirminéal aibhsiú"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Níl teaghrán faoin chúrsóir"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Ní féidir fillteacha a léirscriosadh leis an 'foldmethod' reatha"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: tá liosta na n-athruithe folamh"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Ag tosach liosta na n-athruithe"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Ag deireadh liosta na n-athruithe"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Clóscríobh  :quit<Enter>  chun Vim a scor"
 
 # ouch - English -ed ?
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 líne %s uair amháin"
 
 # ouch - English -ed ?
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 líne %s %d uair"
 
 # ouch - English -ed ?
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> líne %sed uair amháin"
 
 # ouch - English -ed ?
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> líne %sed %d uair"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> líne le heangú... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "eangaíodh líne amháin "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> líne eangaithe "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Níl aon tabhall úsáidte roimhe seo"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "ní féidir a sracadh; scrios mar sin féin"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "athraíodh líne amháin"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "athraíodh %<PRId64> líne"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "%<PRId64> líne á saoradh"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "sracadh bloc de líne amháin"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "sracadh líne amháin"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "sracadh bloc de %<PRId64> líne"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> líne sractha"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Tabhall folamh %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4166,10 +4529,11 @@ msgstr ""
 "\n"
 "--- Tabhaill ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Ainm neamhcheadaithe tabhaill"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4177,157 +4541,185 @@ msgstr ""
 "\n"
 "# Tabhaill:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Cineál anaithnid tabhaill %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Colún; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Roghnaíodh %s%<PRId64> as %<PRId64> Líne; %<PRId64> as %<PRId64> Focal; %<PRId64> as %<PRId64> Beart"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Roghnaíodh %s%<PRId64> as %<PRId64> Líne; %<PRId64> as %<PRId64> Focal; %<PRId64> as %<PRId64> Carachtar; %<PRId64> as "
-"%<PRId64> Beart"
+"Roghnaíodh %s%<PRId64> as %<PRId64> Líne; %<PRId64> as %<PRId64> Focal; "
+"%<PRId64> as %<PRId64> Beart"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col %s as %s; Líne %<PRId64> as %<PRId64>; Focal %<PRId64> as %<PRId64>; Beart %<PRId64> as %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Col %s as %s; Líne %<PRId64> as %<PRId64>; Focal %<PRId64> as %<PRId64>; Carachtar %<PRId64> as %<PRId64>; Beart "
-"%<PRId64> as %<PRId64>"
+"Roghnaíodh %s%<PRId64> as %<PRId64> Líne; %<PRId64> as %<PRId64> Focal; "
+"%<PRId64> as %<PRId64> Carachtar; %<PRId64> as %<PRId64> Beart"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s as %s; Líne %<PRId64> as %<PRId64>; Focal %<PRId64> as %<PRId64>; "
+"Beart %<PRId64> as %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s as %s; Líne %<PRId64> as %<PRId64>; Focal %<PRId64> as %<PRId64>; "
+"Carachtar %<PRId64> as %<PRId64>; Beart %<PRId64> as %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> do BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Leathanach %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Go raibh míle maith agat as Vim a úsáid"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Rogha anaithnid"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Níl an rogha seo ar fáil"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Ní cheadaithe i módlíne"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Tá gá le huimhir i ndiaidh ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Gan aimsiú sa termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Carachtar neamhcheadaithe <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Ní féidir 'term' a shocrú mar theaghrán folamh"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Ní féidir 'term' a athrú sa GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Úsáid \":gui\" chun an GUI a chur ag obair"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: is ionann iad 'backupext' agus 'patchmode'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Ní féidir é a athrú sa GUI GTK+ 2"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Idirstad ar iarraidh"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Teaghrán folamh"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Uimhir ar iarraidh i ndiaidh <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Camóg ar iarraidh"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Caithfidh luach ' a shonrú"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: tá carachtar neamhghrafach nó leathan ann"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Cló(nna) neamhbhailí"
-
-msgid "E597: can't select fontset"
-msgstr "E597: ní féidir tacar cló a roghnú"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Tacar cló neamhbhailí"
-
-msgid "E533: can't select wide font"
-msgstr "E533: ní féidir cló leathan a roghnú"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Cló leathan neamhbhailí"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Carachtar neamhbhailí i ndiaidh <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: tá gá le camóg"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr ""
 "E537: ní mór %s a bheith i 'commentstring', is é sin nó ní mór dó a bheith "
 "folamh"
 
-msgid "E538: No mouse support"
-msgstr "E538: Gan tacaíocht luiche"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Seicheamh gan dúnadh"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: an iomarca míreanna"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: grúpaí neamhchothromaithe"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Tá fuinneog réamhamhairc ann cheana"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: Tá UTF-8 ag teastáil le haghaidh Araibise, socraigh é le ':set "
 "encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Tá gá le %d líne ar a laghad"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Tá gá le %d colún ar a laghad"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Rogha anaithnid: %s"
@@ -4335,10 +4727,12 @@ msgstr "E355: Rogha anaithnid: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Uimhir de dhíth: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4346,6 +4740,7 @@ msgstr ""
 "\n"
 "--- Cóid teirminéil ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4353,6 +4748,7 @@ msgstr ""
 "\n"
 "--- Luachanna na roghanna comhchoiteann ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4360,6 +4756,7 @@ msgstr ""
 "\n"
 "--- Luachanna na roghanna logánta ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4367,142 +4764,21 @@ msgstr ""
 "\n"
 "--- Roghanna ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: EARRÁID get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Carachtar comhoiriúnach ar iarraidh le haghaidh %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Carachtair breise i ndiaidh an idirstad: %s"
 
-msgid "cannot open "
-msgstr "ní féidir a oscailt: "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Ní féidir fuinneog a oscailt!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Tá gá le Amigados leagan 2.04 nó níos déanaí\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Tá gá le %s, leagan %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Ní féidir NIL a oscailt:\n"
-
-msgid "Cannot create "
-msgstr "Ní féidir a chruthú: "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim á scor le stádas %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "ní féidir mód consóil a athrú ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: ní consól é seo??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Ní féidir blaosc a rith le rogha -f"
-
-msgid "Cannot execute "
-msgstr "Ní féidir blaosc a rith: "
-
-msgid "shell "
-msgstr "blaosc "
-
-msgid " returned\n"
-msgstr " aisfhilleadh\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE róbheag."
-
-msgid "I/O ERROR"
-msgstr "EARRÁID I/A"
-
-msgid "Message"
-msgstr "Teachtaireacht"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "ní 80 é 'columns', ní féidir orduithe seachtracha a rith"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Theip ar roghnú printéara"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "go %s ar %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Clófhoireann anaithnid printéara: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Earráid phriontála: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "'%s' á phriontáil"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr ""
-"E244: Ainm neamhcheadaithe ar thacar carachtar \"%s\" mar pháirt d'ainm cló "
-"\"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Carachtar neamhcheadaithe '%c' mar pháirt d'ainm cló \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Comhartha dúbailte, ag scor\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Fuarthas comhartha marfach %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Fuarthas comhartha marfach\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Thóg %<PRId64> ms chun an scáileán X a oscailt"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Fuarthas earráid ó X\n"
-
-msgid "Testing the X display failed"
-msgstr "Theip ar thástáil an scáileáin X"
-
-msgid "Opening the X display timed out"
-msgstr "Oscailt an scáileáin X thar am"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Níorbh fhéidir comhthéacs slándála a fháil le haghaidh "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Níorbh fhéidir comhthéacs slándála a shocrú le haghaidh "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4510,13 +4786,7 @@ msgstr ""
 "\n"
 "Ní féidir blaosc a rith "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Ní féidir an bhlaosc sh a rith\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4524,366 +4794,472 @@ msgstr ""
 "\n"
 "d'aisfhill an bhlaosc "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Ní féidir píopaí a chruthú\n"
+"Níorbh fhéidir comhthéacs slándála a fháil le haghaidh "
 
-# "fork" not in standard refs/corpus.  Maybe want a "gabhl*" word instead? -KPS
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Ní féidir forc a dhéanamh\n"
+"Níorbh fhéidir comhthéacs slándála a shocrú le haghaidh "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Ordú críochnaithe\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "Chaill XSMP an nasc ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Theip ar oscailt an scáileáin X"
-
-msgid "XSMP handling save-yourself request"
-msgstr "Iarratas sábháil-do-féin á láimhseáil ag XSMP"
-
-msgid "XSMP opening connection"
-msgstr "Nasc á oscailt ag XSMP"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Theip ar fhaire nasc ICE XSMP"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "Theip ar XSMP SmcOpenConnection: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Níl aon fháil ar chomhad \"%s\" sa chonair"
 
-msgid "At line"
-msgstr "Ag líne"
-
-msgid "Could not load vim32.dll!"
-msgstr "Níorbh fhéidir vim32.dll a luchtú!"
-
-msgid "VIM Error"
-msgstr "Earráid VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Níorbh fhéidir pointeoirí feidhme a chóiriú i gcomhair an DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "d'aisfhill an bhlaosc %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Fuarthas teagmhas %s\n"
-
-msgid "close"
-msgstr "dún"
-
-msgid "logoff"
-msgstr "logáil amach"
-
-msgid "shutdown"
-msgstr "múchadh"
-
-msgid "E371: Command not found"
-msgstr "E371: Ní bhfuarthas an t-ordú"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"Níor aimsíodh VIMRUN.EXE i do $PATH.\n"
-"Ní mhoilleoidh orduithe seachtracha agus iad curtha i gcrích.\n"
-"Féach ar  :help win32-vimrun  chun níos mó eolas a fháil."
-
-msgid "Vim Warning"
-msgstr "Rabhadh Vim"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: An iomarca %%%c i dteaghrán formáide"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: %%%c gan choinne i dteaghrán formáide"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: ] ar iarraidh i dteaghrán formáide"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c gan tacaíocht i dteaghrán formáide"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: %%%c neamhbhailí i réimír an teaghráin formáide"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: %%%c neamhbhailí i dteaghrán formáide"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: Níl aon phatrún i 'errorformat'"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Ainm comhadlainne ar iarraidh, nó folamh"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Níl aon mhír eile"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d as %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (líne scriosta)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: In íochtar na cruaiche quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: In uachtar na cruaiche quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "liosta earráidí %d as %d; %d earráid"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Ní féidir scríobh, rogha 'buftype' socraithe"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Ainm comhaid ar iarraidh, nó patrún neamhbhailí"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Ní féidir comhad \"%s\" a oscailt"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Níl an maolán luchtaithe"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Bhíothas ag súil le Teaghrán nó Liosta"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: mír neamhbhailí i %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Slonn rófhada"
-
-msgid "E50: Too many \\z("
-msgstr "E50: an iomarca \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: an iomarca %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: \\z( corr"
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: %s%%( corr"
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: %s( corr"
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: %s) corr"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: carachtar neamhbhailí i ndiaidh %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: An iomarca %s{...} coimpléascach"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: %s* neadaithe"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: %s%c neadaithe"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: úsáid neamhbhailí de \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: níl aon rud roimh %s%c"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Cúltagairt neamhbhailí"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: ní cheadaítear \\z( anseo"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: ní cheadaítear \\z1 et al. anseo"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Carachtar neamhbhailí i ndiaidh \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: ] ar iarraidh i ndiaidh %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: %s%%[] folamh"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Carachtar neamhbhailí i ndiaidh %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Carachtar neamhbhailí i ndiaidh %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: ] ar iarraidh i ndiaidh %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: %s%%( corr"
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: %s( corr"
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: %s) corr"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: ní cheadaítear \\z( anseo"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: ní cheadaítear \\z1 et al. anseo"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: ] ar iarraidh i ndiaidh %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: %s%%[] folamh"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Slonn rófhada"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: an iomarca \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: an iomarca %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: \\z( corr"
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: carachtar neamhbhailí i ndiaidh %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: An iomarca %s{...} coimpléascach"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: %s* neadaithe"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: %s%c neadaithe"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: úsáid neamhbhailí de \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: níl aon rud roimh %s%c"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Cúltagairt neamhbhailí"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Carachtar neamhbhailí i ndiaidh \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Carachtar neamhbhailí i ndiaidh %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Carachtar neamhbhailí i ndiaidh %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Earráid chomhréire i %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Fo-mheaitseáil sheachtrach:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: an iomarca \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Ní féidir comhad sealadach a aimsiú chun scríobh ann"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-IONADAIGH"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ATHCHUR"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " TIONTÚ"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " IONSÁ"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (ionsáigh)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (ionadaigh)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-ionadaigh)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Eabhrais"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Araibis"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (teanga)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (greamaigh)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " RADHARCACH"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " LÍNE RADHARCACH"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " BLOC RADHARCACH"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ROGHNÚ"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " SELECT LINE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " SELECT BLOCK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "á thaifeadadh"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Teaghrán cuardaigh neamhbhailí: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: bhuail an cuardach an BARR gan teaghrán comhoiriúnach le %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: bhuail an cuardach an BUN gan teaghrán comhoiriúnach le %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Ag súil le '?' nó '/'  i ndiaidh ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (tá an teaghrán comhoiriúnaithe roimhe seo san áireamh)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Comhaid cheanntáisc "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "gan aimsiú"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "i gconair ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Liostaithe cheana féin)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  AR IARRAIDH"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Comhad ceanntáisc á scanadh: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Comhad ceanntáisc %s á chuardach"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Tá an teaghrán comhoiriúnaithe ar an líne reatha"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Aimsíodh gach comhad ceanntáisc"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Gan comhaid cheanntáisc"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Sainmhíniú gan aimsiú"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Patrún gan aimsiú"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Ionadú "
 
 # in .viminfo
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4894,81 +5270,98 @@ msgstr ""
 "# %sPatrún Cuardaigh Is Déanaí:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Earráid fhormáide i gcomhad litrithe"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Comhad teasctha litrithe"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Téacs chun deiridh i %s líne %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Ainm foircinn rófhada i %s líne %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Earráid fhormáide i gcomhad foircinn FOL, LOW, nó UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Carachtar i FOL, LOW nó UPP as raon"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Crann focal á chomhbhrú..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Níl seiceáil litrithe cumasaithe"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Rabhadh: Ní féidir liosta focal \"%s.%s.spl\" nó \"%s.ascii.spl\" a aimsiú"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Comhad litrithe \"%s\" á léamh"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Níl sé cosúil le comhad litrithe"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Seanchomhad litrithe, tá gá lena nuashonrú"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Oibríonn an comhad litrithe le leagan níos nuaí de Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Rannán gan tacaíocht i gcomhad litrithe"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Rabhadh: réigiún %s gan tacaíocht"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Comhad foircinn %s á léamh..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Theip ar thiontú focail i %s líne %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Tiontú i %s gan tacaíocht: ó %s go %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Tiontú i %s gan tacaíocht"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Luach neamhbhailí ar FLAG i %s líne %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG i ndiaidh bratacha in úsáid i %s líne %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -4977,6 +5370,7 @@ msgstr ""
 "Seans go bhfaighfidh tú torthaí míchearta má chuireann tú COMPOUNDFORBIDFLAG "
 "tar éis míre PFX i %s líne %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -4985,34 +5379,42 @@ msgstr ""
 "Seans go bhfaighfidh tú torthaí míchearta má chuireann tú COMPOUNDPERMITFLAG "
 "tar éis míre PFX i %s líne %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Luach mícheart ar COMPOUNDRULES i %s líne %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Luach mícheart ar COMPOUNDWORDMAX i %s líne %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Luach mícheart ar COMPOUNDMIN i %s líne %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Luach mícheart ar COMPOUNDSYLMAX i %s líne %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Luach mícheart ar CHECKCOMPOUNDPATTERN i %s líne %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "Bratach dhifriúil cheangail i mbloc leanta foircinn i %s líne %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Clib dhúblach i %s líne %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5021,268 +5423,335 @@ msgstr ""
 "Foirceann in úsáid le haghaidh BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
 "NOSUGGEST freisin i %s líne %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Bhíothas ag súil le `Y' nó `N' i %s líne %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Coinníoll briste i %s líne %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Bhíothas ag súil le líon na REP(SAL) i %s líne %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Bhíothas ag súil le líon na MAP i %s líne %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Carachtar dúblach i MAP i %s líne %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Mír anaithnid nó dhúblach i %s líne %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Líne FOL/LOW/UPP ar iarraidh i %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX in úsáid gan SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "An iomarca réimíreanna curtha siar"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "An iomarca bratach comhfhocail"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "An iomarca réimíreanna curtha siar agus/nó bratacha comhfhocal"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Líne SOFO%s ar iarraidh i %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Línte SAL agus SOFO araon i %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Ní uimhir í an bhratach i %s líne %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Bratach neamhcheadaithe i %s líne %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Tá difear idir luach %s agus an luach i gcomhad .aff eile"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Foclóir %s á léamh ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Líon na bhfocal ar iarraidh i %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "líne %6d, focal %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Focal dúblach i %s líne %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "An chéad fhocal dúblach i %s líne %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d focal dúblach i %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Rinneadh neamhshuim ar %d focal le carachtair neamh-ASCII i %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Comhad focail %s á léamh ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Rinneadh neamhshuim ar líne dhúblach `/encoding=' i %s líne %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr ""
 "Rinneadh neamhshuim ar líne `/encoding=' i ndiaidh focail i %s líne %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Rinneadh neamhshuim ar líne `/regions=' i %s líne %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "An iomarca réigiún i %s líne %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Rinneadh neamhshuim ar líne `/' i %s líne %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Uimhir neamhbhailí réigiúin i %s líne %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Bratacha anaithnide i %s líne %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Rinneadh neamhshuim ar %d focal le carachtair neamh-ASCII"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Comhbhrúdh %d as %d nód; %d (%d%%) fágtha"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Comhad litrithe á léamh arís..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Fuaimfhilleadh..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Líon na bhfocal tar éis fuaimfhillte: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Líon iomlán na bhfocal: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Comhad moltaí %s á scríobh ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Cuimhne measta a bheith in úsáid le linn rite: %d beart"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Ní cheadaítear ainm réigiúin in ainm an aschomhaid"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Ní thacaítear le níos mó ná 8 réigiún"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Réigiún neamhbhailí i %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Rabhadh: sonraíodh comhfhocail agus NOBREAK araon"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Comhad litrithe %s á scríobh ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Críochnaithe!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: níl %<PRId64> iontráil i 'spellfile'"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Baineadh focal ó %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Cuireadh focal le %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Tá carachtair dhifriúla fhocail sna comhaid litrithe"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Tá brón orm, níl aon mholadh ann"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Tá brón orm, níl ach %<PRId64> moladh ann"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Athraigh \"%.*s\" go:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Níl aon ionadaí litrithe roimhe seo"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Gan aimsiú: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Níl sé cosúil le comhad .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Seanchomhad .sug, tá gá lena nuashonrú: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Oibríonn an comhad .sug le leagan níos nuaí de Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Níl an comhad .sug comhoiriúnach leis an gcomhad .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: earráid agus comhad .sug á léamh: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: carachtar dúblach in iontráil MAP"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Níl aon mhír chomhréire sainmhínithe le haghaidh an mhaoláin seo"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Argóint neamhcheadaithe: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Níl a leithéid de mhogall comhréire: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Níl aon mhír chomhréire sainmhínithe le haghaidh an mhaoláin seo"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "ag sioncrónú ar nóta den nós C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "gan sioncrónú"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "tosaíonn an sioncrónú "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " línte roimh an bharr"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5290,6 +5759,7 @@ msgstr ""
 "\n"
 "--- Míreanna Comhréire Sionc ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5297,6 +5767,7 @@ msgstr ""
 "\n"
 "ag sioncrónú ar mhíreanna"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5304,199 +5775,275 @@ msgstr ""
 "\n"
 "--- Míreanna comhréire ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Níl a leithéid de mhogall comhréire: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "íosta "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "uasta "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; meaitseáil "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " bristeacha líne"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: tá argóint ann nach nglactar leis anseo"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: ní ghlactar leis an argóint containedin anseo"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Argóint neamhbhailí"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: ní ghlactar le group[t]here anseo"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Níor aimsíodh mír réigiúin le haghaidh %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Tá gá le hainm comhaid"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: An iomarca ainmneacha comhaid"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' ar iarraidh: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' ar iarraidh: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Níl go leor argóintí ann: réigiún comhréire %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Níl a leithéid de mhogall comhréire: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Níor sonraíodh mogall"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Teormharcóir patrúin gan aimsiú: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Dramhaíl i ndiaidh patrúin: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: comhréir sionc: tugadh patrún leanúint líne faoi dhó"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Argóintí neamhcheadaithe: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Sín chothroime ar iarraidh: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Argóint fholamh: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: ní cheadaítear %s anseo"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: ní foláir %s a thabhairt ar dtús sa liosta `contains'"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Ainm anaithnid grúpa: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Fo-ordú neamhbhailí :syntax: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: lúb athchúrsach agus syncolor.vim á luchtú"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Grúpa aibhsithe gan aimsiú: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Easpa argóintí: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: An iomarca argóintí: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr ""
 "E414: tá socruithe ag an ghrúpa, ag déanamh neamhshuim ar nasc aibhsithe"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: sín chothroime gan choinne: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: sín chothroime ar iarraidh: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: argóint ar iarraidh: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Luach neamhcheadaithe: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Dath anaithnid an chúlra"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Dath anaithnid an tulra"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Níor aithníodh ainm/uimhir an datha: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: cód teirminéil rófhada: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Argóint neamhcheadaithe: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: An iomarca tréithe aibhsithe in úsáid"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Carachtar neamhghrafach in ainm grúpa"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Carachtar neamhbhailí in ainm grúpa"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: in íochtar na cruaiche clibeanna"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: in uachtar na cruaiche clibeanna"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Ní féidir a dhul roimh an chéad chlib chomhoiriúnach"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: clib gan aimsiú: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # tos cin clib"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "comhad\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Tá aon chlib chomhoiriúnach amháin"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Ní féidir a dhul thar an chlib chomhoiriúnach deireanach"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Níl a leithéid de chomhad \"%s\" ann"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "clib %d as %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " nó os a chionn"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Ag úsáid clib le cás eile!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Níl a leithéid de chomhad \"%s\""
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5504,62 +6051,79 @@ msgstr ""
 "\n"
 "  # Go clib        Ó    líne  i  gcomhad/téacs"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Comhad clibeanna %s á chuardach"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Teascadh conair an chomhaid clibeanna le haghaidh %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr "Ag déanamh neamhaird de líne fhada sa chomhad clibeanna"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Earráid fhormáide i gcomhad clibeanna \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Roimh bheart %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Comhad clibeanna gan sórtáil: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Níl aon chomhad clibeanna"
 
-msgid "Ignoring long line in tags file"
-msgstr "Ag déanamh neamhaird de líne fhada sa chomhad clibeanna"
-
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Patrún clibe gan aimsiú"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Clib gan aimsiú, ag tabhairt buille faoi thuairim!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Clib dhúblach i %s líne %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' anaithnid. Is iad seo na teirminéil insuite:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "réamhshocrú = '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Ní féidir an comhad termcap a oscailt"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Iontráil teirminéil gan aimsiú sa terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Iontráil teirminéil gan aimsiú sa termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Níl aon iontráil \"%s\" sa termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: tá gá leis an chumas teirminéil \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5567,178 +6131,169 @@ msgstr ""
 "\n"
 "--- Eochracha teirminéil ---"
 
-msgid "new shell started\n"
-msgstr "tosaíodh blaosc nua\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Earráid agus an t-inchomhad á léamh; ag scor...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Úsáideadh CUT_BUFFER0 in ionad roghnúcháin folaimh"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: Athraíodh an maolán gan choinne"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Ní féidir a chealú; lean ar aghaidh mar sin féin"
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Ní féidir comhad a oscailt chun scríobh ann"
 
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Comhad viminfo \"%s\" á scríobh"
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Earráid sa scríobh i gcomhad babhtála"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Comhad focail %s á léamh ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Ní féidir an comhad viminfo a oscailt chun léamh"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Gan aimsiú: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Ní féidir comhad %s a oscailt"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "deireadh ag foinsiú %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Ag an athrú is sine cheana"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Ag an athrú is nuaí cheana"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "Níor aimsíodh cealú uimhir a %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: líne-uimhreacha míchearta"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "líne eile"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "líne eile"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "líne níos lú"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "líne níos lú"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "athrú"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "athrú"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "roimh"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "tar éis"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Níl faic le cealú"
 
-# columns?
-msgid "number changes  time"
-msgstr "uimhir athruithe  am"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> soicind ó shin"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: ní cheadaítear \"undojoin\" tar éis \"undo\""
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: tá an liosta cealaithe truaillithe"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: líne chealaithe ar iarraidh"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Leagan GUI 16/32 giotán MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Leagan GUI 64 giotán MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Leagan GUI 32 giotán MS-Windows"
-
-msgid " in Win32s mode"
-msgstr " i mód Win32s"
-
-msgid " with OLE support"
-msgstr " le tacaíocht OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Leagan consóil 64 giotán MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Leagan consóil 32 giotán MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Leagan 16 giotán MS-Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Leagan 32 giotán MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Leagan 16 giotán MS-DOS"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Leagan MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Leagan MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Leagan MacOS"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"Leagan RISC OS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Leagan OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5746,6 +6301,7 @@ msgstr ""
 "\n"
 "Paistí san áireamh: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5753,9 +6309,11 @@ msgstr ""
 "\n"
 "Paistí sa bhreis: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Mionathraithe ag "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5764,9 +6322,11 @@ msgstr ""
 "Tiomsaithe "
 
 # with "Tiomsaithe"
+#: ../version.c:649
 msgid "by "
 msgstr "ag "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5774,625 +6334,1691 @@ msgstr ""
 "\n"
 "Leagan ollmhór "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Leagan mór "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Leagan coitianta "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Leagan beag "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Leagan beag bídeach "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "gan GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "le GUI GTK2-GNOME."
-
-msgid "with GTK-GNOME GUI."
-msgstr "le GUI GTK-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "le GUI GTK2."
-
-msgid "with GTK GUI."
-msgstr "le GUI GTK."
-
-msgid "with X11-Motif GUI."
-msgstr "le GUI X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "le GUI X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "le GUI X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "le GUI Photon."
-
-msgid "with GUI."
-msgstr "le GUI."
-
-msgid "with Carbon GUI."
-msgstr "le GUI Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "le GUI Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "le GUI (clasaiceach)."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Gnéithe san áireamh (+) nó nach bhfuil (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   comhad vimrc an chórais: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     comhad vimrc úsáideora: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " dara comhad vimrc úsáideora: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " tríú comhad vimrc úsáideora: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      comhad exrc úsáideora: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  dara comhad úsáideora exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  comhad gvimrc córais: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    comhad gvimrc úsáideora: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "dara comhad gvimrc úsáideora: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "tríú comhad gvimrc úsáideora: \""
-
-msgid "    system menu file: \""
-msgstr "    comhad roghchláir an chórais: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  rogha thánaisteach do $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " f-b do $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Tiomsú: "
 
-msgid "Compiler: "
-msgstr "Tiomsaitheoir: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Nascáil: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  LEAGAN DÍFHABHTAITHE"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "leagan "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "le Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Is saorbhogearra é Vim"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Tabhair cabhair do pháistí bochta in Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "clóscríobh  :help iccf<Enter>       chun eolas a fháil "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "clóscríobh  :q<Enter>               chun scoir      "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "clóscríobh  :help<Enter>  nó  <F1>  le haghaidh cabhrach ar líne"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "clóscríobh  :help version7<Enter>   le haghaidh eolais faoin leagan"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Sa mhód comhoiriúnachta Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr ""
 "clóscríobh  :set nocp<Enter>        chun na réamhshocruithe Vim a thaispeáint"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr ""
 "clóscríobh  :help cp-default<Enter> chun níos mó eolas faoi seo a fháil"
 
-# don't see where to localize "Help->Orphans"? --kps
-msgid "menu  Help->Orphans           for information    "
-msgstr "roghchlár  Help->Orphans      chun eolas a fháil "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Á rith gan mhóid, ag ionsá an téacs atá iontráilte"
-
-# same problem --kps
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "roghchlár  Edit->Global Settings->Toggle Insert Mode  "
-
-msgid "                              for two modes      "
-msgstr "                              do dhá mhód       "
-
-# same problem --kps
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "roghchlár  Edit->Global Settings->Toggle Vi Compatible"
-
-msgid "                              for Vim defaults   "
-msgstr "                              le haghaidh réamhshocruithe Vim   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Bí i d'urraitheoir Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Bí i d'úsáideoir cláraithe Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "clóscríobh  :help sponsor<Enter>        chun eolas a fháil "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "clóscríobh  :help register<Enter>       chun eolas a fháil "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "roghchlár  Help->Sponsor/Register       chun eolas a fháil "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "RABHADH: Braitheadh Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "clóscríobh  :help windows95<Enter>      chun eolas a fháil "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Níl ach aon fhuinneog amháin ann cheana"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Níl aon fhuinneog réamhamhairc ann"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Ní féidir a scoilteadh topleft agus botright san am céanna"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Ní féidir rothlú nuair atá fuinneog eile scoilte"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Ní féidir an fhuinneog dheiridh a dhúnadh"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Ní féidir fuinneog autocmd a dhúnadh"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
-msgstr "E814: Ní féidir an fhuinneog a dhúnadh, ní bheadh ach fuinneog autocmd fágtha"
+msgstr ""
+"E814: Ní féidir an fhuinneog a dhúnadh, ní bheadh ach fuinneog autocmd fágtha"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Tá athruithe ann san fhuinneog eile"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Níl ainm comhaid faoin chúrsóir"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Níl aon fháil ar chomhad \"%s\" sa chonair"
+#~ msgid "Patch file"
+#~ msgstr "Comhad paiste"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Níorbh fhéidir an leabharlann %s a oscailt"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Cealaigh"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Tá brón orm, níl an t-ordú seo le fáil: níorbh fhéidir an leabharlann Perl a "
-"luchtú."
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Níl aon nasc le freastalaí Vim"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Ní cheadaítear luacháil Perl i mbosca gainimh gan an modúl Safe"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Ní féidir aon rud a sheoladh chuig %s"
 
-msgid "Edit with &multiple Vims"
-msgstr "Cuir in eagar le Vimeanna io&madúla"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Ní féidir freagra ón fhreastalaí a léamh"
 
-msgid "Edit with single &Vim"
-msgstr "Cuir in eagar le &Vim aonair"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Ní féidir aon rud a sheoladh chuig an chliant"
 
-msgid "Diff with Vim"
-msgstr "Diff le Vim"
+#~ msgid "Save As"
+#~ msgstr "Sábháil Mar"
 
-msgid "Edit with &Vim"
-msgstr "Cuir in Eagar le &Vim"
+#~ msgid "Edit File"
+#~ msgstr "Cuir Comhad in Eagar"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Cuir in Eagar le Vim beo - "
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (AR IARRAIDH)"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Cuir an comhad roghnaithe in eagar le Vim"
+#~ msgid "Source Vim script"
+#~ msgstr "Foinsigh script Vim"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr ""
-"Earráid agus próiseas á chruthú: Deimhnigh go bhfuil gvim i do chonair!"
+#~ msgid "Edit File in new window"
+#~ msgstr "Cuir comhad in eagar i bhfuinneog nua"
 
-msgid "gvimext.dll error"
-msgstr "earráid gvimext.dll"
+#~ msgid "Append File"
+#~ msgstr "Cuir Comhad i nDeireadh"
 
-msgid "Path length too long!"
-msgstr "Conair rófhada!"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Ionad na fuinneoige: X %d, Y %d"
 
-msgid "--No lines in buffer--"
-msgstr "--Tá an maolán folamh--"
+#~ msgid "Save Redirection"
+#~ msgstr "Sábháil Atreorú"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Ordú tobscortha"
+#~ msgid "Save View"
+#~ msgstr "Sábháil an tAmharc"
 
-msgid "E471: Argument required"
-msgstr "E471: Tá gá le hargóint"
+#~ msgid "Save Session"
+#~ msgstr "Sábháil an Seisiún"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: Ba chóir /, ? nó & a chur i ndiaidh \\"
+#~ msgid "Save Setup"
+#~ msgstr "Sábháil an Socrú"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Neamhbhailí i bhfuinneog líne na n-orduithe; <CR>=rith, CTRL-C=scoir"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: níl #< ar fáil gan ghné +eval"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Ní cheadaítear ordú ó exrc/vimrc sa chomhadlann reatha ná ó chuardach "
-"clibe"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Ní cheadaítear déghraif sa leagan seo"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif ar iarraidh"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "is gléas é seo (díchumasaithe le rogha 'opendevice')"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry ar iarraidh"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Ag léamh ón ionchur caighdeánach..."
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile ar iarraidh"
+#~ msgid "[crypted]"
+#~ msgstr "[criptithe]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor ar iarraidh"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "Ní cheadaíonn NetBeans maoláin gan athrú a bheith scríofa"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile gan :while"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Ní cheadaítear maoláin NetBeans a bheith scríofa go neamhiomlán"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor gan :for"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "díchumasaíodh scríobh chuig gléas le rogha 'opendevice'"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Tá comhad ann cheana (cuir ! leis an ordú chun forscríobh)"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Chaillfí an forc acmhainne (cuir ! leis an ordú chun sárú)"
 
-msgid "E472: Command failed"
-msgstr "E472: Theip ar ordú"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Ní féidir an GUI a chur ag obair"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Tacar cló anaithnid: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Ní féidir léamh ó \"%s\""
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Clófhoireann anaithnid: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Ní féidir an GUI a chur ag obair, níl aon chlófhoireann bhailí ann"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Ní cló aonleithid é \"%s\""
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' neamhbhailí"
 
-msgid "E473: Internal error"
-msgstr "E473: Earráid inmheánach"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Luach neamhbhailí ar 'imactivatekey'"
 
-msgid "Interrupted"
-msgstr "Idirbhriste"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Ní féidir dath %s a dháileadh"
 
-msgid "E14: Invalid address"
-msgstr "E14: Drochsheoladh"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Níl a leithéid ag an chúrsóir, ag cuardach ar an chéad cheann eile"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Argóint neamhbhailí"
+#~ msgid "<cannot open> "
+#~ msgstr "<ní féidir a oscailt> "
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Argóint neamhbhailí: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: níl aon fháil ar an chlófhoireann %s"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Slonn neamhbhailí: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr ""
+#~ "E614: vim_SelFile: ní féidir dul ar ais go dtí an chomhadlann reatha"
 
-msgid "E16: Invalid range"
-msgstr "E16: Raon neamhbhailí"
+#~ msgid "Pathname:"
+#~ msgstr "Conair:"
 
-msgid "E476: Invalid command"
-msgstr "E476: Ordú neamhbhailí"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: níl an chomhadlann reatha ar fáil"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: is comhadlann \"%s\""
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Theip ar ghlao leabharlainne \"%s()\""
+#~ msgid "Cancel"
+#~ msgstr "Cealaigh"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Ní féidir feidhm %s leabharlainne a luchtú"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Giuirléid Scrollbharra: Ní féidir céimseata an mhapa picteilíní a fháil."
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Tá líne-uimhir neamhbhailí ag an mharc"
+#~ msgid "Vim dialog"
+#~ msgstr "Dialóg Vim"
 
-msgid "E20: Mark not set"
-msgstr "E20: Marc gan socrú"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: Ní féidir BalloonEval a chruthú le teachtaireacht agus aisghlaoch "
+#~ "araon"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr ""
-"E21: Ní féidir athruithe a chur i bhfeidhm, níl an bhratach 'modifiable' "
-"socraithe"
+#~ msgid "Vim dialog..."
+#~ msgstr "Dialóg Vim..."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: scripteanna neadaithe ródhomhain"
+#~ msgid "Input _Methods"
+#~ msgstr "_Modhanna ionchuir"
 
-msgid "E23: No alternate file"
-msgstr "E23: Níl aon chomhad malartach"
+# in OLT --KPS
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Cuardaigh agus Athchuir..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Níl a leithéid de ghiorrúchán ann"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Cuardaigh..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: Ní cheadaítear !"
+#~ msgid "Find what:"
+#~ msgstr "Aimsigh:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Ní féidir an GUI a úsáid: Níor cumasaíodh é ag am tiomsaithe"
+#~ msgid "Replace with:"
+#~ msgstr "Le cur in ionad:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E26: Níl tacaíocht Eabhraise ar fáil: Níor cumasaíodh é ag am tiomsaithe\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Focal iomlán amháin"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E27: Níl tacaíocht Pheirsise ar fáil: Níor cumasaíodh é ag am tiomsaithe\n"
+#~ msgid "Match case"
+#~ msgstr "Meaitseáil an cás"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E800: Níl tacaíocht Araibise ar fáil: Níor cumasaíodh é ag am tiomsaithe\n"
+#~ msgid "Direction"
+#~ msgstr "Treo"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Níl a leithéid d'ainm grúpa aibhsithe: %s"
+#~ msgid "Up"
+#~ msgstr "Suas"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Níl aon téacs ionsáite go dtí seo"
+#~ msgid "Down"
+#~ msgstr "Síos"
 
-msgid "E30: No previous command line"
-msgstr "E30: Níl aon líne na n-orduithe roimhe seo"
+#~ msgid "Find Next"
+#~ msgstr "An Chéad Cheann Eile"
 
-msgid "E31: No such mapping"
-msgstr "E31: Níl a leithéid de mhapáil"
+#~ msgid "Replace"
+#~ msgstr "Ionadaigh"
 
-msgid "E479: No match"
-msgstr "E479: Níl aon rud comhoiriúnach ann"
+#~ msgid "Replace All"
+#~ msgstr "Ionadaigh Uile"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Níl aon rud comhoiriúnach ann: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Fuarthas iarratas \"die\" ó bhainisteoir an tseisiúin\n"
 
-msgid "E32: No file name"
-msgstr "E32: Níl aon ainm comhaid"
+#~ msgid "Close"
+#~ msgstr "Dún"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Níl aon slonn ionadaíochta roimhe seo"
+#~ msgid "New tab"
+#~ msgstr "Cluaisín nua"
 
-msgid "E34: No previous command"
-msgstr "E34: Níl aon ordú roimhe seo"
+#~ msgid "Open Tab..."
+#~ msgstr "Oscail Cluaisín..."
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Níl aon slonn ionadaíochta roimhe seo"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Milleadh an príomhfhuinneog gan choinne\n"
 
-msgid "E481: No range allowed"
-msgstr "E481: Ní cheadaítear raon"
+#~ msgid "Font Selection"
+#~ msgstr "Roghnú Cló"
 
-msgid "E36: Not enough room"
-msgstr "E36: Níl slí a dhóthain ann"
+#~ msgid "&Filter"
+#~ msgstr "&Scagaire"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: níl aon fhreastalaí cláraithe leis an ainm \"%s\""
+#~ msgid "&Cancel"
+#~ msgstr "&Cealaigh"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Ní féidir comhad %s a chruthú"
+#~ msgid "Directories"
+#~ msgstr "Comhadlanna"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Níl aon fháil ar ainm comhaid sealadach"
+#~ msgid "Filter"
+#~ msgstr "Scagaire"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Ní féidir comhad %s a oscailt"
+#~ msgid "&Help"
+#~ msgstr "&Cabhair"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Ní féidir comhad %s a léamh"
+#~ msgid "Files"
+#~ msgstr "Comhaid"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Tá athruithe ann gan sábháil (cuir ! leis an ordú chun sárú)"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E38: Null argument"
-msgstr "E38: Argóint nialasach"
+#~ msgid "Selection"
+#~ msgstr "Roghnú"
 
-msgid "E39: Number expected"
-msgstr "E39: Ag súil le huimhir"
+#~ msgid "Find &Next"
+#~ msgstr "An Chéad Chea&nn Eile"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Ní féidir an comhad earráide %s a oscailt"
+#~ msgid "&Replace"
+#~ msgstr "&Ionadaigh"
 
-msgid "E233: cannot open display"
-msgstr "E233: ní féidir an scáileán a oscailt"
+#~ msgid "Replace &All"
+#~ msgstr "Ionadaigh &Uile"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Cuimhne ídithe!"
+#~ msgid "&Undo"
+#~ msgstr "&Cealaigh"
 
-msgid "Pattern not found"
-msgstr "Patrún gan aimsiú"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Ní féidir teideal na fuinneoige \"%s\" a aimsiú"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Patrún gan aimsiú: %s"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argóint gan tacaíocht: \"-%s\"; Bain úsáid as an leagan OLE."
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Ní foláir argóint dheimhneach"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Ní féidir fuinneog a oscailt isteach i bhfeidhmchlár MDI"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Ní féidir a fhilleadh ar an chomhadlann roimhe seo"
+#~ msgid "Close tab"
+#~ msgstr "Dún cluaisín"
 
-msgid "E42: No Errors"
-msgstr "E42: Níl Aon Earráid Ann"
+#~ msgid "Open tab..."
+#~ msgstr "Oscail cluaisín..."
 
-msgid "E776: No location list"
-msgstr "E776: Gan liosta suíomh"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Aimsigh teaghrán (bain úsáid as '\\\\' chun '\\' a aimsiú)"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Teaghrán cuardaigh loite"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Aimsigh & Athchuir (úsáid '\\\\' chun '\\' a aimsiú)"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Clár na sloinn ionadaíochta truaillithe"
+#~ msgid "Not Used"
+#~ msgstr "Gan Úsáid"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: tá an rogha 'readonly' socraithe (cuir ! leis an ordú chun sárú)"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Comhadlann\t*.neamhní\n"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Ní féidir athróg inléite amháin \"%s\" a athrú"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Ní féidir iontráil dathmhapála a dháileadh, is féidir go mbeidh "
+#~ "dathanna míchearta ann"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Ní féidir athróg a shocrú sa bhosca gainimh: \"%s\""
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Clónna ar iarraidh le haghaidh na dtacar carachtar i dtacar cló %s:"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Earráid agus comhad earráide á léamh"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Ainm an tacar cló: %s"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Ní cheadaítear é seo i mbosca gainimh"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Ní cló aonleithid é '%s'"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Ní cheadaítear é anseo"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Ainm an tacar cló: %s\n"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Ní féidir an mód scáileáin a shocrú"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Cló0: %s\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Méid neamhbhailí scrollaithe"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Cló1: %s\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: rogha 'shell' folamh"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Níl Cló%<PRId64> níos leithne faoi dhó ná cló0\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Níorbh fhéidir na sonraí comhartha a léamh!"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Leithead Cló0: %<PRId64>\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Earráid agus comhad babhtála á dhúnadh"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Leithead Cló1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: tá cruach na gclibeanna folamh"
+#~ msgid "Invalid font specification"
+#~ msgstr "Sonrú neamhbhailí cló"
 
-msgid "E74: Command too complex"
-msgstr "E74: Ordú róchasta"
+#~ msgid "&Dismiss"
+#~ msgstr "&Ruaig"
 
-msgid "E75: Name too long"
-msgstr "E75: Ainm rófhada"
+#~ msgid "no specific match"
+#~ msgstr "níl a leithéid ann"
 
-msgid "E76: Too many ["
-msgstr "E76: an iomarca ["
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Roghnú Cló"
 
-msgid "E77: Too many file names"
-msgstr "E77: An iomarca ainmneacha comhaid"
+#~ msgid "Name:"
+#~ msgstr "Ainm:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Carachtair chun deiridh"
+#~ msgid "Show size in Points"
+#~ msgstr "Taispeáin méid (Pointí)"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Marc anaithnid"
+#~ msgid "Encoding:"
+#~ msgstr "Ionchódú:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Ní féidir saoróga a leathnú"
+#~ msgid "Font:"
+#~ msgstr "Cló:"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: ní cheadaítear 'winheight' a bheith níos lú ná 'winminheight'"
+#~ msgid "Style:"
+#~ msgstr "Stíl:"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: ní cheadaítear 'winwidth' a bheith níos lú ná 'winminwidth'"
+#~ msgid "Size:"
+#~ msgstr "Méid:"
 
-msgid "E80: Error while writing"
-msgstr "E80: Earráid agus á scríobh"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: EARRÁID leis na huathoibreáin Hangul"
 
-msgid "Zero count"
-msgstr "Nialas"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: earráid stat"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> á úsáid nach i gcomhthéacs scripte"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: ní féidir bunachar sonraí cscope a oscailt: %s"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Fuarthas slonn neamhbhailí"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: ní féidir eolas a fháil faoin bhunachar sonraí cscope"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Réigiún cosanta, ní féidir é a athrú"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Tá brón orm, bhí an t-ordú seo díchumasaithe, níorbh fhéidir "
+#~ "leabharlanna MzScheme a luchtú."
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: Ní cheadaíonn NetBeans aon athrú i gcomhaid inléite amháin"
+#~ msgid "invalid expression"
+#~ msgstr "slonn neamhbhailí"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Earráid inmheánach: %s"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "díchumasaíodh sloinn ag am an tiomsaithe"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: úsáideann an patrún níos mó cuimhne ná 'maxmempattern'"
+#~ msgid "hidden option"
+#~ msgstr "rogha fholaithe"
 
-msgid "E749: empty buffer"
-msgstr "E749: maolán folamh"
+#~ msgid "unknown option"
+#~ msgstr "rogha anaithnid"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Patrún nó teormharcóir neamhbhailí cuardaigh"
+#~ msgid "window index is out of range"
+#~ msgstr "innéacs fuinneoige as raon"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Tá an comhad luchtaithe i maolán eile"
+#~ msgid "couldn't open buffer"
+#~ msgstr "ní féidir maolán a oscailt"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Rogha '%s' gan socrú"
+#~ msgid "cannot save undo information"
+#~ msgstr "ní féidir eolas cealaithe a shábháil"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Buaileadh an BARR le linn an chuardaigh, ag leanúint ag an CHRÍOCH"
+#~ msgid "cannot delete line"
+#~ msgstr "ní féidir an líne a scriosadh"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Buaileadh an BUN le linn an chuardaigh, ag leanúint ag an BHARR"
+#~ msgid "cannot replace line"
+#~ msgstr "ní féidir an líne a athchur"
+
+#~ msgid "cannot insert line"
+#~ msgstr "ní féidir líne a ionsá"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "ní cheadaítear carachtair líne nua sa teaghrán"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "earráid Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "earráid Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "maolán neamhbhailí"
+
+#~ msgid "window is invalid"
+#~ msgstr "fuinneog neamhbhailí"
+
+#~ msgid "linenr out of range"
+#~ msgstr "líne-uimhir as raon"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "ní cheadaítear é seo i mbosca gainimh Vim"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Tá brón orm, níl an t-ordú seo le fáil, níorbh fhéidir an "
+#~ "leabharlann Python a luchtú."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Ní féidir Python a rith go hathchúrsach"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "ní féidir tréithe OutputObject a scriosadh"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "caithfidh softspace a bheith ina shlánuimhir"
+
+#~ msgid "invalid attribute"
+#~ msgstr "aitreabúid neamhbhailí"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "liosta teaghrán ag teastáil ó writelines()"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Earráid agus réada I/A á dtúsú"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "rinneadh iarracht ar mhaolán scriosta a rochtain"
+
+#~ msgid "line number out of range"
+#~ msgstr "líne-uimhir as raon"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<réad maoláin (scriosta) ag %p>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "ainm neamhbhailí mairc"
+
+#~ msgid "no such buffer"
+#~ msgstr "níl a leithéid de mhaolán ann"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "rinneadh iarracht ar fhuinneog scriosta a rochtain"
+
+#~ msgid "readonly attribute"
+#~ msgstr "tréith inléite amháin"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "cúrsóir taobh amuigh den mhaolán"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<réad fuinneoige (scriosta) ag %p>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<réad fuinneoige (anaithnid) ag %p>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<fuinneog %d>"
+
+#~ msgid "no such window"
+#~ msgstr "níl a leithéid d'fhuinneog ann"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: caithfidh $_ a bheith cineál Teaghráin"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Tá brón orm, níl an t-ordú seo le fáil, níorbh fhéidir an "
+#~ "leabharlann Ruby a luchtú."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: \"return\" gan choinne"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: \"next\" gan choinne"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: \"break\" gan choinne"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: \"redo\" gan choinne"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: \"retry\" taobh amuigh de chlásal tarrthála"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: eisceacht gan láimhseáil"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: stádas anaithnid longjmp %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Scoránaigh feidhmiú/sainmhíniú"
+
+#~ msgid "Show base class of"
+#~ msgstr "Taispeáin an bunaicme de"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Taispeáin ballfheidhm sáraithe"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Aisghabh ó chomhad"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Aisghabh ó thionscadal"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Aisghabh ó gach tionscadal"
+
+#~ msgid "Retrieve"
+#~ msgstr "Aisghabh"
+
+#~ msgid "Show source of"
+#~ msgstr "Taispeáin foinse"
+
+#~ msgid "Find symbol"
+#~ msgstr "Aimsigh siombail"
+
+#~ msgid "Browse class"
+#~ msgstr "Brabhsáil aicme"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Taispeáin an aicme in ordlathas"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Taispeáin an aicme in ordlathas srianta"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Tagraíonn Xref do"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref tagartha ag"
+
+#~ msgid "Xref has a"
+#~ msgstr "Rud atá ag Xref:"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref á úsáid ag"
+
+#~ msgid "Show docu of"
+#~ msgstr "Taispeáin eolas faoi"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Gin eolas faoi"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Ní féidir nasc a dhéanamh le SNiFF+. Seiceáil do chuid athróga "
+#~ "thimpeallachta (caithfidh tú sniffemacs a chur i do $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Earráid sa léamh. Dínasctha"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ stádas faoi láthair: "
+
+#~ msgid "not "
+#~ msgstr "ní "
+
+#~ msgid "connected"
+#~ msgstr "nasctha"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Iarratas anaithnid SNiFF+: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Earráid ag nascadh le SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ gan nasc"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ní maolán SNiFF+ é"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Earráid sa scríobh. Dínasctha"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "uimhir neamhbhailí mhaoláin"
+
+#~ msgid "not implemented yet"
+#~ msgstr "níl ar fáil"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "ní féidir lín(t)e a shocrú"
+
+#~ msgid "mark not set"
+#~ msgstr "marc gan socrú"
+
+#~ msgid "row %d column %d"
+#~ msgstr "líne %d colún %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "ní féidir líne a ionsá/iarcheangal"
+
+#~ msgid "unknown flag: "
+#~ msgstr "bratach anaithnid: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "vimOption anaithnid"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "idirbhriseadh méarchláir"
+
+#~ msgid "vim error"
+#~ msgstr "earráid vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "ní féidir ordú maoláin/fuinneoige a chruthú: réad á scriosadh"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "ní féidir ordú aisghlaoch a chlárú: maolán/fuinneog á scriosadh cheana"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: EARRÁID MHARFACH TCL: liosta truaillithe tagartha!? Seol tuairisc "
+#~ "fhabht chuig <vim-dev@vim.org> le do thoil"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "ní féidir ordú aisghlaoch a chlárú: tagairt mhaolán/fhuinneoige gan aimsiú"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Tá brón orm, níl an t-ordú seo le fáil: níorbh fhéidir an "
+#~ "leabharlann Tcl a luchtú."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: EARRÁID TCL: níl an cód scortha ina shlánuimhir!? Seol tuairisc "
+#~ "fhabht chuig <vim-dev@vim.org> le do thoil"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: cód scortha %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "ní féidir an líne a fháil"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Ní féidir ainm fhreastalaí ordaithe a chlárú"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Theip ar sheoladh ordú chuig an sprioc-chlár"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Aitheantas neamhbhailí freastalaí in úsáid: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: Airí míchumtha sa chlárlann áisc VIM.  Scriosta!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Níor tiomsaíodh an leagan Vim seo le `diff' ar fáil."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "Ní féidir '-nb' a úsáid: níor cumasaíodh é ag am tiomsaithe\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Earráid: Theip ar thosú gvim ó NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Nuair nach cásíogair é, cuir '/' ag tosach na brataí chun í a chur sa "
+#~ "chás uachtair"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tCláraigh an gvim seo le haghaidh OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tDíchláraigh an gvim seo le haghaidh OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tRith agus úsáid an GUI (mar \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  nó  --nofork\tTulra: Ná déan forc agus an GUI á thosú"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNá húsáid newcli chun fuinneog a oscailt"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <gléas>\t\tBain úsáid as <gléas> do I/A"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tBain úsáid as <gvimrc> in ionad aon .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tCuir comhaid chriptithe in eagar"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <freastalaí>\tNasc vim leis an bhfreastalaí-X seo"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNá naisc leis an bhfreastalaí X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <comhaid>\tCuir <comhaid> in eagar le freastalaí Vim más féidir"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <comhaid> Mar an gcéanna, ná déan gearán mura bhfuil "
+#~ "freastalaí ann"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <comhaid>  Mar --remote ach fan leis na comhaid a bheith "
+#~ "curtha in eagar"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <comhaid>  Mar an gcéanna, ná déan gearán mura "
+#~ "bhfuil freastalaí ann"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <comhaid>  Cosúil le --remote ach oscail "
+#~ "cluaisín do gach comhad"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <eochracha>\tSeol <eochracha> chuig freastalaí Vim agus "
+#~ "scoir"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <slonn>\tLuacháil <slonn> le freastalaí Vim agus taispeáin "
+#~ "an toradh"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tTaispeáin freastalaithe Vim atá ar fáil agus scoir"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <ainm>\tSeol chuig/Téigh i do fhreastalaí Vim <ainm>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argóintí ar eolas do gvim (leagan Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argóintí ar eolas do gvim (leagan neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argóintí ar eolas do gvim (leagan Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <scáileán>\tRith vim ar <scáileán>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tTosaigh vim sa mhód íoslaghdaithe"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <ainm>\t\tÚsáid acmhainn mar a bheadh vim <ainm>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Níl ar fáil)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <dath>\tBain úsáid as <dath> don chúlra (-bg fosta)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <dath>\tÚsáid <dath> le haghaidh gnáth-théacs (fosta: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <cló>\t\tÚsáid <cló> le haghaidh gnáth-théacs (fosta: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <cló>\tBain úsáid as <cló> do chló trom"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <cló>\tÚsáid <cló> le haghaidh téacs iodálach"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geoim>\tÚsáid <geoim> le haghaidh na céimseatan tosaigh "
+#~ "(fosta: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <leithead>\tSocraigh <leithead> na himlíne (-bw fosta)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <leithead> Socraigh leithead na scrollbharraí a bheith "
+#~ "<leithead> (fosta: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <airde>\tSocraigh airde an bharra roghchláir a bheith <airde> "
+#~ "(fosta: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tÚsáid fís aisiompaithe (fosta: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNá húsáid fís aisiompaithe (fosta: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <acmhainn>\tSocraigh an acmhainn sainithe"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argóintí ar eolas do gvim (leagan RISC OS):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <uimhir>\tLeithead fuinneoige i dtosach (colúin)"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <uimhir>\tAirde fhuinneoige i dtosach (rónna)"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argóintí ar eolas do gvim (leagan GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <scáileán>\tRith vim ar <scáileán> (fosta: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <ról>\tSocraigh ról sainiúil chun an phríomhfhuinneog a aithint"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOscail Vim isteach i ngiuirléid GTK eile"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <máthairchlár>\tOscail Vim isteach sa mháthairchlár"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tOscail Vim isteach i ngiuirléid win32 eile"
+
+#~ msgid "No display"
+#~ msgstr "Gan taispeáint"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Theip ar seoladh.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Theip ar seoladh. Ag baint triail as go logánta\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d as %d déanta"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Gan taispeáint: Theip ar sheoladh sloinn.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Theip ar sheoladh sloinn.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Ní códleathanach bailí é"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Theip ar chruthú comhthéacs ionchuir"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Theip ar oscailt mhodh ionchuir"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Rabhadh: Níorbh fhéidir aisghlaoch léirscriosta a shocrú le IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Ní thacaíonn an modh ionchuir aon stíl"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: ní thacaíonn an modh ionchuir mo chineál réamheagair"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: tacar cló ag teastáil ó stíl thar-an-spota"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr ""
+#~ "E291: Tá an GTK+ atá agat níos sine ná leagan 1.2.3. Díchumasaítear an "
+#~ "limistéar stádais"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Níl an Freastalaí Mhodh Ionchuir ag rith"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [ní inúsáidte leis an leagan seo Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Bain an roghchlár seo"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialóg `Roghnaigh Comhadlann'"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialóg `Sábháil Comhad'"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialóg `Oscail Comhad'"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Níl brabhsálaí comhaid ar fáil sa mhód consóil"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: comhaid á gcaomhnú...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Críochnaithe.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "EARRÁID: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[beart] iomlán dáilte-saor %<PRIu64>-%<PRIu64>, in úsáid %<PRIu64>, buaic "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[glaonna] re/malloc(): %<PRIu64>, free(): %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Tá an líne ag éirí rófhada"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Earráid inmheánach: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Cruth neamhcheadaithe luiche"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Iontráil eochair chriptiúcháin: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Iontráil an eochair arís: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Níl na heochracha comhoiriúnach le chéile!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Ní féidir nascadh le Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Ní féidir nascadh le Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Mód mícheart rochtana ar an chomhad eolas naisc NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "léadh ó shoicéad Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Cailleadh nasc NetBeans le haghaidh maoláin %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Níl an ghné Eval le fáil"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "%<PRId64> líne á saoradh"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Ní féidir 'term' a athrú sa GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Úsáid \":gui\" chun an GUI a chur ag obair"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Ní féidir é a athrú sa GUI GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Cló(nna) neamhbhailí"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: ní féidir tacar cló a roghnú"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Tacar cló neamhbhailí"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: ní féidir cló leathan a roghnú"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Cló leathan neamhbhailí"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Gan tacaíocht luiche"
+
+#~ msgid "cannot open "
+#~ msgstr "ní féidir a oscailt: "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Ní féidir fuinneog a oscailt!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Tá gá le Amigados leagan 2.04 nó níos déanaí\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Tá gá le %s, leagan %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Ní féidir NIL a oscailt:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Ní féidir a chruthú: "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim á scor le stádas %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "ní féidir mód consóil a athrú ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: ní consól é seo??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Ní féidir blaosc a rith le rogha -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Ní féidir blaosc a rith: "
+
+#~ msgid "shell "
+#~ msgstr "blaosc "
+
+#~ msgid " returned\n"
+#~ msgstr " aisfhilleadh\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE róbheag."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "EARRÁID I/A"
+
+#~ msgid "Message"
+#~ msgstr "Teachtaireacht"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "ní 80 é 'columns', ní féidir orduithe seachtracha a rith"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Theip ar roghnú printéara"
+
+#~ msgid "to %s on %s"
+#~ msgstr "go %s ar %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Clófhoireann anaithnid printéara: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Earráid phriontála: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "'%s' á phriontáil"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: Ainm neamhcheadaithe ar thacar carachtar \"%s\" mar pháirt d'ainm "
+#~ "cló \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Carachtar neamhcheadaithe '%c' mar pháirt d'ainm cló \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Comhartha dúbailte, ag scor\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Fuarthas comhartha marfach %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Fuarthas comhartha marfach\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Thóg %<PRId64> ms chun an scáileán X a oscailt"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Fuarthas earráid ó X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Theip ar thástáil an scáileáin X"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Oscailt an scáileáin X thar am"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ní féidir an bhlaosc sh a rith\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ní féidir píopaí a chruthú\n"
+
+# "fork" not in standard refs/corpus.  Maybe want a "gabhl*" word instead? -KPS
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ní féidir forc a dhéanamh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Ordú críochnaithe\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "Chaill XSMP an nasc ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Theip ar oscailt an scáileáin X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "Iarratas sábháil-do-féin á láimhseáil ag XSMP"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "Nasc á oscailt ag XSMP"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Theip ar fhaire nasc ICE XSMP"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "Theip ar XSMP SmcOpenConnection: %s"
+
+#~ msgid "At line"
+#~ msgstr "Ag líne"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Níorbh fhéidir vim32.dll a luchtú!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Earráid VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Níorbh fhéidir pointeoirí feidhme a chóiriú i gcomhair an DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "d'aisfhill an bhlaosc %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Fuarthas teagmhas %s\n"
+
+#~ msgid "close"
+#~ msgstr "dún"
+
+#~ msgid "logoff"
+#~ msgstr "logáil amach"
+
+#~ msgid "shutdown"
+#~ msgstr "múchadh"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Ní bhfuarthas an t-ordú"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "Níor aimsíodh VIMRUN.EXE i do $PATH.\n"
+#~ "Ní mhoilleoidh orduithe seachtracha agus iad curtha i gcrích.\n"
+#~ "Féach ar  :help win32-vimrun  chun níos mó eolas a fháil."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Rabhadh Vim"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Tiontú i %s gan tacaíocht"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: ní ghlactar leis an argóint containedin anseo"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Teascadh conair an chomhaid clibeanna le haghaidh %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "tosaíodh blaosc nua\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Úsáideadh CUT_BUFFER0 in ionad roghnúcháin folaimh"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Ní féidir a chealú; lean ar aghaidh mar sin féin"
+
+# columns?
+#~ msgid "number changes  time"
+#~ msgstr "uimhir athruithe  am"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan GUI 16/32 giotán MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan GUI 64 giotán MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan GUI 32 giotán MS-Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " i mód Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " le tacaíocht OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan consóil 64 giotán MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan consóil 32 giotán MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan 16 giotán MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan 32 giotán MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan 16 giotán MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan RISC OS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan mór "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan coitianta "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan beag "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Leagan beag bídeach "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "le GUI GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "le GUI GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "le GUI GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "le GUI GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "le GUI X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "le GUI X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "le GUI X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "le GUI Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "le GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "le GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "le GUI Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "le GUI (clasaiceach)."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  comhad gvimrc córais: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    comhad gvimrc úsáideora: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "dara comhad gvimrc úsáideora: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "tríú comhad gvimrc úsáideora: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    comhad roghchláir an chórais: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Tiomsaitheoir: "
+
+# don't see where to localize "Help->Orphans"? --kps
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "roghchlár  Help->Orphans      chun eolas a fháil "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Á rith gan mhóid, ag ionsá an téacs atá iontráilte"
+
+# same problem --kps
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "roghchlár  Edit->Global Settings->Toggle Insert Mode  "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              do dhá mhód       "
+
+# same problem --kps
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "roghchlár  Edit->Global Settings->Toggle Vi Compatible"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              le haghaidh réamhshocruithe Vim   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "RABHADH: Braitheadh Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "clóscríobh  :help windows95<Enter>      chun eolas a fháil "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Níorbh fhéidir an leabharlann %s a oscailt"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Tá brón orm, níl an t-ordú seo le fáil: níorbh fhéidir an leabharlann "
+#~ "Perl a luchtú."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Ní cheadaítear luacháil Perl i mbosca gainimh gan an modúl Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Cuir in eagar le Vimeanna io&madúla"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Cuir in eagar le &Vim aonair"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diff le Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Cuir in Eagar le &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Cuir in Eagar le Vim beo - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Cuir an comhad roghnaithe in eagar le Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr ""
+#~ "Earráid agus próiseas á chruthú: Deimhnigh go bhfuil gvim i do chonair!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "earráid gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Conair rófhada!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Tacar cló anaithnid: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Clófhoireann anaithnid: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Ní cló aonleithid é \"%s\""
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Ní féidir feidhm %s leabharlainne a luchtú"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Níl tacaíocht Eabhraise ar fáil: Níor cumasaíodh é ag am tiomsaithe\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Níl tacaíocht Pheirsise ar fáil: Níor cumasaíodh é ag am tiomsaithe\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Níl tacaíocht Araibise ar fáil: Níor cumasaíodh é ag am tiomsaithe\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: níl aon fhreastalaí cláraithe leis an ainm \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: ní féidir an scáileán a oscailt"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Fuarthas slonn neamhbhailí"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Réigiún cosanta, ní féidir é a athrú"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: Ní cheadaíonn NetBeans aon athrú i gcomhaid inléite amháin"
 
 #~ msgid "E569: maximum number of cscope connections reached"
 #~ msgstr "E569: ní cheadaítear níos mó ná an líon uasta nasc cscope"

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -1858,10 +1858,6 @@ msgstr "%<PRId64> linee,"
 msgid "1 character"
 msgstr "1 carattere"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> caratteri"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -13,173 +13,217 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.4b\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-29 16:11+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date:  2013-08-03 17:14+0200\n"
 "Last-Translator:   Vlad Sandrini   <vlad.gently@gmail.com>\n"
-"Language-Team:     Italian"
-"                   Antonio Colombo <azc100@gmail.com>"
-"                   Vlad Sandrini <vlad.gently@gmail.com>"
-"                   Luciano Montanaro <mikelima@cirulla.net>\n"
+"Language-Team:     Italian                   Antonio Colombo <azc100@gmail."
+"com>                   Vlad Sandrini <vlad.gently@gmail."
+"com>                   Luciano Montanaro <mikelima@cirulla.net>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO_8859-1\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: chiamata a bf_key_init() con password nulla"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "impossibile ottenere il valore di opzione"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "errore interno: tipo di opzione sconosciuto"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: uso errato di big/little endian in Blowfish"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: test sha256 fallito"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: test Blowfish fallito"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Lista Locazioni]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Lista Quickfix]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Comando non completato a causa di autocomandi"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Non riesco ad allocare alcun buffer, esco..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Non riesco ad allocare un buffer, uso l'altro..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Nessun buffer scaricato"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Nessun buffer tolto dalla lista"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Nessun buffer cancellato"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer scaricato"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffer scaricati"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer tolto dalla lista"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffer tolti dalla lista"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer cancellato"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffer cancellati"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Non riesco a scaricare l'ultimo buffer"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nessun buffer risulta modificato"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Non c'è alcun buffer elencato"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Non esiste il buffer %<PRId64>"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Non posso oltrepassare l'ultimo buffer"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Non posso andare prima del primo buffer"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Buffer %<PRId64> non salvato dopo modifica (aggiungi ! per eseguire comunque)"
+"E89: Buffer %<PRId64> non salvato dopo modifica (aggiungi ! per eseguire "
+"comunque)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Non riesco a scaricare l'ultimo buffer"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Attenzione: Superato limite della lista dei nomi di file"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Buffer %<PRId64> non trovato"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Più di una corrispondenza per %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Nessun buffer corrispondente a %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "linea %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: C'è già un buffer con questo nome"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modificato]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Non elaborato]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[File nuovo]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Errori in lettura]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[Sola Lettura]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[in sola lettura]"
 
+#: ../buffer.c:2524
+#, c-format
 msgid "1 line --%d%%--"
 msgstr "1 linea --%d%%--"
 
+#: ../buffer.c:2526
+#, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> linee --%d%%--"
 
+#: ../buffer.c:2530
+#, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "linea %<PRId64> di %<PRId64> --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Senza nome]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "aiuto"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Aiuto]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Anteprima]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Tut"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Fon"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Cim"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -187,9 +231,11 @@ msgstr ""
 "\n"
 "# Lista Buffer:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Volatile]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -197,143 +243,199 @@ msgstr ""
 "\n"
 "--- Segni ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Segni per %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    linea=%<PRId64> id=%d, nome=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Manca ':'"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Modalità non valida"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: aspettavo un numero"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Percentuale non valida"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Non supporto differenze fra più di %<PRId64> buffer"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Non riesco a leggere o scrivere file temporanei"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Non riesco a creare differenze"
 
-msgid "Patch file"
-msgstr "File di differenze"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Non riesco a leggere output del comando 'patch'"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Non riesco a leggere output del comando 'diff'"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Buffer corrente non in modalità 'diff'"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Nessun altro buffer è modificabile in modalità 'diff'"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Non c'è nessun altro buffer in modalità 'diff'"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Più di due buffer in modalità 'diff', non so quale usare"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Non riesco a trovare il buffer: \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Il buffer \"%s\" non è in modalità 'diff'"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Il buffer è variato inaspettatamente"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape not ammesso nei digrammi"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: File keymap non trovato"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Uso di :loadkeymap fuori da un file di comandi"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Nessuna keymap per questo tasto"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Completamento Keyword (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " modalità ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Completamento Linea Intera (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Completamento nomi File (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Completamento Tag (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Completamento modello Path (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Completamento Definizione (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Completamento Dizionario (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Completamento Thesaurus (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Completamento linea comandi (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Completamento definito dall'utente (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Completamento globale (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Suggerimento ortografico (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Completamento Keyword Locale (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Giunto alla fine del paragrafo"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: La funzione di completamento ha modificato la finestra"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: La funzione di completamento ha eliminato del testo"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "l'opzione 'dictionary' non è impostata"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "l'opzione 'thesaurus' non è impostata"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Scansione dizionario: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (inserisci) Scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (sostituisci) Scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Scansione: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Scansione tag."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Aggiungo"
 
@@ -341,461 +443,577 @@ msgstr " Aggiungo"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Ricerca..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Ritorno all'originale"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Parola da un'altra linea"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "L'unica corrispondenza"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "corrispondenza %d di %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "corrispondenza %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caratteri non previsti in :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: indice lista fuori intervallo: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Variabile non definita: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Manca ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: L'argomento di %s deve essere una Lista"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: L'argomento di %s deve essere una Lista o un Dizionario"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Non posso usare una chiave nulla per il Dizionario"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: È necessaria una Lista"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: È necessario un Dizionario"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Troppi argomenti per la funzione: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Chiave assente dal Dizionario: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: La funzione %s esiste già, aggiungi ! per sostituirla"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: C'è già la voce nel Dizionario"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref necessario"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Non posso usare [:] con un Dizionario"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Tipo di variabile errato per %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Funzione sconosciuta: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Nome di variabile non ammesso: %s"
 
 # nuovo
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: uso di un numero con virgola come stringa"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Destinazioni più numerose degli elementi di Lista"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Destinazioni meno numerose degli elementi di Lista"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Doppio ; nella lista di variabili"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Non riesco a elencare le variabili per %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Posso indicizzare solo una Lista o un Dizionario"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] deve essere alla fine"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] necessita un valore Lista"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Il valore Lista ha più elementi della destinazione"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Il valore Lista non ha elementi sufficienti"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Manca \"in\" dopo :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Mancano parentesi: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Variabile inesistente: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variabile troppo nidificata per lock/unlock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Manca ':' dopo '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Posso confrontare una Lista solo con un'altra Lista"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Operazione non valida per Liste"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Posso confrontare un Dizionario solo con un altro Dizionario"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Operazione non valida per Dizionari"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Posso confrontare un Funcref solo con un Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Operazione non valida per Funcref"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Non si può usare '%' con un numero con virgola"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Manca ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Non posso indicizzare un Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Nome Opzione mancante: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Opzione inesistente: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Manca '\"': %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Manca apostrofo: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Manca virgola nella Lista: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Manca ']' a fine Lista: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Manca ':' nel Dizionario: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Chiave duplicata nel Dizionario: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Manca virgola nel Dizionario: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Manca '}' a fine Dizionario: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variabile troppo nidificata per la visualizzazione"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Troppi argomenti per la funzione: %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Argomenti non validi per la funzione: %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Funzione sconosciuta: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: La funzione: %s richiede più argomenti"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Uso di <SID> fuori dal contesto di uno script: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Chiamata di funzione dict in assenza di Dizionario: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Ci vuole un numero intero o con virgola"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "argomento di add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Troppi argomenti"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() può essere usata solo in modalità inserimento"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&OK"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Chiave già esistente: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "argomento di extend()"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "argomento di map()"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "argomento di filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld linee: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Funzione sconosciuta: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Non eseguire"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() chiamata più volte di inputsave()"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "argomento di insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Intervallo non consentito"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Tipo non valido per len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Incremento indice a zero"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Indice iniziale superiore a quello finale"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<vuoto>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Manca connessione con server Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Impossibile inviare a %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Non riesco a leggere una risposta del server"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "argomento di remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Troppi link simbolici (circolarità?)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "argomento di reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Impossibile inviare al client"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "argomento di sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argomento di add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funzione confronto nel sort non riuscita"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funzione confronto nel sort non riuscita"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Non valido)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Errore in scrittura su file temporaneo"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Uso di un numero con virgola come intero"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Uso di Funcref come Numero"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Uso di Lista come Numero"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Uso di Dizionario come Numero"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: uso di Funcref come Stringa"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: uso di Lista come Stringa"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: uso di Dizionario come Stringa"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Tipo di variabile non corrispondente per: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Non posso cancellare la variabile %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr ""
 "E704: Il nome della variabile Funcref deve iniziare con una maiuscola: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Nome di variabile in conflitto con una funzione esistente: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Valore di %s non modificabile"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Sconosciuto"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Non riesco a cambiare il valore di %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Variabile troppo nidificata per poterla copiare"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Funzione non definita: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Manca '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Non si può usare g: qui"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Argomento non ammesso: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Nome argomento duplicato: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Manca :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Nome funzione in conflitto con la variabile: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Non posso ridefinire la funzione %s: È in uso"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Il nome funzione non corrisponde al nome file dello script: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Nome funzione necessario"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Il nome funzione deve iniziare con una maiuscola o contenere ':': %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Il nome funzione deve iniziare con una maiuscola o contenere ':': %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Non posso eliminare la funzione %s: È in uso"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr ""
 "E132: Nidificazione della chiamata di funzione maggiore di 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "chiamo %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s non completata"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s ritorno #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s ritorno %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "continuo in %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return fuori da una funzione"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -803,6 +1021,7 @@ msgstr ""
 "\n"
 "# variabili globali:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -810,82 +1029,104 @@ msgstr ""
 "\n"
 "\tImpostata l'ultima volta da "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Nessun file elaborato in precedenza"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Esa %02x,  Ottale %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Esa %04x, Ottale %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Esa %08x, Ottale %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Movimento di linee verso se stesse"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 linea mossa"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> linee mosse"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> linee filtrate"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Gli autocomandi non devono modificare il buffer in uso"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Non salvato dopo l'ultima modifica]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s nella linea: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Troppi errori, ignoro il resto del file"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Lettura file viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informazione"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " mark"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " file elaborati in precedenza"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FALLITO"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: File viminfo \"%s\" inaccessibile in scrittura"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Non riesco a scrivere il file viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Scrivo file viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Questo file viminfo è stato generato da Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -893,40 +1134,47 @@ msgstr ""
 "# File modificabile, attento a quel che fai!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Valore di 'encoding' al momento della scrittura di questo file\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Carattere iniziale non ammesso"
 
-msgid "Save As"
-msgstr "Salva con Nome"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Scrivo il file incompleto?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Usa ! per scrivere il buffer incompleto"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Riscrittura del file esistente \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Il file swap \"%s\" esiste già, sovrascrivo?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: File swap esistente: %s (:silent! per sovrascriverlo)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Manca nome file per il buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: File non scritto: Scrittura inibita da opzione 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -935,6 +1183,7 @@ msgstr ""
 "opzione 'readonly' attiva per \"%s\".\n"
 "Vuoi scrivere comunque?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -945,69 +1194,84 @@ msgstr ""
 "Questo potrebbe non impedire la scrittura.\n"
 "Vuoi provare?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" è in sola lettura (aggiungi ! per eseguire comunque)"
 
-msgid "Edit File"
-msgstr "Elabora File"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr ""
 "E143: Gli autocomandi hanno inaspettatamente cancellato il nuovo buffer %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: argomento non-numerico a :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Comandi Shell non permessi in rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Le espressioni regolari non possono essere delimitate da lettere"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "sostituire con %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Interrotto) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 corrisp."
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 sostituzione"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> corrisp."
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> sostituzioni"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " in 1 linea"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " in %<PRId64> linee"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global non può essere usato ricorsivamente"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Manca espressione regolare nel comando 'global'"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Espressione trovata su ogni linea: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Espressione non trovata: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1017,265 +1281,336 @@ msgstr ""
 "# Ultima Stringa Sostituzione:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Non lasciarti prendere dal panico!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Spiacente, nessun aiuto '%s' per %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Spiacente, nessun aiuto per %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Spiacente, non trovo file di aiuto \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s non è una directory"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Non posso aprire %s in scrittura"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Non riesco ad aprire %s in lettura"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Codifiche diverse fra file di aiuto nella stessa lingua: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Tag duplicato \"%s\" nel file %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Comando 'sign' sconosciuto: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Manca nome 'sign'"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Troppi 'sign' definiti"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Testo 'sign' non valido: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 'sign' sconosciuto: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Manca numero 'sign'"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Nome buffer non valido: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: ID 'sign' non valido: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NON TROVATO)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (non supportata)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Cancellato]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Entro modalità Debug.  Batti \"cont\" per continuare."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "linea %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "com: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Pausa in \"%s%s\" linea %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Breakpoint %s non trovato"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Nessun 'breakpoint' definito"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s linea %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Usare prima \":profile start {fname}\""
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Salvare modifiche a \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Senza Nome"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Buffer \"%s\" non salvato dopo modifica"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Attenzione: Entrato in altro buffer inaspettatamente (controllare "
 "autocomandi)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: C'è un solo file da elaborare"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Non posso andare davanti al primo file"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Non posso oltrepassare l'ultimo file"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: compilatore non supportato: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Cerco \"%s\" in \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Cerco \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "non trovato in 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Esegui script Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Non riesco ad eseguire una directory: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "non riesco ad eseguire \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "linea %<PRId64>: non riesco ad eseguire \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "eseguo \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "linea %<PRId64>: eseguo \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "esecuzione di %s terminata"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modeline"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "argomento --cmd"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "argomento -c"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "variabile d'ambiente"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "gestore di errore"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Attenzione: Separatore di linea errato, forse manca ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding usato fuori da un file di comandi"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish usato fuori da file di comandi"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Lingua %sin uso: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Non posso impostare lingua a \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Entro modalità Ex.  Batti \"visual\" per tornare a modalità Normale."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Alla fine-file"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Comando troppo ricorsivo"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Eccezione non intercettata: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Fine del file di comandi"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Fine funzione"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Uso ambiguo di comando definito dall'utente"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Non è un comando dell'editor"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Intervallo rovesciato"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Intervallo rovesciato, OK invertirlo"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Usa w oppure w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Spiacente, comando non disponibile in questa versione"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Ammesso un solo nome file"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 ulteriore file da elaborare.  Esco lo stesso?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d ulteriori file da elaborare.  Esco lo stesso?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: ancora 1 file da elaborare"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: ancora %<PRId64> file da elaborare"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Il comando esiste già: aggiungi ! per sostituirlo"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1283,300 +1618,346 @@ msgstr ""
 "\n"
 "    Nome        Arg. Inter Completo  Definizione"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Non trovo comandi definiti dall'utente"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nessun attributo specificato"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Numero di argomenti non valido"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Non si può specificare due volte il contatore"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Valore predefinito del contatore non valido"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: argomento necessario per -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Attributo non valido: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Nome comando non valido"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr ""
 "E183: I comandi definiti dall'utente devono iniziare con lettera maiuscola"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: Nome riservato, non usabile in un comando definito dall'utente"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Comando definito dall'utente %s inesistente"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Valore %s non valido per 'complete'"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Argomento di completamento permesso solo per completamento "
 "personalizzato"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr ""
 "E467: Il completamento personalizzato richiede un argomento di funzione"
 
-msgid "unknown"
-msgstr "sconosciuto"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Non riesco a trovare schema colore '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Salve, utente Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Non posso chiudere l'ultima linguetta"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "C'è già una linguetta sola"
 
-msgid "Edit File in new window"
-msgstr "Apri il File in una nuova finestra"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Linguetta %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Non posso creare un file di swap"
 
-msgid "Append File"
-msgstr "In aggiunta al File"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Non posso cambiare directory, buffer modificato (aggiungi ! per "
 "eseguire comunque)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Non c'è una directory precedente"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Sconosciuto"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize richiede due argomenti numerici"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Posizione finestra: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Informazioni posizione finestra non disponibili su questa piattaforma"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos richiede due argomenti numerici"
 
-msgid "Save Redirection"
-msgstr "Salva Redirezione"
-
-msgid "Save View"
-msgstr "Salva Veduta"
-
-msgid "Save Session"
-msgstr "Salva Sessione"
-
-msgid "Save Setup"
-msgstr "Salva Setup"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Non posso creare la directory: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" esiste (aggiungi ! per eseguire comunque)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Non riesco ad aprire \"%s\" in scrittura"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr ""
 "E191: L'argomento deve essere una lettera, oppure un apice/apice retroverso"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Uso ricorsivo di :normal troppo esteso"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< non disponibile se Vim è compilato senza +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Nessun nome file alternativo da sostituire a '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: nessun file di autocomandi da sostituire per \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr ""
 "E496: nessun numero di buffer di autocomandi da sostituire per \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: nessun nome di autocomandi trovato da sostituire per \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr ""
 "E498: nessun nome di file :source trovato da sostituire per \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: nessun numero di riga da usare per \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Un nome di file nullo per '%' o '#', va bene solo con \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Il valore è una stringa nulla"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Non posso aprire il file viminfo in lettura"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Digrammi non supportati in questa versione"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Impossibile lanciare eccezioni con prefisso 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Eccezione lanciata: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Eccezione finita: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Eccezione scartata: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, linea %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Eccezione intercettata: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s reso 'pending'"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s ripristinato"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s scartato"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Eccezione"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Errore ed interruzione"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Errore"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Interruzione"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: nidificazione di :if troppo estesa"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif senza :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else senza :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif senza :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: :else multipli"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif dopo :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: nidificazione di :while/:for troppo estesa"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue senza :while o :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break senza :while o :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Uso di :endfor con :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Uso di :endwhile con :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: nidificazione di :try troppo estesa"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch senza :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch dopo :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally senza :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: :finally multipli"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry senza :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction non contenuto in una funzione"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Non si può aprire ora un altro buffer"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Non consentito modificare informazioni del buffer ora"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nome_tag"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " tipo file\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "l'opzione 'history' è a zero"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1585,196 +1966,255 @@ msgstr ""
 "\n"
 "# %s Storia (da più recente a meno recente):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Linea di Comando"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Stringa di Ricerca"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Espressione"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Linea di Input"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar dopo la fine del comando"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Finestra attiva o buffer cancellato"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: percorso troppo lungo per il completamento"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Percorso non valido: '**[numero]' deve essere a fine percorso o essere "
+"seguito da '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Non riesco a trovare la directory \"%s\" nel 'cdpath'"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Non riesco a trovare il file \"%s\" nel percorso"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Nessun altra directory \"%s\" trovata nel 'cdpath'"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Nessun altro file \"%s\" trovato nel percorso"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Gli autocomandi hanno modificato il buffer o il nome del buffer"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Nome di file non ammesso"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "è una directory"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "non è un file"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "è una periferica (disabilitata con l'opzione 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[File nuovo]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nuova DIRECTORY]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[File troppo grande]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Tipo di accesso non consentito]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Gli autocomandi *ReadPre hanno reso il file illeggibile"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Gli autocomandi *ReadPre non devono modificare il buffer in uso"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Leggo da 'stdin'...\n"
 
-msgid "Reading from stdin..."
-msgstr "Leggo da 'stdin'..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: La conversione ha reso il file illeggibile!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[character special]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[manca CR]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[linee lunghe divise]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NON convertito]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[convertito]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[cifrato]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ERRORE DI CONVERSIONE alla linea %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[BYTE NON VALIDO alla linea %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ERRORI IN LETTURA]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Non riesco a trovare il file temp per leggerlo"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Conversione fallita con 'charconvert'"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "non riesco a leggere il risultato di 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: File cifrato con metodo sconosciuto"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Nessun autocomando corrispondente per buffer acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Buffer in scrittura cancellato o scaricato dagli autocomandi"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: L'autocomando ha modificato numero linee in maniera imprevista"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans non permette la scrittura di un buffer non modificato"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Scrittura parziale disabilitata per i buffer di NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "non è un file o un dispositivo su cui si possa scrivere"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "scrittura su periferica disabilitata con l'opzione 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "è in sola lettura (aggiungi ! per eseguire comunque)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Non posso scrivere sul file di backup (aggiungi ! per eseguire "
 "comunque)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: Errore in chiusura sul file di backup (aggiungi ! per eseguire "
 "comunque)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Non riesco a leggere il file di backup (aggiungi ! per eseguire "
 "comunque)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Non posso creare il file di backup (aggiungi ! per eseguire comunque)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Non posso fare il file di backup (aggiungi ! per eseguire comunque)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr ""
-"E460: La 'fork' sulla risorsa verrebbe persa (aggiungi ! per eseguire "
-"comunque)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Non riesco a trovare un file 'temp' su cui scrivere"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Non riesco a convertire (aggiungi ! per scrivere senza conversione)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Non posso aprire il file collegato ('linked') in scrittura"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Non posso aprire il file in scrittura"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync fallito"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Chiusura fallita"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: errore in scrittura, conversione fallita (rendere 'fenc' nullo per "
 "eseguire comunque)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
@@ -1783,43 +2223,56 @@ msgstr ""
 "E513: errore in scrittura, conversione fallita alla linea %<PRId64> (rendere "
 "'fenc' nullo per eseguire comunque)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: errore in scrittura ('File System' pieno?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ERRORE DI CONVERSIONE"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " alla linea %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Dispositivo]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nuovo]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " aggiunto in fondo"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [s]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " scritti"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: non posso salvare il file originale"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: non posso alterare il file vuoto originale"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Non riesco a cancellare il file di backup"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1827,76 +2280,96 @@ msgstr ""
 "\n"
 "ATTENZIONE: Il file originale può essere perso o danneggiato\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "non uscire dall'editor prima della fine della scrittura del file!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[DOS]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[in formato DOS]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[MAC]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[in formato MAC]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[UNIX]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[in formato UNIX]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 linea, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> linee,"
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 carattere"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> caratteri"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Manca carattere di fine linea]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ATTENZIONE: File modificato dopo essere stato letto dall'Editor!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Vuoi davvero riscriverlo"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Errore in scrittura di \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Errore in chiusura di \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Errore in lettura di \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: L'autocomando 'FileChangedShell' ha cancellato il buffer"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Il file \"%s\" non esiste più"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1904,30 +2377,38 @@ msgid ""
 msgstr ""
 "W12: Attenzione: File \"%s\" modificato su disco ed anche nel buffer di Vim"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Vedere \":help W12\" per ulteriori informazioni."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Attenzione: File \"%s\" modificato dopo l'apertura"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Vedere \":help W11\" per ulteriori informazioni."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Attenzione: Modo File \"%s\" modificato dopo l'apertura"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Vedere \":help W16\" per ulteriori informazioni."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Attenzione: Il file \"%s\" risulta creato dopo l'apertura"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Attenzione"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1935,39 +2416,48 @@ msgstr ""
 "&OK\n"
 "&Carica File"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Non riesco a preparare per ri-caricare \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Non riesco a ri-caricare \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Cancellato--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "auto-rimozione dell'autocomando: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Gruppo inesistente: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Carattere non ammesso dopo *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Evento inesistente: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Evento o gruppo inesistente: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1975,536 +2465,760 @@ msgstr ""
 "\n"
 "--- Auto-Comandi ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: numero buffer non valido"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Non posso eseguire autocomandi for TUTTI gli eventi"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Nessun autocomando corrispondente"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: nidificazione dell'autocomando troppo estesa"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto comandi per \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Eseguo %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocomando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Manca {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Manca }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Non trovo alcuna piegatura"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Non posso create piegatura con il 'foldmethod' in uso"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Non posso cancellare piegatura con il 'foldmethod' in uso"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld linee piegate"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Aggiunto al buffer di lettura"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: mapping ricorsivo"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: una abbreviazione globale già esiste per %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: un mapping globale già esiste per %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: una abbreviazione già esiste per %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: un mapping già esiste per %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Non trovo l'abbreviazione"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Non trovo il mapping"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: modo non consentito"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Creazione di un nuovo processo fallita per la GUI"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--File vuoto--"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Il processo figlio non è riuscito a far partire la GUI"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Comando finito male"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Non posso inizializzare la GUI"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argomento necessario"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Non posso leggere da \"%s\""
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ dovrebbe essere seguito da /, ? oppure &"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Non posso inizializzare la GUI, nessun font valido trovato"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Non valido nella finestra comandi; <INVIO> esegue, CTRL-C ignora"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' non valido"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Il valore di 'imactivatekey' non è valido"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Non riesco ad allocare il colore %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Nessuna corrispondenza al cursore, cerco la prossima"
-
-msgid "<cannot open> "
-msgstr "<non posso aprire> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: non riesco a trovare il font %s"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: non posso tornare alla directory in uso"
-
-msgid "Pathname:"
-msgstr "Nome percorso:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: non riesco ad ottenere la directory in uso"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Non eseguire"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Non riesco a ottenere geometria del 'thumb pixmap'."
-
-msgid "Vim dialog"
-msgstr "Dialogo Vim"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Non riesco a creare 'BalloonEval' con sia messaggio che callback"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Y Sì\n"
-"&No\n"
-"&C Ignora"
+"E12: Comando non ammesso da exrc/vimrc nella dir. in uso o nella ricerca tag"
 
-msgid "Input _Methods"
-msgstr "_Metodi di inserimento"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Manca :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Sostituisci..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Manca :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Cerca..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Manca :endwhile"
 
-msgid "Find what:"
-msgstr "Trova cosa:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Manca :endfor"
 
-msgid "Replace with:"
-msgstr "Sostituisci con:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile senza :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Cerca solo la parola intera"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor senza :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Maiuscole/minuscole"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: File esistente (aggiungi ! per riscriverlo)"
 
-msgid "Direction"
-msgstr "Direzione"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Comando fallito"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Su"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Errore interno"
 
-msgid "Down"
-msgstr "Giù"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Interrotto"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Trova il Prossimo"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Indirizzo non valido"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "Sostituisci"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Argomento non valido"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Sostituisci Tutto"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Ricevuta richiesta \"die\" dal session manager\n"
-
-msgid "Close"
-msgstr "Chiusura"
-
-msgid "New tab"
-msgstr "Nuova linguetta"
-
-msgid "Open Tab..."
-msgstr "Apri linguetta..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Finestra principale distrutta inaspettatamente\n"
-
-msgid "&Filter"
-msgstr "&Filtro"
-
-msgid "&Cancel"
-msgstr "&C Non eseguire"
-
-msgid "Directories"
-msgstr "Directory"
-
-msgid "Filter"
-msgstr "Filtro"
-
-msgid "&Help"
-msgstr "&H Aiuto"
-
-msgid "Files"
-msgstr "File"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Selezione"
-
-msgid "Find &Next"
-msgstr "&N Trova il Prossimo"
-
-msgid "&Replace"
-msgstr "&R Sostituisci"
-
-msgid "Replace &All"
-msgstr "&A Sostituisci Tutto"
-
-msgid "&Undo"
-msgstr "&U Disfa"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Non trovo il titolo della finestra \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Argomento non valido: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argomento non supportato: \"-%s\"; Usa la versione OLE."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Espressione non valida: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Non posso aprire la finestra in un'applicazione MDI"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Intervallo non valido"
 
-msgid "Close tab"
-msgstr "Chiudi linguetta"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Comando non valido"
 
-msgid "Open tab..."
-msgstr "Apri linguetta..."
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" è una directory"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Stringa di ricerca (usa '\\\\' per cercare  un '\\')"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Quantità di 'scroll' non valida"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Sostituisci (usa '\\\\' per cercare  un '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Non Utilizzato"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Directory\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Non riesco ad allocare elemento di colormap, possibili colori "
-"errati"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Mancano descrizioni per i seguenti caratteri nel font: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nome fontset: %s"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Chiamata a libreria fallita per \"%s()\""
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 'Mark' con numero linea non valido"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 'Mark' non impostato"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Non posso fare modifiche, 'modifiable' è inibito"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Script troppo nidificati"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Nessun file alternato"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Abbreviazione inesistente"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! non consentito"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI non utilizzabile: Non abilitata in compilazione"
+
+#: ../globals.h:1036
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Il font '%s' non di larghezza fissa"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Nome di gruppo di evidenziazione inesistente: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Ancora nessun testo inserito"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Nessuna linea comandi precedente"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Mapping inesistente"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Nessuna corrispondenza"
+
+#: ../globals.h:1041
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Nome fontset: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Nessuna corrispondenza: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Manca nome file"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Nessuna espressione regolare precedente di 'substitute'"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Nessun comando precedente"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Nessuna espressione regolare precedente"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Nessun intervallo consentito"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Manca spazio"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font0: %s"
-msgstr "Font0: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Non riesco a creare il file %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Non riesco ad ottenere nome file 'temp'"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font1: %s"
-msgstr "Font1: %s"
+msgid "E484: Can't open file %s"
+msgstr "E484: Non riesco ad aprire il file %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "La larghezza di font%<PRId64> non è doppia di quella di font0"
+msgid "E485: Can't read file %s"
+msgstr "E485: Non riesco a leggere il file %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Non salvato dopo modifica (aggiungi ! per eseguire comunque)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Non salvato dopo l'ultima modifica]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Argomento nullo"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Mi aspettavo un numero"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Larghezza di Font0: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Non riesco ad aprire il file errori %s"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Non c'è più memoria!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Espressione non trovata"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Larghezza di Font1: %<PRId64>"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Espressione non trovata: %s"
 
-msgid "Invalid font specification"
-msgstr "Specifica di font non valida"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: L'argomento deve essere positivo"
 
-msgid "&Dismiss"
-msgstr "&D Non ora"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Non posso tornare alla directory precedente"
 
-msgid "no specific match"
-msgstr "nessuna corrispondenza specifica"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Nessun Errore"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Selettore Font"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Nessuna lista locazioni"
 
-msgid "Name:"
-msgstr "Nome:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Stringa di confronto danneggiata"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Mostra dimensione in Punti"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Programma 'regexp' corrotto"
 
-msgid "Encoding:"
-msgstr "Codifica:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: file in sola lettura (aggiungi ! per eseguire comunque)"
 
-msgid "Font:"
-msgstr "Font:"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Non posso cambiare la variabile read-only \"%s\""
 
-msgid "Style:"
-msgstr "Stile:"
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr ""
+"E794: Non posso impostare la variabile read-only in ambiente protetto: \"%s\""
 
-msgid "Size:"
-msgstr "Dimensione:"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Errore leggendo il file errori"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ERRORE processore Hangul"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Non ammesso in ambiente protetto"
 
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Non consentito qui"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Impostazione modalità schermo non supportata"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Quantità di 'scroll' non valida"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: opzione 'shell' non impostata"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Errore -- non sono riuscito a leggere i dati del 'sign'!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Errore durante chiusura swap file"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tag stack ancora vuoto"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Comando troppo complesso"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Nome troppo lungo"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Troppe ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Troppi nomi file"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Caratteri in più a fine comando"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 'Mark' sconosciuto"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Non posso espandere 'wildcard'"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' non può essere inferiore a 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' non può essere inferiore a 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Errore in scrittura"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Contatore a zero"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Uso di <SID> fuori dal contesto di uno script"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Errore interno: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: l'espressione usa troppa memoria rispetto a 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: buffer vuoto"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Espressione o delimitatore di ricerca non validi"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: File già caricato in un altro buffer"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: opzione '%s' non impostata"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Nome registro non valido"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "raggiunta la CIMA nella ricerca, continuo dal FONDO"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "raggiunto il FONDO nella ricerca, continuo dalla CIMA"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Manca ':'"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Componente non valido"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: aspettavo un numero"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Pagina %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Manca testo da stampare"
 
+#: ../hardcopy.c:668
+#, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Sto stampando pagina %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Copia %d di %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Stampato: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Stampa non completata"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Errore in scrittura a file PostScript di output"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Non riesco ad aprire il file \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Non riesco a leggere file risorse PostScript \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: file \"%s\" non è un file di risorse PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: file \"%s\" non è un file di risorse PostScript supportato"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: il file di risorse \"%s\" ha una versione sbagliata"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Codifica e set di caratteri multi-byte non compatibili."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset non può essere nullo con codifica multi-byte."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Font predefinito non specificato per stampa multi-byte."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Non riesco ad aprire file PostScript di output"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Non riesco ad aprire il file \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Non trovo file risorse PostScript \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Non trovo file risorse PostScript \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Non trovo file risorse PostScript \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Impossibile convertire a codifica di stampa \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Invio a stampante..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Non riesco ad aprire file PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Richiesta di stampa inviata."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Aggiungi un nuovo database"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Cerca un modello"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Visualizza questo messaggio"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Termina una connessione"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Reinizializza tutte le connessioni"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Visualizza connessioni"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Uso: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Questo comando cscope non gestisce la divisione delle schermo.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Uso: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tag non trovato"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: errore stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: errore stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s non è una directory o un database cscope valido"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Aggiunto database cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: errore leggendo connessione cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: tipo di ricerca cscope sconosciuta"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Non riesco a creare pipes cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Non riesco a fare fork per cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection setpgid fallita"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection exec fallita"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen di to_fp fallita"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen di fr_fp fallita"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Non riesco a generare processo cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: nessuna connessione cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: flag cscopequickfix %c non valido per %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: nessuna corrispondenza trovata per la richiesta cscope %s di %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "comandi cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Uso: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2526,32 +3240,31 @@ msgstr ""
 "       s: Trova questo simbolo C\n"
 "       t: Trova questa stringa\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: impossibile aprire database cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: impossibile leggere informazioni sul database cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: database cscope duplicato, non aggiunto"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: connessione cscope %s non trovata"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "connessione cscope %s chiusa"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: errore irreparabile in cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Tag cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2559,365 +3272,87 @@ msgstr ""
 "\n"
 "   #   linea"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "nomefile / contest / linea\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Errore cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Tutti i database cscope annullati"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "nessuna connessione cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    database nome                       prepend path\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Non riesco a caricare libreria Lua."
-
-msgid "cannot save undo information"
-msgstr "non riesco a salvare informazioni per 'undo'"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Spiacente, comando non disponibile, non riesco a caricare librerie "
-"programmi MzScheme."
-
-msgid "invalid expression"
-msgstr "espressione non valida"
-
-msgid "expressions disabled at compile time"
-msgstr "espressioni disabilitate in compilazione"
-
-msgid "hidden option"
-msgstr "opzione nascosta"
-
-msgid "unknown option"
-msgstr "opzione inesistente"
-
-msgid "window index is out of range"
-msgstr "indice della finestra non nell'intervallo"
-
-msgid "couldn't open buffer"
-msgstr "non sono riuscito ad aprire il buffer"
-
-msgid "cannot delete line"
-msgstr "non posso cancellare la linea"
-
-msgid "cannot replace line"
-msgstr "non posso sostituire la linea"
-
-msgid "cannot insert line"
-msgstr "non posso inserire la linea"
-
-msgid "string cannot contain newlines"
-msgstr "la stringa non può contenere caratteri 'A CAPO'"
-
-msgid "error converting Scheme values to Vim"
-msgstr "errore nel convertire i valori Scheme a Vim"
-
-msgid "Vim error: ~a"
-msgstr "Errore Vim: ~a"
-
-msgid "Vim error"
-msgstr "Errore Vim"
-
-msgid "buffer is invalid"
-msgstr "buffer non valido"
-
-msgid "window is invalid"
-msgstr "finestra non valida"
-
-msgid "linenr out of range"
-msgstr "numero linea non nell'intervallo"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "non ammesso in ambiente protetto"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: Impossibile usare :py e :py3 nella stessa sessione"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Impossibile usare ora :py3 dopo aver usato :python"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Spiacente, comando non disponibile, non riesco a caricare libreria "
-"programmi Python."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python non può essere chiamato ricorsivamente"
-
-msgid "line number out of range"
-msgstr "numero linea non nell'intervallo"
-
-msgid "invalid mark name"
-msgstr "nome di mark non valido"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ deve essere un'istanza di String"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Spiacente, comando non disponibile, non riesco a caricare libreria "
-"programmi Ruby."
-
-msgid "E267: unexpected return"
-msgstr "E267: return imprevisto"
-
-msgid "E268: unexpected next"
-msgstr "E268: next imprevisto"
-
-msgid "E269: unexpected break"
-msgstr "E269: break imprevisto"
-
-msgid "E270: unexpected redo"
-msgstr "E270: redo imprevisto"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry fuori da clausola rescue"
-
-msgid "E272: unhandled exception"
-msgstr "E272: eccezione non gestita"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: tipo sconosciuto di salto nel programma %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Implementazione/definizione Sì/No"
-
-msgid "Show base class of"
-msgstr "Visualizza classe base di"
-
-msgid "Show overridden member function"
-msgstr "Visualizza funzione modulo sovrascritto"
-
-msgid "Retrieve from file"
-msgstr "Carica da file"
-
-msgid "Retrieve from project"
-msgstr "Carica da progetto"
-
-msgid "Retrieve from all projects"
-msgstr "Carica da tutti i progetti"
-
-msgid "Retrieve"
-msgstr "Carica successivo"
-
-msgid "Show source of"
-msgstr "Visualizza sorgente di"
-
-msgid "Find symbol"
-msgstr "Trova simbolo"
-
-msgid "Browse class"
-msgstr "Esplora classe"
-
-msgid "Show class in hierarchy"
-msgstr "Visualizza classe in gerarchia"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Visualizza classe nella gerarchia ristretta"
-
-msgid "Xref refers to"
-msgstr "Xref si riferisce a"
-
-msgid "Xref referred by"
-msgstr "Xref referenziato da"
-
-msgid "Xref has a"
-msgstr "Xref ha un"
-
-msgid "Xref used by"
-msgstr "Xref usato da"
-
-msgid "Show docu of"
-msgstr "Visualizza docu di"
-
-msgid "Generate docu for"
-msgstr "Genera docu per"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Non riesco a connettermi a SNiFF+. Controllare ambiente (sniffemacs deve "
-"essere presente in $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Errore in lettura. Disconnessione."
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ è al momento "
-
-msgid "not "
-msgstr "non "
-
-msgid "connected"
-msgstr "connesso"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Richiesta SNiFF+ sconosciuta: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Errore di connessione a SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ non connesso"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Non è un buffer SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Errore in scrittura. Disconnesso"
-
-msgid "invalid buffer number"
-msgstr "numero buffer non valido"
-
-msgid "not implemented yet"
-msgstr "non ancora implementato"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "non posso impostare linea(e)"
-
-msgid "mark not set"
-msgstr "mark non impostato"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "riga %d colonna %d"
-
-msgid "cannot insert/append line"
-msgstr "non riesco a inserire/aggiungere linea"
-
-msgid "unknown flag: "
-msgstr "opzione inesistente: "
-
-msgid "unknown vimOption"
-msgstr "'vimOption' inesistente"
-
-msgid "keyboard interrupt"
-msgstr "interruzione dalla tastiera"
-
-msgid "vim error"
-msgstr "errore vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr ""
-"non riesco a creare comando buffer/finestra: oggetto in via di cancellazione"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"non posso registrare comando callback: buffer/finestra già in cancellazione"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: ERRORE FATALE TCL: reflist corrotta!? Si prega notificare a vim-"
-"dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"non posso registrare comando callback: riferimento a buffer/finestra "
-"inesistente"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Spiacente, comando non disponibile, non riesco a caricare libreria "
-"programmi Tcl."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: codice di uscita %d"
-
-msgid "cannot get line"
-msgstr "non riesco a ottenere la linea"
-
-msgid "Unable to register a command server name"
-msgstr "Non riesco a registrare un nome di server comando"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Fallito invio comando a programma destinatario"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Identificativo di server non valido: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Proprietà registry relative a VIM non adeguate.  Cancellate!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Argomento di opzione sconosciuto"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Troppi argomenti di edit"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argomento mancante dopo"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Spazzatura dopo argomento di opzione"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Troppi argomenti \"+command\", \"-c command\" o \"--cmd command\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Argomento non valido per"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d file da elaborare\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans non è supportato con questa GUI\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Vim non compilato con funzionalità 'diff'."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' non disponibile: non abilitato in compilazione\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Tento di riaprire lo script file: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Non posso aprire in lettura: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Non posso aprire come script output: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Errore: Avvio di gvim da NetBeans non riuscito\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Attenzione: Output non diretto a un terminale\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Attenzione: Input non proveniente da un terminale\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "linea comandi prima di vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Non posso leggere da \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2925,18 +3360,23 @@ msgstr ""
 "\n"
 "Maggiori informazioni con: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[file ..]       apri file(s) specificati"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               leggi testo da 'stdin'"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          apri file in cui è definito il tag"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  apri file col primo errore"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2946,9 +3386,11 @@ msgstr ""
 "\n"
 "  uso:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argomenti] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2956,13 +3398,7 @@ msgstr ""
 "\n"
 "    o:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Quando si ignorano maiusc./minusc. preporre / per rendere il flag maiusc."
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2972,323 +3408,192 @@ msgstr ""
 "\n"
 "Argomenti:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tSolo nomi file da qui in poi"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNon espandere wildcard"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistra questo gvim a OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tDeregistra gvim a OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tEsegui usando GUI (come \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f opp. --nofork\tForeground: Non usare 'fork' inizializzando GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tModalità Vi (come \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tModalità Ex (come \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tModalità Ex migliorata"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tModalità Silenziosa (batch) (solo per \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tModalità Diff (come \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tModalità Facile (come \"evim\", senza modalità)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModalità Sola Lettura (come \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tModalità Ristretta (come \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tRiscritture del file non permesse"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModifiche nel file non permesse"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tModalità Binaria"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tModalità Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tCompatibile con Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNon interamente compatibile con Vi: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][fname]\t\tVerbosità [livello N] [log su file fname]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tModalità Debug"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNiente file di swap, usa solo memoria"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tLista swap file ed esci"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (e nome file)\tRecupera da sessione finita male"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tCome -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNon usare newcli per aprire finestra"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <dispositivo>\t\tUsa <dispositivo> per I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tComincia in modalità Araba"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tComincia in modalità Ebraica"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tComincia in modalità Farsi (Persiano)"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminale>\tImposta tipo terminale a <terminale>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tUsa <vimrc> invece di .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tUsa <gvimrc> invece di .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNon caricare script plugin"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-o[N]\t\tApri N linguette (predefinito: una per ogni file)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tApri N finestre (predefinito: una per ogni file)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tCome -o ma dividi le finestre in verticale"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tPosizionati alla fine del file"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tPosizionati alla linea <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr ""
 "--cmd <comando>\t\tEsegui <comando> prima di caricare eventuali file vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <comando>\t\tEsegui <comando> dopo caricamento primo file"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sessione>\tEsegui comandi in file <sessione> dopo caricamento primo file"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tLeggi comandi in modalità normale da file <scriptin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\tAggiungi tutti i comandi immessi a file <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\tScrivi tutti i comandi immessi in file <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tApri un file cifrato"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <schermo>\tEsegui vim a questo particolare server X"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNon connetterti a server X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <file>\tApri <file> in un server Vim se possibile"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <file>   Stessa cosa, ignora se non esiste un server"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <file>   Come --remote ma aspetta che i file siano elaborati"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <file>   Stessa cosa, ignora se non esiste un server"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <file>  Come --remote ma apre una linguetta per "
-"file"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <tasti>\tInvia <tasti> a un server Vim ed esci"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote--expr <expr>\tEsegui <expr> in un server Vim e stampa risultato"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tLista nomi server Vim disponibili ed esci"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nome>\tInvia a/diventa server Vim di nome <nome>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <file>\tScrivi tutti i messaggi iniziali di timing in <file>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUsa <viminfo> invece di .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h opp. --help\tStampa Aiuto (questo messaggio) ed esci"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tStampa informazioni sulla versione ed esci"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Opzioni accettate da gvim (versione Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Opzioni accettate da gvim (versione neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Opzioni accettate da gvim (versione Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <schermo>\tEsegui vim su <schermo>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tInizia vim riducendolo ad icona"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <colore>\tUsa <colore> come sfondo (anche: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <colore>\tUsa <colore> per il testo normale (anche: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tUsa <font> for il testo normale (anche: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\tUsa <font> per testo in grassetto"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\tUsa <font> per testo in corsivo"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\tUsa <geom> per la geometria iniziale (anche: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <larg>\tUsa larghezza <larg> per bordo (anche: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <larg>  Usa larghezza <larg> per scrollbar (anche: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <alt>\tUsa altezza <alt> per barra menu (anche: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tUsa colori invertiti (anche: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNon usare colori invertiti (anche: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <risorsa>\tImposta la risorsa specificata"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argomenti accettati da gvim (versione GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <schermo>\tEsegui vim su <schermo> (anche: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <ruolo>\tImposta un ruolo univoco per identificare la finestra "
-"principale"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tApri Vim dentro un altro widget GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tStampa il Window ID su stdout"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <titolo padre>\tApri Vim in un'applicazione padre"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tApri Vim dentro un altro widget win32"
-
-msgid "No display"
-msgstr "Manca display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Invio fallito.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Invio fallito. Tento di eseguire localmente\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d di %d elaborato"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Nessun display: Invio di espressione fallito.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Invio di espressione fallito.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Nessun mark impostato"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Nessun mark corrispondente a \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3297,6 +3602,7 @@ msgstr ""
 "mark linea col.file/testo"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3305,6 +3611,7 @@ msgstr ""
 " salt.linea col.file/testo"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3312,6 +3619,7 @@ msgstr ""
 "\n"
 "modif linea  col testo"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3320,6 +3628,7 @@ msgstr ""
 "# File mark:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3327,6 +3636,7 @@ msgstr ""
 "\n"
 "# Jumplist (dai più recenti):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3334,89 +3644,85 @@ msgstr ""
 "\n"
 "# Storia dei mark all'interno dei file (dai più recenti ai meno recenti):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Manca '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Codepage non valido"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Non posso assegnare valori IC"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Creazione di un contesto di input fallita"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Apertura 'input method' fallita"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Attenzione: Non posso assegnare IM a 'destroy callback'"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 'input method' non sopporta alcuno stile"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 'input method' non supporta il mio tipo di preedit"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: il blocco non era riservato"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Errore di posizionamento durante lettura swap file"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Errore leggendo swap file"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Errore di posizionamento scrivendo swap file"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Errore scrivendo swap file"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Lo swap file esiste già (un link simbolico?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Non riesco a leggere blocco numero 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Non riesco a leggere blocco numero 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Non riesco a leggere blocco numero 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Errore aggiornando cifratura dello swap file"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ahimè, lo swap file è perduto!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Non riesco a rinominare lo swap file"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Non riesco ad aprile lo swap file per \"%s\", recupero impossibile"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Non riesco a leggere blocco 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Nessun swap file trovato per %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Dimmi numero di swap file da usare (0 per lasciar perdere): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Non riesco ad aprire %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Non riesco a leggere il blocco 0 da "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3424,22 +3730,28 @@ msgstr ""
 "\n"
 "Forse non ci sono state modifiche oppure Vim non ha aggiornato lo swap file."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " non può essere usato con questa versione di Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Usa Vim versione 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s non sembra uno swap file Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " non può essere usato su questo computer.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Il file è stato creato il "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3447,105 +3759,87 @@ msgstr ""
 ",\n"
 "o il file è stato danneggiato."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s è cifrato e questa versione di Vim non supporta la cifratura"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr ""
 " è stato danneggiato (la dimensione della pagina è inferiore al minimo).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Uso swap file \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "File originale \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr ""
 "E308: Attenzione: il file originale può essere stato modificato nel frattempo"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Il file swap è cifrato: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Se hai immesso una chiave di cifratura senza riscrivere il file di testo,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"immetti la nuova chiave di cifratura."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Se hai riscritto il file dopo aver cambiato chiave di cifr., premi Invio"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"per usare la stessa chiave sia per il testo che per il file swap"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Impossibile leggere blocco 1 da %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???MOLTE LINEE MANCANTI"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???CONTATORE LINEE ERRATO"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???BLOCCO VUOTO"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LINEE MANCANTI"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID del Blocco 1 errato (che %s non sia un .swp file?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOCCO MANCANTE"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? da qui fino a ???END le linee possono essere fuori ordine"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr ""
 "??? da qui fino a ???END linee possono essere state inserite/cancellate"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Recupero Interrotto"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Errori durante recupero; controlla linee che iniziano con ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Vedere \":help E312\" per ulteriori informazioni."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Recupero completato. Dovresti controllare se va tutto bene."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3553,13 +3847,16 @@ msgstr ""
 "\n"
 "(Potresti salvare questo file con un altro nome ed eseguire\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "'diff' rispetto al file originale per vedere le differenze)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr ""
 "Ripristino effettuato. Il contenuto del buffer coincide con quello del file."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3569,43 +3866,52 @@ msgstr ""
 "È consigliato cancellare il file .swp adesso.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Uso la chiave di cifratura del file swap per il file di testo.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Swap file trovati:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   Nella directory in uso:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Uso il nome fornito:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   Nella directory "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- nessuno --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "      proprietario: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "  datato: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "            datato: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [da Vim versione 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "        [non assomiglia ad uno swap file Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         nome file: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3613,12 +3919,15 @@ msgstr ""
 "\n"
 "        modificato: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "YES"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "no"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3626,9 +3935,11 @@ msgstr ""
 "\n"
 "       nome utente: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   nome computer: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3636,6 +3947,7 @@ msgstr ""
 "\n"
 "          nome computer: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3643,16 +3955,11 @@ msgstr ""
 "\n"
 "   ID del processo: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (ancora attivo)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [non utilizzabile con questa versione di Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3660,75 +3967,97 @@ msgstr ""
 "\n"
 "         [not utilizzabile su questo computer]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "          [non leggibile]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "     [non riesco ad aprire]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Non posso preservare, manca swap file"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "File preservato"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Preservazione fallita"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: numero linea non valido: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: non riesco a trovare la linea %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ID blocco puntatori errato 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx dovrebbe essere 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Aggiornati troppi blocchi?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: ID blocco puntatori errato 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "cancellato blocco 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Non riesco a trovare la linea %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: ID blocco puntatori errato"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count a zero"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: numero linea non ammissibile: %<PRId64> dopo la fine"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: contatore linee errato nel blocco %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Dimensione stack aumentata"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: ID blocco puntatori errato 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Collegamento simbolico ricorsivo per \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ATTENZIONE"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3736,14 +4065,15 @@ msgstr ""
 "\n"
 "Trovato uno swap file di nome \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Mentre aprivo file \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      più RECENTE dello swap file!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3755,15 +4085,19 @@ msgstr ""
 "    Se è così, attenzione a non trovarti con due versioni\n"
 "    differenti dello stesso file a cui vengono apportate modifiche."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Esci, o continua con prudenza.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Una sessione di edit per questo file è finita male.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Se è così, usa \":recover\" oppure \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3771,9 +4105,11 @@ msgstr ""
 "\"\n"
 "    per recuperare modifiche fatte (vedi \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Se hai già fatto ciò, cancella il file di swap \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3781,18 +4117,23 @@ msgstr ""
 "\"\n"
 "    per non ricevere ancora questo messaggio.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Swap file \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" già esistente!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ATTENZIONE"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Lo swap file esiste già!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3806,6 +4147,7 @@ msgstr ""
 "&Q Esci\n"
 "&Annulla"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3821,36 +4163,58 @@ msgstr ""
 "&Q Esci\n"
 "&Annulla"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Trovati troppi swap file"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Non c'è più memoria! (stavo allocando %<PRIu64> byte)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr ""
 "E327: Parte del percorso di questo elemento di Menu non è un sotto-Menu"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: I Menu esistono solo in un'altra modalità"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Nessun Menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Nome menu non valido"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Il percorso del Menu non deve condurre a un sotto-Menu"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr ""
 "E331: Non devi aggiungere elementi di Menu direttamente alla barra Menu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Il separatore non può far parte di un percorso di Menu"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3858,60 +4222,73 @@ msgstr ""
 "\n"
 "--- Menu ---"
 
-msgid "Tear off this menu"
-msgstr "Togli questo Menu"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Il percorso Menu deve condurre ad un elemento Menu"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Menu non trovato: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menu non definito per la modalità %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Il percorso Menu deve condurre ad un sotto-Menu"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Menu non trovato - controlla nomi Menu"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Errore/i eseguendo %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "linea %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nome registro non valido: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Manutentore messaggi: Vlad Sandrini <marco@sandrini.biz>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Interruzione: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Premi INVIO o un comando per proseguire"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s linea %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Ancora --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPAZIO/d/j: schermo/pagina/linea giù, b/u/k: su, q: abbandona "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Domanda"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3919,6 +4296,17 @@ msgstr ""
 "&Y Sì\n"
 "&No"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Y Sì\n"
+"&No\n"
+"&C Ignora"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3932,272 +4320,175 @@ msgstr ""
 "&D Scarta Tutto\n"
 "&Cancella"
 
-msgid "Select Directory dialog"
-msgstr "Scelta Directory dialogo"
-
-msgid "Save File dialog"
-msgstr "Salva File dialogo"
-
-msgid "Open File dialog"
-msgstr "Apri File dialogo"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Spiacente, niente esplorazione file in modalità console"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Argomenti non sufficienti per printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Numero con virgola atteso come argomento per printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Troppi argomenti per printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Attenzione: Modifica a un file in sola-lettura"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "Inserire un numero e <Invio> o fare clic (lasciare vuoto per annullare): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Inserire numero e <Invio> (vuoto per annullare): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 linea in più"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 linea in meno"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> linee in più"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> linee in meno"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Interrotto)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Beep!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: preservo file...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Finito.\n"
-
-msgid "ERROR: "
-msgstr "ERRORE: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[byte] totali alloc-rilasc %<PRIu64>-%<PRIu64>, in uso %<PRIu64>, max uso %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[chiamate] totale re/malloc() %<PRIu64>, totale free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: La linea sta diventando troppo lunga"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Errore interno: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Non c'è più memoria! (stavo allocando %<PRIu64> byte)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Chiamo lo shell per eseguire: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Manca ':'"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Modalità non valida"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Forma del mouse non valida"
-
-msgid "E548: digit expected"
-msgstr "E548: aspettavo un numero"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Percentuale non valida"
-
-msgid "Enter encryption key: "
-msgstr "Immetti chiave di cifratura: "
-
-msgid "Enter same key again: "
-msgstr "Ribatti per conferma la stessa chiave: "
-
-msgid "Keys don't match!"
-msgstr "Le chiavi non corrispondono!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: percorso troppo lungo per il completamento"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Percorso non valido: '**[numero]' deve essere a fine percorso o essere "
-"seguito da '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Non riesco a trovare la directory \"%s\" nel 'cdpath'"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Non riesco a trovare il file \"%s\" nel percorso"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Nessun altra directory \"%s\" trovata nel 'cdpath'"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Nessun altro file \"%s\" trovato nel percorso"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Non posso connettermi a Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Non posso connettermi a Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Modalità errata di accesso a file info connessione NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "lettura da socket Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Connessione NetBeans persa per il buffer %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans non è supportato con questa GUI"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans già connesso"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s è in sola lettura (aggiungi ! per eseguire comunque)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Nessun identificativo sotto il cursore"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: opzione 'operatorfunc' non impostata"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Funzionalità [eval] non disponibile"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Attenzione: il terminale non è in grado di evidenziare"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Nessuna stringa sotto il cursore"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Non posso togliere piegature con il 'foldmethod' in uso"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: lista modifiche assente"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: All'inizio della lista modifiche"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Alla fine della lista modifiche"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Batti :quit<Invio>  per uscire da Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 linea %sa 1 volta"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 linea %sa %d volte"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> linee %se 1 volta"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> linee %se %d volte"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> linee da rientrare... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 linea rientrata "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> linee rientrate "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Nessun registro usato in precedenza"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "non riesco a salvare in un registro; cancello comunque"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 linea cambiata"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> linee cambiate"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "libero %<PRId64> linee"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "blocco di 1 linea messo in registro"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 linea messa in registro"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "blocco di %<PRId64> linee messo in registro"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> linee messe in registro"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Niente nel registro %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4205,9 +4496,11 @@ msgstr ""
 "\n"
 "--- Registri ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Nome registro non ammesso"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4215,162 +4508,181 @@ msgstr ""
 "\n"
 "# Registri:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Tipo di registro sconosciuto: %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Col.; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selezionate %s%<PRId64> di %<PRId64> Linee; %<PRId64> di %<PRId64> Parole; %<PRId64> di %<PRId64> Caratt."
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Selezionate %s%<PRId64> di %<PRId64> Linee; %<PRId64> di %<PRId64> Parole; %<PRId64> di %<PRId64> Caratt.; %<PRId64> "
-"di %<PRId64> Byte"
+"Selezionate %s%<PRId64> di %<PRId64> Linee; %<PRId64> di %<PRId64> Parole; "
+"%<PRId64> di %<PRId64> Caratt."
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col. %s di %s; Linea %<PRId64> di %<PRId64>; Parola %<PRId64> di %<PRId64>; Caratt. %<PRId64> di %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Col. %s di %s; Linea %<PRId64> di %<PRId64>; Parola %<PRId64> di %<PRId64>; Caratt. %<PRId64> di %<PRId64>; Byte "
-"%<PRId64> di %<PRId64>"
+"Selezionate %s%<PRId64> di %<PRId64> Linee; %<PRId64> di %<PRId64> Parole; "
+"%<PRId64> di %<PRId64> Caratt.; %<PRId64> di %<PRId64> Byte"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Col. %s di %s; Linea %<PRId64> di %<PRId64>; Parola %<PRId64> di %<PRId64>; "
+"Caratt. %<PRId64> di %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Col. %s di %s; Linea %<PRId64> di %<PRId64>; Parola %<PRId64> di %<PRId64>; "
+"Caratt. %<PRId64> di %<PRId64>; Byte %<PRId64> di %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> per BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Pagina %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Grazie per aver volato con Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Opzione inesistente"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opzione non supportata"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Non consentito in una 'modeline'"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Key code non impostato"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Ci vuole un numero dopo ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Non trovato in 'termcap'"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Carattere non ammesso <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Non posso assegnare a 'term' il valore 'stringa nulla'"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Non posso modificare 'term' mentre sono nella GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Usa \":gui\" per far partire la GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' e 'patchmode' sono uguali"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Conflitto con il valore di 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Conflitto con il valore di 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Non può essere cambiato nella GUI GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Manca ':'"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Stringa nulla"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Manca numero dopo <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Manca virgola"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Devi specificare un valore '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: contiene carattere 'wide' o non-stampabile"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Font non validi"
-
-msgid "E597: can't select fontset"
-msgstr "E597: non posso selezionare fontset"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Fontset non valido"
-
-msgid "E533: can't select wide font"
-msgstr "E533: non posso selezionare 'wide font'"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 'Wide font' non valido"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Carattere non ammesso dopo <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: virgola mancante"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' deve essere nulla o contenere %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Manca supporto mouse"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Espressione non terminata"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: troppi elementi"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: gruppi sbilanciati"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Una finestra di pre-visualizzazione esiste già"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabo richiede UTF-8, esegui ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Servono almeno %d linee"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Servono almeno %d colonne"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Opzione inesistente: %s"
@@ -4378,10 +4690,12 @@ msgstr "E355: Opzione inesistente: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Ci vuole un numero: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4389,6 +4703,7 @@ msgstr ""
 "\n"
 "--- Codici terminale ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4396,6 +4711,7 @@ msgstr ""
 "\n"
 "--- Valori opzioni globali ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4403,6 +4719,7 @@ msgstr ""
 "\n"
 "--- Valore opzioni locali ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4410,139 +4727,21 @@ msgstr ""
 "\n"
 "--- Opzioni ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ERRORE get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Manca carattere corrispondente per %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Caratteri in più dopo il ';': %s"
 
-msgid "cannot open "
-msgstr "non riesco ad aprire "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Non riesco ad aprire la finestra!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Serve Amigados versione 2.04 o successiva\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Serve %s versione %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Non riesco ad aprire NIL:\n"
-
-msgid "Cannot create "
-msgstr "Non riesco a creare "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim esce con %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "non posso modificare modalità console ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: non una console??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Non posso eseguire lo shell con l'opzione -f"
-
-msgid "Cannot execute "
-msgstr "Non riesco a eseguire "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " ottenuto\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE troppo piccolo."
-
-msgid "I/O ERROR"
-msgstr "ERRORE I/O"
-
-msgid "Message"
-msgstr "Messaggio"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' non vale 80, non riesco ad eseguire comandi esterni"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Scelta stampante non riuscita"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "a %s su %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Font per stampante sconosciuto: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Errore durante stampa: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Stampato: '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Nome di charset non ammesso \"%s\" nel fonte di nome \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Carattere non ammesso '%c' nel font di nome \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Segnale doppio, esco\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Intercettato segnale fatale %s\n"
-
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Intercettato segnale fatale\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Attivazione visualizzazione X ha richiesto %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Preso errore X\n"
-
-msgid "Testing the X display failed"
-msgstr "Prova visualizzazione X fallita"
-
-msgid "Opening the X display timed out"
-msgstr "Apertura visualizzazione X: tempo scaduto"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Non posso ottenere il contesto di sicurezza per "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Non posso impostare il contesto di sicurezza per "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4550,13 +4749,7 @@ msgstr ""
 "\n"
 "Non riesco a eseguire shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Non riesco a eseguire shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4564,425 +4757,474 @@ msgstr ""
 "\n"
 "shell terminato con return-code "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Non posso creare 'pipe'\n"
+"Non posso ottenere il contesto di sicurezza per "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Non riesco ad effettuare 'fork'\n"
+"Non posso impostare il contesto di sicurezza per "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Comando terminato\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP ha perso la connessione ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Apertura visualizzazione X fallita"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP gestione richiesta 'save-yourself'"
-
-msgid "XSMP opening connection"
-msgstr "XSMP apertura connessione"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP osservazione connessione ICE fallita"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection fallita: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Non riesco a trovare il file \"%s\" nel percorso"
 
-msgid "At line"
-msgstr "Alla linea"
-
-msgid "Could not load vim32.dll!"
-msgstr "Non riesco a caricare vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Errore VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Non sono riuscito a impostare puntatori di funzione verso la DLL!"
-
+#: ../quickfix.c:359
 #, c-format
-msgid "shell returned %d"
-msgstr "shell terminato con return-code %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Intercettato evento %s\n"
-
-msgid "close"
-msgstr "chiusura"
-
-msgid "logoff"
-msgstr "logoff"
-
-msgid "shutdown"
-msgstr "shutdown"
-
-msgid "E371: Command not found"
-msgstr "E371: Comando non trovato"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE non trovato nel tuo $PATH.\n"
-"I comandi esterni non faranno una pausa dopo aver finito l'esecuzione.\n"
-"Vedi  :help win32-vimrun  per ulteriori informazioni."
-
-msgid "Vim Warning"
-msgstr "Avviso da Vim"
-
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Troppi %%%c nella stringa di 'format'"
 
+#: ../quickfix.c:371
+#, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: %%%c imprevisto nella stringa di 'format'"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Manca ] nella stringa di 'format'"
 
+#: ../quickfix.c:431
+#, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c non supportato nella stringa di 'format'"
 
+#: ../quickfix.c:448
+#, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: %%%c non valido nel prefisso della stringa di 'format'"
 
+#: ../quickfix.c:454
+#, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: %%%c non valido nella stringa di 'format'"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' non contiene alcun modello"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Nome directory mancante o nullo"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Non ci sono più elementi"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d di %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (linea cancellata)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Al fondo dello stack di quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: In cima allo stack di quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "lista errori %d di %d; %d errori"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Non posso scrivere, l'opzione 'buftype' è impostata"
 
-msgid "Error file"
-msgstr "File errori"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Nome file mancante o espressione non valida"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Non riesco ad aprire il file \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Buffer non caricato"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: aspettavo Stringa o Lista"
 
+#: ../regexp.c:359
+#, fuzzy, c-format
+msgid "E369: invalid item in %s%%[]"
+msgstr "E239: Testo 'sign' non valido: %s"
+
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Manca ] dopo %s["
 
+#: ../regexp.c:375
+#, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Senza riscontro: %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Senza riscontro: %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Senza riscontro: %s)"
 
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( non consentito qui"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 ecc. non consentiti qui"
 
+#: ../regexp.c:380
+#, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Manca ] dopo %s%%["
 
+#: ../regexp.c:381
+#, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] vuoto"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Espressione troppo lunga"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Troppe \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Troppe %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Senza riscontro: \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: Carattere non ammesso dopo %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Troppi %s{...}s complessi"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: %s* nidificato"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: %s%c nidificato"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: uso non valido di \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c senza nulla prima"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Riferimento all'indietro non ammesso"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Carattere non ammesso dopo \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Carattere non valido dopo %s%%[dxouU]"
 
+#: ../regexp.c:2107
+#, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Carattere non ammesso dopo %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Errore sintattico in %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Sotto-corrispondenze esterne:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
-"E864: \\%#= può essere seguito solo da 0, 1 o 2. Sarà usato il motore automatico "
+"E864: \\%#= può essere seguito solo da 0, 1 o 2. Sarà usato il motore "
+"automatico "
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) Fine prematura dell'espressione regolare"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA regexp) %c fuori posto"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) Fine prematura dell'espressione regolare"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Operatore sconosciuto '\\z%c'"
 
+#: ../regexp_nfa.c:1387
+#, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) Operatore sconosciuto '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Errore nel build di NFA con classe di equivalenza!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Operatore sconosciuto '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFA regexp) Errore nella lettura dei limiti di ripetizione"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (NFA regexp) Non si può avere multi dopo multi !"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA regexp) Troppi '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA regexp) Troppi \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA regexp) errore di terminazione corretta"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Impossibile riprendere lo stack !"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
-msgstr "E875: (NFA regexp) (Nella conversione da postfix a NFA), "
-"troppi stati lasciati sullo stack"
+msgstr ""
+"E875: (NFA regexp) (Nella conversione da postfix a NFA), troppi stati "
+"lasciati sullo stack"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA regexp) Non c'è spazio per immagazzinare l'intero NFA "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Non posso allocare memoria per il zigzag di ramo!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
 "Non posso aprire il file temporaneo per la scrittura, mostro su stderr ... "
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) IMPOSSIBILE APRIRE %s !"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Non posso aprire il log temporaneo in scrittura "
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-SOSTITUISCI"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " SOSTITUISCI"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " INVERTITO"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERISCI"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (inserisci)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (sostituisci)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-sostituisci)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Ebraico"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabo"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lingua)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (incolla)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUALE"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUALE LINEA"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUALE BLOCCO"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " SELEZIONA"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " SELEZIONA LINEA"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " SELEZIONA BLOCCO"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "registrazione"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Stringa di ricerca non valida: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: la ricerca ha raggiunto la CIMA senza successo per: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: la ricerca ha raggiunto il FONDO senza successo per: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: '?' o '/' atteso dopo ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (comprese corrispondenze elencate prima)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- File inclusi "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "non trovati "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "nel percorso ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Già elencati)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NON TROVATO"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Scandisco file incluso: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Cerco nel file incluso: %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Corrispondenza nella linea corrente"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Tutti i file inclusi sono stati trovati"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Nessun file incluso"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Non sono riuscito a trovare la definizione"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Non sono riuscito a trovare il modello"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Sostituzione "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4993,84 +5235,97 @@ msgstr ""
 "# Ult. %sEspressione di Ricerca:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Errore di formato nel file ortografico"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: File ortografico troncato"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Testo in eccesso in %s linea %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Nome affisso troppo lungo in %s linea %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Errore di formato nel file affissi FOL, LOW o UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Carattere fuori intervallo in FOL, LOW o UPP"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Comprimo albero di parole..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Controllo ortografico non abilitato"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr "Attenzione: Non trovo lista parole \"%s_%s.spl\" o \"%s_ascii.spl\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Attenzione: Non trovo lista parole \"%s.%s.spl\" o \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Lettura file ortografico \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Questo non sembra un file ortografico"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: File ortografico obsoleto, è necessario aggiornarlo"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Il file ortografico è per versioni di Vim più recenti"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Sezione non supportata nel file ortografico"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Attenzione: regione %s non supportata"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Lettura file affissi %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Conversione fallita per una parola in %s linea %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Conversione in %s non supportata: da %s a %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Conversione in %s non supportata"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Valore di FLAG non valido in %s linea %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG dopo l'uso di flags in %s linea %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5079,6 +5334,7 @@ msgstr ""
 "Definire COMPOUNDFORBIDFLAG dopo l'elemento PFX potrebbe dare risultati "
 "errati in %s linea %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5087,35 +5343,43 @@ msgstr ""
 "Definire COMPOUNDPERMITFLAG dopo l'elemento PFX potrebbe dare risultati "
 "errati in %s linea %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Valore errato per COMPOUNDRULES in %s linea %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Valore errato per COMPOUNDWORDMAX in %s linea %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Valore errato per COMPOUNDMIN in %s linea %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Valore errato per COMPOUNDSYLMAX in %s linea %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Valore errato per CHECKCOMPOUNDPATTERN in %s linea %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Flag combinazione diverso in blocco affissi continuo in %s linea %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Affisso duplicato in %s linea %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5124,269 +5388,334 @@ msgstr ""
 "Affisso usato anche per BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
 "in %s linea %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Y o N deve essere presente in %s linea %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Condizione non rispettata in %s linea %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Contatore REP(SAL) necessario in %s linea %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Contatore MAP necessario in %s linea %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Carattere duplicato in MAP in %s linea %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Elemento non riconosciuto o duplicato in %s linea %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Linea FOL/LOW/UPP mancante in %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX usato senza SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Troppi suffissi"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Troppi flag composti"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Troppi suffissi e/o flag composti"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Linea SOFO%s mancante in %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Linee sia SAL che SOFO in %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Il flag non è un numero in %s linea %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Flag non ammesso in %s linea %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Il valore di %s è diverso da quello usato in un altro file .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Lettura file dizionario %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Nessun contatore parole in %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "linea %6d, parola %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Parola duplicata in %s linea %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Prima parola duplicata in %s linea %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d parole duplicate in %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "%d parole con caratteri non-ASCII ignorate in %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Lettura file parole %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Linea /encoding= duplicata ignorata in %s linea %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Linea /encoding= dopo parola ignorata in %s linea %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Linea /regions= duplicata ignorata in %s linea %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Troppe regioni in %s linea %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Linea / ignorata in %s linea %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "N. regione non valido in %s linea %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Flag non riconosciuti in %s linea %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "%d parole con caratteri non-ASCII ignorate"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Memoria insufficiente, la lista parole sarà incompleta"
-
+#: ../spell.c:6656
+#, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "%d di %d nodi compressi; ne restano %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Rilettura file ortografico..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Eseguo soundfolding..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Numero di parole dopo soundfolding: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Conteggio totale delle parole: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Scrivo file di suggerimenti %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Uso stimato di memoria durante esecuzione: %d byte"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Il nome del file di output non deve avere il nome di regione"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Sono supportate fino ad 8 regioni"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Regione non valida in %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Attenzione: specificati sia composizione sia NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Scrivo file ortografico %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Fatto!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' non ha %<PRId64> elementi"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Parola rimossa da %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Parola aggiunta a %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Caratteri di parola differenti nei file ortografici"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Spiacente, nessun suggerimento"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Spiacente, solo %<PRId64> suggerimenti"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Cambiare \"%.*s\" in:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Nessuna sostituzione ortografica precedente"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Non trovato: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Questo non sembra un file .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: File .sug obsoleto, è necessario aggiornarlo: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Il file .sug è per versioni di Vim più recenti: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Il file .sug non corrisponde al file .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Errore leggendo il file .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: carattere duplicato nell'elemento MAP"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Nessun elemento sintattico definito per questo buffer"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Argomento non ammesso: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 'cluster' sintattico inesistente: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "sincronizzo i commenti nello stile C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "nessuna sincronizzazione"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "la sincronizzazione inizia "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " linee prima della linea iniziale"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5394,6 +5723,7 @@ msgstr ""
 "\n"
 "--- Elementi sincronizzazione sintassi ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5401,6 +5731,7 @@ msgstr ""
 "\n"
 "sincronizzo elementi"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5408,213 +5739,273 @@ msgstr ""
 "\n"
 "--- Elementi sintattici ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 'cluster' sintattico inesistente: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimale "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "massimale "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; corrisp. "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " interruzioni di linea"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: contiene argomenti non accettati qui"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: valore cchar non valido"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here non ammesso qui"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Elemento di 'region' non trovato per %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Nome file necessario"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Troppe inclusioni di sintassi"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Manca ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Manca '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Argomenti non sufficienti per: 'syntax region' %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Troppi 'cluster' sintattici"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Nessun 'cluster' specificato"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Delimitatore di espressione non trovato: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Spazzatura dopo espressione: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: syntax sync: espressione di continuazione linea specificata due volte"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Argomenti non validi: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Manca '=': %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Argomento nullo: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s non consentito qui"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s deve venire per primo nella lista 'contains'"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nome gruppo sconosciuto: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Sotto-comando :syntax non valido: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  TOTALE     CONT.  CORRIS. PIU LENTO   MEDIA     NOME               MODELLO"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: ciclo ricorsivo nel caricamento di syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: gruppo evidenziazione non trovato: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Argomenti non sufficienti: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Troppi argomenti: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: 'group' ha impostazioni, 'highlight link' ignorato"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: segno '=' inatteso: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: manca segno '=': %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: manca argomento: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Valore non ammesso: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: colore di testo sconosciuto"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: colore di sfondo sconosciuto"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Numero o nome di colore non riconosciuto: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: codice terminale troppo lungo: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Argomento non ammesso: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Troppi gruppi evidenziazione differenti in uso"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Carattere non stampabile in un nome di gruppo"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Carattere non ammesso in un nome di gruppo"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Troppi gruppi di evidenziazione e sintassi"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: al fondo dello stack dei tag"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: in cima allo stack dei tag"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Non posso andare prima del primo tag corrispondente"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tag non trovato: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri tipo tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "file\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: C'è solo un tag corrispondente"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Non posso andare oltre l'ultimo tag corrispondente"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Il file \"%s\" non esiste"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d di %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " o più"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Uso tag ignorando maiuscole/minuscole!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Il file \"%s\" non esiste"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5622,66 +6013,79 @@ msgstr ""
 "\n"
 "  # A  tag         DA__ linea in file/testo"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Ricerca nel tag file %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Percorso tag file troncato per %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Linea lunga ignorata nel tag file"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Errore di formato nel tag file \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Prima del byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag file non ordinato alfabeticamente: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Nessun tag file"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Non riesco a trovare modello tag"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Non riesco a trovare tag, sto solo tirando a indovinare!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Nome di campo duplicato: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' non noto. Terminali disponibili predisposti sono:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "predefinito a '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Non posso aprire file 'termcap'"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Descrizione terminale non trovata in 'terminfo'"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Descrizione terminale non trovata in 'termcap'"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Nessuna descrizione per \"%s\" in 'termcap'"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: capacità \"cm\" del terminale necessaria"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5689,244 +6093,169 @@ msgstr ""
 "\n"
 "--- Tasti Terminale ---"
 
-msgid "new shell started\n"
-msgstr "fatto eseguire nuovo shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Errore leggendo l'input, esco...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Uso CUT_BUFFER0 invece che una scelta nulla"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Il conteggio delle righe è inaspettatamente cambiato"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "'undo' non più possibile; continuo comunque"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Non posso aprire il file Undo in scrittura: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: File Undo corrotto (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Non posso scrivere un file Undo in alcuna directory di 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "File Undo non sovrascritto, non riesco a leggere: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Non sovrascritto, non è un file Undo: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Ometto scrittura del file Undo, non ci sono modifiche"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Scrivo file Undo: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: errore scrivendo nel file Undo: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Non leggo file Undo, appartiene a un altro utente: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Lettura file Undo: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Non posso aprire il file Undo in lettura: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Non è un file Undo: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: File non cifrato con file Undo cifrato: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Decifratura fallita del file Undo: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: File Undo cifrato: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: File Undo incompatibile: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "File ulteriormente modificato, non posso usare informazioni di Undo"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Lettura del file Undo %s effettuata"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Questa è già la prima modifica"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Questa è già l'ultima modifica"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Undo numero %<PRId64> non trovato"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: numeri linee errati"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "linea in più"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "linee in più"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "linea in meno"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "linee in meno"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "modifica"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "modifiche"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "prima"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "dopo"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nessuna modifica, Undo impossibile"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "numero modif.   quando             salv."
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> secondi fa"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin non è consentito dopo undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: lista 'undo' non valida"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: linea di 'undo' mancante"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"versione MS-Windows 16/32-bit GUI"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Versione MS-Windows 64-bit GUI"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Versione MS-Windows 32-bit GUI"
-
-msgid " in Win32s mode"
-msgstr " in modalità Win32s"
-
-msgid " with OLE support"
-msgstr " con supporto OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Versione MS-Windows 64-bit console"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Versione MS-Windows 32-bit console"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Versione MS-Windows 16-bit"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Version MS-DOS 32-bit"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versione MS-DOS 16-bit"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Versione MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Versione X MacOS"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Versione MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Versione OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5934,6 +6263,7 @@ msgstr ""
 "\n"
 "Patch incluse: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5941,9 +6271,11 @@ msgstr ""
 "\n"
 "Patch aggiuntive: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modificato da "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5951,9 +6283,11 @@ msgstr ""
 "\n"
 "Compilato "
 
+#: ../version.c:649
 msgid "by "
 msgstr "da "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5961,839 +6295,1891 @@ msgstr ""
 "\n"
 "Versione gigante "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Versione grande "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Versione normale "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Versione piccola "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Versione minuscola "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "senza GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "con GUI GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "con GUI GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "con GUI X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "con GUI X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "con GUI X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "con GUI Photon."
-
-msgid "with GUI."
-msgstr "con GUI."
-
-msgid "with Carbon GUI."
-msgstr "con GUI Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "con GUI Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "con GUI (classica)."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Funzionalità incluse (+) o escluse (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   file vimrc di sistema: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "       file vimrc utente: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "    II file vimrc utente: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "   III file vimrc utente: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "        file exrc utente: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "     II file exrc utente: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  file gvimrc di sistema: \""
-
-msgid "    user gvimrc file: \""
-msgstr "      file gvimrc utente: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "   II file gvimrc utente: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "  III file gvimrc utente: \""
-
-msgid "    system menu file: \""
-msgstr "    file menu di sistema: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "         $VIM di riserva: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " $VIMRUNTIME di riserva: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Compilazione: "
 
-msgid "Compiler: "
-msgstr "Compilatore: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Link: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  VERSIONE DEBUG"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved (VI Migliorato)"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versione "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "di Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim è 'open source' e può essere distribuito liberamente"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Aiuta i bambini poveri dell'Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "batti :help iccf<Invio>       per informazioni            "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "batti :q<Invio>               per uscire                  "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "batti :help<Invio>  o  <F1>   per aiuto online            "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "batti :help version7<Invio>   per informazioni su versione"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Eseguo in modalità compatibile Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "batti :set nocp<Invio>        per valori predefiniti Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "batti :help cp-default<Enter> per info al riguardo"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu  Aiuto->Orfani           per informazioni   "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Esecuzione senza modalità: solo inserimento"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menu Modifica->Impost.Globali->Modal.Inser. Sì/No"
-
-msgid "                              for two modes      "
-msgstr "                          per modo Inser./Comandi"
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menu Modifica->Impost.Globali->Compatibile Vi Sì/No"
-
-msgid "                              for Vim defaults   "
-msgstr "                            modo Vim predefinito "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Sponsorizza lo sviluppo di Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Diventa un utente Vim registrato!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "batti :help sponsor<Invio>    per informazioni "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "batti :help register<Invio>   per informazioni "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu  Aiuto->Sponsor/Registrazione  per informazioni "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ATTENZIONE: Trovato Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "batti :help windows95<Enter>  per info al riguardo"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "C'è già una finestra sola"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Non c'è una finestra di pre-visualizzazione"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Non riesco a dividere ALTO-SX e BASSO-DX contemporaneamente"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Non posso ruotare quando un'altra finestra è divisa in due"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Non riesco a chiudere l'ultima finestra"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Non riesco a chiudere la finestra autocomandi"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr ""
 "E814: Non posso chiudere questa finestra, rimarrebbe solo la finestra "
 "autocomandi"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Altre finestre contengono modifiche"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Nessun nome file sotto il cursore"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Non riesco a trovare il file \"%s\" nel percorso"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: chiamata a bf_key_init() con password nulla"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Non riesco a caricare la libreria %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Spiacente, comando non disponibile, non riesco a caricare libreria programmi "
-"Perl."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: uso errato di big/little endian in Blowfish"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Valorizzazione Perl vietata in ambiente protetto senza il modulo Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: test sha256 fallito"
 
-msgid "Edit with &multiple Vims"
-msgstr "Apri con &molti Vim"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: test Blowfish fallito"
 
-msgid "Edit with single &Vim"
-msgstr "Apri con un solo &Vim"
+#~ msgid "Patch file"
+#~ msgstr "File di differenze"
 
-msgid "Diff with Vim"
-msgstr "Differenza con Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Non eseguire"
 
-msgid "Edit with &Vim"
-msgstr "Apri con &Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Manca connessione con server Vim"
 
-msgid "Edit with existing Vim - "
-msgstr "Apri con Vim esistente - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Impossibile inviare a %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Apri i(l) file scelto(i) con Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Non riesco a leggere una risposta del server"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr ""
-"Errore creando il processo: Controllate che gvim sia incluso nel vostro "
-"percorso (PATH)"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Impossibile inviare al client"
 
-msgid "gvimext.dll error"
-msgstr "errore gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Salva con Nome"
 
-msgid "Path length too long!"
-msgstr "Percorso file troppo lungo!"
+#~ msgid "Edit File"
+#~ msgstr "Elabora File"
 
-msgid "--No lines in buffer--"
-msgstr "--File vuoto--"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NON TROVATO)"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Comando finito male"
+#~ msgid "Source Vim script"
+#~ msgstr "Esegui script Vim"
 
-msgid "E471: Argument required"
-msgstr "E471: Argomento necessario"
+#~ msgid "unknown"
+#~ msgstr "sconosciuto"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ dovrebbe essere seguito da /, ? oppure &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Apri il File in una nuova finestra"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Non valido nella finestra comandi; <INVIO> esegue, CTRL-C ignora"
+#~ msgid "Append File"
+#~ msgstr "In aggiunta al File"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Comando non ammesso da exrc/vimrc nella dir. in uso o nella ricerca tag"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Posizione finestra: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Manca :endif"
+#~ msgid "Save Redirection"
+#~ msgstr "Salva Redirezione"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Manca :endtry"
+#~ msgid "Save View"
+#~ msgstr "Salva Veduta"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Manca :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Salva Sessione"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Manca :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Salva Setup"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile senza :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< non disponibile se Vim è compilato senza +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor senza :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Digrammi non supportati in questa versione"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: File esistente (aggiungi ! per riscriverlo)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "è una periferica (disabilitata con l'opzione 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Comando fallito"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Leggo da 'stdin'..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Fontset sconosciuto: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Font sconosciuto: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[cifrato]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Font \"%s\" non di larghezza fissa"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: File cifrato con metodo sconosciuto"
 
-msgid "E473: Internal error"
-msgstr "E473: Errore interno"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans non permette la scrittura di un buffer non modificato"
 
-msgid "Interrupted"
-msgstr "Interrotto"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Scrittura parziale disabilitata per i buffer di NetBeans"
 
-msgid "E14: Invalid address"
-msgstr "E14: Indirizzo non valido"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "scrittura su periferica disabilitata con l'opzione 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Argomento non valido"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: La 'fork' sulla risorsa verrebbe persa (aggiungi ! per eseguire "
+#~ "comunque)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Argomento non valido: %s"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Creazione di un nuovo processo fallita per la GUI"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Espressione non valida: %s"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Il processo figlio non è riuscito a far partire la GUI"
 
-msgid "E16: Invalid range"
-msgstr "E16: Intervallo non valido"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Non posso inizializzare la GUI"
 
-msgid "E476: Invalid command"
-msgstr "E476: Comando non valido"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Non posso leggere da \"%s\""
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" è una directory"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Non posso inizializzare la GUI, nessun font valido trovato"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Chiamata a libreria fallita per \"%s()\""
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' non valido"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Non posso caricare la funzione di libreria %s"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Il valore di 'imactivatekey' non è valido"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 'Mark' con numero linea non valido"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Non riesco ad allocare il colore %s"
 
-msgid "E20: Mark not set"
-msgstr "E20: 'Mark' non impostato"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Nessuna corrispondenza al cursore, cerco la prossima"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Non posso fare modifiche, 'modifiable' è inibito"
+#~ msgid "<cannot open> "
+#~ msgstr "<non posso aprire> "
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Script troppo nidificati"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: non riesco a trovare il font %s"
 
-msgid "E23: No alternate file"
-msgstr "E23: Nessun file alternato"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: non posso tornare alla directory in uso"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Abbreviazione inesistente"
+#~ msgid "Pathname:"
+#~ msgstr "Nome percorso:"
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! non consentito"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: non riesco ad ottenere la directory in uso"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI non utilizzabile: Non abilitata in compilazione"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Ebraico non utilizzabile: Non abilitato in compilazione\n"
+#~ msgid "Cancel"
+#~ msgstr "Non eseguire"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi non utilizzabile: Non abilitato in compilazione\n"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Scrollbar Widget: Non riesco a ottenere geometria del 'thumb pixmap'."
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabo non utilizzabile: Non abilitato in compilazione\n"
+#~ msgid "Vim dialog"
+#~ msgstr "Dialogo Vim"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Nome di gruppo di evidenziazione inesistente: %s"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: Non riesco a creare 'BalloonEval' con sia messaggio che callback"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Ancora nessun testo inserito"
+#~ msgid "Input _Methods"
+#~ msgstr "_Metodi di inserimento"
 
-msgid "E30: No previous command line"
-msgstr "E30: Nessuna linea comandi precedente"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Sostituisci..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Mapping inesistente"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Cerca..."
 
-msgid "E479: No match"
-msgstr "E479: Nessuna corrispondenza"
+#~ msgid "Find what:"
+#~ msgstr "Trova cosa:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Nessuna corrispondenza: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Sostituisci con:"
 
-msgid "E32: No file name"
-msgstr "E32: Manca nome file"
+#~ msgid "Match whole word only"
+#~ msgstr "Cerca solo la parola intera"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Nessuna espressione regolare precedente di 'substitute'"
+#~ msgid "Match case"
+#~ msgstr "Maiuscole/minuscole"
 
-msgid "E34: No previous command"
-msgstr "E34: Nessun comando precedente"
+#~ msgid "Direction"
+#~ msgstr "Direzione"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Nessuna espressione regolare precedente"
+#~ msgid "Up"
+#~ msgstr "Su"
 
-msgid "E481: No range allowed"
-msgstr "E481: Nessun intervallo consentito"
+#~ msgid "Down"
+#~ msgstr "Giù"
 
-msgid "E36: Not enough room"
-msgstr "E36: Manca spazio"
+#~ msgid "Find Next"
+#~ msgstr "Trova il Prossimo"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: non esiste server registrato con nome \"%s\""
+#~ msgid "Replace"
+#~ msgstr "Sostituisci"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Non riesco a creare il file %s"
+#~ msgid "Replace All"
+#~ msgstr "Sostituisci Tutto"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Non riesco ad ottenere nome file 'temp'"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Ricevuta richiesta \"die\" dal session manager\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Non riesco ad aprire il file %s"
+#~ msgid "Close"
+#~ msgstr "Chiusura"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Non riesco a leggere il file %s"
+#~ msgid "New tab"
+#~ msgstr "Nuova linguetta"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Non salvato dopo modifica (aggiungi ! per eseguire comunque)"
+#~ msgid "Open Tab..."
+#~ msgstr "Apri linguetta..."
 
-msgid "E38: Null argument"
-msgstr "E38: Argomento nullo"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Finestra principale distrutta inaspettatamente\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Mi aspettavo un numero"
+#~ msgid "&Filter"
+#~ msgstr "&Filtro"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Non riesco ad aprire il file errori %s"
+#~ msgid "&Cancel"
+#~ msgstr "&C Non eseguire"
 
-msgid "E233: cannot open display"
-msgstr "E233: non riesco ad aprire lo schermo"
+#~ msgid "Directories"
+#~ msgstr "Directory"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Non c'è più memoria!"
+#~ msgid "Filter"
+#~ msgstr "Filtro"
 
-msgid "Pattern not found"
-msgstr "Espressione non trovata"
+#~ msgid "&Help"
+#~ msgstr "&H Aiuto"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Espressione non trovata: %s"
+#~ msgid "Files"
+#~ msgstr "File"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: L'argomento deve essere positivo"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Non posso tornare alla directory precedente"
+#~ msgid "Selection"
+#~ msgstr "Selezione"
 
-msgid "E42: No Errors"
-msgstr "E42: Nessun Errore"
+#~ msgid "Find &Next"
+#~ msgstr "&N Trova il Prossimo"
 
-msgid "E776: No location list"
-msgstr "E776: Nessuna lista locazioni"
+#~ msgid "&Replace"
+#~ msgstr "&R Sostituisci"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Stringa di confronto danneggiata"
+#~ msgid "Replace &All"
+#~ msgstr "&A Sostituisci Tutto"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Programma 'regexp' corrotto"
+#~ msgid "&Undo"
+#~ msgstr "&U Disfa"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: file in sola lettura (aggiungi ! per eseguire comunque)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Non trovo il titolo della finestra \"%s\""
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Non posso cambiare la variabile read-only \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argomento non supportato: \"-%s\"; Usa la versione OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr ""
-"E794: Non posso impostare la variabile read-only in ambiente protetto: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Non posso aprire la finestra in un'applicazione MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Errore leggendo il file errori"
+#~ msgid "Close tab"
+#~ msgstr "Chiudi linguetta"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Non ammesso in ambiente protetto"
+#~ msgid "Open tab..."
+#~ msgstr "Apri linguetta..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Non consentito qui"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Stringa di ricerca (usa '\\\\' per cercare  un '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Impostazione modalità schermo non supportata"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Sostituisci (usa '\\\\' per cercare  un '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Quantità di 'scroll' non valida"
+#~ msgid "Not Used"
+#~ msgstr "Non Utilizzato"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: opzione 'shell' non impostata"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Directory\t*.nothing\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Errore -- non sono riuscito a leggere i dati del 'sign'!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Non riesco ad allocare elemento di colormap, possibili colori "
+#~ "errati"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Errore durante chiusura swap file"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Mancano descrizioni per i seguenti caratteri nel font: %s"
 
-msgid "E73: tag stack empty"
-msgstr "E73: tag stack ancora vuoto"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nome fontset: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Comando troppo complesso"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Il font '%s' non di larghezza fissa"
 
-msgid "E75: Name too long"
-msgstr "E75: Nome troppo lungo"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Nome fontset: %s"
 
-msgid "E76: Too many ["
-msgstr "E76: Troppe ["
+#~ msgid "Font0: %s"
+#~ msgstr "Font0: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: Troppi nomi file"
+#~ msgid "Font1: %s"
+#~ msgstr "Font1: %s"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Caratteri in più a fine comando"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "La larghezza di font%<PRId64> non è doppia di quella di font0"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 'Mark' sconosciuto"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Larghezza di Font0: %<PRId64>"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Non posso espandere 'wildcard'"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Larghezza di Font1: %<PRId64>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' non può essere inferiore a 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Specifica di font non valida"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' non può essere inferiore a 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "&D Non ora"
 
-msgid "E80: Error while writing"
-msgstr "E80: Errore in scrittura"
+#~ msgid "no specific match"
+#~ msgstr "nessuna corrispondenza specifica"
 
-msgid "Zero count"
-msgstr "Contatore a zero"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Selettore Font"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Uso di <SID> fuori dal contesto di uno script"
+#~ msgid "Name:"
+#~ msgstr "Nome:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Ricevuta un'espressione non valida"
+#~ msgid "Show size in Points"
+#~ msgstr "Mostra dimensione in Punti"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Regione protetta, impossibile modificare"
+#~ msgid "Encoding:"
+#~ msgstr "Codifica:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans non permette modifiche a file di sola lettura"
+#~ msgid "Font:"
+#~ msgstr "Font:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Errore interno: %s"
+#~ msgid "Style:"
+#~ msgstr "Stile:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: l'espressione usa troppa memoria rispetto a 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Dimensione:"
 
-msgid "E749: empty buffer"
-msgstr "E749: buffer vuoto"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ERRORE processore Hangul"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Espressione o delimitatore di ricerca non validi"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: errore stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: File già caricato in un altro buffer"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: impossibile aprire database cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: opzione '%s' non impostata"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: impossibile leggere informazioni sul database cscope"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Nome registro non valido"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Non riesco a caricare libreria Lua."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "raggiunta la CIMA nella ricerca, continuo dal FONDO"
+#~ msgid "cannot save undo information"
+#~ msgstr "non riesco a salvare informazioni per 'undo'"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "raggiunto il FONDO nella ricerca, continuo dalla CIMA"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Spiacente, comando non disponibile, non riesco a caricare librerie "
+#~ "programmi MzScheme."
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Serve una chiave di cifratura per \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "espressione non valida"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "attesa istanza di str() o unicode(), trovato invece %s"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "espressioni disabilitate in compilazione"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "attesa istanza di bytes() o str(), trovato invece %s"
+#~ msgid "hidden option"
+#~ msgstr "opzione nascosta"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr ""
-"atteso int(), long() o qualcosa che supporti forzatura a long(), trovato invece %s"
+#~ msgid "unknown option"
+#~ msgstr "opzione inesistente"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "atteso int() o qualcosa che supporti forzatura a int(), trovato invece %s"
+#~ msgid "window index is out of range"
+#~ msgstr "indice della finestra non nell'intervallo"
 
-msgid "value is too large to fit into C int type"
-msgstr "valore troppo grande per il tipo int del C"
+#~ msgid "couldn't open buffer"
+#~ msgstr "non sono riuscito ad aprire il buffer"
 
-msgid "value is too small to fit into C int type"
-msgstr "valore troppo piccolo per il tipo int del C"
+#~ msgid "cannot delete line"
+#~ msgstr "non posso cancellare la linea"
 
-msgid "number must be greater then zero"
-msgstr "il numero dev'essere maggiore di zero"
+#~ msgid "cannot replace line"
+#~ msgstr "non posso sostituire la linea"
 
-msgid "number must be greater or equal to zero"
-msgstr "il numero dev'essere maggiore o uguale a zero"
+#~ msgid "cannot insert line"
+#~ msgstr "non posso inserire la linea"
 
-msgid "can't delete OutputObject attributes"
-msgstr "non riesco a cancellare gli attributi OutputObject"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "la stringa non può contenere caratteri 'A CAPO'"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "attributo non valido: %s"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "errore nel convertire i valori Scheme a Vim"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Errore di inizializzazione oggetti I/O"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Errore Vim: ~a"
 
-msgid "failed to change directory"
-msgstr "cambio directory non riuscito"
+#~ msgid "Vim error"
+#~ msgstr "Errore Vim"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "atteso terzetto come risultato di imp.find_module(), trovato invece %s"
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer non valido"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "atteso terzetto come risultato di imp.find_module(), trovato invece tuple di dimens. %d"
+#~ msgid "window is invalid"
+#~ msgstr "finestra non valida"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "errore interno: imp.find_module restituisce tuple con NULL"
+#~ msgid "linenr out of range"
+#~ msgstr "numero linea non nell'intervallo"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "non riesco a cancellare gli attributi vim.Dictionary"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "non ammesso in ambiente protetto"
 
-msgid "cannot modify fixed dictionary"
-msgstr "non posso modificare il dizionario fisso"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Python: Impossibile usare :py e :py3 nella stessa sessione"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "non posso impostare attributo %s"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Impossibile usare ora :py3 dopo aver usato :python"
 
-msgid "hashtab changed during iteration"
-msgstr "hashtab cambiato durante l'iterazione"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Spiacente, comando non disponibile, non riesco a caricare libreria "
+#~ "programmi Python."
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "atteso elemento sequenza di dimensione 2, trovata sequenza di dimensione %d"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python non può essere chiamato ricorsivamente"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "il costruttore di lista non accetta parole chiave come argomenti"
+#~ msgid "line number out of range"
+#~ msgstr "numero linea non nell'intervallo"
 
-msgid "list index out of range"
-msgstr "indice di lista non nell'intervallo"
+#~ msgid "invalid mark name"
+#~ msgstr "nome di mark non valido"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "errore interno: non ho potuto ottenere l'elemento di vim list %d"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ deve essere un'istanza di String"
 
-msgid "failed to add item to list"
-msgstr "non ho potuto aggiungere un elemento alla lista"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Spiacente, comando non disponibile, non riesco a caricare libreria "
+#~ "programmi Ruby."
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "errore interno: non c'è un elemento di vim list %d"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: return imprevisto"
 
-msgid "internal error: failed to add item to list"
-msgstr "errore interno: non ho potuto aggiungere un elemento alla lista"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: next imprevisto"
 
-msgid "cannot delete vim.List attributes"
-msgstr "non riesco a cancellare gli attributi vim.List"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: break imprevisto"
 
-msgid "cannot modify fixed list"
-msgstr "non posso modificare la lista fissa"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: redo imprevisto"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "la funzione anonima %s non esiste"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry fuori da clausola rescue"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "la funzione %s non esiste"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: eccezione non gestita"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "il costruttore di funzione non accetta parole chiave come argomenti"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: tipo sconosciuto di salto nel programma %d"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "esecuzione non riuscita della funzione %s"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Implementazione/definizione Sì/No"
 
-msgid "unable to get option value"
-msgstr "impossibile ottenere il valore di opzione"
+#~ msgid "Show base class of"
+#~ msgstr "Visualizza classe base di"
 
-msgid "internal error: unknown option type"
-msgstr "errore interno: tipo di opzione sconosciuto"
+#~ msgid "Show overridden member function"
+#~ msgstr "Visualizza funzione modulo sovrascritto"
 
-msgid "problem while switching windows"
-msgstr "problema nel cambio finestra"
+#~ msgid "Retrieve from file"
+#~ msgstr "Carica da file"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "impossibile deimpostare l'opzione globale %s"
+#~ msgid "Retrieve from project"
+#~ msgstr "Carica da progetto"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "impossibile deimpostare l'opzione %s che non ha un valore globale"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Carica da tutti i progetti"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "tentativo di riferimento a linguetta cancellata"
+#~ msgid "Retrieve"
+#~ msgstr "Carica successivo"
 
-msgid "no such tab page"
-msgstr "linguetta inesistente"
+#~ msgid "Show source of"
+#~ msgstr "Visualizza sorgente di"
 
-msgid "attempt to refer to deleted window"
-msgstr "tentativo di riferimento a una finestra cancellata"
+#~ msgid "Find symbol"
+#~ msgstr "Trova simbolo"
 
-msgid "readonly attribute: buffer"
-msgstr "attributo in sola lettura: buffer"
+#~ msgid "Browse class"
+#~ msgstr "Esplora classe"
 
-msgid "cursor position outside buffer"
-msgstr "posizione cursore fuori dal buffer"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Visualizza classe in gerarchia"
 
-msgid "no such window"
-msgstr "finestra inesistente"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Visualizza classe nella gerarchia ristretta"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "tentativo di riferimento a buffer cancellato"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref si riferisce a"
 
-msgid "failed to rename buffer"
-msgstr "cambio nome buffer non riuscito"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref referenziato da"
 
-msgid "mark name must be a single character"
-msgstr "il nome mark dev'essere un carattere singolo"
+#~ msgid "Xref has a"
+#~ msgstr "Xref ha un"
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "atteso oggetto vim.Buffer, trovato %s"
+#~ msgid "Xref used by"
+#~ msgstr "Xref usato da"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "passaggio non riuscito al buffer %d"
+#~ msgid "Show docu of"
+#~ msgstr "Visualizza docu di"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "atteso oggetto vim.Window, trovato %s"
+#~ msgid "Generate docu for"
+#~ msgstr "Genera docu per"
 
-msgid "failed to find window in the current tab page"
-msgstr "non è stato possibile trovare la finestra nella pagina con linguette corrente"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Non riesco a connettermi a SNiFF+. Controllare ambiente (sniffemacs deve "
+#~ "essere presente in $PATH).\n"
 
-msgid "did not switch to the specified window"
-msgstr "passaggio alla finestra specificata non effettuato"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Errore in lettura. Disconnessione."
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "atteso oggetto vim.TabPage, trovato %s"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ è al momento "
 
-msgid "did not switch to the specified tab page"
-msgstr "passaggio alla linguetta specificata non effettuato"
+#~ msgid "not "
+#~ msgstr "non "
 
-msgid "failed to run the code"
-msgstr "esecuzione del codice non riuscita"
+#~ msgid "connected"
+#~ msgstr "connesso"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval non ha restituito un oggetto python valido"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Richiesta SNiFF+ sconosciuta: %s"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Conversione non riuscita dell'oggetto python risultato a un valore vim"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Errore di connessione a SNiFF+"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "impossibile convertire %s a dizionario vim"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ non connesso"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "impossibile convertire %s a struttura vim"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Non è un buffer SNiFF+"
 
-msgid "internal error: NULL reference passed"
-msgstr "errore interno: passato riferimento NULL"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Errore in scrittura. Disconnesso"
 
-msgid "internal error: invalid value type"
-msgstr "errore interno: tipo di valore non valido"
+#~ msgid "invalid buffer number"
+#~ msgstr "numero buffer non valido"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Impostazione dell'ancora di percorso non riuscita: sys.path_hooks non è una lista\n"
-"Dovresti fare così:\n"
-"- aggiungere vim.path_hook a vim.path_hooks\n"
-"- aggiungere vim.VIM_SPECIAL_PATH a sys.path\n"
+#~ msgid "not implemented yet"
+#~ msgstr "non ancora implementato"
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Impostazione di percorso non riuscita: sys.path non è una lista\n"
-"Dovresti aggiungere vim.VIM_SPECIAL_PATH a sys.path"
+#~ msgid "cannot set line(s)"
+#~ msgstr "non posso impostare linea(e)"
 
+#~ msgid "mark not set"
+#~ msgstr "mark non impostato"
+
+#~ msgid "row %d column %d"
+#~ msgstr "riga %d colonna %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "non riesco a inserire/aggiungere linea"
+
+#~ msgid "unknown flag: "
+#~ msgstr "opzione inesistente: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "'vimOption' inesistente"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "interruzione dalla tastiera"
+
+#~ msgid "vim error"
+#~ msgstr "errore vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "non riesco a creare comando buffer/finestra: oggetto in via di "
+#~ "cancellazione"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "non posso registrare comando callback: buffer/finestra già in "
+#~ "cancellazione"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ERRORE FATALE TCL: reflist corrotta!? Si prega notificare a vim-"
+#~ "dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "non posso registrare comando callback: riferimento a buffer/finestra "
+#~ "inesistente"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Spiacente, comando non disponibile, non riesco a caricare libreria "
+#~ "programmi Tcl."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: codice di uscita %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "non riesco a ottenere la linea"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Non riesco a registrare un nome di server comando"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Fallito invio comando a programma destinatario"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Identificativo di server non valido: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: Proprietà registry relative a VIM non adeguate.  Cancellate!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans non è supportato con questa GUI\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Vim non compilato con funzionalità 'diff'."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' non disponibile: non abilitato in compilazione\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Errore: Avvio di gvim da NetBeans non riuscito\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Quando si ignorano maiusc./minusc. preporre / per rendere il flag maiusc."
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistra questo gvim a OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tDeregistra gvim a OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tEsegui usando GUI (come \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f opp. --nofork\tForeground: Non usare 'fork' inizializzando GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNon usare newcli per aprire finestra"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <dispositivo>\t\tUsa <dispositivo> per I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tUsa <gvimrc> invece di .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tApri un file cifrato"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <schermo>\tEsegui vim a questo particolare server X"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNon connetterti a server X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <file>\tApri <file> in un server Vim se possibile"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <file>   Stessa cosa, ignora se non esiste un server"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <file>   Come --remote ma aspetta che i file siano elaborati"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <file>   Stessa cosa, ignora se non esiste un server"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <file>  Come --remote ma apre una linguetta "
+#~ "per file"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <tasti>\tInvia <tasti> a un server Vim ed esci"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote--expr <expr>\tEsegui <expr> in un server Vim e stampa risultato"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tLista nomi server Vim disponibili ed esci"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nome>\tInvia a/diventa server Vim di nome <nome>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Opzioni accettate da gvim (versione Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Opzioni accettate da gvim (versione neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Opzioni accettate da gvim (versione Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <schermo>\tEsegui vim su <schermo>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tInizia vim riducendolo ad icona"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <colore>\tUsa <colore> come sfondo (anche: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <colore>\tUsa <colore> per il testo normale (anche: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tUsa <font> for il testo normale (anche: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\tUsa <font> per testo in grassetto"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\tUsa <font> per testo in corsivo"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tUsa <geom> per la geometria iniziale (anche: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <larg>\tUsa larghezza <larg> per bordo (anche: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <larg>  Usa larghezza <larg> per scrollbar (anche: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <alt>\tUsa altezza <alt> per barra menu (anche: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tUsa colori invertiti (anche: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNon usare colori invertiti (anche: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <risorsa>\tImposta la risorsa specificata"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argomenti accettati da gvim (versione GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <schermo>\tEsegui vim su <schermo> (anche: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <ruolo>\tImposta un ruolo univoco per identificare la finestra "
+#~ "principale"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tApri Vim dentro un altro widget GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tStampa il Window ID su stdout"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <titolo padre>\tApri Vim in un'applicazione padre"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tApri Vim dentro un altro widget win32"
+
+#~ msgid "No display"
+#~ msgstr "Manca display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Invio fallito.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Invio fallito. Tento di eseguire localmente\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d di %d elaborato"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Nessun display: Invio di espressione fallito.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Invio di espressione fallito.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Codepage non valido"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Non posso assegnare valori IC"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Creazione di un contesto di input fallita"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Apertura 'input method' fallita"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Attenzione: Non posso assegnare IM a 'destroy callback'"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 'input method' non sopporta alcuno stile"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 'input method' non supporta il mio tipo di preedit"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Errore aggiornando cifratura dello swap file"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s è cifrato e questa versione di Vim non supporta la cifratura"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Il file swap è cifrato: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Se hai immesso una chiave di cifratura senza riscrivere il file di testo,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "immetti la nuova chiave di cifratura."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Se hai riscritto il file dopo aver cambiato chiave di cifr., premi Invio"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "per usare la stessa chiave sia per il testo che per il file swap"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "Uso la chiave di cifratura del file swap per il file di testo.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [non utilizzabile con questa versione di Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Togli questo Menu"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Scelta Directory dialogo"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Salva File dialogo"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Apri File dialogo"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Spiacente, niente esplorazione file in modalità console"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: preservo file...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Finito.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ERRORE: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[byte] totali alloc-rilasc %<PRIu64>-%<PRIu64>, in uso %<PRIu64>, max uso "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[chiamate] totale re/malloc() %<PRIu64>, totale free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: La linea sta diventando troppo lunga"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Errore interno: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Forma del mouse non valida"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Immetti chiave di cifratura: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Ribatti per conferma la stessa chiave: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Le chiavi non corrispondono!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Non posso connettermi a Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Non posso connettermi a Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Modalità errata di accesso a file info connessione NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "lettura da socket Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Connessione NetBeans persa per il buffer %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans non è supportato con questa GUI"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans già connesso"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s è in sola lettura (aggiungi ! per eseguire comunque)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Funzionalità [eval] non disponibile"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "libero %<PRId64> linee"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Non posso modificare 'term' mentre sono nella GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Usa \":gui\" per far partire la GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Non può essere cambiato nella GUI GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Font non validi"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: non posso selezionare fontset"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Fontset non valido"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: non posso selezionare 'wide font'"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 'Wide font' non valido"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Manca supporto mouse"
+
+#~ msgid "cannot open "
+#~ msgstr "non riesco ad aprire "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Non riesco ad aprire la finestra!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Serve Amigados versione 2.04 o successiva\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Serve %s versione %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Non riesco ad aprire NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Non riesco a creare "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim esce con %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "non posso modificare modalità console ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: non una console??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Non posso eseguire lo shell con l'opzione -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Non riesco a eseguire "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " ottenuto\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE troppo piccolo."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ERRORE I/O"
+
+#~ msgid "Message"
+#~ msgstr "Messaggio"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' non vale 80, non riesco ad eseguire comandi esterni"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Scelta stampante non riuscita"
+
+#~ msgid "to %s on %s"
+#~ msgstr "a %s su %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Font per stampante sconosciuto: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Errore durante stampa: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Stampato: '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Nome di charset non ammesso \"%s\" nel fonte di nome \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Carattere non ammesso '%c' nel font di nome \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Segnale doppio, esco\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Intercettato segnale fatale %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Intercettato segnale fatale\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Attivazione visualizzazione X ha richiesto %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Preso errore X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Prova visualizzazione X fallita"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Apertura visualizzazione X: tempo scaduto"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Non riesco a eseguire shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Non posso creare 'pipe'\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Non riesco ad effettuare 'fork'\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Comando terminato\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP ha perso la connessione ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Apertura visualizzazione X fallita"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP gestione richiesta 'save-yourself'"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP apertura connessione"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP osservazione connessione ICE fallita"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection fallita: %s"
+
+#~ msgid "At line"
+#~ msgstr "Alla linea"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Non riesco a caricare vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Errore VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Non sono riuscito a impostare puntatori di funzione verso la DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "shell terminato con return-code %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Intercettato evento %s\n"
+
+#~ msgid "close"
+#~ msgstr "chiusura"
+
+#~ msgid "logoff"
+#~ msgstr "logoff"
+
+#~ msgid "shutdown"
+#~ msgstr "shutdown"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Comando non trovato"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE non trovato nel tuo $PATH.\n"
+#~ "I comandi esterni non faranno una pausa dopo aver finito l'esecuzione.\n"
+#~ "Vedi  :help win32-vimrun  per ulteriori informazioni."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Avviso da Vim"
+
+#~ msgid "Error file"
+#~ msgstr "File errori"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: Errore nel build di NFA con classe di equivalenza!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) Non posso allocare memoria per il zigzag di ramo!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr "Attenzione: Non trovo lista parole \"%s_%s.spl\" o \"%s_ascii.spl\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Conversione in %s non supportata"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: Memoria insufficiente, la lista parole sarà incompleta"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Percorso tag file troncato per %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "fatto eseguire nuovo shell\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Uso CUT_BUFFER0 invece che una scelta nulla"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "'undo' non più possibile; continuo comunque"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: File non cifrato con file Undo cifrato: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Decifratura fallita del file Undo: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: File Undo cifrato: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "versione MS-Windows 16/32-bit GUI"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MS-Windows 64-bit GUI"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MS-Windows 32-bit GUI"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " in modalità Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " con supporto OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MS-Windows 64-bit console"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MS-Windows 32-bit console"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MS-Windows 16-bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Version MS-DOS 32-bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MS-DOS 16-bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione X MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versione OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versione grande "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versione normale "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versione piccola "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versione minuscola "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "con GUI GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "con GUI GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "con GUI X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "con GUI X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "con GUI X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "con GUI Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "con GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "con GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "con GUI Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "con GUI (classica)."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  file gvimrc di sistema: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "      file gvimrc utente: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "   II file gvimrc utente: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "  III file gvimrc utente: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    file menu di sistema: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Compilatore: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu  Aiuto->Orfani           per informazioni   "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Esecuzione senza modalità: solo inserimento"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menu Modifica->Impost.Globali->Modal.Inser. Sì/No"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                          per modo Inser./Comandi"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menu Modifica->Impost.Globali->Compatibile Vi Sì/No"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                            modo Vim predefinito "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ATTENZIONE: Trovato Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "batti :help windows95<Enter>  per info al riguardo"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Non riesco a caricare la libreria %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Spiacente, comando non disponibile, non riesco a caricare libreria "
+#~ "programmi Perl."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Valorizzazione Perl vietata in ambiente protetto senza il modulo "
+#~ "Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Apri con &molti Vim"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Apri con un solo &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Differenza con Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Apri con &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Apri con Vim esistente - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Apri i(l) file scelto(i) con Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr ""
+#~ "Errore creando il processo: Controllate che gvim sia incluso nel vostro "
+#~ "percorso (PATH)"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "errore gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Percorso file troppo lungo!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Fontset sconosciuto: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Font sconosciuto: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Font \"%s\" non di larghezza fissa"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Non posso caricare la funzione di libreria %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Ebraico non utilizzabile: Non abilitato in compilazione\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsi non utilizzabile: Non abilitato in compilazione\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabo non utilizzabile: Non abilitato in compilazione\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: non esiste server registrato con nome \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: non riesco ad aprire lo schermo"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Ricevuta un'espressione non valida"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Regione protetta, impossibile modificare"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans non permette modifiche a file di sola lettura"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Serve una chiave di cifratura per \"%s\""
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "attesa istanza di str() o unicode(), trovato invece %s"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "attesa istanza di bytes() o str(), trovato invece %s"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "atteso int(), long() o qualcosa che supporti forzatura a long(), trovato "
+#~ "invece %s"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr ""
+#~ "atteso int() o qualcosa che supporti forzatura a int(), trovato invece %s"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "valore troppo grande per il tipo int del C"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "valore troppo piccolo per il tipo int del C"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "il numero dev'essere maggiore di zero"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "il numero dev'essere maggiore o uguale a zero"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "non riesco a cancellare gli attributi OutputObject"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "attributo non valido: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Errore di inizializzazione oggetti I/O"
+
+#~ msgid "failed to change directory"
+#~ msgstr "cambio directory non riuscito"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr ""
+#~ "atteso terzetto come risultato di imp.find_module(), trovato invece %s"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr ""
+#~ "atteso terzetto come risultato di imp.find_module(), trovato invece tuple "
+#~ "di dimens. %d"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "errore interno: imp.find_module restituisce tuple con NULL"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "non riesco a cancellare gli attributi vim.Dictionary"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "non posso modificare il dizionario fisso"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "non posso impostare attributo %s"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "hashtab cambiato durante l'iterazione"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "atteso elemento sequenza di dimensione 2, trovata sequenza di dimensione "
+#~ "%d"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "il costruttore di lista non accetta parole chiave come argomenti"
+
+#~ msgid "list index out of range"
+#~ msgstr "indice di lista non nell'intervallo"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "errore interno: non ho potuto ottenere l'elemento di vim list %d"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "non ho potuto aggiungere un elemento alla lista"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "errore interno: non c'è un elemento di vim list %d"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "errore interno: non ho potuto aggiungere un elemento alla lista"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "non riesco a cancellare gli attributi vim.List"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "non posso modificare la lista fissa"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "la funzione anonima %s non esiste"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "la funzione %s non esiste"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "il costruttore di funzione non accetta parole chiave come argomenti"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "esecuzione non riuscita della funzione %s"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "problema nel cambio finestra"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "impossibile deimpostare l'opzione globale %s"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "impossibile deimpostare l'opzione %s che non ha un valore globale"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "tentativo di riferimento a linguetta cancellata"
+
+#~ msgid "no such tab page"
+#~ msgstr "linguetta inesistente"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "tentativo di riferimento a una finestra cancellata"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "attributo in sola lettura: buffer"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "posizione cursore fuori dal buffer"
+
+#~ msgid "no such window"
+#~ msgstr "finestra inesistente"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "tentativo di riferimento a buffer cancellato"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "cambio nome buffer non riuscito"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "il nome mark dev'essere un carattere singolo"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "atteso oggetto vim.Buffer, trovato %s"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "passaggio non riuscito al buffer %d"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "atteso oggetto vim.Window, trovato %s"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr ""
+#~ "non è stato possibile trovare la finestra nella pagina con linguette "
+#~ "corrente"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "passaggio alla finestra specificata non effettuato"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "atteso oggetto vim.TabPage, trovato %s"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "passaggio alla linguetta specificata non effettuato"
+
+#~ msgid "failed to run the code"
+#~ msgstr "esecuzione del codice non riuscita"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval non ha restituito un oggetto python valido"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr ""
+#~ "E859: Conversione non riuscita dell'oggetto python risultato a un valore "
+#~ "vim"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "impossibile convertire %s a dizionario vim"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "impossibile convertire %s a struttura vim"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "errore interno: passato riferimento NULL"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "errore interno: tipo di valore non valido"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Impostazione dell'ancora di percorso non riuscita: sys.path_hooks non è "
+#~ "una lista\n"
+#~ "Dovresti fare così:\n"
+#~ "- aggiungere vim.path_hook a vim.path_hooks\n"
+#~ "- aggiungere vim.VIM_SPECIAL_PATH a sys.path\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Impostazione di percorso non riuscita: sys.path non è una lista\n"
+#~ "Dovresti aggiungere vim.VIM_SPECIAL_PATH a sys.path"

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-06 13:50+0900\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-07-06 15:00+0900\n"
 "Last-Translator: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
 "Language-Team: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
@@ -23,164 +23,204 @@ msgstr ""
 "Content-Type: text/plain; charset=euc-jp\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() が空パスワードで呼び出されました"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "オプションの値は取得できません"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "内部エラー: 未知のオプション型です"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish暗号のビッグ/リトルエンディアンが間違っています"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256のテストに失敗しました"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish暗号のテストに失敗しました"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[場所リスト]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Quickfixリスト]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: autocommandがコマンドの停止を引き起こしました"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: バッファを1つも作成できないので, 終了します..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: バッファを作成できないので, 他のを使用します..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 解放されたバッファはありません"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 削除されたバッファはありません"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 破棄されたバッファはありません"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 個のバッファが解放されました"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d 個のバッファが解放されました"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 個のバッファが削除されました"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d 個のバッファが削除されました"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 個のバッファが破棄されました"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d 個のバッファが破棄されました"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 最後のバッファは解放できません"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 変更されたバッファはありません"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: リスト表示されるバッファはありません"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: バッファ %<PRId64> はありません"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 最後のバッファを越えて移動はできません"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 最初のバッファより前へは移動できません"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: バッファ %<PRId64> の変更は保存されていません (! で変更を破棄)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 最後のバッファは解放できません"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: ファイル名のリストが長過ぎます"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: バッファ %<PRId64> が見つかりません"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s に複数の該当がありました"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: %s に該当するバッファはありませんでした"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "行 %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: この名前のバッファは既にあります"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [変更あり]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未編集]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新ファイル]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[読込エラー]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[読専]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[読込専用]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 行 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64> (全体 %<PRId64>) --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[無名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ヘルプ"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[ヘルプ]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[プレビュー]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全て"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "末尾"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "先頭"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -188,9 +228,11 @@ msgstr ""
 "\n"
 "# バッファリスト:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[下書き]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -198,144 +240,200 @@ msgstr ""
 "\n"
 "--- サイン ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s のサイン:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  識別子=%d  名前=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: コロンがありません"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 不正なモードです"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 数値が必要です"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 不正なパーセンテージです"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: %<PRId64> 以上のバッファはdiffできません"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 一時ファイルの読込もしくは書込ができません"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 差分を作成できません "
 
-msgid "Patch file"
-msgstr "パッチファイル"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: patchの出力を読込めません"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: diffの出力を読込めません"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 現在のバッファは差分モードではありません"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: 差分モードである他のバッファは変更可能です"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 差分モードである他のバッファはありません"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: 差分モードのバッファが2個以上あるので、どれを使うか特定できません"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: バッファ \"%s\" が見つかりません"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: バッファ \"%s\" は差分モードではありません"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 予期せずバッファが変更変更されました"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 合字にEscapeは使用できません"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: キーマップファイルが見つかりません"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :source で取込むファイル以外では :loadkeymap を使えません"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: 空のキーマップエントリ"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " キーワード補完 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X モード (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 行(全体)補完 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr "ファイル名補完 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " タグ補完 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " パスパターン補完 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定義補完 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " 辞書補完 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " シソーラス補完 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " コマンドライン補完 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " ユーザ定義補完 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 綴り修正候補 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "段落の最後にヒット"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: 補間関数がウィンドウを変更しました"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: 補完関数がテキストを削除しました"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary' オプションが空です"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus' オプションが空です"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "辞書をスキャン中: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (挿入) スクロール(^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (置換) スクロール (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "スキャン中: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "タグをスキャン中."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 追加中"
 
@@ -343,459 +441,574 @@ msgstr " 追加中"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 検索中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "始めに戻る"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "他の行の単語"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "唯一の該当"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "%d 番目の該当 (全該当 %d 個中)"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "%d 番目の該当"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: 予期せぬ文字が :let にありました"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: リストのインデックスが範囲外です: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 未定義の変数です: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']' が見つかりません"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s の引数はリスト型でなければなりません"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s の引数はリスト型または辞書型でなければなりません"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: 辞書型に空のキーを使うことはできません"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: リスト型が必要です"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: 辞書型が必要です"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 関数の引数が多過ぎます: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: 辞書型にキーが存在しません: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 関数 %s は定義済です, 再定義するには ! を追加してください"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: 辞書型内にエントリが既に存在します"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: 関数参照型が要求されます"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: [:] を辞書型と組み合わせては使えません"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: 異なった型の変数です %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 未知の関数です: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 不正な変数名です: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: 浮動小数点数を文字列として扱っています"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: ターゲットがリスト型内の要素よりも少ないです"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: ターゲットがリスト型内の要素よりも多いです"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "リスト型の値に2つ以上の ; が検出されました"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: %s の値を一覧表示できません"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: リスト型と辞書型以外はインデックス指定できません"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] は最後でなければいけません"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] にはリスト型の値が必要です"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: リスト型変数にターゲットよりも多い要素があります"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: リスト型変数に十分な数の要素がありません"
 
 #
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for の後に \"in\" がありません"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: カッコ '(' がありません: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: その変数はありません: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: (アン)ロックするには変数の入れ子が深過ぎます"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' の後に ':' がありません"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: リスト型はリスト型としか比較できません"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: リスト型には無効な操作です"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: 辞書型は辞書型としか比較できません"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: 辞書型には無効な操作です"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: 関数参照型は関数参照型としか比較できません"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: 関数参照型には無効な操作です"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: '%' を浮動小数点数と組み合わせては使えません"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' が見つかりません"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: 関数参照型はインデックスできません"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: オプション名がありません: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 未知のオプションです: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 引用符 (\") がありません: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 引用符 (') がありません: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: リスト型にカンマがありません: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: リスト型の最後に ']' がありません: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: 辞書型にコロンがありません: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: 辞書型に重複キーがあります: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: 辞書型にカンマがありません: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: 辞書型の最後に '}' がありません: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 表示するには変数の入れ子が深過ぎます"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: 関数の引数が多過ぎます: %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: 関数の無効な引数です: %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: 未知の関数です: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: 関数の引数が少な過ぎます: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: スクリプト以外で<SID>が使われました: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: 辞書用関数が呼ばれましたが辞書がありません: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: 数値か浮動小数点数が必要です"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "add() の引数"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 引数が多過ぎます"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() は挿入モードでしか利用できません"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: キーは既に存在します: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "extend() の引数"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "map() の引数"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "filter() の引数"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 行: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 未知の関数です: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"決定(&O)\n"
-"キャンセル(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() が inputsave() よりも多く呼ばれました"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "insert() の引数"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 範囲指定は許可されていません"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len() には無効な型です"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: ストライド(前進量)が 0 です"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 開始位置が終了位置を越えました"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<空>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Vim サーバへの接続がありません"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: %s へ送ることができません"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: サーバの応答がありません"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "remove() の引数"
 
 # Added at 10-Mar-2004.
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: シンボリックリンクが多過ぎます (循環している可能性があります)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "reverse() の引数"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: クライアントへ送ることができません"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "sort() の引数"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "add() の引数"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: ソートの比較関数が失敗しました"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: ソートの比較関数が失敗しました"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(無効)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 一時ファイル書込中にエラーが発生しました"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: 浮動小数点数を数値として扱っています"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: 関数参照型を数値として扱っています。"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: リスト型を数値として扱っています"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 辞書型を数値として扱っています"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: 関数参照型を文字列として扱っています"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: リスト型を文字列として扱っています"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: 辞書型を文字列として扱っています"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 変数の型が一致しません: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: 変数 %s を削除できません"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: 関数参照型変数名は大文字で始まらなければなりません: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: 変数名が既存の関数名と衝突します: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 値がロックされています: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "不明"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: %s の値を変更できません"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: コピーを取るには変数の入れ子が深過ぎます"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: 未定義の関数です: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '(' がありません: %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: ここでは g: は使えません"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 不正な引数です: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: 引数名が重複しています: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction がありません"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: 関数名が変数名と衝突します: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: 関数 %s を再定義できません: 使用中です"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 関数名がスクリプトのファイル名と一致しません: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 関数名が要求されます"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 関数 %s を削除できません: 使用中です"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 関数呼出の入れ子数が 'maxfuncdepth' を超えました"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s を実行中です"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s が中断されました"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s が #%<PRId64> を返しました"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s が %s を返しました"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "%s の実行を継続中です"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: 関数外に :return がありました"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -803,6 +1016,7 @@ msgstr ""
 "\n"
 "# グローバル変数:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -810,82 +1024,104 @@ msgstr ""
 "\n"
 "\tLast set from "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "古いファイルはありません"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  16進数 %02x,  8進数 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 16進数 %04x, 8進数 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 16進数 %08x, 8進数 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 行をそれ自身には移動できません"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 行が移動されました"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> 行が移動されました"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> 行がフィルタ処理されました"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *フィルタ* autocommandは現在のバッファを変更してはいけません"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[最後の変更が保存されていません]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 行目: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: エラーが多過ぎるので, 以降はスキップします"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "viminfoファイル \"%s\"%s%s%s を読込み中 "
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 情報"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " マーク"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " 旧ファイル群"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失敗"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: viminfoファイルが書込みできません: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: viminfoファイル %s を保存できません!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "viminfoファイル \"%s\" を書込み中"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# この viminfo ファイルは Vim %s によって生成されました.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -893,40 +1129,47 @@ msgstr ""
 "# 変更する際には十分注意してください!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# このファイルが書かれた時の 'encoding' の値\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "不正な先頭文字です"
 
-msgid "Save As"
-msgstr "別名で保存"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "ファイルを部分的に保存しますか?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: バッファを部分的に保存するには ! を使ってください"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "既存のファイル \"%s\" を上書きしますか?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "スワップファイル \"%s\" が存在します. 上書きを強制しますか?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: スワップファイルが存在します: %s (:silent! を追加で上書)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: バッファ %<PRId64> には名前がありません"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ファイルは保存されませんでした: 'write' オプションにより無効です"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -935,6 +1178,7 @@ msgstr ""
 "\"%s\" には 'readonly' オプションが設定されています.\n"
 "上書き強制をしますか?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -945,68 +1189,83 @@ msgstr ""
 "それでも恐らく書き込むことは可能です.\n"
 "継続しますか?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" は読込専用です (強制書込には ! を追加)"
 
-msgid "Edit File"
-msgstr "ファイルを編集"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: autocommandが予期せず新しいバッファ %s を削除しました"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 数ではない引数が :z に渡されました"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvimではシェルコマンドを使えません"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正規表現は文字で区切ることができません"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "%s に置換しますか? (y/n/a/q/l/^E/^Y)"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(割込まれました) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 箇所該当しました"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 箇所置換しました"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> 箇所該当しました"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> 箇所置換しました"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " (計 1 行内)"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " (計 %<PRId64> 行内)"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global を再帰的には使えません"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: globalコマンドに正規表現が指定されていません"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "パターンが全ての行で見つかりました: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "パターンは見つかりませんでした: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1016,265 +1275,335 @@ msgstr ""
 "# 最後に置換された文字列:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 慌てないでください"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 残念ですが '%s' のヘルプが %s にはありません"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 残念ですが %s にはヘルプがありません"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "残念ですがヘルプファイル \"%s\" が見つかりません"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: ディレクトリではありません: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 書込み用に %s を開けません"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 読込用に %s を開けません"
 
 # Added at 29-Apr-2004.
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 1つの言語のヘルプファイルに複数のエンコードが混在しています: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: タグ \"%s\" がファイル %s/%s に重複しています"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未知のsignコマンドです: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: sign名がありません"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: signの定義が多数見つかりました"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 無効なsignのテキストです: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 未知のsignです: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: signの番号がありません"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 無効なバッファ名です: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
-# Added at 27-Jan-2004.
-msgid " (NOT FOUND)"
-msgstr "  (見つかりません)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (非サポート)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[削除済]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "デバッグモードに入ります. 続けるには \"cont\" と入力してください."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "行 %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "ブレークポイント \"%s%s\" 行 %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: ブレークポイントが見つかりません: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "ブレークポイントが定義されていません"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  行 %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 初めに \":profile start {fname}\" を実行してください"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "変更を \"%s\" に保存しますか?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "無題"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: バッファ \"%s\" の変更は保存されていません"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "警告: 予期せず他バッファへ移動しました (autocommands を調べてください)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 編集するファイルは1つしかありません"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 最初のファイルより前には行けません"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 最後のファイルを越えて後には行けません"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: そのコンパイラには対応していません: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "\"%s\" を \"%s\" から検索中"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "\"%s\" を検索中"
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "'runtimepath' の中には見つかりません: \"%s\""
 
-msgid "Source Vim script"
-msgstr "Vimスクリプトの取込み"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "ディレクトリは取込めません: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\" を取込めません"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "行 %<PRId64>: \"%s\" を取込めません"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" を取込中"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "行 %<PRId64>: %s を取込中"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "%s の取込を完了"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "モード行"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 引数"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 引数"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "環境変数"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "エラーハンドラ"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 警告: 行区切が不正です. ^M がないのでしょう"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding が取込スクリプト以外で使用されました"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish が取込スクリプト以外で使用されました"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "現在の %s言語: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 言語を \"%s\" に設定できません"
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Exモードに入ります. ノーマルに戻るには\"visual\"と入力してください."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: ファイルの終了位置"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: コマンドが再帰的過ぎます"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 例外が捕捉されませんでした: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "取込ファイルの最後です"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "関数の最後です"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: ユーザ定義コマンドのあいまいな使用です"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: エディタのコマンドではありません"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 逆さまの範囲が指定されました"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "逆さまの範囲が指定されました, 入替えますか?"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: w もしくは w>> を使用してください"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: このバージョンではこのコマンドは利用できません, ごめんなさい"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: ファイル名は 1 つにしてください"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "編集すべきファイルが 1 個ありますが, 終了しますか?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "編集すべきファイルがあと %d 個ありますが, 終了しますか?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 編集すべきファイルが 1 個あります"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 編集すべきファイルがあと %<PRId64> 個あります"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1282,293 +1611,339 @@ msgstr ""
 "\n"
 "    名前        引数 範囲  補完      定義"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "ユーザ定義コマンドが見つかりませんでした"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 属性は定義されていません"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 引数の数が無効です"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: カウントを2重指定することはできません"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: カウントの省略値が無効です"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -補完のための引数が必要です"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 無効な属性です: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 無効なコマンド名です"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: ユーザ定義コマンドは英大文字で始まらなければなりません"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: 予約名なので, ユーザ定義コマンドに利用できません"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: そのユーザ定義コマンドはありません: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 無効な補完指定です: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 補完引数はカスタム補完でしか使用できません"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: カスタム補完には引数として関数が必要です"
 
-msgid "unknown"
-msgstr "不明"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: カラースキーム '%s' が見つかりません"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Vim 使いさん、やあ!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 最後のタブページを閉じることはできません"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "既にタブページは1つしかありません"
 
-msgid "Edit File in new window"
-msgstr "新しいウィンドウでファイルを編集します"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "タブページ %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "スワップファイルがありません"
 
-msgid "Append File"
-msgstr "追加ファイル"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: バッファが修正されているので, ディレクトリを変更できません (! を追加で"
 "上書)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 前のディレクトリはありません"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize には2つの数値の引数が必要です"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "ウィンドウ位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: このプラットホームにはウィンドウ位置の取得機能は実装されていません"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos には2つの数値の引数が必要です"
 
-msgid "Save Redirection"
-msgstr "リダイレクトを保存します"
-
-msgid "Save View"
-msgstr "ビューを保存します"
-
-msgid "Save Session"
-msgstr "セッション情報を保存します"
-
-msgid "Save Setup"
-msgstr "設定を保存します"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: ディレクトリを作成できません: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" が存在します (上書するには ! を追加してください)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" を書込み用として開けません"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 引数は1文字の英字か引用符 (' か `) でなければいけません"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal の再帰利用が深くなり過ぎました"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< は +eval 機能が無いと利用できません"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: '#'を置き換える副ファイルの名前がありません"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: \"<afile>\"を置き換えるautocommandのファイル名がありません"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: \"<abuf>\"を置き換えるautocommandバッファ番号がありません"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: \"<amatch>\"を置き換えるautocommandの該当名がありません"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: \"<sfile>\"を置き換える :source 対象ファイル名がありません"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: \"<slnum>\"を置き換える行番号がありません"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr ""
 "E499: '%' や '#' が無名ファイルなので \":p:h\" を伴わない使い方はできません"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 空文字列として評価されました"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: viminfoファイルを読込用として開けません"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: このバージョンに合字はありません"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 'Vim' で始まる例外は :throw できません"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "例外が発生しました: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "例外が収束しました: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "例外が破棄されました: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "例外が捕捉されました: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s により未決定状態が生じました"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s が再開しました"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s が破棄されました"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "例外"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "エラーと割込み"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "エラー"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "割込み"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if の入れ子が深過ぎます"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :if のない :endif があります"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :if のない :else があります"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :if のない :elseif があります"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 複数の :else があります"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :else の後に :elseif があります"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while や :for の入れ子が深過ぎます"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :while や :for のない :continue があります"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :while や :for のない :break があります"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :endfor を :while と組み合わせています"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :endwhile を :for と組み合わせています"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try の入れ子が深過ぎます"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :try のない :catch があります"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :finally の後に :catch があります"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :try のない :finally があります"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 複数の :finally があります"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :try のない :endtry です"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: 関数の外に :endfunction がありました"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 現在は他のバッファを編集することは許されません"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: 現在はバッファ情報を変更することは許されません"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "タグ名"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " ファイル種類\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "オプション 'history' がゼロです"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1577,230 +1952,303 @@ msgstr ""
 "\n"
 "# %s 項目の履歴 (新しいものから古いものへ):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "コマンドライン"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "検索文字列"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "式"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "入力行"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar がコマンド長を超えました"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: アクティブなウィンドウかバッファが削除されました"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: パスが長過ぎて補完できません"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: 無効なパスです: '**[数値]' はpathの最後か '%s' が続いてないといけませ"
+"ん."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpathには \"%s\" というファイルがありません"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: pathには \"%s\" というファイルがありません"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: cdpathにはこれ以上 \"%s\" というファイルがありません"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: パスにはこれ以上 \"%s\" というファイルがありません"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: autocommandがバッファかバッファ名を変更しました"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "不正なファイル名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr " はディレクトリです"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr " はファイルではありません"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr " はデバイスです ('opendevice' オプションで回避できます)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[新ファイル]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[新規ディレクトリ]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[ファイル過大]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[認可がありません]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre autocommand がファイルを読込不可にしました"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre autocommand は現在のバッファを変えられません"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 標準入力から読込中...\n"
 
-msgid "Reading from stdin..."
-msgstr "標準入力から読込み中..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 変換がファイルを読込不可にしました"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[FIFO/ソケット]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[FIFO]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[ソケット]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[キャラクタ・デバイス]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR無]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[長行分割]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未変換]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[変換済]"
 
-msgid "[blowfish]"
-msgstr "[blowfish暗号化]"
-
-msgid "[crypted]"
-msgstr "[暗号化]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[%<PRId64> 行目で変換エラー]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[%<PRId64> 行目の不正なバイト]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[読込エラー]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "変換に必要な一時ファイルが見つかりません"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert' による変換が失敗しました"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "'charconvert' の出力を読込めませんでした"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: ファイルが未知の方法で暗号化されています"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: acwriteバッファの該当するautocommandは存在しません"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 保存するバッファをautocommandが削除か解放しました"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: autocommandが予期せぬ方法で行数を変更しました"
 
-# Added at 19-Jan-2004.
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeansは未変更のバッファを上書することは許可していません"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeansバッファの一部を書き出すことはできません"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "はファイルでも書込み可能デバイスでもありません"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "'opendevice' オプションによりデバイスへの書き込みはできません"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "は読込専用です (強制書込には ! を追加)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: バックアップファイルを保存できません (! を追加で強制保存)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: バックアップファイルを閉じる際にエラーが発生しました (! を追加で強制)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: バックアップ用ファイルを読込めません (! を追加で強制読込)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: バックアップファイルを作れません (! を追加で強制作成)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: バックアップファイルを作れません (! を追加で強制作成)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: リソースフォークが失われるかもしれません (! を追加で強制)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 保存用一時ファイルが見つかりません"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 変換できません (! を追加で変換せずに保存)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: リンクされたファイルに書込めません"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 書込み用にファイルを開けません"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: fsync に失敗しました"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 閉じることに失敗"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 書込みエラー, 変換失敗 (上書するには 'fenc' を空にしてください)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にしてくださ"
-"い)"
+"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にして"
+"ください)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 書込みエラー, (ファイルシステムが満杯?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 変換エラー"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "行 %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[デバイス]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 追加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 書込み"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: 原本ファイルを保存できません"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: 空の原本ファイルをtouchできません"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: バックアップファイルを消せません"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1808,110 +2256,134 @@ msgstr ""
 "\n"
 "警告: 原本ファイルが失われたか変更されました\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ファイルの保存に成功するまでエディタを終了しないでください!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dosフォーマット]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[macフォーマット]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unixフォーマット]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 文字"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 文字"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> 文字"
-
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[最終行が不完全]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 読込んだ後にファイルに変更がありました!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "本当に上書きしますか"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: \"%s\" を書込み中のエラーです"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: \"%s\" を閉じる時にエラーです"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: \"%s\" を読込中のエラーです"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: autocommand の FileChangedShell がバッファを削除しました"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: ファイル \"%s\" は既に存在しません"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: ファイル \"%s\" が変更されVimのバッファも変更されました"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "詳細は \":help W12\" を参照してください"
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: ファイル \"%s\" は編集開始後に変更されました"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "詳細は \":help W11\" を参照してください"
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: ファイル \"%s\" のモードが編集開始後に変更されました"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "詳細は \":help W16\" を参照してください"
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: ファイル \"%s\" は編集開始後に作成されました"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1919,39 +2391,48 @@ msgstr ""
 "&OK\n"
 "ファイル読込(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: \"%s\" をリロードする準備ができませんでした"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\" はリロードできませんでした"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--削除済--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "autocommand: %s <バッファ=%d> が自動的に削除されます"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: そのグループはありません: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * の後に不正な文字がありました: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: そのようなイベントはありません: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: そのようなグループもしくはイベントはありません: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1959,536 +2440,760 @@ msgstr ""
 "\n"
 "--- Auto-Commands ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <バッファ=%d>: 無効なバッファ番号です "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 全てのイベントに対してのautocommandは実行できません"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "該当するautocommandは存在しません"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocommandの入れ子が深過ぎます"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto commands for \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s を実行しています"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { がありません."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } がありません."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 折畳みがありません"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 現在の 'foldmethod' では折畳みを作成できません"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 現在の 'foldmethod' では折畳みを削除できません"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld 行が折畳まれました "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 読込バッファへ追加"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 再帰的マッピング"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s というグローバル短縮入力は既に存在します"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s というグローバルマッピングは既に存在します"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s という短縮入力は既に存在します"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s というマッピングは既に存在します"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "短縮入力は見つかりませんでした"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "マッピングは見つかりませんでした"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 不正なモード"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: GUI用のプロセスの起動に失敗しました"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--バッファに行がありません--"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: 子プロセスがGUIの起動に失敗しました"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: コマンドが中断されました"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUIを開始できません"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 引数が必要です"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: \"%s\"から読込むことができません"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ の後は / か ? か & でなければなりません"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 有効なフォントが見つからないので, GUIを開始できません"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' が無効です"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' に設定された値が無効です"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: %s の色を割り当てられません"
-
-msgid "No match at cursor, finding next"
-msgstr "カーソルの位置にマッチはありません, 次を検索しています"
-
-msgid "<cannot open> "
-msgstr "<開けません> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: フォント %s を取得できません"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 現在のディレクトリに戻れません"
-
-msgid "Pathname:"
-msgstr "パス名:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 現在のディレクトリを取得できません"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "キャンセル"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "スクロールバー: 画像を取得できませんでした."
-
-msgid "Vim dialog"
-msgstr "Vim ダイアログ"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: メッセージとコールバックのある BalloonEval を作成できません"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"はい(&Y)\n"
-"いいえ(&N)\n"
-"キャンセル(&C)"
+"E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"
 
-msgid "Input _Methods"
-msgstr "インプットメソッド"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif がありません"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 検索と置換..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry がありません"
 
-msgid "VIM - Search..."
-msgstr "VIM - 検索..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile がありません"
 
-msgid "Find what:"
-msgstr "検索文字列:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor がありません"
 
-msgid "Replace with:"
-msgstr "置換文字列:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :while のない :endwhile があります"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "正確に該当するものだけ"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor のない :for があります"
 
-#. match case button
-msgid "Match case"
-msgstr "大文字/小文字を区別する"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: ファイルが存在します (! を追加で上書)"
 
-msgid "Direction"
-msgstr "方向"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: コマンドが失敗しました"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "上"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 内部エラーです"
 
-msgid "Down"
-msgstr "下"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "割込まれました"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "次を検索"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 無効なアドレスです"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "置換"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 無効な引数です"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "全て置換"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: セッションマネージャから \"die\" 要求を受け取りました\n"
-
-msgid "Close"
-msgstr "閉じる"
-
-msgid "New tab"
-msgstr "新規タブページ"
-
-msgid "Open Tab..."
-msgstr "タブページを開く..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: メインウィンドウが不意に破壊されました\n"
-
-msgid "&Filter"
-msgstr "フィルタ(&F)"
-
-msgid "&Cancel"
-msgstr "キャンセル(&C)"
-
-msgid "Directories"
-msgstr "ディレクトリ"
-
-msgid "Filter"
-msgstr "フィルタ"
-
-msgid "&Help"
-msgstr "ヘルプ(&H)"
-
-msgid "Files"
-msgstr "ファイル"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "選択"
-
-msgid "Find &Next"
-msgstr "次を検索(&N)"
-
-msgid "&Replace"
-msgstr "置換(&R)"
-
-msgid "Replace &All"
-msgstr "全て置換(&A)"
-
-msgid "&Undo"
-msgstr "アンドゥ(&U)"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: タイトルが \"%s\" のウィンドウは見つかりません"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 無効な引数です: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 引数はサポートされません: \"-%s\"; OLE版を使用してください."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 無効な式です: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: MDIアプリの中ではウィンドウを開けません"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 無効な範囲です"
 
-msgid "Close tab"
-msgstr "タブページを閉じる"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 無効なコマンドです"
 
-msgid "Open tab..."
-msgstr "タブページを開く"
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "検索文字列 ('\\' を検索するには '\\\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "検索・置換 ('\\' を検索するには '\\\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "使われません"
-
-msgid "Directory\t*.nothing\n"
-msgstr "ディレクトリ\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 色指定が正しくないのでエントリを割り当てられません"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: 以下の文字セットのフォントがありません %s:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" はディレクトリです"
 
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 無効なスクロール量です"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
+msgstr ""
+
+#: ../globals.h:1022
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: フォントセット名: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "フォント '%s' は固定幅ではありません"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: \"%s\"() のライブラリ呼出に失敗しました"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: マークに無効な行番号が指定されていました"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: マークは設定されていません"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 'modifiable' がオフなので, 変更できません"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: スクリプトの入れ子が深過ぎます"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 副ファイルはありません"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: そのような短縮入力はありません"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! は許可されていません"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUIは使用不可能です: コンパイル時に無効にされています"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: フォントセット名: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: そのような名のハイライトグループはありません: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: まだテキストが挿入されていません"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 以前にコマンド行がありません"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: そのようなマッピングはありません"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 該当はありません"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font0: %s"
-msgstr "フォント0: %s"
+msgid "E480: No match: %s"
+msgstr "E480: 該当はありません: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ファイル名がありません"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 正規表現置換がまだ実行されていません"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: コマンドがまだ実行されていません"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 正規表現がまだ実行されていません"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 範囲指定は許可されていません"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: ウィンドウに十分な高さもしくは幅がありません"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font1: %s"
-msgstr "フォント1: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: ファイル %s を作成できません"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 一時ファイルの名前を取得できません"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
+msgid "E484: Can't open file %s"
+msgstr "E484: ファイル \"%s\" を開けません"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "フォント0の幅: %<PRId64>"
+msgid "E485: Can't read file %s"
+msgstr "E485: ファイル %s を読込めません"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[最後の変更が保存されていません]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 引数が空です"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 数値が要求されています"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "フォント1の幅: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: エラーファイル %s を開けません"
 
-msgid "Invalid font specification"
-msgstr "無効なフォント指定です"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: メモリが尽き果てました!"
 
-msgid "&Dismiss"
-msgstr "却下する(&D)"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "パターンは見つかりませんでした"
 
-msgid "no specific match"
-msgstr "マッチするものがありません"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: パターンは見つかりませんでした: %s"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - フォント選択"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 引数は正の値でなければなりません"
 
-msgid "Name:"
-msgstr "名前:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 前のディレクトリに戻れません"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "サイズをポイントで表示する"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: エラーはありません"
 
-msgid "Encoding:"
-msgstr "エンコード:"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 場所リストはありません"
 
-msgid "Font:"
-msgstr "フォント:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 該当文字列が破損しています"
 
-msgid "Style:"
-msgstr "スタイル:"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 不正な正規表現プログラムです"
 
-msgid "Size:"
-msgstr "サイズ:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' オプションが設定されています (! を追加で上書き)"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ハングルオートマトンエラー"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 読取専用変数 \"%s\" には値を設定できません"
 
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: サンドボックスでは変数 \"%s\" に値を設定できません"
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: エラーファイルの読込中にエラーが発生しました"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: サンドボックスでは許されません"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: ここでは許可されません"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: スクリーンモードの設定には対応していません"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 無効なスクロール量です"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' オプションが空です"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: sign のデータを読込めませんでした"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: スワップファイルのクローズ時エラーです"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: タグスタックが空です"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: コマンドが複雑過ぎます"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名前が長過ぎます"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [ が多過ぎます"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: ファイル名が多過ぎます"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 余分な文字が後ろにあります"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 未知のマーク"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: ワイルドカードを展開できません"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' は 'winminheight' より小さくできません"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' は 'winminwidth' より小さくできません"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 書込み中のエラー"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "ゼロカウント"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: スクリプト以外で<SID>が使われました"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 内部エラーです: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: バッファが空です"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 検索パターンか区切り記号が不正です"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 同じ名前のファイルが他のバッファで読込まれています"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: オプション '%s' は設定されていません"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: 無効なレジスタ名です"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "上まで検索したので下に戻ります"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "下まで検索したので上に戻ります"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: コロンがありません"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 不正な構文要素です"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 数値が必要です"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "%d ページ"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "印刷するテキストがありません"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "印刷中: ページ %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " コピー %d (全 %d 中)"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "印刷しました: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "印刷が中止されました"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: PostScript出力ファイルの書込みエラーです"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: ファイル \"%s\" を開けません"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: PostScriptのリソースファイル \"%s\" を読込めません"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: ファイル \"%s\" は PostScript リソースファイルではありません"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: ファイル \"%s\" は対応していない PostScript リソースファイルです"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: リソースファイル \"%s\" はバージョンが異なります"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 互換性の無いマルチバイトエンコーディングと文字セットです"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: マルチバイトエンコーディングでは printmbcharset を空にできません"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr ""
 "E675: マルチバイト文字を印刷するためのデフォルトフォントが指定されていません"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript出力用のファイルを開けません"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: ファイル \"%s\" を開けません"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: PostScriptのリソースファイル \"prolog.ps\" が見つかりません"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: PostScriptのリソースファイル \"cidfont.ps\" が見つかりません"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: PostScriptのリソースファイル \"%s.ps\" が見つかりません"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: 印刷エンコード \"%s\" へ変換できません"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "プリンタに送信中..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScriptファイルの印刷に失敗しました"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "印刷ジョブを送信しました."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "新データベースを追加"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "パターンのクエリーを追加"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "このメッセージを表示する"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "接続を終了する"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "全ての接続を再初期化する"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "接続を表示する"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 使用方法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "このcscopeコマンドは分割ウィンドウではサポートされません.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 使用法: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: タグが見つかりません"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) エラー: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat エラー"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s はディレクトリ及び有効なcscopeのデータベースではありません"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "cscopeデータベース %s を追加"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: cscopeの接続 %<PRId64> を読込み中のエラーです"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知のcscope検索型です"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscopeパイプを作成できませんでした"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: cscopeの起動準備(fork)に失敗しました"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection への setpgid に失敗しました"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection の実行に失敗しました"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: to_fp の fdopen に失敗しました"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fr_fp の fdopen に失敗しました"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: cscopeプロセスを起動できませんでした"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: cscope接続に失敗しました"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: 無効な cscopequickfix フラグ %c の %c です"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: cscopeクエリー %s of %s に該当がありませんでした"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscopeコマンド:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (使用法: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2510,32 +3215,31 @@ msgstr ""
 "       s: このCシンボルを探す\n"
 "       t: このテキスト文字列を探す\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: cscopeデータベース: %s を開くことができません"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: cscopeデータベースの情報を取得できません"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重複するcscopeデータベースは追加されませんでした"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope接続 %s が見つかりませんでした"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope接続 %s が閉じられました"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches で致命的なエラーです"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope タグ: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2543,377 +3247,87 @@ msgstr ""
 "\n"
 "   #   行番号"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "ファイル名 / 文脈 / 行\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: cscopeエラー: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "全てのcscopeデータベースをリセットします"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "cscope接続がありません\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    データベース名                      prepend パス\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Luaライブラリをロードできません."
-
-msgid "cannot save undo information"
-msgstr "アンドゥ情報が保存できません"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr "E815: このコマンドは無効です. MzScheme ライブラリをロードできません."
-
-msgid "invalid expression"
-msgstr "無効な式です"
-
-msgid "expressions disabled at compile time"
-msgstr "式はコンパイル時に無効にされています"
-
-msgid "hidden option"
-msgstr "隠しオプション"
-
-msgid "unknown option"
-msgstr "未知のオプションです"
-
-msgid "window index is out of range"
-msgstr "範囲外のウィンドウ番号です"
-
-msgid "couldn't open buffer"
-msgstr "バッファを開けません"
-
-msgid "cannot delete line"
-msgstr "行を消せません"
-
-msgid "cannot replace line"
-msgstr "行を置換できません"
-
-msgid "cannot insert line"
-msgstr "行を挿入できません"
-
-msgid "string cannot contain newlines"
-msgstr "文字列には改行文字を含められません"
-
-msgid "error converting Scheme values to Vim"
-msgstr "Scheme値のVimへの変換エラー"
-
-msgid "Vim error: ~a"
-msgstr "Vim エラー: ~a"
-
-msgid "Vim error"
-msgstr "Vim エラー"
-
-msgid "buffer is invalid"
-msgstr "バッファは無効です"
-
-msgid "window is invalid"
-msgstr "ウィンドウは無効です"
-
-msgid "linenr out of range"
-msgstr "範囲外の行番号です"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "サンドボックスでは許されません"
-
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: ライブラリ %s をロードできませんでした"
-
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"このコマンドは無効です, ごめんなさい: Perlライブラリをロードできませんでした."
-
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: サンドボックスでは Safe モジュールを使用しないPerlスクリプトは禁じられ"
-"ています"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: このVimでは :py3 を使った後に :python を使えません"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: このコマンドは無効です,ごめんなさい: Pythonライブラリをロードできません"
-"でした."
-
-# Added at 07-Feb-2004.
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python を再帰的に実行することはできません"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: このVimでは :python を使った後に :py3 を使えません"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ は文字列のインスタンスでなければなりません"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: このコマンドは無効です,ごめんなさい: Rubyライブラリをロードできませんで"
-"した."
-
-msgid "E267: unexpected return"
-msgstr "E267: 予期せぬ return です"
-
-msgid "E268: unexpected next"
-msgstr "E268: 予期せぬ next です"
-
-msgid "E269: unexpected break"
-msgstr "E269: 予期せぬ break です"
-
-msgid "E270: unexpected redo"
-msgstr "E270: 予期せぬ redo です"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: rescue の外の retry です"
-
-msgid "E272: unhandled exception"
-msgstr "E272: 取り扱われなかった例外があります"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知のlongjmp状態: %d"
-
-msgid "Toggle implementation/definition"
-msgstr "実装と定義を切り替える"
-
-msgid "Show base class of"
-msgstr "次のクラスの基底を表示"
-
-msgid "Show overridden member function"
-msgstr "オーバーライドされたメンバ関数を表示"
-
-msgid "Retrieve from file"
-msgstr "ファイルから回復する"
-
-msgid "Retrieve from project"
-msgstr "プロジェクトから回復する"
-
-msgid "Retrieve from all projects"
-msgstr "全てのプロジェクトから回復する"
-
-msgid "Retrieve"
-msgstr "回復"
-
-msgid "Show source of"
-msgstr "次のソースを表示する"
-
-msgid "Find symbol"
-msgstr "見つけたシンボル"
-
-msgid "Browse class"
-msgstr "クラスを参照"
-
-msgid "Show class in hierarchy"
-msgstr "階層でクラスを表示"
-
-msgid "Show class in restricted hierarchy"
-msgstr "限定された階層でクラスを表示"
-
-msgid "Xref refers to"
-msgstr "Xref の参照先"
-
-msgid "Xref referred by"
-msgstr "Xref が参照される"
-
-msgid "Xref has a"
-msgstr "Xref が次のものをもっています"
-
-msgid "Xref used by"
-msgstr "Xref が使用される"
-
-msgid "Show docu of"
-msgstr "次の文章を表示"
-
-msgid "Generate docu for"
-msgstr "次の文章を生成"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"SNiFF+に接続できません. 環境をチェックしてください(sniffemacs が $PATH になけ"
-"ればなりません).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 読込中にエラーが発生しました. 切断しました"
-
-msgid "SNiFF+ is currently "
-msgstr "現在SNiFF+ の状態は「"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "接続」です"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 未知の SNiFF+ リクエストです: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: SNiFF+ への接続中のエラーです"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ に接続されていません"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: SNiFF+ バッファがありません"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 書込み中にエラーが発生したので切断しました"
-
-msgid "invalid buffer number"
-msgstr "無効なバッファ番号です"
-
-msgid "not implemented yet"
-msgstr "まだ実装されていません"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "行を設定できません"
-
-msgid "invalid mark name"
-msgstr "無効なマーク名です"
-
-msgid "mark not set"
-msgstr "マークは設定されていません"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "行 %d 列 %d"
-
-msgid "cannot insert/append line"
-msgstr "行の挿入/追加をできません"
-
-msgid "line number out of range"
-msgstr "範囲外の行番号です"
-
-msgid "unknown flag: "
-msgstr "未知のフラグ: "
-
-msgid "unknown vimOption"
-msgstr "未知の vimOption です"
-
-msgid "keyboard interrupt"
-msgstr "キーボード割込み"
-
-msgid "vim error"
-msgstr "vim エラー"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr ""
-"バッファ/ウィンドウ作成コマンドを作成できません: オブジェクトが消去されていま"
-"した"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"コールバックコマンドを登録できません: バッファ/ウィンドウが既に消去されました"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL 致命的エラー: reflist 汚染!? vim-dev@vim.org に報告してください"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"コールバックコマンドを登録できません: バッファ/ウィンドウの参照が見つかりませ"
-"ん"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: このコマンドは無効です,ごめんなさい: Tclライブラリをロードできませんで"
-"した."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 終了コード %d"
-
-msgid "cannot get line"
-msgstr "行を取得できません"
-
-msgid "Unable to register a command server name"
-msgstr "命令サーバの名前を登録できません"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: 目的のプログラムへのコマンド送信に失敗しました"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 無効なサーバIDが使われました: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 実体の登録プロパティが不正です. 消去しました!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "未知のオプション引数です"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "編集引数が多過ぎます"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "引数がありません"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "オプション引数の後にゴミがあります"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "\"+command\", \"-c command\", \"--cmd command\" の引数が多過ぎます"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "無効な引数です: "
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d 個のファイルが編集を控えています\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans はこのGUIでは利用できません\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "このVimにはdiff機能がありません(コンパイル時設定)."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' 使用不可能です: コンパイル時に無効にされています\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "スクリプトファイルを再び開いてみます: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "読込用として開けません"
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "スクリプト出力用を開けません"
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 端末への出力ではありません\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 警告: 端末からの入力ではありません\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "vimrc前のコマンドライン"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: \"%s\"から読込むことができません"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2921,18 +3335,23 @@ msgstr ""
 "\n"
 "より詳細な情報は: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[ファイル..]    あるファイルを編集する"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               標準入力からテキストを読込む"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t タグ         タグが定義されたところから編集する"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  最初のエラーで編集する"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2942,9 +3361,11 @@ msgstr ""
 "\n"
 "使用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [引数] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2952,13 +3373,7 @@ msgstr ""
 "\n"
 "   もしくは:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"大小文字が無視される場合は大文字にするために / を前置してください"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2968,315 +3383,189 @@ msgstr ""
 "\n"
 "引数:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tこのあとにはファイル名だけ"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tワイルドカードを展開しない"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tこのgvimをOLEとして登録する"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tgvimのOLE登録を解除する"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tGUIで起動する (\"gvim\" と同じ)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f or  --nofork\tフォアグラウンド: GUIを始めるときにforkしない"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tViモード (\"vi\" と同じ)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tExモード (\"ex\" と同じ)"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\t改良Exモード"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tサイレント(バッチ)モード (\"ex\" 専用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\t差分モード (\"vidiff\" と同じ)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tイージーモード (\"evim\" と同じ, モード無)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t読込専用モード (\"view\" と同じ)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t制限モード (\"rvim\" と同じ)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t変更 (ファイル保存時) をできないようにする"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tテキストの編集を行なえないようにする"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tバイナリモード"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLispモード"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVi互換モード: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tVi非互換モード: 'nocompatible"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][fname]\t\tログ出力設定 [レベル N] [ログファイル名 fname]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tデバッグモード"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tスワップファイルを使用せずメモリだけ"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tスワップファイルを列挙し終了"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (ファイル名)\tクラッシュしたセッションを復帰"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t-rと同じ"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tウィンドウを開くのに newcli を使用しない"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tI/Oに <device> を使用する"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tアラビア語モードで起動する"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tヘブライ語モードで起動する"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tペルシア語モードで起動する"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t端末を <terminal> に設定する"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t.vimrcの代わりに <vimrc> を使う"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t.gvimrcの代わりに <gvimrc> を使う"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tプラグインスクリプトをロードしない"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tN 個タブページを開く(省略値: ファイルにつき1個)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tN 個ウィンドウを開く(省略値: ファイルにつき1個)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t-oと同じだが垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tファイルの最後からはじめる"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t<lnum> 行からはじめる"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\tvimrcをロードする前に <command> を実行する"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t最初のファイルをロード後 <command> を実行する"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t最初のファイルをロード後ファイル <session> を取込む"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tファイル <scriptin> からノーマルコマンドを読込む"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t入力した全コマンドをファイル <scriptout> に追加する"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t入力した全コマンドをファイル <scriptout> に保存する"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t暗号化されたファイルを編集する"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tvimを指定した X サーバに接続する"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tXサーバに接続しない"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t可能ならばVimサーバで <files> を編集する"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  同上, サーバが無くても警告文を出力しない"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>\t--remote後 ファイルの編集が終わるのを待つ"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  同上, サーバが無くても警告文を出力しない"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <files>  --remoteでファイル1つにつき1つのタブ"
-"ページを開く"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\tVimサーバに <keys> を送信して終了する"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\tサーバで <expr> を実行して結果を表示する"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVimサーバ名の一覧を表示して終了する"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\tVimサーバ <name> に送信/名前設定する"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <file>\t起動にかかった時間の詳細を <file> へ出力する"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t.viminfoの代わりに <viminfo> を使う"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h or  --help\tヘルプ(このメッセージ)を表示し終了する"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tバージョン情報を表示し終了する"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(Motifバージョン):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(neXtawバージョン):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(Athenaバージョン):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t<display> でvimを実行する"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t最小化した状態でvimを起動する"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t背景色に <color> を使う(同義: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t前景色に <color> を使う(同義: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tテキスト表示に <font> を使う(同義: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t太字に <font> を使う"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <for>\t斜体字に <font> を使う"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t初期配置に <geom> を使う(同義: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t境界の幅を <width> にする(同義: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <width>  スクロールバーの幅を <width> にする(同義: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\tメニューバーの高さを <height> にする(同義: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t反転映像を使用する(同義: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t反転映像を使用しない(同義: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t特定のリソースを使用する"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(GTK+バージョン):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t異なるGTK widgetでVimを開く"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tウィンドウIDを標準出力に出力する"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <親のタイトル>\tVimを親アプリケーションの中で起動する"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\t異なるWin32 widgetの内部にVimを開く"
-
-msgid "No display"
-msgstr "ディスプレイが見つかりません"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 送信に失敗しました.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 送信に失敗しました. ローカルでの実行を試みています\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d 個 (%d 個中) のファイルを編集しました"
-
-msgid "No display: Send expression failed.\n"
-msgstr "ディスプレイがありません: 式の送信に失敗しました.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 式の送信に失敗しました.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "マークが設定されていません"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\" に該当するマークがありません"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3285,6 +3574,7 @@ msgstr ""
 "mark   行   列 ファイル/テキスト"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3293,6 +3583,7 @@ msgstr ""
 " jump   行   列 ファイル/テキスト"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3300,6 +3591,7 @@ msgstr ""
 "\n"
 "変更   行    列  テキスト"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3308,6 +3600,7 @@ msgstr ""
 "# ファイルマーク:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3315,6 +3608,7 @@ msgstr ""
 "\n"
 "# ジャンプリスト (新しいものが先):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3322,88 +3616,84 @@ msgstr ""
 "\n"
 "# ファイル内マークの履歴 (新しいものから古いもの):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>' が見つかりません"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 無効なコードページです"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: ICの値を設定できません"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: インプットコンテキストの作成に失敗しました"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: インプットメソッドのオープンに失敗しました"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: IMの破壊コールバックを設定できませんでした"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: インプットメソッドはどんなスタイルもサポートしません"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: インプットメソッドは my preedit type をサポートしません"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: ブロックがロックされていません"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: スワップファイル読込時にシークエラーです"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: スワップファイルの読込みエラーです"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: スワップファイル書込み時にシークエラーです"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: スワップファイルの書込みエラーです"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: スワップファイルが既に存在します (symlinkによる攻撃?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: ブロック 0 を取得できません?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: ブロック 1 を取得できません?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: ブロック 2 を取得できません?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: スワップファイルの暗号を更新中にエラーが発生しました"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: おっと, スワップファイルが失われました!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: スワップファイルの名前を変えられません"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: \"%s\" のスワップファイルを開けないのでリカバリは不可能です"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): ブロック 0 を取得できませんでした??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: %s にはスワップファイルが見つかりません"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "使用するスワップファイルの番号を入力してください(0 で終了): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s を開けません"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "ブロック 0 を読込めません "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3411,22 +3701,28 @@ msgstr ""
 "\n"
 "恐らく変更がされていないかVimがスワップファイルを更新していません."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " Vimのこのバージョンでは使用できません.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Vimのバージョン3.0を使用してください.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s はVimのスワップファイルではないようです"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " このコンピュータでは使用できません.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "このファイルは次の場所で作られました "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3434,104 +3730,85 @@ msgstr ""
 ",\n"
 "もしくはファイルが損傷しています."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr ""
-"E833: %s はこのバージョンのVimでサポートしていない形式で暗号化されています"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " は損傷しています (ページサイズが最小値を下回っています).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "スワップファイル \"%s\" を使用中"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原本ファイル \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原本ファイルが変更されています"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "スワップファイルは暗号化されています: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"新しい暗号キーを入力したあとにテキストファイルを保存していない場合は,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"新しい暗号キーを入力してください."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"暗号キーを変えたあとにテキストファイルを保存した場合は, テキストファイルと"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"スワップファイルに同じ暗号キーを使うためにenterだけを押してください."
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: %s からブロック 1 を読込めません"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???多くの行が失われています"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???行数が間違っています"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???ブロックが空です"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???行が失われています"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ブロック 1 のIDが間違っています(%s が.swpファイルでない?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???ブロックがありません"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? ここから ???END までの行が破壊されているようです"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? ここから ???END までの行が挿入か削除されたようです"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: リカバリが割込まれました"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: リカバリの最中にエラーが検出されました; ???で始まる行を参照してください"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "詳細は \":help E312\" を参照してください"
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "リカバリが終了しました. 全てが正しいかチェックしてください."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3539,12 +3816,15 @@ msgstr ""
 "\n"
 "(変更をチェックするために, このファイルを別の名前で保存した上で\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "原本ファイルとの diff を実行すると良いでしょう)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "復元完了. バッファの内容はファイルと同じになりました."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3554,43 +3834,52 @@ msgstr ""
 "それから.swpファイルを削除してください\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "スワップファイルから取得した暗号キーをテキストファイルに使います.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "スワップファイルが複数見つかりました:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   現在のディレクトリ:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   ある名前を使用中:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   ディレクトリ "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- なし --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            所有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   日付: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             日付: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [from Vim version 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [Vimのスワップファイルではないようです]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "        ファイル名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3598,12 +3887,15 @@ msgstr ""
 "\n"
 "          変更状態: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "あり"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "なし"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3611,9 +3903,11 @@ msgstr ""
 "\n"
 "          ユーザ名: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   ホスト名: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3621,6 +3915,7 @@ msgstr ""
 "\n"
 "          ホスト名: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3628,16 +3923,11 @@ msgstr ""
 "\n"
 "        プロセスID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (まだ実行中)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [このVimバージョンでは使用できません]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3645,75 +3935,97 @@ msgstr ""
 "\n"
 "         [このコンピュータでは使用できません]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [読込めません]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [開けません]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: スワップファイルが無いので維持できません"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "ファイルが維持されます"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 維持に失敗しました"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 無効なlnumです: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 行 %<PRId64> を見つけられません"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ポインタブロックのIDが間違っています 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx は 0 であるべきです"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新されたブロックが多過ぎるかも?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: ポインタブロックのIDが間違っています 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "ブロック 1 は消された?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 行 %<PRId64> が見つかりません"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: ポインタブロックのIDが間違っています"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count がゼロです"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行番号が範囲外です: %<PRId64> 超えています"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: ブロック %<PRId64> の行カウントが間違っています"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "スタックサイズが増えます"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: ポインタブロックのIDが間違っています 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: \"%s\" のシンボリックリンクがループになっています"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3721,14 +4033,15 @@ msgstr ""
 "\n"
 "次の名前でスワップファイルを見つけました \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "次のファイルを開いている最中 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      スワップファイルよりも新しいです!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3740,15 +4053,19 @@ msgstr ""
 "    この場合には, 変更をした際に最終的に, 同じファイルの異なる\n"
 "    2つのインスタンスができてしまうことに注意してください."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  終了するか, 注意しながら続けてください.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) このファイルの編集セッションがクラッシュした.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    この場合には \":recover\" か \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3756,9 +4073,11 @@ msgstr ""
 "\"\n"
 "    を使用して変更をリカバーします(\":help recovery\" を参照).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    既にこれを行なったのならば, スワップファイル \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3766,18 +4085,23 @@ msgstr ""
 "\"\n"
 "    を消せばこのメッセージを回避できます.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "スワップファイル \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" が既にあります!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "スワップファイルが既に存在します!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3791,6 +4115,7 @@ msgstr ""
 "終了する(&Q)\n"
 "中止する(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3806,34 +4131,56 @@ msgstr ""
 "終了する(&Q)\n"
 "中止する(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: スワップファイルが多数見つかりました"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: メニューアイテムのパスの部分がサブメニューではありません"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: メニューは他のモードにだけあります"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: \"%s\" というメニューはありません"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: メニュー名が空です"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: メニューパスはサブメニューを生じるべきではありません"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: メニューバーには直接メニューアイテムを追加できません"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 区切りはメニューパスの一部ではありません"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3841,60 +4188,73 @@ msgstr ""
 "\n"
 "--- メニュー ---"
 
-msgid "Tear off this menu"
-msgstr "このメニューを切り取る"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: メニューパスはメニューアイテムを生じなければいけません"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: メニューが見つかりません: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s にはメニューが定義されていません"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: メニューパスはサブメニューを生じなければいけません"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: メニューが見つかりません - メニュー名を確認してください"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "%s の処理中にエラーが検出されました:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "行 %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 無効なレジスタ名: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "日本語メッセージ翻訳/監修: 村岡 太郎 <koron.kaoriya@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "割込み: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "続けるにはENTERを押すかコマンドを入力してください"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 行 %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 継続 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: 画面/ページ/行 下, b/u/k: 上, q: 終了 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "質問"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3902,6 +4262,17 @@ msgstr ""
 "はい(&Y)\n"
 "いいえ(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"はい(&Y)\n"
+"いいえ(&N)\n"
+"キャンセル(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3915,272 +4286,175 @@ msgstr ""
 "全て放棄(&D)\n"
 "キャンセル(&C)"
 
-msgid "Select Directory dialog"
-msgstr "ディレクトリ選択ダイアログ"
-
-msgid "Save File dialog"
-msgstr "ファイル保存ダイアログ"
-
-msgid "Open File dialog"
-msgstr "ファイル読込ダイアログ"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: コンソールモードではファイルブラウザを使えません, ごめんなさい"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() の引数が不十分です"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: printf() の引数には浮動少数点数が期待されています"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf() の引数が多過ぎます"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 警告: 読込専用ファイルを変更します"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "番号と<Enter>を入力するかマウスでクリックしてください (空でキャンセル): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "番号と<Enter>を入力してください (空でキャンセル): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 行 追加しました"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 行 削除しました"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> 行 追加しました"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> 行 削除しました"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (割込まれました)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "ビーッ!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: ファイルを保存中...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 終了しました.\n"
-
-msgid "ERROR: "
-msgstr "エラー: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピーク時 %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 行が長くなり過ぎました"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "実行のためにシェルを呼出し中: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: コロンがありません"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 不正なモードです"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 不正な 'mouseshape' です"
-
-msgid "E548: digit expected"
-msgstr "E548: 数値が必要です"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 不正なパーセンテージです"
-
-msgid "Enter encryption key: "
-msgstr "暗号化用のキーを入力してください: "
-
-msgid "Enter same key again: "
-msgstr "もう一度同じキーを入力してください: "
-
-msgid "Keys don't match!"
-msgstr "キーが一致しません"
-
-msgid "E854: path too long for completion"
-msgstr "E854: パスが長過ぎて補完できません"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: 無効なパスです: '**[数値]' はpathの最後か '%s' が続いてないといけませ"
-"ん."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpathには \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: pathには \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: cdpathにはこれ以上 \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: パスにはこれ以上 \"%s\" というファイルがありません"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Netbeans #2 に接続できません"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Netbeans に接続できません"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: NetBeansの接続情報ファイルのアクセスモードに問題があります: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "Netbeans のソケットを読込み"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: NetBeansはこのGUIには対応していません"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: NetBeansは既に接続しています"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s は読込専用です (強制書込には ! を追加)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: カーソルの位置には識別子がありません"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' オプションが空です"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: 式評価機能が無効になっています"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "警告: 使用している端末はハイライトできません"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: カーソルの位置には文字列がありません"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 現在の 'foldmethod' では折畳みを消去できません"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 変更リストが空です"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 変更リストの先頭"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 行が %s で 1 回処理されました"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 行が %s で %d 回処理されました"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行が %s で 1 回処理されました"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行が %s で %d 回処理されました"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> 行がインデントされます... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 行をインデントしました "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> 行をインデントしました "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: まだレジスタを使用していません"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "ヤンクできません; とにかく消去"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 行が変更されました"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> 行が変更されました"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "%<PRId64> 行を解放中"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "1 行のブロックがヤンクされました"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 行がヤンクされました"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "%<PRId64> 行のブロックがヤンクされました"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> 行がヤンクされました"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: レジスタ %s には何もありません"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4188,9 +4462,11 @@ msgstr ""
 "\n"
 "--- レジスタ ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "不正なレジスタ名"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4198,160 +4474,182 @@ msgstr ""
 "\n"
 "# レジスタ:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 列; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> バイト"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト %<PRId64> / %<PRId64>"
-
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 %<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
+"選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / "
+"%<PRId64> バイト"
 
+#: ../ops.c:5105
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / "
+"%<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト "
+"%<PRId64> / %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 "
+"%<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=%N ページ"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Vim を使ってくれてありがとう"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 未知のオプションです"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: オプションはサポートされていません"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: modeline では許可されません"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: キーコードが設定されていません"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = の後には数字が必要です"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: termcap 内に見つかりません"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正な文字です <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' には空文字列を設定できません"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: GUIでは 'term' を変更できません"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: GUIをスタートするには \":gui\" を使用してください"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' と 'patchmode' が同じです"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: 'listchars'の値に矛盾があります"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: 'fillchars'の値に矛盾があります"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: GTK+2 GUIでは変更できません"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: コロンがありません"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 文字列の長さがゼロです"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> の後に数字がありません"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: カンマがありません"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: ' の値を指定しなければなりません"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 表示できない文字かワイド文字を含んでいます"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 無効なフォントです"
-
-msgid "E597: can't select fontset"
-msgstr "E597: フォントセットを選択できません"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 無効なフォントセットです"
-
-msgid "E533: can't select wide font"
-msgstr "E533: ワイドフォントを選択できません"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 無効なワイドフォントです"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> の後に不正な文字があります"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: カンマが必要です"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' は空であるか %s を含む必要があります"
 
-msgid "E538: No mouse support"
-msgstr "E538: マウスはサポートされません"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 式が終了していません"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 要素が多過ぎます"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: グループが釣合いません"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: プレビューウィンドウが既に存在します"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: アラビア文字にはUTF-8が必要なので, ':set encoding=utf-8' してください"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 最低 %d の行数が必要です"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 最低 %d のカラム幅が必要です"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 未知のオプションです: %s"
@@ -4359,10 +4657,12 @@ msgstr "E355: 未知のオプションです: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: 数字が必要です: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4370,6 +4670,7 @@ msgstr ""
 "\n"
 "--- 端末コード ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4377,6 +4678,7 @@ msgstr ""
 "\n"
 "--- グローバルオプション値 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4384,6 +4686,7 @@ msgstr ""
 "\n"
 "--- ローカルオプション値 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4391,140 +4694,21 @@ msgstr ""
 "\n"
 "--- オプション ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp エラー"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': %s に対応する文字がありません"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': セミコロンの後に余分な文字があります: %s"
 
-msgid "cannot open "
-msgstr "開けません "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: ウィンドウを開けません!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "%s のバージョン %<PRId64> が必要です\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "NILを開けません:\n"
-
-msgid "Cannot create "
-msgstr "作成できません "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vimは %d で終了します\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "コンソールモードを変更できません?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: コンソールではない??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: -f オプションでシェルを実行できません"
-
-msgid "Cannot execute "
-msgstr "実行できません "
-
-msgid "shell "
-msgstr "シェル "
-
-msgid " returned\n"
-msgstr " 戻りました\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE が小さ過ぎます."
-
-msgid "I/O ERROR"
-msgstr "入出力エラー"
-
-msgid "Message"
-msgstr "メッセージ"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' が80ではないため, 外部コマンドを実行できません"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: プリンタの選択に失敗しました"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "%s へ (%s 上の)"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 未知のプリンタオプションです: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 印刷エラー: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "印刷しています: '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 文字セット名 \"%s\" は不正です (フォント名 \"%s\")"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: '%c' は不正な文字です (フォント名 \"%s\")"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 2重のシグナルのため, 終了します\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: 致命的シグナル %s を検知しました\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 致命的シグナルを検知しました\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X のエラーを検出しましたr\n"
-
-msgid "Testing the X display failed"
-msgstr "X display のチェックに失敗しました"
-
-msgid "Opening the X display timed out"
-msgstr "X display の open がタイムアウトしました"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"セキュリティコンテキストを取得できません "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"セキュリティコンテキストを設定できません "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4532,13 +4716,7 @@ msgstr ""
 "\n"
 "シェルを実行できません "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"sh シェルを実行できません\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4546,451 +4724,484 @@ msgstr ""
 "\n"
 "シェルが値を返しました "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"パイプを作成できません\n"
+"セキュリティコンテキストを取得できません "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"fork できません\n"
+"セキュリティコンテキストを設定できません "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"コマンドを中断しました\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP がICE接続を失いました"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "X display の open に失敗しました"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP がsave-yourself要求を処理しています"
-
-msgid "XSMP opening connection"
-msgstr "XSMP が接続を開始しています"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE接続が失敗したようです"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnectionが失敗しました: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: pathには \"%s\" というファイルがありません"
 
-msgid "At line"
-msgstr "行"
-
-msgid "Could not load vim32.dll!"
-msgstr "vim32.dll をロードできませんでした"
-
-msgid "VIM Error"
-msgstr "VIMエラー"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "DLLから関数ポインタを取得できませんでした"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "シェルがコード %d で終了しました"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: イベント %s を検知\n"
-
-msgid "close"
-msgstr "閉じる"
-
-msgid "logoff"
-msgstr "ログオフ"
-
-msgid "shutdown"
-msgstr "シャットダウン"
-
-msgid "E371: Command not found"
-msgstr "E371: コマンドがありません"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXEが $PATH の中に見つかりません.\n"
-"外部コマンドの終了後に一時停止をしません.\n"
-"詳細は  :help win32-vimrun  を参照してください."
-
-msgid "Vim Warning"
-msgstr "Vimの警告"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: フォーマット文字列に %%%c が多過ぎます"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: フォーマット文字列に予期せぬ %%%c がありました"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: フォーマット文字列に ] がありません"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: フォーマット文字列では %%%c はサポートされません"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: フォーマット文字列の前置に無効な %%%c があります"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: フォーマット文字列に無効な %%%c があります"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' にパターンが指定されていません"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: ディレクトリ名が無いか空です"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 要素がもうありません"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d of %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行が削除されました)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: quickfix スタックの末尾です"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: quickfix スタックの先頭です"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "エラー一覧 %d of %d; %d 個エラー"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 'buftype' オプションが設定されているので書込みません"
 
-msgid "Error file"
-msgstr "エラーファイル"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: ファイル名が無いか無効なパターンです"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "ファイル \"%s\" を開けません"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: バッファは読み込まれませんでした"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: 文字列かリストが必要です"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: 無効な項目です: %s%%[]"
 
 #
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ の後に ] がありません"
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: %s%%( が釣り合っていません"
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: %s( が釣り合っていません"
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: %s) が釣り合っていません"
 
 #
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( はココでは許可されていません"
 
 #
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 その他はココでは許可されていません"
 
 #
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: %s%%[ の後に ] がありません"
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] が空です"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: パターンが長過ぎます"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: \\z( が多過ぎます"
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: %s( が多過ぎます"
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: \\z( が釣り合っていません"
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: %s@ の後に不正な文字がありました"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: 複雑な %s{...} が多過ぎます"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61:%s* が入れ子になっています"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62:%s%c が入れ子になっています"
 
 #
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: \\_ の無効な使用方法です"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64:%s%c の後になにもありません"
 
 #
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: 不正な後方参照です"
 
 #
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: \\z の後に不正な文字がありました"
 
 #
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: %s%%[dxouU] の後に不正な文字がありました"
 
 #
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: %s%% の後に不正な文字がありました"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...} 内に文法エラーがあります"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部の部分該当:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
-"E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。"
-"正規表現エンジンは自動選択されます。"
+"E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。正規表現エンジンは自動選"
+"択されます。"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) 期待より早く正規表現の終端に到達しました"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA 正規表現) 位置が誤っています: %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) 期待より早く正規表現の終端に到達しました"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) 未知のオペレータです: '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) 未知のオペレータです: '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: 等価クラスを含むNFA構築に失敗しました!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) 未知のオペレータです: '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFA 正規表現) 繰り返しの制限回数を読込中にエラー"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (NFA 正規表現) 繰り返し の後に 繰り返し はできません!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA 正規表現) '(' が多過ぎます"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA 正規表現) \\z( が多過ぎます"
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA 正規表現) 終端記号がありません"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) スタックをポップできません!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
 msgstr ""
-"E875: (NFA 正規表現) (後置文字列をNFAに変換中に) "
-"スタックに残されたステートが多過ぎます"
+"E875: (NFA 正規表現) (後置文字列をNFAに変換中に) スタックに残されたステートが"
+"多過ぎます"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA 正規表現) NFA全体を保存するには空きスペースが足りません"
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) 現在横断中のブランチに十分なメモリを割り当てられません!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
-msgstr "NFA正規表現エンジン用のログファイルを書込用として開けません。"
-"ログは標準出力に出力します。"
+msgstr ""
+"NFA正規表現エンジン用のログファイルを書込用として開けません。ログは標準出力に"
+"出力します。"
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) ログファイル %s を開けません!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "NFA正規表現エンジン用のログファイルを書込用として開けません。"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " 仮想置換"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 置換"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反転"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 挿入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (挿入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (置換)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (仮想置換)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " ヘブライ"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " アラビア"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (言語)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (貼り付け)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ビジュアル"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ビジュアル 行"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ビジュアル 矩形"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " セレクト"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 行指向選択"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 矩形選択"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "記録中"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 無効な検索文字列です: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 上まで検索しましたが該当箇所はありません: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 下まで検索しましたが該当箇所はありません: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ';' のあとには '?' か '/' が期待されている"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (前に列挙した該当箇所を含む)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- インクルードされたファイル "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "見つかりません "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "パスに ----\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (既に列挙)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  見つかりません"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "インクルードされたファイルをスキャン中: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "インクルードされたファイルをスキャン中 %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 現在行に該当があります"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "全てのインクルードされたファイルが見つかりました"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "インクルードファイルはありません"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 定義を見つけられません"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: パターンを見つけられません"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Substitute "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5001,87 +5212,99 @@ msgstr ""
 "# 最後の %s検索パターン:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: スペルファイルの書式エラーです"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: スペルファイルが切取られているようです"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "%s (%d 行目) に続くテキスト: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "%s (%d 行目) の affix 名が長過ぎます: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr ""
 "E761: affixファイルの FOL, LOW もしくは UPP のフォーマットにエラーがあります"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL, LOW もしくは UPP の文字が範囲外です"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "単語ツリーを圧縮しています..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: スペルチェックは無効化されています"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"警告: 単語リスト \"%s_%s.spl\" および \"%s_ascii.spl\" は見つかりません"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "警告: 単語リスト \"%s.%s.spl\" および \"%s.ascii.spl\" は見つかりません"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "スペルファイル \"%s\" を読込中"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: スペルファイルではないようです"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 古いスペルファイルなので, アップデートしてください"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: より新しいバージョンの Vim 用のスペルファイルです"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: スペルファイルにサポートしていないセクションがあります"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "警告9: %s という範囲はサポートされていません"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "affix ファイル %s を読込中..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "%s (%d 行目) の単語を変換できませんでした: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "%s 内の次の変換はサポートされていません: %s から %s へ"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "%s 内の変換はサポートされていません"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 内の %d 行目の FLAG に無効な値があります: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 内の %d 行目にフラグの二重使用があります: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5090,6 +5313,7 @@ msgstr ""
 "%s の %d 行目の PFX 項目の後の COMPOUNDFORBIDFLAG の定義は誤った結果を生じる"
 "ことがあります"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5098,35 +5322,43 @@ msgstr ""
 "%s の %d 行目の PFX 項目の後の COMPOUNDPERMITFLAG の定義は誤った結果を生じる"
 "ことがあります"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "COMPOUNDRULES の値に誤りがあります. ファイル %s の %d 行目: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDWORDMAX の値に誤りがあります: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDMIN の値に誤りがあります: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDSYLMAX の値に誤りがあります: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s の %d 行目の CHECKCOMPOUNDPATTERN の値に誤りがあります: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "%s の %d 行目の 連続 affix ブロックのフラグの組合せに違いがあります: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s の %d 行目に 重複した affix を検出しました: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5135,270 +5367,334 @@ msgstr ""
 "%s の %d 行目の affix は BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
 "に使用してください: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s の %d 行目では Y か N が必要です: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s の %d 行目の 条件は壊れています: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s の %d 行目には REP(SAL) の回数が必要です"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s の %d 行目には MAP の回数が必要です"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s の %d 行目の MAP に重複した文字があります"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s の %d 行目に 認識できないか重複した項目があります: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s 行目に FOL/LOW/UPP がありません"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "SYLLABLE が指定されない COMPOUNDSYLMAX"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "遅延後置子が多過ぎます"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "複合フラグが多過ぎます"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "遅延後置子 と/もしくは 複合フラグが多過ぎます"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "SOFO%s 行が %s にありません"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "SAL行 と SOFO行 が %s で両方指定されています"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s の %d 行の フラグが数値ではありません: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s の %d 行目の フラグが不正です: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "値 %s は他の .aff ファイルで使用されたのと異なります"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "辞書ファイル %s をスキャン中..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s には単語数がありません"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "行 %6d, 単語 %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s の %d 行目で 重複単語が見つかりました: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "重複のうち最初の単語は %s の %d 行目です: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d 個の単語が見つかりました (%s 内)"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "非ASCII文字を含む %d 個の単語を無視しました (%s 内)"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "標準入力から読込み中 %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した /encoding= 行を無視しました: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 単語の後の /encoding= 行を無視しました: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した /regions= 行を無視しました: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s の %d 行目, 範囲指定が多過ぎます: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した / 行を無視しました: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s の %d 行目 無効な nr 領域です: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s の %d 行目 認識不能なフラグです: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "非ASCII文字を含む %d 個の単語を無視しました"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: メモリが足りないので、単語リストは不完全です"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "ノード %d 個(全 %d 個中) を圧縮しました; 残り %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "スペルファイルを逆読込中"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "音声畳込みを実行中..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "音声畳込み後の総単語数: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "総単語数: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "修正候補ファイル \"%s\" を書込み中..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "推定メモリ使用量: %d バイト"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 出力ファイル名には範囲名を含められません"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 範囲は 8 個までしかサポートされていません"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: 無効な範囲です: %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "警告: 複合フラグと NOBREAK が両方とも指定されました"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "スペルファイル %s を書込み中..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "実行しました!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "%s から単語が削除されました"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "%s に単語が追加されました"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 単語の文字がスペルファイルと異なります"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "残念ですが, 修正候補はありません"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "残念ですが, 修正候補は %<PRId64> 個しかありません"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "\"%.*s\" を次へ変換:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: スペル置換がまだ実行されていません"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 見つかりません: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: .sug ファイルではないようです: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: 古い .sug ファイルなので, アップデートしてください: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: より新しいバージョンの Vim 用の .sug ファイルです: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug ファイルが .spl ファイルと一致しません: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: .sug ファイルの読込中にエラーが発生しました: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: MAP エントリに重複文字が存在します"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "このバッファに定義された構文要素はありません"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 不正な引数です: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: そのような構文クラスタはありません: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C言語風コメントから同期中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "非同期"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同期開始 "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " 行前(トップ行よりも)"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5406,6 +5702,7 @@ msgstr ""
 "\n"
 "--- 構文同期要素 ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5413,6 +5710,7 @@ msgstr ""
 "\n"
 "要素上で同期中"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5420,212 +5718,272 @@ msgstr ""
 "\n"
 "--- 構文要素 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: そのような構文クラスタはありません: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; 該当 "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " 個の改行"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: この場所では引数containsは許可されていません"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: 無効なccharの値です"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: ここではグループは許可されません"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: %s の範囲要素が見つかりません"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: ファイル名が必要です"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: 構文の取り込み(include)が多過ぎます"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' がありません: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' がありません: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: 引数が足りません: 構文範囲 %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: 構文クラスタが多過ぎます"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: クラスタが指定されていません"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: パターン区切りが見つかりません: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: パターンのあとにゴミがあります: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 構文同期: 連続行パターンが2度指定されました"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 不正な引数です: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 等号がありません: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空の引数: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s はココでは許可されていません"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s は内容リストの先頭でなければならない"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 未知のグループ名: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 無効な :syntax のサブコマンド: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: syncolor.vim の再帰呼び出しを検出しました"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: ハイライトグループが見つかりません: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 引数が充分ではない: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 引数が多過ぎます: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: グループが設定されているのでハイライトリンクは無視されます"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 予期せぬ等号です: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 等号ががありません: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 引数がありません: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不正な値です: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 未知の前景色です"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 未知の背景色です"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: カラー名や番号を認識できません: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 終端コードが長過ぎます: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 不正な引数です: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 多くの異なるハイライト属性が使われ過ぎています"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: グループ名に印刷不可能な文字があります"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: グループ名に不正な文字があります"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: ハイライトと構文グループが多過ぎます"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: タグスタックの末尾です"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: タグスタックの先頭です"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 最初の該当タグを超えて戻ることはできません"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: タグが見つかりません: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "ファイル\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 該当タグが1つだけしかありません"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 最後に該当するタグを超えて進むことはできません"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "ファイル \"%s\" がありません"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "タグ %d (全%d%s)"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " かそれ以上"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  タグを異なるcaseで使用します!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: ファイル \"%s\" がありません"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5633,66 +5991,79 @@ msgstr ""
 "\n"
 "  # TO タグ        FROM 行    in file/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "タグファイル %s を検索中"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: タグファイルのパスが %s に切り捨てられました\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "タグファイル内の長い行を無視します"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: タグファイル \"%s\" のフォーマットにエラーがあります"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "直前の %<PRId64> バイト"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: タグファイルがソートされていません: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: タグファイルがありません"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: タグパターンを見つけられません"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: タグを見つけられないので単に推測します!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "重複したフィールド名: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' は未知です. 現行の組み込み端末は次のとおりです:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "省略値を次のように設定します '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: termcapファイルを開けません"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: terminfoに端末エントリを見つけられません"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: termcapに端末エントリを見つけられません"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcapに \"%s\" のエントリがありません"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 端末に \"cm\" 機能が必要です"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5700,244 +6071,169 @@ msgstr ""
 "\n"
 "--- 端末キー ---"
 
-msgid "new shell started\n"
-msgstr "新しいシェルを起動します\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 入力を読込み中のエラーにより終了します...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "空の選択領域のかわりにCUT_BUFFER0が使用されました"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: 予期せず行カウントが変わりました"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "可能なアンドゥはありません: とりあえず続けます"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: 書込み用にアンドゥファイルを開けません: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: アンドゥファイルが壊れています (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "'undodir'のディレクトリにアンドゥファイルを書き込めません"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "アンドゥファイルとして読み込めないので上書きしません: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "アンドゥファイルではないので上書きしません: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "対象がないのでアンドゥファイルの書き込みをスキップします"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "アンドゥファイル書き込み中: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: アンドゥファイルの書き込みエラーです: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "オーナーが異なるのでアンドゥファイルを読み込みません: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "アンドゥファイル読込中: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: アンドゥファイルを読込用として開けません: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: アンドゥファイルではありません: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: 非暗号化ファイルが暗号化されたアンドゥファイルを使ってます: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: 暗号化されたアンドゥファイルの解読に失敗しました: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: アンドゥファイルが暗号化されています: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: 互換性の無いアンドゥファイルです: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "ファイルの内容が変わっているため、アンドゥ情報を利用できません"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "アンドゥファイル %s の取込を完了"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "既に一番古い変更です"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "既に一番新しい変更です"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: アンドゥ番号 %<PRId64> は見つかりません"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行番号が間違っています"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "行 追加しました"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "行 追加しました"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "行 削除しました"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "行 削除しました"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "箇所変更しました"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "箇所変更しました"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "前方"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "後方"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "アンドゥ対象がありません"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "通番   変更数   変更時期           保存済"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> 秒経過しています"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo の直後に undojoin はできません"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: アンドゥリストが壊れています"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: アンドゥ行がありません"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 ビット GUI 版"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64 ビット GUI 版"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 ビット GUI 版"
-
-msgid " in Win32s mode"
-msgstr " in Win32s モード"
-
-msgid " with OLE support"
-msgstr " with OLE サポート"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 64 ビット コンソール 版"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 ビット コンソール 版"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 ビット 版"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 ビット MS-DOS 版"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 ビット MS-DOS 版"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS 版"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5945,6 +6241,7 @@ msgstr ""
 "\n"
 "適用済パッチ: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5952,9 +6249,11 @@ msgstr ""
 "\n"
 "追加拡張パッチ: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modified by "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5962,9 +6261,11 @@ msgstr ""
 "\n"
 "Compiled "
 
+#: ../version.c:649
 msgid "by "
 msgstr "by "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5972,837 +6273,1883 @@ msgstr ""
 "\n"
 "Huge 版 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Big 版 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"通常 版 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Small 版 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Tiny 版 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "without GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "with GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "with GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "with X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "with X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "with X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "with Photon GUI."
-
-msgid "with GUI."
-msgstr "with GUI."
-
-msgid "with Carbon GUI."
-msgstr "with Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "with Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "with (クラシック) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能の一覧 有効(+)/無効(-)\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "      システム vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        ユーザ vimrc: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "     第2ユーザ vimrc: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "     第3ユーザ vimrc: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         ユーザ exrc: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "      第2ユーザ exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "     システム gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       ユーザ gvimrc: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "    第2ユーザ gvimrc: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "    第3ユーザ gvimrc: \""
-
-msgid "    system menu file: \""
-msgstr "    システムメニュー: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       省略時の $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "省略時の $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "コンパイル: "
 
-msgid "Compiler: "
-msgstr "コンパイラ: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "リンク: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "デバッグビルド"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "version "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "by Bram Moolenaar 他."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim はオープンソースであり自由に配布可能です"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "ウガンダの恵まれない子供たちに援助を!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "詳細な情報は           :help iccf<Enter>      "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "終了するには           :q<Enter>              "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "バージョン情報は       :help version7<Enter>  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi互換モードで動作中"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "Vim推奨値にするには    :set nocp<Enter>       "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "詳細な情報は           :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "詳細はメニューの ヘルプ→孤児 を参照して下さい   "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "モード無で実行中, タイプした文字が挿入されます"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "メニューの 編集→全体設定→挿入(初心者)モード切替 "
-
-msgid "                              for two modes      "
-msgstr "                              でモード有に       "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "メニューの 編集→全体設定→Vi互換モード切替      "
-
-msgid "                              for Vim defaults   "
-msgstr "                              でVimとして動作    "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Vimの開発を応援してください!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Vimの登録ユーザになってください!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "詳細な情報は           :help sponsor<Enter>   "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "詳細な情報は           :help register<Enter>  "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "詳細はメニューの ヘルプ→スポンサー/登録 を参照して下さい   "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "   警告: Windows 95/98/Me を検出  "
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr " 詳細な情報は          :help windows95<Enter> "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "既にウィンドウは1つしかありません"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: プレビューウィンドウがありません"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: 左上と右下を同時に分割することはできません"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: 他のウィンドウが分割されている時には順回できません"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: 最後のウィンドウを閉じることはできません"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: autocmdウィンドウは閉じられません"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: autocmdウィンドウしか残らないため、ウィンドウは閉じられません"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: 他のウィンドウには変更があります"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: カーソルの下にファイル名がありません"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: pathには \"%s\" というファイルがありません"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() が空パスワードで呼び出されました"
 
-msgid "Edit with &multiple Vims"
-msgstr "複数のVimで編集する (&M)"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Edit with single &Vim"
-msgstr "1つのVimで編集する (&V)"
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish暗号のビッグ/リトルエンディアンが間違っています"
 
-msgid "Diff with Vim"
-msgstr "Vimで差分を表示する"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256のテストに失敗しました"
 
-msgid "Edit with &Vim"
-msgstr "Vimで編集する (&V)"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish暗号のテストに失敗しました"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "起動済のVimで編集する - "
+#~ msgid "Patch file"
+#~ msgstr "パッチファイル"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "選択したファイルをVimで編集する"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "決定(&O)\n"
+#~ "キャンセル(&C)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "プロセスの作成に失敗: gvimが環境変数PATH上にあるか確認してください!"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Vim サーバへの接続がありません"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll エラー"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: %s へ送ることができません"
 
-msgid "Path length too long!"
-msgstr "パスが長すぎます!"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: サーバの応答がありません"
 
-msgid "--No lines in buffer--"
-msgstr "--バッファに行がありません--"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: クライアントへ送ることができません"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: コマンドが中断されました"
+#~ msgid "Save As"
+#~ msgstr "別名で保存"
 
-msgid "E471: Argument required"
-msgstr "E471: 引数が必要です"
+#~ msgid "Edit File"
+#~ msgstr "ファイルを編集"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ の後は / か ? か & でなければなりません"
+# Added at 27-Jan-2004.
+#~ msgid " (NOT FOUND)"
+#~ msgstr "  (見つかりません)"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
+#~ msgid "Source Vim script"
+#~ msgstr "Vimスクリプトの取込み"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"
+#~ msgid "unknown"
+#~ msgstr "不明"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif がありません"
+#~ msgid "Edit File in new window"
+#~ msgstr "新しいウィンドウでファイルを編集します"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry がありません"
+#~ msgid "Append File"
+#~ msgstr "追加ファイル"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile がありません"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "ウィンドウ位置: X %d, Y %d"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor がありません"
+#~ msgid "Save Redirection"
+#~ msgstr "リダイレクトを保存します"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :while のない :endwhile があります"
+#~ msgid "Save View"
+#~ msgstr "ビューを保存します"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor のない :for があります"
+#~ msgid "Save Session"
+#~ msgstr "セッション情報を保存します"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: ファイルが存在します (! を追加で上書)"
+#~ msgid "Save Setup"
+#~ msgstr "設定を保存します"
 
-msgid "E472: Command failed"
-msgstr "E472: コマンドが失敗しました"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< は +eval 機能が無いと利用できません"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 未知のフォントセット: %s"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: このバージョンに合字はありません"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 未知のフォント: %s"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr " はデバイスです ('opendevice' オプションで回避できます)"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: フォント \"%s\" は固定幅ではありません"
+#~ msgid "Reading from stdin..."
+#~ msgstr "標準入力から読込み中..."
 
-msgid "E473: Internal error"
-msgstr "E473: 内部エラーです"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish暗号化]"
 
-msgid "Interrupted"
-msgstr "割込まれました"
+#~ msgid "[crypted]"
+#~ msgstr "[暗号化]"
 
-msgid "E14: Invalid address"
-msgstr "E14: 無効なアドレスです"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: ファイルが未知の方法で暗号化されています"
 
-msgid "E474: Invalid argument"
-msgstr "E474: 無効な引数です"
+# Added at 19-Jan-2004.
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeansは未変更のバッファを上書することは許可していません"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 無効な引数です: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeansバッファの一部を書き出すことはできません"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 無効な式です: %s"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "'opendevice' オプションによりデバイスへの書き込みはできません"
 
-msgid "E16: Invalid range"
-msgstr "E16: 無効な範囲です"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: リソースフォークが失われるかもしれません (! を追加で強制)"
 
-msgid "E476: Invalid command"
-msgstr "E476: 無効なコマンドです"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: GUI用のプロセスの起動に失敗しました"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" はディレクトリです"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: 子プロセスがGUIの起動に失敗しました"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: \"%s\"() のライブラリ呼出に失敗しました"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUIを開始できません"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: ライブラリの関数 %s をロードできませんでした"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: \"%s\"から読込むことができません"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: マークに無効な行番号が指定されていました"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 有効なフォントが見つからないので, GUIを開始できません"
 
-msgid "E20: Mark not set"
-msgstr "E20: マークは設定されていません"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' が無効です"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 'modifiable' がオフなので, 変更できません"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' に設定された値が無効です"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: スクリプトの入れ子が深過ぎます"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: %s の色を割り当てられません"
 
-msgid "E23: No alternate file"
-msgstr "E23: 副ファイルはありません"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "カーソルの位置にマッチはありません, 次を検索しています"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: そのような短縮入力はありません"
+#~ msgid "<cannot open> "
+#~ msgstr "<開けません> "
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! は許可されていません"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: フォント %s を取得できません"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUIは使用不可能です: コンパイル時に無効にされています"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 現在のディレクトリに戻れません"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: ヘブライ語は使用不可能です: コンパイル時に無効にされています\n"
+#~ msgid "Pathname:"
+#~ msgstr "パス名:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: ペルシア語は使用不可能です: コンパイル時に無効にされています\n"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 現在のディレクトリを取得できません"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: アラビア語は使用不可能です: コンパイル時に無効にされています\n"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: そのような名のハイライトグループはありません: %s"
+#~ msgid "Cancel"
+#~ msgstr "キャンセル"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: まだテキストが挿入されていません"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "スクロールバー: 画像を取得できませんでした."
 
-msgid "E30: No previous command line"
-msgstr "E30: 以前にコマンド行がありません"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim ダイアログ"
 
-msgid "E31: No such mapping"
-msgstr "E31: そのようなマッピングはありません"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: メッセージとコールバックのある BalloonEval を作成できません"
 
-msgid "E479: No match"
-msgstr "E479: 該当はありません"
+#~ msgid "Input _Methods"
+#~ msgstr "インプットメソッド"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 該当はありません: %s"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 検索と置換..."
 
-msgid "E32: No file name"
-msgstr "E32: ファイル名がありません"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 検索..."
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 正規表現置換がまだ実行されていません"
+#~ msgid "Find what:"
+#~ msgstr "検索文字列:"
 
-msgid "E34: No previous command"
-msgstr "E34: コマンドがまだ実行されていません"
+#~ msgid "Replace with:"
+#~ msgstr "置換文字列:"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: 正規表現がまだ実行されていません"
+#~ msgid "Match whole word only"
+#~ msgstr "正確に該当するものだけ"
 
-msgid "E481: No range allowed"
-msgstr "E481: 範囲指定は許可されていません"
+#~ msgid "Match case"
+#~ msgstr "大文字/小文字を区別する"
 
-msgid "E36: Not enough room"
-msgstr "E36: ウィンドウに十分な高さもしくは幅がありません"
+#~ msgid "Direction"
+#~ msgstr "方向"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: %s という名前の登録されたサーバはありません"
+#~ msgid "Up"
+#~ msgstr "上"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: ファイル %s を作成できません"
+#~ msgid "Down"
+#~ msgstr "下"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: 一時ファイルの名前を取得できません"
+#~ msgid "Find Next"
+#~ msgstr "次を検索"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: ファイル \"%s\" を開けません"
+#~ msgid "Replace"
+#~ msgstr "置換"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: ファイル %s を読込めません"
+#~ msgid "Replace All"
+#~ msgstr "全て置換"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: セッションマネージャから \"die\" 要求を受け取りました\n"
 
-msgid "E38: Null argument"
-msgstr "E38: 引数が空です"
+#~ msgid "Close"
+#~ msgstr "閉じる"
 
-msgid "E39: Number expected"
-msgstr "E39: 数値が要求されています"
+#~ msgid "New tab"
+#~ msgstr "新規タブページ"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: エラーファイル %s を開けません"
+#~ msgid "Open Tab..."
+#~ msgstr "タブページを開く..."
 
-msgid "E233: cannot open display"
-msgstr "E233: ディスプレイを開けません"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: メインウィンドウが不意に破壊されました\n"
 
-msgid "E41: Out of memory!"
-msgstr "E41: メモリが尽き果てました!"
+#~ msgid "&Filter"
+#~ msgstr "フィルタ(&F)"
 
-msgid "Pattern not found"
-msgstr "パターンは見つかりませんでした"
+#~ msgid "&Cancel"
+#~ msgstr "キャンセル(&C)"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: パターンは見つかりませんでした: %s"
+#~ msgid "Directories"
+#~ msgstr "ディレクトリ"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: 引数は正の値でなければなりません"
+#~ msgid "Filter"
+#~ msgstr "フィルタ"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 前のディレクトリに戻れません"
+#~ msgid "&Help"
+#~ msgstr "ヘルプ(&H)"
 
-msgid "E42: No Errors"
-msgstr "E42: エラーはありません"
+#~ msgid "Files"
+#~ msgstr "ファイル"
 
-msgid "E776: No location list"
-msgstr "E776: 場所リストはありません"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E43: Damaged match string"
-msgstr "E43: 該当文字列が破損しています"
+#~ msgid "Selection"
+#~ msgstr "選択"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 不正な正規表現プログラムです"
+#~ msgid "Find &Next"
+#~ msgstr "次を検索(&N)"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' オプションが設定されています (! を追加で上書き)"
+#~ msgid "&Replace"
+#~ msgstr "置換(&R)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 読取専用変数 \"%s\" には値を設定できません"
+#~ msgid "Replace &All"
+#~ msgstr "全て置換(&A)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: サンドボックスでは変数 \"%s\" に値を設定できません"
+#~ msgid "&Undo"
+#~ msgstr "アンドゥ(&U)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: エラーファイルの読込中にエラーが発生しました"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: タイトルが \"%s\" のウィンドウは見つかりません"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: サンドボックスでは許されません"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 引数はサポートされません: \"-%s\"; OLE版を使用してください."
 
-msgid "E523: Not allowed here"
-msgstr "E523: ここでは許可されません"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: MDIアプリの中ではウィンドウを開けません"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: スクリーンモードの設定には対応していません"
+#~ msgid "Close tab"
+#~ msgstr "タブページを閉じる"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: 無効なスクロール量です"
+#~ msgid "Open tab..."
+#~ msgstr "タブページを開く"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' オプションが空です"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "検索文字列 ('\\' を検索するには '\\\\')"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: sign のデータを読込めませんでした"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "検索・置換 ('\\' を検索するには '\\\\')"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: スワップファイルのクローズ時エラーです"
+#~ msgid "Not Used"
+#~ msgstr "使われません"
 
-msgid "E73: tag stack empty"
-msgstr "E73: タグスタックが空です"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "ディレクトリ\t*.nothing\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: コマンドが複雑過ぎます"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 色指定が正しくないのでエントリを割り当てられません"
 
-msgid "E75: Name too long"
-msgstr "E75: 名前が長過ぎます"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: 以下の文字セットのフォントがありません %s:"
 
-msgid "E76: Too many ["
-msgstr "E76: [ が多過ぎます"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: フォントセット名: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: ファイル名が多過ぎます"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "フォント '%s' は固定幅ではありません"
 
-msgid "E488: Trailing characters"
-msgstr "E488: 余分な文字が後ろにあります"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: フォントセット名: %s"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 未知のマーク"
+#~ msgid "Font0: %s"
+#~ msgstr "フォント0: %s"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: ワイルドカードを展開できません"
+#~ msgid "Font1: %s"
+#~ msgstr "フォント1: %s"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' は 'winminheight' より小さくできません"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' は 'winminwidth' より小さくできません"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "フォント0の幅: %<PRId64>"
 
-msgid "E80: Error while writing"
-msgstr "E80: 書込み中のエラー"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "フォント1の幅: %<PRId64>"
 
-msgid "Zero count"
-msgstr "ゼロカウント"
+#~ msgid "Invalid font specification"
+#~ msgstr "無効なフォント指定です"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: スクリプト以外で<SID>が使われました"
+#~ msgid "&Dismiss"
+#~ msgstr "却下する(&D)"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: 無効な式を受け取りました"
+#~ msgid "no specific match"
+#~ msgstr "マッチするものがありません"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: 領域が保護されているので, 変更できません"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - フォント選択"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans は読込専用ファイルを変更することを許しません"
+#~ msgid "Name:"
+#~ msgstr "名前:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 内部エラーです: %s"
+#~ msgid "Show size in Points"
+#~ msgstr "サイズをポイントで表示する"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
+#~ msgid "Encoding:"
+#~ msgstr "エンコード:"
 
-msgid "E749: empty buffer"
-msgstr "E749: バッファが空です"
+#~ msgid "Font:"
+#~ msgstr "フォント:"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 検索パターンか区切り記号が不正です"
+#~ msgid "Style:"
+#~ msgstr "スタイル:"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 同じ名前のファイルが他のバッファで読込まれています"
+#~ msgid "Size:"
+#~ msgstr "サイズ:"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: オプション '%s' は設定されていません"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ハングルオートマトンエラー"
 
-msgid "E850: Invalid register name"
-msgstr "E850: 無効なレジスタ名です"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat エラー"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "上まで検索したので下に戻ります"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: cscopeデータベース: %s を開くことができません"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "下まで検索したので上に戻ります"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: cscopeデータベースの情報を取得できません"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "暗号キーが必要です: \"%s\""
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Luaライブラリをロードできません."
 
-msgid "empty keys are not allowed"
-msgstr "空のキーは許可されていません"
+#~ msgid "cannot save undo information"
+#~ msgstr "アンドゥ情報が保存できません"
 
-msgid "dictionary is locked"
-msgstr "辞書はロックされています"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: このコマンドは無効です. MzScheme ライブラリをロードできません."
 
-msgid "list is locked"
-msgstr "リストはロックされています"
+#~ msgid "invalid expression"
+#~ msgstr "無効な式です"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "辞書にキー '%s' を追加するのに失敗しました"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "式はコンパイル時に無効にされています"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "インデックスは %s ではなく整数かスライスにしてください"
+#~ msgid "hidden option"
+#~ msgstr "隠しオプション"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "str() もしくは unicode() のインスタンスが期待されているのに %s でした"
+#~ msgid "unknown option"
+#~ msgstr "未知のオプションです"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "bytes() もしくは str() のインスタンスが期待されているのに %s でした"
+#~ msgid "window index is out of range"
+#~ msgstr "範囲外のウィンドウ番号です"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr "long() かそれへ変換可能なものが期待されているのに %s でした"
+#~ msgid "couldn't open buffer"
+#~ msgstr "バッファを開けません"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "int() かそれへ変換可能なものが期待されているのに %s でした"
+#~ msgid "cannot delete line"
+#~ msgstr "行を消せません"
 
-msgid "value is too large to fit into C int type"
-msgstr "C言語の int 型としては値が大き過ぎます"
+#~ msgid "cannot replace line"
+#~ msgstr "行を置換できません"
 
-msgid "value is too small to fit into C int type"
-msgstr "C言語の int 型としては値が小さ過ぎます"
+#~ msgid "cannot insert line"
+#~ msgstr "行を挿入できません"
 
-msgid "number must be greater then zero"
-msgstr "数値は 0 より大きくなければなりません"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "文字列には改行文字を含められません"
 
-msgid "number must be greater or equal to zero"
-msgstr "数値は 0 かそれ以上でなければなりません"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "Scheme値のVimへの変換エラー"
 
-msgid "can't delete OutputObject attributes"
-msgstr "OutputObject属性を消せません"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim エラー: ~a"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "無効な属性です: %s"
+#~ msgid "Vim error"
+#~ msgstr "Vim エラー"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: I/Oオブジェクトの初期化エラー"
+#~ msgid "buffer is invalid"
+#~ msgstr "バッファは無効です"
 
-msgid "failed to change directory"
-msgstr "辞書の変更に失敗しました"
+#~ msgid "window is invalid"
+#~ msgstr "ウィンドウは無効です"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "imp.find_module() が %s を返しました (期待値: 2 要素のタプル)"
+#~ msgid "linenr out of range"
+#~ msgstr "範囲外の行番号です"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "impl.find_module() が %d 要素のタプルを返しました (期待値: 2)"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "サンドボックスでは許されません"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "内部エラー: imp.find_module が NULL を含むタプルを返しました"
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: ライブラリ %s をロードできませんでした"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "vim.Dictionary属性は消せません"
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "このコマンドは無効です, ごめんなさい: Perlライブラリをロードできませんでし"
+#~ "た."
 
-msgid "cannot modify fixed dictionary"
-msgstr "固定された辞書は変更できません"
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: サンドボックスでは Safe モジュールを使用しないPerlスクリプトは禁じら"
+#~ "れています"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "属性 %s は設定できません"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: このVimでは :py3 を使った後に :python を使えません"
 
-msgid "hashtab changed during iteration"
-msgstr "イテレーション中に hashtab が変更されました"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: このコマンドは無効です,ごめんなさい: Pythonライブラリをロードできま"
+#~ "せんでした."
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "シーケンスの要素数には 2 が期待されていましたが %d でした"
+# Added at 07-Feb-2004.
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python を再帰的に実行することはできません"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "リストのコンストラクタはキーワード引数を受け付けません"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: このVimでは :python を使った後に :py3 を使えません"
 
-msgid "list index out of range"
-msgstr "リスト範囲外のインデックスです"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ は文字列のインスタンスでなければなりません"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "内部エラー: vimのリスト要素 %d の取得に失敗しました"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: このコマンドは無効です,ごめんなさい: Rubyライブラリをロードできませ"
+#~ "んでした."
 
-msgid "failed to add item to list"
-msgstr "リストへの要素追加に失敗しました"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: 予期せぬ return です"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "内部エラー: vimのリスト要素 %d はありません"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: 予期せぬ next です"
 
-msgid "internal error: failed to add item to list"
-msgstr "内部エラー: リストへの要素追加に失敗しました"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: 予期せぬ break です"
 
-msgid "cannot delete vim.List attributes"
-msgstr "vim.List 属性は消せません"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: 予期せぬ redo です"
 
-msgid "cannot modify fixed list"
-msgstr "固定されたリストは変更できません"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: rescue の外の retry です"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "無名関数 %s は存在しません"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: 取り扱われなかった例外があります"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "関数 %s がありません"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知のlongjmp状態: %d"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "関数のコンストラクタはキーワード引数を受け付けません"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "実装と定義を切り替える"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "関数 %s の実行に失敗しました"
+#~ msgid "Show base class of"
+#~ msgstr "次のクラスの基底を表示"
 
-msgid "unable to get option value"
-msgstr "オプションの値は取得できません"
+#~ msgid "Show overridden member function"
+#~ msgstr "オーバーライドされたメンバ関数を表示"
 
-msgid "internal error: unknown option type"
-msgstr "内部エラー: 未知のオプション型です"
+#~ msgid "Retrieve from file"
+#~ msgstr "ファイルから回復する"
 
-msgid "problem while switching windows"
-msgstr "ウィンドウを切換中に問題が発生しました"
+#~ msgid "Retrieve from project"
+#~ msgstr "プロジェクトから回復する"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "グローバルオプション %s の設定解除はできません"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "全てのプロジェクトから回復する"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "グローバルな値の無いオプション %s の設定解除はできません"
+#~ msgid "Retrieve"
+#~ msgstr "回復"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "削除されたタブを参照しようとしました"
+#~ msgid "Show source of"
+#~ msgstr "次のソースを表示する"
 
-msgid "no such tab page"
-msgstr "そのようなタブページはありません"
+#~ msgid "Find symbol"
+#~ msgstr "見つけたシンボル"
 
-msgid "attempt to refer to deleted window"
-msgstr "削除されたウィンドウを参照しようとしました"
+#~ msgid "Browse class"
+#~ msgstr "クラスを参照"
 
-msgid "readonly attribute: buffer"
-msgstr "読込専用属性: バッファー"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "階層でクラスを表示"
 
-msgid "cursor position outside buffer"
-msgstr "カーソル位置がバッファの外側です"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "限定された階層でクラスを表示"
 
-msgid "no such window"
-msgstr "そのようなウィンドウはありません"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref の参照先"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "削除されたバッファを参照しようとしました"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref が参照される"
 
-msgid "failed to rename buffer"
-msgstr "バッファ名の変更に失敗しました"
+#~ msgid "Xref has a"
+#~ msgstr "Xref が次のものをもっています"
 
-msgid "mark name must be a single character"
-msgstr "マーク名は1文字のアルファベットでなければなりません"
+#~ msgid "Xref used by"
+#~ msgstr "Xref が使用される"
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "vim.Bufferオブジェクトが期待されているのに %s でした"
+#~ msgid "Show docu of"
+#~ msgstr "次の文章を表示"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "指定されたバッファ %d への切り替えに失敗しました"
+#~ msgid "Generate docu for"
+#~ msgstr "次の文章を生成"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "vim.Windowオブジェクトが期待されているのに %s でした"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "SNiFF+に接続できません. 環境をチェックしてください(sniffemacs が $PATH に"
+#~ "なければなりません).\n"
 
-msgid "failed to find window in the current tab page"
-msgstr "現在のタブには指定されたウィンドウがありませんでした"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 読込中にエラーが発生しました. 切断しました"
 
-msgid "did not switch to the specified window"
-msgstr "指定されたウィンドウに切り替えませんでした"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "現在SNiFF+ の状態は「"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "vim.TabPageオブジェクトが期待されているのに %s でした"
+#~ msgid "not "
+#~ msgstr "未"
 
-msgid "did not switch to the specified tab page"
-msgstr "指定されたタブページに切り替えませんでした"
+#~ msgid "connected"
+#~ msgstr "接続」です"
 
-msgid "failed to run the code"
-msgstr "コードの実行に失敗しました"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 未知の SNiFF+ リクエストです: %s"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: 式評価は有効なpythonオブジェクトを返しませんでした"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: SNiFF+ への接続中のエラーです"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: 返されたpythonオブジェクトをvimの値に変換できませんでした"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ に接続されていません"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "%s vimの辞書型に変換できません"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: SNiFF+ バッファがありません"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "%s をvimの構造体に変換できません"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 書込み中にエラーが発生したので切断しました"
 
-msgid "internal error: NULL reference passed"
-msgstr "内部エラー: NULL参照が渡されました"
+#~ msgid "invalid buffer number"
+#~ msgstr "無効なバッファ番号です"
 
-msgid "internal error: invalid value type"
-msgstr "内部エラー: 無効な値型です"
+#~ msgid "not implemented yet"
+#~ msgstr "まだ実装されていません"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"パスフックの設定に失敗しました: sys.path_hooks がリストではありません\n"
-"すぐに下記を実施してください:\n"
-"- vim.path_hooks を sys.path_hooks へ追加\n"
-"- vim.VIM_SPECIAL_PATH を sys.path へ追加\n"
+#~ msgid "cannot set line(s)"
+#~ msgstr "行を設定できません"
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"パスの設定に失敗しました: sys.path がリストではありません\n"
-"すぐに vim.VIM_SPECIAL_PATH を sys.path に追加してください"
+#~ msgid "invalid mark name"
+#~ msgstr "無効なマーク名です"
+
+#~ msgid "mark not set"
+#~ msgstr "マークは設定されていません"
+
+#~ msgid "row %d column %d"
+#~ msgstr "行 %d 列 %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "行の挿入/追加をできません"
+
+#~ msgid "line number out of range"
+#~ msgstr "範囲外の行番号です"
+
+#~ msgid "unknown flag: "
+#~ msgstr "未知のフラグ: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "未知の vimOption です"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "キーボード割込み"
+
+#~ msgid "vim error"
+#~ msgstr "vim エラー"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "バッファ/ウィンドウ作成コマンドを作成できません: オブジェクトが消去されて"
+#~ "いました"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "コールバックコマンドを登録できません: バッファ/ウィンドウが既に消去されま"
+#~ "した"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL 致命的エラー: reflist 汚染!? vim-dev@vim.org に報告してください"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "コールバックコマンドを登録できません: バッファ/ウィンドウの参照が見つかり"
+#~ "ません"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: このコマンドは無効です,ごめんなさい: Tclライブラリをロードできません"
+#~ "でした."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 終了コード %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "行を取得できません"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "命令サーバの名前を登録できません"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 目的のプログラムへのコマンド送信に失敗しました"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 無効なサーバIDが使われました: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 実体の登録プロパティが不正です. 消去しました!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans はこのGUIでは利用できません\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "このVimにはdiff機能がありません(コンパイル時設定)."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' 使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "大小文字が無視される場合は大文字にするために / を前置してください"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tこのgvimをOLEとして登録する"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tgvimのOLE登録を解除する"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tGUIで起動する (\"gvim\" と同じ)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f or  --nofork\tフォアグラウンド: GUIを始めるときにforkしない"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tウィンドウを開くのに newcli を使用しない"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tI/Oに <device> を使用する"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t.gvimrcの代わりに <gvimrc> を使う"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t暗号化されたファイルを編集する"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tvimを指定した X サーバに接続する"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tXサーバに接続しない"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t可能ならばVimサーバで <files> を編集する"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  同上, サーバが無くても警告文を出力しない"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>\t--remote後 ファイルの編集が終わるのを待つ"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  同上, サーバが無くても警告文を出力しない"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <files>  --remoteでファイル1つにつき1つのタブ"
+#~ "ページを開く"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\tVimサーバに <keys> を送信して終了する"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\tサーバで <expr> を実行して結果を表示する"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVimサーバ名の一覧を表示して終了する"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\tVimサーバ <name> に送信/名前設定する"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(Motifバージョン):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(neXtawバージョン):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(Athenaバージョン):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t<display> でvimを実行する"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t最小化した状態でvimを起動する"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t背景色に <color> を使う(同義: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t前景色に <color> を使う(同義: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tテキスト表示に <font> を使う(同義: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t太字に <font> を使う"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <for>\t斜体字に <font> を使う"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t初期配置に <geom> を使う(同義: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t境界の幅を <width> にする(同義: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <width>  スクロールバーの幅を <width> にする(同義: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <height>\tメニューバーの高さを <height> にする(同義: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t反転映像を使用する(同義: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t反転映像を使用しない(同義: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t特定のリソースを使用する"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(GTK+バージョン):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t異なるGTK widgetでVimを開く"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tウィンドウIDを標準出力に出力する"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <親のタイトル>\tVimを親アプリケーションの中で起動する"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\t異なるWin32 widgetの内部にVimを開く"
+
+#~ msgid "No display"
+#~ msgstr "ディスプレイが見つかりません"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 送信に失敗しました.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 送信に失敗しました. ローカルでの実行を試みています\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d 個 (%d 個中) のファイルを編集しました"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "ディスプレイがありません: 式の送信に失敗しました.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 式の送信に失敗しました.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 無効なコードページです"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: ICの値を設定できません"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: インプットコンテキストの作成に失敗しました"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: インプットメソッドのオープンに失敗しました"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: IMの破壊コールバックを設定できませんでした"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: インプットメソッドはどんなスタイルもサポートしません"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: インプットメソッドは my preedit type をサポートしません"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: スワップファイルの暗号を更新中にエラーが発生しました"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s はこのバージョンのVimでサポートしていない形式で暗号化されています"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "スワップファイルは暗号化されています: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "新しい暗号キーを入力したあとにテキストファイルを保存していない場合は,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "新しい暗号キーを入力してください."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "暗号キーを変えたあとにテキストファイルを保存した場合は, テキストファイルと"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "スワップファイルに同じ暗号キーを使うためにenterだけを押してください."
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "スワップファイルから取得した暗号キーをテキストファイルに使います.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [このVimバージョンでは使用できません]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "このメニューを切り取る"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "ディレクトリ選択ダイアログ"
+
+#~ msgid "Save File dialog"
+#~ msgstr "ファイル保存ダイアログ"
+
+#~ msgid "Open File dialog"
+#~ msgstr "ファイル読込ダイアログ"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr ""
+#~ "E338: コンソールモードではファイルブラウザを使えません, ごめんなさい"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: ファイルを保存中...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 終了しました.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "エラー: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピー"
+#~ "ク時 %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 行が長くなり過ぎました"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 不正な 'mouseshape' です"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "暗号化用のキーを入力してください: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "もう一度同じキーを入力してください: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "キーが一致しません"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Netbeans #2 に接続できません"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Netbeans に接続できません"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: NetBeansの接続情報ファイルのアクセスモードに問題があります: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "Netbeans のソケットを読込み"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: NetBeansはこのGUIには対応していません"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: NetBeansは既に接続しています"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s は読込専用です (強制書込には ! を追加)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: 式評価機能が無効になっています"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "%<PRId64> 行を解放中"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: GUIでは 'term' を変更できません"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: GUIをスタートするには \":gui\" を使用してください"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: GTK+2 GUIでは変更できません"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 無効なフォントです"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: フォントセットを選択できません"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 無効なフォントセットです"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: ワイドフォントを選択できません"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 無効なワイドフォントです"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: マウスはサポートされません"
+
+#~ msgid "cannot open "
+#~ msgstr "開けません "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: ウィンドウを開けません!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "%s のバージョン %<PRId64> が必要です\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "NILを開けません:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "作成できません "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vimは %d で終了します\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "コンソールモードを変更できません?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: コンソールではない??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: -f オプションでシェルを実行できません"
+
+#~ msgid "Cannot execute "
+#~ msgstr "実行できません "
+
+#~ msgid "shell "
+#~ msgstr "シェル "
+
+#~ msgid " returned\n"
+#~ msgstr " 戻りました\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE が小さ過ぎます."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "入出力エラー"
+
+#~ msgid "Message"
+#~ msgstr "メッセージ"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' が80ではないため, 外部コマンドを実行できません"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: プリンタの選択に失敗しました"
+
+#~ msgid "to %s on %s"
+#~ msgstr "%s へ (%s 上の)"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 未知のプリンタオプションです: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 印刷エラー: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "印刷しています: '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 文字セット名 \"%s\" は不正です (フォント名 \"%s\")"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: '%c' は不正な文字です (フォント名 \"%s\")"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 2重のシグナルのため, 終了します\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: 致命的シグナル %s を検知しました\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 致命的シグナルを検知しました\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X のエラーを検出しましたr\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "X display のチェックに失敗しました"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "X display の open がタイムアウトしました"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "sh シェルを実行できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "パイプを作成できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "fork できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "コマンドを中断しました\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP がICE接続を失いました"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "X display の open に失敗しました"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP がsave-yourself要求を処理しています"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP が接続を開始しています"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE接続が失敗したようです"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnectionが失敗しました: %s"
+
+#~ msgid "At line"
+#~ msgstr "行"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "vim32.dll をロードできませんでした"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIMエラー"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "DLLから関数ポインタを取得できませんでした"
+
+#~ msgid "shell returned %d"
+#~ msgstr "シェルがコード %d で終了しました"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: イベント %s を検知\n"
+
+#~ msgid "close"
+#~ msgstr "閉じる"
+
+#~ msgid "logoff"
+#~ msgstr "ログオフ"
+
+#~ msgid "shutdown"
+#~ msgstr "シャットダウン"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: コマンドがありません"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXEが $PATH の中に見つかりません.\n"
+#~ "外部コマンドの終了後に一時停止をしません.\n"
+#~ "詳細は  :help win32-vimrun  を参照してください."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vimの警告"
+
+#~ msgid "Error file"
+#~ msgstr "エラーファイル"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: 等価クラスを含むNFA構築に失敗しました!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) 現在横断中のブランチに十分なメモリを割り当てられません!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "警告: 単語リスト \"%s_%s.spl\" および \"%s_ascii.spl\" は見つかりません"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "%s 内の変換はサポートされていません"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: メモリが足りないので、単語リストは不完全です"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: タグファイルのパスが %s に切り捨てられました\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "新しいシェルを起動します\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "空の選択領域のかわりにCUT_BUFFER0が使用されました"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "可能なアンドゥはありません: とりあえず続けます"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr ""
+#~ "E832: 非暗号化ファイルが暗号化されたアンドゥファイルを使ってます: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: 暗号化されたアンドゥファイルの解読に失敗しました: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: アンドゥファイルが暗号化されています: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 ビット GUI 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64 ビット GUI 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 ビット GUI 版"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " in Win32s モード"
+
+#~ msgid " with OLE support"
+#~ msgstr " with OLE サポート"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64 ビット コンソール 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 ビット コンソール 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 ビット 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 ビット MS-DOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 ビット MS-DOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "OpenVMS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Big 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "通常 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Small 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Tiny 版 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "with GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "with GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "with X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "with X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "with X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "with Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "with GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "with Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "with Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "with (クラシック) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "     システム gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       ユーザ gvimrc: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "    第2ユーザ gvimrc: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "    第3ユーザ gvimrc: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    システムメニュー: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "コンパイラ: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "詳細はメニューの ヘルプ→孤児 を参照して下さい   "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "モード無で実行中, タイプした文字が挿入されます"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "メニューの 編集→全体設定→挿入(初心者)モード切替 "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              でモード有に       "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "メニューの 編集→全体設定→Vi互換モード切替      "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              でVimとして動作    "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "   警告: Windows 95/98/Me を検出  "
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr " 詳細な情報は          :help windows95<Enter> "
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "複数のVimで編集する (&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "1つのVimで編集する (&V)"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Vimで差分を表示する"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Vimで編集する (&V)"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "起動済のVimで編集する - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "選択したファイルをVimで編集する"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "プロセスの作成に失敗: gvimが環境変数PATH上にあるか確認してください!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll エラー"
+
+#~ msgid "Path length too long!"
+#~ msgstr "パスが長すぎます!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 未知のフォントセット: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 未知のフォント: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: フォント \"%s\" は固定幅ではありません"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: ライブラリの関数 %s をロードできませんでした"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: ヘブライ語は使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: ペルシア語は使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: アラビア語は使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: %s という名前の登録されたサーバはありません"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: ディスプレイを開けません"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 無効な式を受け取りました"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 領域が保護されているので, 変更できません"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans は読込専用ファイルを変更することを許しません"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "暗号キーが必要です: \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "空のキーは許可されていません"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "辞書はロックされています"
+
+#~ msgid "list is locked"
+#~ msgstr "リストはロックされています"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "辞書にキー '%s' を追加するのに失敗しました"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "インデックスは %s ではなく整数かスライスにしてください"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr ""
+#~ "str() もしくは unicode() のインスタンスが期待されているのに %s でした"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "bytes() もしくは str() のインスタンスが期待されているのに %s でした"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr "long() かそれへ変換可能なものが期待されているのに %s でした"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr "int() かそれへ変換可能なものが期待されているのに %s でした"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "C言語の int 型としては値が大き過ぎます"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "C言語の int 型としては値が小さ過ぎます"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "数値は 0 より大きくなければなりません"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "数値は 0 かそれ以上でなければなりません"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "OutputObject属性を消せません"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "無効な属性です: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: I/Oオブジェクトの初期化エラー"
+
+#~ msgid "failed to change directory"
+#~ msgstr "辞書の変更に失敗しました"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "imp.find_module() が %s を返しました (期待値: 2 要素のタプル)"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr "impl.find_module() が %d 要素のタプルを返しました (期待値: 2)"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "内部エラー: imp.find_module が NULL を含むタプルを返しました"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "vim.Dictionary属性は消せません"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "固定された辞書は変更できません"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "属性 %s は設定できません"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "イテレーション中に hashtab が変更されました"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr "シーケンスの要素数には 2 が期待されていましたが %d でした"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "リストのコンストラクタはキーワード引数を受け付けません"
+
+#~ msgid "list index out of range"
+#~ msgstr "リスト範囲外のインデックスです"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "内部エラー: vimのリスト要素 %d の取得に失敗しました"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "リストへの要素追加に失敗しました"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "内部エラー: vimのリスト要素 %d はありません"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "内部エラー: リストへの要素追加に失敗しました"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "vim.List 属性は消せません"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "固定されたリストは変更できません"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "無名関数 %s は存在しません"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "関数 %s がありません"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "関数のコンストラクタはキーワード引数を受け付けません"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "関数 %s の実行に失敗しました"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "ウィンドウを切換中に問題が発生しました"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "グローバルオプション %s の設定解除はできません"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "グローバルな値の無いオプション %s の設定解除はできません"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "削除されたタブを参照しようとしました"
+
+#~ msgid "no such tab page"
+#~ msgstr "そのようなタブページはありません"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "削除されたウィンドウを参照しようとしました"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "読込専用属性: バッファー"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "カーソル位置がバッファの外側です"
+
+#~ msgid "no such window"
+#~ msgstr "そのようなウィンドウはありません"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "削除されたバッファを参照しようとしました"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "バッファ名の変更に失敗しました"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "マーク名は1文字のアルファベットでなければなりません"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "vim.Bufferオブジェクトが期待されているのに %s でした"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "指定されたバッファ %d への切り替えに失敗しました"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "vim.Windowオブジェクトが期待されているのに %s でした"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "現在のタブには指定されたウィンドウがありませんでした"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "指定されたウィンドウに切り替えませんでした"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "vim.TabPageオブジェクトが期待されているのに %s でした"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "指定されたタブページに切り替えませんでした"
+
+#~ msgid "failed to run the code"
+#~ msgstr "コードの実行に失敗しました"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: 式評価は有効なpythonオブジェクトを返しませんでした"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: 返されたpythonオブジェクトをvimの値に変換できませんでした"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "%s vimの辞書型に変換できません"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "%s をvimの構造体に変換できません"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "内部エラー: NULL参照が渡されました"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "内部エラー: 無効な値型です"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "パスフックの設定に失敗しました: sys.path_hooks がリストではありません\n"
+#~ "すぐに下記を実施してください:\n"
+#~ "- vim.path_hooks を sys.path_hooks へ追加\n"
+#~ "- vim.VIM_SPECIAL_PATH を sys.path へ追加\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "パスの設定に失敗しました: sys.path がリストではありません\n"
+#~ "すぐに vim.VIM_SPECIAL_PATH を sys.path に追加してください"

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -1839,10 +1839,6 @@ msgstr "%<PRId64> 行, "
 msgid "1 character"
 msgstr "1 文字"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> 文字"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-06 13:50+0900\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-07-06 15:00+0900\n"
 "Last-Translator: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
 "Language-Team: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
@@ -23,164 +23,204 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() が空パスワードで呼び出されました"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "オプションの値は取得できません"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "内部エラー: 未知のオプション型です"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish暗号のビッグ/リトルエンディアンが間違っています"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256のテストに失敗しました"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish暗号のテストに失敗しました"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[場所リスト]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Quickfixリスト]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: autocommandがコマンドの停止を引き起こしました"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: バッファを1つも作成できないので, 終了します..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: バッファを作成できないので, 他のを使用します..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 解放されたバッファはありません"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 削除されたバッファはありません"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 破棄されたバッファはありません"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 個のバッファが解放されました"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d 個のバッファが解放されました"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 個のバッファが削除されました"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d 個のバッファが削除されました"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 個のバッファが破棄されました"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d 個のバッファが破棄されました"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 最後のバッファは解放できません"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 変更されたバッファはありません"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: リスト表示されるバッファはありません"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: バッファ %<PRId64> はありません"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 最後のバッファを越えて移動はできません"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 最初のバッファより前へは移動できません"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: バッファ %<PRId64> の変更は保存されていません (! で変更を破棄)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 最後のバッファは解放できません"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: ファイル名のリストが長過ぎます"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: バッファ %<PRId64> が見つかりません"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s に複数の該当がありました"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: %s に該当するバッファはありませんでした"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "行 %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: この名前のバッファは既にあります"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [変更あり]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未編集]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新ファイル]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[読込エラー]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[読専]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[読込専用]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 行 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64> (全体 %<PRId64>) --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[無名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ヘルプ"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[ヘルプ]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[プレビュー]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全て"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "末尾"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "先頭"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -188,9 +228,11 @@ msgstr ""
 "\n"
 "# バッファリスト:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[下書き]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -198,144 +240,200 @@ msgstr ""
 "\n"
 "--- サイン ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s のサイン:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  識別子=%d  名前=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: コロンがありません"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 不正なモードです"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 数値が必要です"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 不正なパーセンテージです"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: %<PRId64> 以上のバッファはdiffできません"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 一時ファイルの読込もしくは書込ができません"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 差分を作成できません "
 
-msgid "Patch file"
-msgstr "パッチファイル"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: patchの出力を読込めません"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: diffの出力を読込めません"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 現在のバッファは差分モードではありません"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: 差分モードである他のバッファは変更可能です"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 差分モードである他のバッファはありません"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: 差分モードのバッファが2個以上あるので、どれを使うか特定できません"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: バッファ \"%s\" が見つかりません"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: バッファ \"%s\" は差分モードではありません"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 予期せずバッファが変更変更されました"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 合字にEscapeは使用できません"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: キーマップファイルが見つかりません"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :source で取込むファイル以外では :loadkeymap を使えません"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: 空のキーマップエントリ"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " キーワード補完 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X モード (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 行(全体)補完 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr "ファイル名補完 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " タグ補完 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " パスパターン補完 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定義補完 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " 辞書補完 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " シソーラス補完 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " コマンドライン補完 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " ユーザ定義補完 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 綴り修正候補 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "段落の最後にヒット"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: 補間関数がウィンドウを変更しました"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: 補完関数がテキストを削除しました"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary' オプションが空です"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus' オプションが空です"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "辞書をスキャン中: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (挿入) スクロール(^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (置換) スクロール (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "スキャン中: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "タグをスキャン中."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 追加中"
 
@@ -343,459 +441,574 @@ msgstr " 追加中"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 検索中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "始めに戻る"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "他の行の単語"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "唯一の該当"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "%d 番目の該当 (全該当 %d 個中)"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "%d 番目の該当"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: 予期せぬ文字が :let にありました"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: リストのインデックスが範囲外です: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 未定義の変数です: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']' が見つかりません"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s の引数はリスト型でなければなりません"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s の引数はリスト型または辞書型でなければなりません"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: 辞書型に空のキーを使うことはできません"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: リスト型が必要です"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: 辞書型が必要です"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 関数の引数が多過ぎます: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: 辞書型にキーが存在しません: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 関数 %s は定義済です, 再定義するには ! を追加してください"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: 辞書型内にエントリが既に存在します"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: 関数参照型が要求されます"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: [:] を辞書型と組み合わせては使えません"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: 異なった型の変数です %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 未知の関数です: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 不正な変数名です: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: 浮動小数点数を文字列として扱っています"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: ターゲットがリスト型内の要素よりも少ないです"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: ターゲットがリスト型内の要素よりも多いです"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "リスト型の値に2つ以上の ; が検出されました"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: %s の値を一覧表示できません"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: リスト型と辞書型以外はインデックス指定できません"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] は最後でなければいけません"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] にはリスト型の値が必要です"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: リスト型変数にターゲットよりも多い要素があります"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: リスト型変数に十分な数の要素がありません"
 
 #
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for の後に \"in\" がありません"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: カッコ '(' がありません: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: その変数はありません: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: (アン)ロックするには変数の入れ子が深過ぎます"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' の後に ':' がありません"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: リスト型はリスト型としか比較できません"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: リスト型には無効な操作です"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: 辞書型は辞書型としか比較できません"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: 辞書型には無効な操作です"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: 関数参照型は関数参照型としか比較できません"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: 関数参照型には無効な操作です"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: '%' を浮動小数点数と組み合わせては使えません"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' が見つかりません"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: 関数参照型はインデックスできません"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: オプション名がありません: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 未知のオプションです: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 引用符 (\") がありません: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 引用符 (') がありません: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: リスト型にカンマがありません: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: リスト型の最後に ']' がありません: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: 辞書型にコロンがありません: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: 辞書型に重複キーがあります: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: 辞書型にカンマがありません: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: 辞書型の最後に '}' がありません: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 表示するには変数の入れ子が深過ぎます"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: 関数の引数が多過ぎます: %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: 関数の無効な引数です: %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: 未知の関数です: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: 関数の引数が少な過ぎます: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: スクリプト以外で<SID>が使われました: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: 辞書用関数が呼ばれましたが辞書がありません: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: 数値か浮動小数点数が必要です"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "add() の引数"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 引数が多過ぎます"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() は挿入モードでしか利用できません"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: キーは既に存在します: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "extend() の引数"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "map() の引数"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "filter() の引数"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 行: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 未知の関数です: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"決定(&O)\n"
-"キャンセル(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() が inputsave() よりも多く呼ばれました"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "insert() の引数"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 範囲指定は許可されていません"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len() には無効な型です"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: ストライド(前進量)が 0 です"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 開始位置が終了位置を越えました"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<空>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Vim サーバへの接続がありません"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: %s へ送ることができません"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: サーバの応答がありません"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "remove() の引数"
 
 # Added at 10-Mar-2004.
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: シンボリックリンクが多過ぎます (循環している可能性があります)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "reverse() の引数"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: クライアントへ送ることができません"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "sort() の引数"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "add() の引数"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: ソートの比較関数が失敗しました"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: ソートの比較関数が失敗しました"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(無効)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 一時ファイル書込中にエラーが発生しました"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: 浮動小数点数を数値として扱っています"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: 関数参照型を数値として扱っています。"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: リスト型を数値として扱っています"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 辞書型を数値として扱っています"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: 関数参照型を文字列として扱っています"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: リスト型を文字列として扱っています"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: 辞書型を文字列として扱っています"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 変数の型が一致しません: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: 変数 %s を削除できません"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: 関数参照型変数名は大文字で始まらなければなりません: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: 変数名が既存の関数名と衝突します: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 値がロックされています: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "不明"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: %s の値を変更できません"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: コピーを取るには変数の入れ子が深過ぎます"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: 未定義の関数です: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '(' がありません: %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: ここでは g: は使えません"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 不正な引数です: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: 引数名が重複しています: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction がありません"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: 関数名が変数名と衝突します: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: 関数 %s を再定義できません: 使用中です"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 関数名がスクリプトのファイル名と一致しません: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 関数名が要求されます"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 関数 %s を削除できません: 使用中です"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 関数呼出の入れ子数が 'maxfuncdepth' を超えました"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s を実行中です"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s が中断されました"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s が #%<PRId64> を返しました"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s が %s を返しました"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "%s の実行を継続中です"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: 関数外に :return がありました"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -803,6 +1016,7 @@ msgstr ""
 "\n"
 "# グローバル変数:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -810,82 +1024,104 @@ msgstr ""
 "\n"
 "\tLast set from "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "古いファイルはありません"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  16進数 %02x,  8進数 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 16進数 %04x, 8進数 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 16進数 %08x, 8進数 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 行をそれ自身には移動できません"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 行が移動されました"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> 行が移動されました"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> 行がフィルタ処理されました"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *フィルタ* autocommandは現在のバッファを変更してはいけません"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[最後の変更が保存されていません]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 行目: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: エラーが多過ぎるので, 以降はスキップします"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "viminfoファイル \"%s\"%s%s%s を読込み中 "
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 情報"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " マーク"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " 旧ファイル群"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失敗"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: viminfoファイルが書込みできません: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: viminfoファイル %s を保存できません!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "viminfoファイル \"%s\" を書込み中"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# この viminfo ファイルは Vim %s によって生成されました.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -893,40 +1129,47 @@ msgstr ""
 "# 変更する際には十分注意してください!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# このファイルが書かれた時の 'encoding' の値\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "不正な先頭文字です"
 
-msgid "Save As"
-msgstr "別名で保存"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "ファイルを部分的に保存しますか?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: バッファを部分的に保存するには ! を使ってください"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "既存のファイル \"%s\" を上書きしますか?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "スワップファイル \"%s\" が存在します. 上書きを強制しますか?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: スワップファイルが存在します: %s (:silent! を追加で上書)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: バッファ %<PRId64> には名前がありません"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ファイルは保存されませんでした: 'write' オプションにより無効です"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -935,6 +1178,7 @@ msgstr ""
 "\"%s\" には 'readonly' オプションが設定されています.\n"
 "上書き強制をしますか?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -945,68 +1189,83 @@ msgstr ""
 "それでも恐らく書き込むことは可能です.\n"
 "継続しますか?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" は読込専用です (強制書込には ! を追加)"
 
-msgid "Edit File"
-msgstr "ファイルを編集"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: autocommandが予期せず新しいバッファ %s を削除しました"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 数ではない引数が :z に渡されました"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvimではシェルコマンドを使えません"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正規表現は文字で区切ることができません"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "%s に置換しますか? (y/n/a/q/l/^E/^Y)"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(割込まれました) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 箇所該当しました"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 箇所置換しました"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> 箇所該当しました"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> 箇所置換しました"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " (計 1 行内)"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " (計 %<PRId64> 行内)"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global を再帰的には使えません"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: globalコマンドに正規表現が指定されていません"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "パターンが全ての行で見つかりました: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "パターンは見つかりませんでした: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1016,265 +1275,335 @@ msgstr ""
 "# 最後に置換された文字列:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 慌てないでください"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 残念ですが '%s' のヘルプが %s にはありません"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 残念ですが %s にはヘルプがありません"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "残念ですがヘルプファイル \"%s\" が見つかりません"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: ディレクトリではありません: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 書込み用に %s を開けません"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 読込用に %s を開けません"
 
 # Added at 29-Apr-2004.
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 1つの言語のヘルプファイルに複数のエンコードが混在しています: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: タグ \"%s\" がファイル %s/%s に重複しています"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未知のsignコマンドです: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: sign名がありません"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: signの定義が多数見つかりました"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 無効なsignのテキストです: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 未知のsignです: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: signの番号がありません"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 無効なバッファ名です: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
-# Added at 27-Jan-2004.
-msgid " (NOT FOUND)"
-msgstr "  (見つかりません)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (非サポート)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[削除済]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "デバッグモードに入ります. 続けるには \"cont\" と入力してください."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "行 %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "ブレークポイント \"%s%s\" 行 %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: ブレークポイントが見つかりません: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "ブレークポイントが定義されていません"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  行 %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 初めに \":profile start {fname}\" を実行してください"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "変更を \"%s\" に保存しますか?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "無題"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: バッファ \"%s\" の変更は保存されていません"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "警告: 予期せず他バッファへ移動しました (autocommands を調べてください)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 編集するファイルは1つしかありません"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 最初のファイルより前には行けません"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 最後のファイルを越えて後には行けません"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: そのコンパイラには対応していません: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "\"%s\" を \"%s\" から検索中"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "\"%s\" を検索中"
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "'runtimepath' の中には見つかりません: \"%s\""
 
-msgid "Source Vim script"
-msgstr "Vimスクリプトの取込み"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "ディレクトリは取込めません: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\" を取込めません"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "行 %<PRId64>: \"%s\" を取込めません"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" を取込中"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "行 %<PRId64>: %s を取込中"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "%s の取込を完了"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "モード行"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 引数"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 引数"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "環境変数"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "エラーハンドラ"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 警告: 行区切が不正です. ^M がないのでしょう"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding が取込スクリプト以外で使用されました"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish が取込スクリプト以外で使用されました"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "現在の %s言語: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 言語を \"%s\" に設定できません"
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Exモードに入ります. ノーマルに戻るには\"visual\"と入力してください."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: ファイルの終了位置"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: コマンドが再帰的過ぎます"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 例外が捕捉されませんでした: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "取込ファイルの最後です"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "関数の最後です"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: ユーザ定義コマンドのあいまいな使用です"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: エディタのコマンドではありません"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 逆さまの範囲が指定されました"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "逆さまの範囲が指定されました, 入替えますか?"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: w もしくは w>> を使用してください"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: このバージョンではこのコマンドは利用できません, ごめんなさい"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: ファイル名は 1 つにしてください"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "編集すべきファイルが 1 個ありますが, 終了しますか?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "編集すべきファイルがあと %d 個ありますが, 終了しますか?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 編集すべきファイルが 1 個あります"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 編集すべきファイルがあと %<PRId64> 個あります"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1282,293 +1611,339 @@ msgstr ""
 "\n"
 "    名前        引数 範囲  補完      定義"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "ユーザ定義コマンドが見つかりませんでした"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 属性は定義されていません"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 引数の数が無効です"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: カウントを2重指定することはできません"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: カウントの省略値が無効です"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -補完のための引数が必要です"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 無効な属性です: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 無効なコマンド名です"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: ユーザ定義コマンドは英大文字で始まらなければなりません"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: 予約名なので, ユーザ定義コマンドに利用できません"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: そのユーザ定義コマンドはありません: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 無効な補完指定です: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 補完引数はカスタム補完でしか使用できません"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: カスタム補完には引数として関数が必要です"
 
-msgid "unknown"
-msgstr "不明"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: カラースキーム '%s' が見つかりません"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Vim 使いさん、やあ!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 最後のタブページを閉じることはできません"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "既にタブページは1つしかありません"
 
-msgid "Edit File in new window"
-msgstr "新しいウィンドウでファイルを編集します"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "タブページ %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "スワップファイルがありません"
 
-msgid "Append File"
-msgstr "追加ファイル"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: バッファが修正されているので, ディレクトリを変更できません (! を追加で"
 "上書)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 前のディレクトリはありません"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize には2つの数値の引数が必要です"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "ウィンドウ位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: このプラットホームにはウィンドウ位置の取得機能は実装されていません"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos には2つの数値の引数が必要です"
 
-msgid "Save Redirection"
-msgstr "リダイレクトを保存します"
-
-msgid "Save View"
-msgstr "ビューを保存します"
-
-msgid "Save Session"
-msgstr "セッション情報を保存します"
-
-msgid "Save Setup"
-msgstr "設定を保存します"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: ディレクトリを作成できません: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" が存在します (上書するには ! を追加してください)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" を書込み用として開けません"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 引数は1文字の英字か引用符 (' か `) でなければいけません"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal の再帰利用が深くなり過ぎました"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< は +eval 機能が無いと利用できません"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: '#'を置き換える副ファイルの名前がありません"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: \"<afile>\"を置き換えるautocommandのファイル名がありません"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: \"<abuf>\"を置き換えるautocommandバッファ番号がありません"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: \"<amatch>\"を置き換えるautocommandの該当名がありません"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: \"<sfile>\"を置き換える :source 対象ファイル名がありません"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: \"<slnum>\"を置き換える行番号がありません"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr ""
 "E499: '%' や '#' が無名ファイルなので \":p:h\" を伴わない使い方はできません"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 空文字列として評価されました"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: viminfoファイルを読込用として開けません"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: このバージョンに合字はありません"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 'Vim' で始まる例外は :throw できません"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "例外が発生しました: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "例外が収束しました: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "例外が破棄されました: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "例外が捕捉されました: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s により未決定状態が生じました"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s が再開しました"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s が破棄されました"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "例外"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "エラーと割込み"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "エラー"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "割込み"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if の入れ子が深過ぎます"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :if のない :endif があります"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :if のない :else があります"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :if のない :elseif があります"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 複数の :else があります"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :else の後に :elseif があります"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while や :for の入れ子が深過ぎます"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :while や :for のない :continue があります"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :while や :for のない :break があります"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :endfor を :while と組み合わせています"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :endwhile を :for と組み合わせています"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try の入れ子が深過ぎます"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :try のない :catch があります"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :finally の後に :catch があります"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :try のない :finally があります"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 複数の :finally があります"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :try のない :endtry です"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: 関数の外に :endfunction がありました"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 現在は他のバッファを編集することは許されません"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: 現在はバッファ情報を変更することは許されません"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "タグ名"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " ファイル種類\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "オプション 'history' がゼロです"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1577,230 +1952,303 @@ msgstr ""
 "\n"
 "# %s 項目の履歴 (新しいものから古いものへ):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "コマンドライン"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "検索文字列"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "式"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "入力行"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar がコマンド長を超えました"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: アクティブなウィンドウかバッファが削除されました"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: パスが長過ぎて補完できません"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: 無効なパスです: '**[数値]' はpathの最後か '%s' が続いてないといけませ"
+"ん."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpathには \"%s\" というファイルがありません"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: pathには \"%s\" というファイルがありません"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: cdpathにはこれ以上 \"%s\" というファイルがありません"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: パスにはこれ以上 \"%s\" というファイルがありません"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: autocommandがバッファかバッファ名を変更しました"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "不正なファイル名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr " はディレクトリです"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr " はファイルではありません"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr " はデバイスです ('opendevice' オプションで回避できます)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[新ファイル]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[新規ディレクトリ]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[ファイル過大]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[認可がありません]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre autocommand がファイルを読込不可にしました"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre autocommand は現在のバッファを変えられません"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 標準入力から読込中...\n"
 
-msgid "Reading from stdin..."
-msgstr "標準入力から読込み中..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 変換がファイルを読込不可にしました"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[FIFO/ソケット]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[FIFO]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[ソケット]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[キャラクタ・デバイス]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR無]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[長行分割]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未変換]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[変換済]"
 
-msgid "[blowfish]"
-msgstr "[blowfish暗号化]"
-
-msgid "[crypted]"
-msgstr "[暗号化]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[%<PRId64> 行目で変換エラー]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[%<PRId64> 行目の不正なバイト]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[読込エラー]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "変換に必要な一時ファイルが見つかりません"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert' による変換が失敗しました"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "'charconvert' の出力を読込めませんでした"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: ファイルが未知の方法で暗号化されています"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: acwriteバッファの該当するautocommandは存在しません"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 保存するバッファをautocommandが削除か解放しました"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: autocommandが予期せぬ方法で行数を変更しました"
 
-# Added at 19-Jan-2004.
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeansは未変更のバッファを上書することは許可していません"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeansバッファの一部を書き出すことはできません"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "はファイルでも書込み可能デバイスでもありません"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "'opendevice' オプションによりデバイスへの書き込みはできません"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "は読込専用です (強制書込には ! を追加)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: バックアップファイルを保存できません (! を追加で強制保存)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: バックアップファイルを閉じる際にエラーが発生しました (! を追加で強制)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: バックアップ用ファイルを読込めません (! を追加で強制読込)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: バックアップファイルを作れません (! を追加で強制作成)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: バックアップファイルを作れません (! を追加で強制作成)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: リソースフォークが失われるかもしれません (! を追加で強制)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 保存用一時ファイルが見つかりません"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 変換できません (! を追加で変換せずに保存)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: リンクされたファイルに書込めません"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 書込み用にファイルを開けません"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: fsync に失敗しました"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 閉じることに失敗"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 書込みエラー, 変換失敗 (上書するには 'fenc' を空にしてください)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にしてくださ"
-"い)"
+"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にして"
+"ください)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 書込みエラー, (ファイルシステムが満杯?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 変換エラー"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "行 %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[デバイス]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 追加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 書込み"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: 原本ファイルを保存できません"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: 空の原本ファイルをtouchできません"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: バックアップファイルを消せません"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1808,106 +2256,134 @@ msgstr ""
 "\n"
 "警告: 原本ファイルが失われたか変更されました\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ファイルの保存に成功するまでエディタを終了しないでください!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dosフォーマット]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[macフォーマット]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unixフォーマット]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 文字"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 文字"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[最終行が不完全]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 読込んだ後にファイルに変更がありました!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "本当に上書きしますか"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: \"%s\" を書込み中のエラーです"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: \"%s\" を閉じる時にエラーです"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: \"%s\" を読込中のエラーです"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: autocommand の FileChangedShell がバッファを削除しました"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: ファイル \"%s\" は既に存在しません"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: ファイル \"%s\" が変更されVimのバッファも変更されました"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "詳細は \":help W12\" を参照してください"
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: ファイル \"%s\" は編集開始後に変更されました"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "詳細は \":help W11\" を参照してください"
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: ファイル \"%s\" のモードが編集開始後に変更されました"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "詳細は \":help W16\" を参照してください"
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: ファイル \"%s\" は編集開始後に作成されました"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1915,39 +2391,48 @@ msgstr ""
 "&OK\n"
 "ファイル読込(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: \"%s\" をリロードする準備ができませんでした"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\" はリロードできませんでした"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--削除済--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "autocommand: %s <バッファ=%d> が自動的に削除されます"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: そのグループはありません: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * の後に不正な文字がありました: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: そのようなイベントはありません: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: そのようなグループもしくはイベントはありません: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1955,536 +2440,760 @@ msgstr ""
 "\n"
 "--- Auto-Commands ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <バッファ=%d>: 無効なバッファ番号です "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 全てのイベントに対してのautocommandは実行できません"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "該当するautocommandは存在しません"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocommandの入れ子が深過ぎます"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto commands for \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s を実行しています"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { がありません."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } がありません."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 折畳みがありません"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 現在の 'foldmethod' では折畳みを作成できません"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 現在の 'foldmethod' では折畳みを削除できません"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld 行が折畳まれました "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 読込バッファへ追加"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 再帰的マッピング"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s というグローバル短縮入力は既に存在します"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s というグローバルマッピングは既に存在します"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s という短縮入力は既に存在します"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s というマッピングは既に存在します"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "短縮入力は見つかりませんでした"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "マッピングは見つかりませんでした"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 不正なモード"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: GUI用のプロセスの起動に失敗しました"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--バッファに行がありません--"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: 子プロセスがGUIの起動に失敗しました"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: コマンドが中断されました"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUIを開始できません"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 引数が必要です"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: \"%s\"から読込むことができません"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ の後は / か ? か & でなければなりません"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 有効なフォントが見つからないので, GUIを開始できません"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' が無効です"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' に設定された値が無効です"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: %s の色を割り当てられません"
-
-msgid "No match at cursor, finding next"
-msgstr "カーソルの位置にマッチはありません, 次を検索しています"
-
-msgid "<cannot open> "
-msgstr "<開けません> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: フォント %s を取得できません"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 現在のディレクトリに戻れません"
-
-msgid "Pathname:"
-msgstr "パス名:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 現在のディレクトリを取得できません"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "キャンセル"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "スクロールバー: 画像を取得できませんでした."
-
-msgid "Vim dialog"
-msgstr "Vim ダイアログ"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: メッセージとコールバックのある BalloonEval を作成できません"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"はい(&Y)\n"
-"いいえ(&N)\n"
-"キャンセル(&C)"
+"E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"
 
-msgid "Input _Methods"
-msgstr "インプットメソッド"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif がありません"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 検索と置換..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry がありません"
 
-msgid "VIM - Search..."
-msgstr "VIM - 検索..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile がありません"
 
-msgid "Find what:"
-msgstr "検索文字列:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor がありません"
 
-msgid "Replace with:"
-msgstr "置換文字列:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :while のない :endwhile があります"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "正確に該当するものだけ"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor のない :for があります"
 
-#. match case button
-msgid "Match case"
-msgstr "大文字/小文字を区別する"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: ファイルが存在します (! を追加で上書)"
 
-msgid "Direction"
-msgstr "方向"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: コマンドが失敗しました"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "上"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 内部エラーです"
 
-msgid "Down"
-msgstr "下"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "割込まれました"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "次を検索"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 無効なアドレスです"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "置換"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 無効な引数です"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "全て置換"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: セッションマネージャから \"die\" 要求を受け取りました\n"
-
-msgid "Close"
-msgstr "閉じる"
-
-msgid "New tab"
-msgstr "新規タブページ"
-
-msgid "Open Tab..."
-msgstr "タブページを開く..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: メインウィンドウが不意に破壊されました\n"
-
-msgid "&Filter"
-msgstr "フィルタ(&F)"
-
-msgid "&Cancel"
-msgstr "キャンセル(&C)"
-
-msgid "Directories"
-msgstr "ディレクトリ"
-
-msgid "Filter"
-msgstr "フィルタ"
-
-msgid "&Help"
-msgstr "ヘルプ(&H)"
-
-msgid "Files"
-msgstr "ファイル"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "選択"
-
-msgid "Find &Next"
-msgstr "次を検索(&N)"
-
-msgid "&Replace"
-msgstr "置換(&R)"
-
-msgid "Replace &All"
-msgstr "全て置換(&A)"
-
-msgid "&Undo"
-msgstr "アンドゥ(&U)"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: タイトルが \"%s\" のウィンドウは見つかりません"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 無効な引数です: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 引数はサポートされません: \"-%s\"; OLE版を使用してください."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 無効な式です: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: MDIアプリの中ではウィンドウを開けません"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 無効な範囲です"
 
-msgid "Close tab"
-msgstr "タブページを閉じる"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 無効なコマンドです"
 
-msgid "Open tab..."
-msgstr "タブページを開く"
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "検索文字列 ('\\' を検索するには '\\\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "検索・置換 ('\\' を検索するには '\\\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "使われません"
-
-msgid "Directory\t*.nothing\n"
-msgstr "ディレクトリ\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 色指定が正しくないのでエントリを割り当てられません"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: 以下の文字セットのフォントがありません %s:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" はディレクトリです"
 
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 無効なスクロール量です"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
+msgstr ""
+
+#: ../globals.h:1022
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: フォントセット名: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "フォント '%s' は固定幅ではありません"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: \"%s\"() のライブラリ呼出に失敗しました"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: マークに無効な行番号が指定されていました"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: マークは設定されていません"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 'modifiable' がオフなので, 変更できません"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: スクリプトの入れ子が深過ぎます"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 副ファイルはありません"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: そのような短縮入力はありません"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! は許可されていません"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUIは使用不可能です: コンパイル時に無効にされています"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: フォントセット名: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: そのような名のハイライトグループはありません: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: まだテキストが挿入されていません"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 以前にコマンド行がありません"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: そのようなマッピングはありません"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 該当はありません"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font0: %s"
-msgstr "フォント0: %s"
+msgid "E480: No match: %s"
+msgstr "E480: 該当はありません: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ファイル名がありません"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 正規表現置換がまだ実行されていません"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: コマンドがまだ実行されていません"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 正規表現がまだ実行されていません"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 範囲指定は許可されていません"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: ウィンドウに十分な高さもしくは幅がありません"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font1: %s"
-msgstr "フォント1: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: ファイル %s を作成できません"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 一時ファイルの名前を取得できません"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
+msgid "E484: Can't open file %s"
+msgstr "E484: ファイル \"%s\" を開けません"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "フォント0の幅: %<PRId64>"
+msgid "E485: Can't read file %s"
+msgstr "E485: ファイル %s を読込めません"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[最後の変更が保存されていません]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 引数が空です"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 数値が要求されています"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "フォント1の幅: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: エラーファイル %s を開けません"
 
-msgid "Invalid font specification"
-msgstr "無効なフォント指定です"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: メモリが尽き果てました!"
 
-msgid "&Dismiss"
-msgstr "却下する(&D)"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "パターンは見つかりませんでした"
 
-msgid "no specific match"
-msgstr "マッチするものがありません"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: パターンは見つかりませんでした: %s"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - フォント選択"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 引数は正の値でなければなりません"
 
-msgid "Name:"
-msgstr "名前:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 前のディレクトリに戻れません"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "サイズをポイントで表示する"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: エラーはありません"
 
-msgid "Encoding:"
-msgstr "エンコード:"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 場所リストはありません"
 
-msgid "Font:"
-msgstr "フォント:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 該当文字列が破損しています"
 
-msgid "Style:"
-msgstr "スタイル:"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 不正な正規表現プログラムです"
 
-msgid "Size:"
-msgstr "サイズ:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' オプションが設定されています (! を追加で上書き)"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ハングルオートマトンエラー"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 読取専用変数 \"%s\" には値を設定できません"
 
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: サンドボックスでは変数 \"%s\" に値を設定できません"
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: エラーファイルの読込中にエラーが発生しました"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: サンドボックスでは許されません"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: ここでは許可されません"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: スクリーンモードの設定には対応していません"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 無効なスクロール量です"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' オプションが空です"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: sign のデータを読込めませんでした"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: スワップファイルのクローズ時エラーです"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: タグスタックが空です"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: コマンドが複雑過ぎます"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名前が長過ぎます"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [ が多過ぎます"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: ファイル名が多過ぎます"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 余分な文字が後ろにあります"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 未知のマーク"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: ワイルドカードを展開できません"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' は 'winminheight' より小さくできません"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' は 'winminwidth' より小さくできません"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 書込み中のエラー"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "ゼロカウント"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: スクリプト以外で<SID>が使われました"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 内部エラーです: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: バッファが空です"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 検索パターンか区切り記号が不正です"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 同じ名前のファイルが他のバッファで読込まれています"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: オプション '%s' は設定されていません"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: 無効なレジスタ名です"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "上まで検索したので下に戻ります"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "下まで検索したので上に戻ります"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: コロンがありません"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 不正な構文要素です"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 数値が必要です"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "%d ページ"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "印刷するテキストがありません"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "印刷中: ページ %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " コピー %d (全 %d 中)"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "印刷しました: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "印刷が中止されました"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: PostScript出力ファイルの書込みエラーです"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: ファイル \"%s\" を開けません"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: PostScriptのリソースファイル \"%s\" を読込めません"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: ファイル \"%s\" は PostScript リソースファイルではありません"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: ファイル \"%s\" は対応していない PostScript リソースファイルです"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: リソースファイル \"%s\" はバージョンが異なります"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 互換性の無いマルチバイトエンコーディングと文字セットです"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: マルチバイトエンコーディングでは printmbcharset を空にできません"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr ""
 "E675: マルチバイト文字を印刷するためのデフォルトフォントが指定されていません"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript出力用のファイルを開けません"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: ファイル \"%s\" を開けません"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: PostScriptのリソースファイル \"prolog.ps\" が見つかりません"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: PostScriptのリソースファイル \"cidfont.ps\" が見つかりません"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: PostScriptのリソースファイル \"%s.ps\" が見つかりません"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: 印刷エンコード \"%s\" へ変換できません"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "プリンタに送信中..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScriptファイルの印刷に失敗しました"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "印刷ジョブを送信しました."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "新データベースを追加"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "パターンのクエリーを追加"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "このメッセージを表示する"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "接続を終了する"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "全ての接続を再初期化する"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "接続を表示する"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 使用方法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "このcscopeコマンドは分割ウィンドウではサポートされません.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 使用法: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: タグが見つかりません"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) エラー: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat エラー"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s はディレクトリ及び有効なcscopeのデータベースではありません"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "cscopeデータベース %s を追加"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: cscopeの接続 %<PRId64> を読込み中のエラーです"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知のcscope検索型です"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscopeパイプを作成できませんでした"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: cscopeの起動準備(fork)に失敗しました"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection への setpgid に失敗しました"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection の実行に失敗しました"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: to_fp の fdopen に失敗しました"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fr_fp の fdopen に失敗しました"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: cscopeプロセスを起動できませんでした"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: cscope接続に失敗しました"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: 無効な cscopequickfix フラグ %c の %c です"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: cscopeクエリー %s of %s に該当がありませんでした"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscopeコマンド:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (使用法: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2506,32 +3215,31 @@ msgstr ""
 "       s: このCシンボルを探す\n"
 "       t: このテキスト文字列を探す\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: cscopeデータベース: %s を開くことができません"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: cscopeデータベースの情報を取得できません"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重複するcscopeデータベースは追加されませんでした"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope接続 %s が見つかりませんでした"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope接続 %s が閉じられました"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches で致命的なエラーです"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope タグ: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2539,377 +3247,87 @@ msgstr ""
 "\n"
 "   #   行番号"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "ファイル名 / 文脈 / 行\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: cscopeエラー: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "全てのcscopeデータベースをリセットします"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "cscope接続がありません\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    データベース名                      prepend パス\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Luaライブラリをロードできません."
-
-msgid "cannot save undo information"
-msgstr "アンドゥ情報が保存できません"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr "E815: このコマンドは無効です. MzScheme ライブラリをロードできません."
-
-msgid "invalid expression"
-msgstr "無効な式です"
-
-msgid "expressions disabled at compile time"
-msgstr "式はコンパイル時に無効にされています"
-
-msgid "hidden option"
-msgstr "隠しオプション"
-
-msgid "unknown option"
-msgstr "未知のオプションです"
-
-msgid "window index is out of range"
-msgstr "範囲外のウィンドウ番号です"
-
-msgid "couldn't open buffer"
-msgstr "バッファを開けません"
-
-msgid "cannot delete line"
-msgstr "行を消せません"
-
-msgid "cannot replace line"
-msgstr "行を置換できません"
-
-msgid "cannot insert line"
-msgstr "行を挿入できません"
-
-msgid "string cannot contain newlines"
-msgstr "文字列には改行文字を含められません"
-
-msgid "error converting Scheme values to Vim"
-msgstr "Scheme値のVimへの変換エラー"
-
-msgid "Vim error: ~a"
-msgstr "Vim エラー: ~a"
-
-msgid "Vim error"
-msgstr "Vim エラー"
-
-msgid "buffer is invalid"
-msgstr "バッファは無効です"
-
-msgid "window is invalid"
-msgstr "ウィンドウは無効です"
-
-msgid "linenr out of range"
-msgstr "範囲外の行番号です"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "サンドボックスでは許されません"
-
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: ライブラリ %s をロードできませんでした"
-
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"このコマンドは無効です, ごめんなさい: Perlライブラリをロードできませんでした."
-
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: サンドボックスでは Safe モジュールを使用しないPerlスクリプトは禁じられ"
-"ています"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: このVimでは :py3 を使った後に :python を使えません"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: このコマンドは無効です,ごめんなさい: Pythonライブラリをロードできません"
-"でした."
-
-# Added at 07-Feb-2004.
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python を再帰的に実行することはできません"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: このVimでは :python を使った後に :py3 を使えません"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ は文字列のインスタンスでなければなりません"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: このコマンドは無効です,ごめんなさい: Rubyライブラリをロードできませんで"
-"した."
-
-msgid "E267: unexpected return"
-msgstr "E267: 予期せぬ return です"
-
-msgid "E268: unexpected next"
-msgstr "E268: 予期せぬ next です"
-
-msgid "E269: unexpected break"
-msgstr "E269: 予期せぬ break です"
-
-msgid "E270: unexpected redo"
-msgstr "E270: 予期せぬ redo です"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: rescue の外の retry です"
-
-msgid "E272: unhandled exception"
-msgstr "E272: 取り扱われなかった例外があります"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知のlongjmp状態: %d"
-
-msgid "Toggle implementation/definition"
-msgstr "実装と定義を切り替える"
-
-msgid "Show base class of"
-msgstr "次のクラスの基底を表示"
-
-msgid "Show overridden member function"
-msgstr "オーバーライドされたメンバ関数を表示"
-
-msgid "Retrieve from file"
-msgstr "ファイルから回復する"
-
-msgid "Retrieve from project"
-msgstr "プロジェクトから回復する"
-
-msgid "Retrieve from all projects"
-msgstr "全てのプロジェクトから回復する"
-
-msgid "Retrieve"
-msgstr "回復"
-
-msgid "Show source of"
-msgstr "次のソースを表示する"
-
-msgid "Find symbol"
-msgstr "見つけたシンボル"
-
-msgid "Browse class"
-msgstr "クラスを参照"
-
-msgid "Show class in hierarchy"
-msgstr "階層でクラスを表示"
-
-msgid "Show class in restricted hierarchy"
-msgstr "限定された階層でクラスを表示"
-
-msgid "Xref refers to"
-msgstr "Xref の参照先"
-
-msgid "Xref referred by"
-msgstr "Xref が参照される"
-
-msgid "Xref has a"
-msgstr "Xref が次のものをもっています"
-
-msgid "Xref used by"
-msgstr "Xref が使用される"
-
-msgid "Show docu of"
-msgstr "次の文章を表示"
-
-msgid "Generate docu for"
-msgstr "次の文章を生成"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"SNiFF+に接続できません. 環境をチェックしてください(sniffemacs が $PATH になけ"
-"ればなりません).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 読込中にエラーが発生しました. 切断しました"
-
-msgid "SNiFF+ is currently "
-msgstr "現在SNiFF+ の状態は「"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "接続」です"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 未知の SNiFF+ リクエストです: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: SNiFF+ への接続中のエラーです"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ に接続されていません"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: SNiFF+ バッファがありません"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 書込み中にエラーが発生したので切断しました"
-
-msgid "invalid buffer number"
-msgstr "無効なバッファ番号です"
-
-msgid "not implemented yet"
-msgstr "まだ実装されていません"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "行を設定できません"
-
-msgid "invalid mark name"
-msgstr "無効なマーク名です"
-
-msgid "mark not set"
-msgstr "マークは設定されていません"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "行 %d 列 %d"
-
-msgid "cannot insert/append line"
-msgstr "行の挿入/追加をできません"
-
-msgid "line number out of range"
-msgstr "範囲外の行番号です"
-
-msgid "unknown flag: "
-msgstr "未知のフラグ: "
-
-msgid "unknown vimOption"
-msgstr "未知の vimOption です"
-
-msgid "keyboard interrupt"
-msgstr "キーボード割込み"
-
-msgid "vim error"
-msgstr "vim エラー"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr ""
-"バッファ/ウィンドウ作成コマンドを作成できません: オブジェクトが消去されていま"
-"した"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"コールバックコマンドを登録できません: バッファ/ウィンドウが既に消去されました"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL 致命的エラー: reflist 汚染!? vim-dev@vim.org に報告してください"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"コールバックコマンドを登録できません: バッファ/ウィンドウの参照が見つかりませ"
-"ん"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: このコマンドは無効です,ごめんなさい: Tclライブラリをロードできませんで"
-"した."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 終了コード %d"
-
-msgid "cannot get line"
-msgstr "行を取得できません"
-
-msgid "Unable to register a command server name"
-msgstr "命令サーバの名前を登録できません"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: 目的のプログラムへのコマンド送信に失敗しました"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 無効なサーバIDが使われました: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 実体の登録プロパティが不正です. 消去しました!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "未知のオプション引数です"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "編集引数が多過ぎます"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "引数がありません"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "オプション引数の後にゴミがあります"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "\"+command\", \"-c command\", \"--cmd command\" の引数が多過ぎます"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "無効な引数です: "
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d 個のファイルが編集を控えています\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans はこのGUIでは利用できません\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "このVimにはdiff機能がありません(コンパイル時設定)."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' 使用不可能です: コンパイル時に無効にされています\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "スクリプトファイルを再び開いてみます: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "読込用として開けません"
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "スクリプト出力用を開けません"
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 端末への出力ではありません\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 警告: 端末からの入力ではありません\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "vimrc前のコマンドライン"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: \"%s\"から読込むことができません"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2917,18 +3335,23 @@ msgstr ""
 "\n"
 "より詳細な情報は: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[ファイル..]    あるファイルを編集する"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               標準入力からテキストを読込む"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t タグ         タグが定義されたところから編集する"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  最初のエラーで編集する"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2938,9 +3361,11 @@ msgstr ""
 "\n"
 "使用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [引数] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2948,13 +3373,7 @@ msgstr ""
 "\n"
 "   もしくは:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"大小文字が無視される場合は大文字にするために / を前置してください"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2964,315 +3383,189 @@ msgstr ""
 "\n"
 "引数:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tこのあとにはファイル名だけ"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tワイルドカードを展開しない"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tこのgvimをOLEとして登録する"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tgvimのOLE登録を解除する"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tGUIで起動する (\"gvim\" と同じ)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f or  --nofork\tフォアグラウンド: GUIを始めるときにforkしない"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tViモード (\"vi\" と同じ)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tExモード (\"ex\" と同じ)"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\t改良Exモード"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tサイレント(バッチ)モード (\"ex\" 専用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\t差分モード (\"vidiff\" と同じ)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tイージーモード (\"evim\" と同じ, モード無)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t読込専用モード (\"view\" と同じ)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t制限モード (\"rvim\" と同じ)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t変更 (ファイル保存時) をできないようにする"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tテキストの編集を行なえないようにする"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tバイナリモード"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLispモード"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVi互換モード: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tVi非互換モード: 'nocompatible"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][fname]\t\tログ出力設定 [レベル N] [ログファイル名 fname]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tデバッグモード"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tスワップファイルを使用せずメモリだけ"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tスワップファイルを列挙し終了"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (ファイル名)\tクラッシュしたセッションを復帰"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t-rと同じ"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tウィンドウを開くのに newcli を使用しない"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tI/Oに <device> を使用する"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tアラビア語モードで起動する"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tヘブライ語モードで起動する"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tペルシア語モードで起動する"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t端末を <terminal> に設定する"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t.vimrcの代わりに <vimrc> を使う"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t.gvimrcの代わりに <gvimrc> を使う"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tプラグインスクリプトをロードしない"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tN 個タブページを開く(省略値: ファイルにつき1個)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tN 個ウィンドウを開く(省略値: ファイルにつき1個)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t-oと同じだが垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tファイルの最後からはじめる"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t<lnum> 行からはじめる"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\tvimrcをロードする前に <command> を実行する"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t最初のファイルをロード後 <command> を実行する"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t最初のファイルをロード後ファイル <session> を取込む"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tファイル <scriptin> からノーマルコマンドを読込む"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t入力した全コマンドをファイル <scriptout> に追加する"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t入力した全コマンドをファイル <scriptout> に保存する"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t暗号化されたファイルを編集する"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tvimを指定した X サーバに接続する"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tXサーバに接続しない"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t可能ならばVimサーバで <files> を編集する"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  同上, サーバが無くても警告文を出力しない"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>\t--remote後 ファイルの編集が終わるのを待つ"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  同上, サーバが無くても警告文を出力しない"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <files>  --remoteでファイル1つにつき1つのタブ"
-"ページを開く"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\tVimサーバに <keys> を送信して終了する"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\tサーバで <expr> を実行して結果を表示する"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVimサーバ名の一覧を表示して終了する"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\tVimサーバ <name> に送信/名前設定する"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <file>\t起動にかかった時間の詳細を <file> へ出力する"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t.viminfoの代わりに <viminfo> を使う"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h or  --help\tヘルプ(このメッセージ)を表示し終了する"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tバージョン情報を表示し終了する"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(Motifバージョン):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(neXtawバージョン):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(Athenaバージョン):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t<display> でvimを実行する"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t最小化した状態でvimを起動する"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t背景色に <color> を使う(同義: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t前景色に <color> を使う(同義: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tテキスト表示に <font> を使う(同義: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t太字に <font> を使う"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <for>\t斜体字に <font> を使う"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t初期配置に <geom> を使う(同義: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t境界の幅を <width> にする(同義: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <width>  スクロールバーの幅を <width> にする(同義: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\tメニューバーの高さを <height> にする(同義: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t反転映像を使用する(同義: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t反転映像を使用しない(同義: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t特定のリソースを使用する"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(GTK+バージョン):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t異なるGTK widgetでVimを開く"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tウィンドウIDを標準出力に出力する"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <親のタイトル>\tVimを親アプリケーションの中で起動する"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\t異なるWin32 widgetの内部にVimを開く"
-
-msgid "No display"
-msgstr "ディスプレイが見つかりません"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 送信に失敗しました.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 送信に失敗しました. ローカルでの実行を試みています\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d 個 (%d 個中) のファイルを編集しました"
-
-msgid "No display: Send expression failed.\n"
-msgstr "ディスプレイがありません: 式の送信に失敗しました.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 式の送信に失敗しました.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "マークが設定されていません"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\" に該当するマークがありません"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3281,6 +3574,7 @@ msgstr ""
 "mark   行   列 ファイル/テキスト"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3289,6 +3583,7 @@ msgstr ""
 " jump   行   列 ファイル/テキスト"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3296,6 +3591,7 @@ msgstr ""
 "\n"
 "変更   行    列  テキスト"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3304,6 +3600,7 @@ msgstr ""
 "# ファイルマーク:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3311,6 +3608,7 @@ msgstr ""
 "\n"
 "# ジャンプリスト (新しいものが先):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3318,88 +3616,84 @@ msgstr ""
 "\n"
 "# ファイル内マークの履歴 (新しいものから古いもの):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>' が見つかりません"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 無効なコードページです"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: ICの値を設定できません"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: インプットコンテキストの作成に失敗しました"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: インプットメソッドのオープンに失敗しました"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: IMの破壊コールバックを設定できませんでした"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: インプットメソッドはどんなスタイルもサポートしません"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: インプットメソッドは my preedit type をサポートしません"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: ブロックがロックされていません"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: スワップファイル読込時にシークエラーです"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: スワップファイルの読込みエラーです"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: スワップファイル書込み時にシークエラーです"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: スワップファイルの書込みエラーです"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: スワップファイルが既に存在します (symlinkによる攻撃?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: ブロック 0 を取得できません?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: ブロック 1 を取得できません?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: ブロック 2 を取得できません?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: スワップファイルの暗号を更新中にエラーが発生しました"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: おっと, スワップファイルが失われました!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: スワップファイルの名前を変えられません"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: \"%s\" のスワップファイルを開けないのでリカバリは不可能です"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): ブロック 0 を取得できませんでした??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: %s にはスワップファイルが見つかりません"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "使用するスワップファイルの番号を入力してください(0 で終了): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s を開けません"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "ブロック 0 を読込めません "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3407,22 +3701,28 @@ msgstr ""
 "\n"
 "恐らく変更がされていないかVimがスワップファイルを更新していません."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " Vimのこのバージョンでは使用できません.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Vimのバージョン3.0を使用してください.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s はVimのスワップファイルではないようです"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " このコンピュータでは使用できません.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "このファイルは次の場所で作られました "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3430,104 +3730,85 @@ msgstr ""
 ",\n"
 "もしくはファイルが損傷しています."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr ""
-"E833: %s はこのバージョンのVimでサポートしていない形式で暗号化されています"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " は損傷しています (ページサイズが最小値を下回っています).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "スワップファイル \"%s\" を使用中"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原本ファイル \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原本ファイルが変更されています"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "スワップファイルは暗号化されています: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"新しい暗号キーを入力したあとにテキストファイルを保存していない場合は,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"新しい暗号キーを入力してください."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"暗号キーを変えたあとにテキストファイルを保存した場合は, テキストファイルと"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"スワップファイルに同じ暗号キーを使うためにenterだけを押してください."
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: %s からブロック 1 を読込めません"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???多くの行が失われています"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???行数が間違っています"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???ブロックが空です"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???行が失われています"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ブロック 1 のIDが間違っています(%s が.swpファイルでない?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???ブロックがありません"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? ここから ???END までの行が破壊されているようです"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? ここから ???END までの行が挿入か削除されたようです"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: リカバリが割込まれました"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: リカバリの最中にエラーが検出されました; ???で始まる行を参照してください"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "詳細は \":help E312\" を参照してください"
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "リカバリが終了しました. 全てが正しいかチェックしてください."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3535,12 +3816,15 @@ msgstr ""
 "\n"
 "(変更をチェックするために, このファイルを別の名前で保存した上で\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "原本ファイルとの diff を実行すると良いでしょう)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "復元完了. バッファの内容はファイルと同じになりました."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3550,43 +3834,52 @@ msgstr ""
 "それから.swpファイルを削除してください\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "スワップファイルから取得した暗号キーをテキストファイルに使います.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "スワップファイルが複数見つかりました:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   現在のディレクトリ:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   ある名前を使用中:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   ディレクトリ "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- なし --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            所有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   日付: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             日付: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [from Vim version 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [Vimのスワップファイルではないようです]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "        ファイル名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3594,12 +3887,15 @@ msgstr ""
 "\n"
 "          変更状態: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "あり"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "なし"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3607,9 +3903,11 @@ msgstr ""
 "\n"
 "          ユーザ名: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   ホスト名: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3617,6 +3915,7 @@ msgstr ""
 "\n"
 "          ホスト名: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3624,16 +3923,11 @@ msgstr ""
 "\n"
 "        プロセスID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (まだ実行中)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [このVimバージョンでは使用できません]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3641,75 +3935,97 @@ msgstr ""
 "\n"
 "         [このコンピュータでは使用できません]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [読込めません]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [開けません]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: スワップファイルが無いので維持できません"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "ファイルが維持されます"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 維持に失敗しました"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 無効なlnumです: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 行 %<PRId64> を見つけられません"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ポインタブロックのIDが間違っています 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx は 0 であるべきです"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新されたブロックが多過ぎるかも?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: ポインタブロックのIDが間違っています 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "ブロック 1 は消された?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 行 %<PRId64> が見つかりません"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: ポインタブロックのIDが間違っています"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count がゼロです"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行番号が範囲外です: %<PRId64> 超えています"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: ブロック %<PRId64> の行カウントが間違っています"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "スタックサイズが増えます"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: ポインタブロックのIDが間違っています 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: \"%s\" のシンボリックリンクがループになっています"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3717,14 +4033,15 @@ msgstr ""
 "\n"
 "次の名前でスワップファイルを見つけました \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "次のファイルを開いている最中 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      スワップファイルよりも新しいです!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3736,15 +4053,19 @@ msgstr ""
 "    この場合には, 変更をした際に最終的に, 同じファイルの異なる\n"
 "    2つのインスタンスができてしまうことに注意してください."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  終了するか, 注意しながら続けてください.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) このファイルの編集セッションがクラッシュした.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    この場合には \":recover\" か \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3752,9 +4073,11 @@ msgstr ""
 "\"\n"
 "    を使用して変更をリカバーします(\":help recovery\" を参照).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    既にこれを行なったのならば, スワップファイル \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3762,18 +4085,23 @@ msgstr ""
 "\"\n"
 "    を消せばこのメッセージを回避できます.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "スワップファイル \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" が既にあります!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "スワップファイルが既に存在します!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3787,6 +4115,7 @@ msgstr ""
 "終了する(&Q)\n"
 "中止する(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3802,34 +4131,56 @@ msgstr ""
 "終了する(&Q)\n"
 "中止する(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: スワップファイルが多数見つかりました"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: メニューアイテムのパスの部分がサブメニューではありません"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: メニューは他のモードにだけあります"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: \"%s\" というメニューはありません"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: メニュー名が空です"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: メニューパスはサブメニューを生じるべきではありません"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: メニューバーには直接メニューアイテムを追加できません"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 区切りはメニューパスの一部ではありません"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3837,60 +4188,73 @@ msgstr ""
 "\n"
 "--- メニュー ---"
 
-msgid "Tear off this menu"
-msgstr "このメニューを切り取る"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: メニューパスはメニューアイテムを生じなければいけません"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: メニューが見つかりません: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s にはメニューが定義されていません"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: メニューパスはサブメニューを生じなければいけません"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: メニューが見つかりません - メニュー名を確認してください"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "%s の処理中にエラーが検出されました:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "行 %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 無効なレジスタ名: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "日本語メッセージ翻訳/監修: 村岡 太郎 <koron.kaoriya@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "割込み: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "続けるにはENTERを押すかコマンドを入力してください"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 行 %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 継続 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: 画面/ページ/行 下, b/u/k: 上, q: 終了 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "質問"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3898,6 +4262,17 @@ msgstr ""
 "はい(&Y)\n"
 "いいえ(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"はい(&Y)\n"
+"いいえ(&N)\n"
+"キャンセル(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3911,272 +4286,175 @@ msgstr ""
 "全て放棄(&D)\n"
 "キャンセル(&C)"
 
-msgid "Select Directory dialog"
-msgstr "ディレクトリ選択ダイアログ"
-
-msgid "Save File dialog"
-msgstr "ファイル保存ダイアログ"
-
-msgid "Open File dialog"
-msgstr "ファイル読込ダイアログ"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: コンソールモードではファイルブラウザを使えません, ごめんなさい"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() の引数が不十分です"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: printf() の引数には浮動少数点数が期待されています"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf() の引数が多過ぎます"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 警告: 読込専用ファイルを変更します"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "番号と<Enter>を入力するかマウスでクリックしてください (空でキャンセル): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "番号と<Enter>を入力してください (空でキャンセル): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 行 追加しました"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 行 削除しました"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> 行 追加しました"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> 行 削除しました"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (割込まれました)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "ビーッ!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: ファイルを保存中...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 終了しました.\n"
-
-msgid "ERROR: "
-msgstr "エラー: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピーク時 %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 行が長くなり過ぎました"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "実行のためにシェルを呼出し中: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: コロンがありません"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 不正なモードです"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 不正な 'mouseshape' です"
-
-msgid "E548: digit expected"
-msgstr "E548: 数値が必要です"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 不正なパーセンテージです"
-
-msgid "Enter encryption key: "
-msgstr "暗号化用のキーを入力してください: "
-
-msgid "Enter same key again: "
-msgstr "もう一度同じキーを入力してください: "
-
-msgid "Keys don't match!"
-msgstr "キーが一致しません"
-
-msgid "E854: path too long for completion"
-msgstr "E854: パスが長過ぎて補完できません"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: 無効なパスです: '**[数値]' はpathの最後か '%s' が続いてないといけませ"
-"ん."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpathには \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: pathには \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: cdpathにはこれ以上 \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: パスにはこれ以上 \"%s\" というファイルがありません"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Netbeans #2 に接続できません"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Netbeans に接続できません"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: NetBeansの接続情報ファイルのアクセスモードに問題があります: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "Netbeans のソケットを読込み"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: NetBeansはこのGUIには対応していません"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: NetBeansは既に接続しています"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s は読込専用です (強制書込には ! を追加)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: カーソルの位置には識別子がありません"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' オプションが空です"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: 式評価機能が無効になっています"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "警告: 使用している端末はハイライトできません"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: カーソルの位置には文字列がありません"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 現在の 'foldmethod' では折畳みを消去できません"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 変更リストが空です"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 変更リストの先頭"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 行が %s で 1 回処理されました"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 行が %s で %d 回処理されました"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行が %s で 1 回処理されました"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行が %s で %d 回処理されました"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> 行がインデントされます... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 行をインデントしました "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> 行をインデントしました "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: まだレジスタを使用していません"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "ヤンクできません; とにかく消去"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 行が変更されました"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> 行が変更されました"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "%<PRId64> 行を解放中"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "1 行のブロックがヤンクされました"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 行がヤンクされました"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "%<PRId64> 行のブロックがヤンクされました"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> 行がヤンクされました"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: レジスタ %s には何もありません"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4184,9 +4462,11 @@ msgstr ""
 "\n"
 "--- レジスタ ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "不正なレジスタ名"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4194,160 +4474,182 @@ msgstr ""
 "\n"
 "# レジスタ:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 列; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> バイト"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト %<PRId64> / %<PRId64>"
-
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 %<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
+"選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / "
+"%<PRId64> バイト"
 
+#: ../ops.c:5105
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / "
+"%<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト "
+"%<PRId64> / %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 "
+"%<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=%N ページ"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Vim を使ってくれてありがとう"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 未知のオプションです"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: オプションはサポートされていません"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: modeline では許可されません"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: キーコードが設定されていません"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = の後には数字が必要です"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: termcap 内に見つかりません"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正な文字です <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' には空文字列を設定できません"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: GUIでは 'term' を変更できません"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: GUIをスタートするには \":gui\" を使用してください"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' と 'patchmode' が同じです"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: 'listchars'の値に矛盾があります"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: 'fillchars'の値に矛盾があります"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: GTK+2 GUIでは変更できません"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: コロンがありません"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 文字列の長さがゼロです"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> の後に数字がありません"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: カンマがありません"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: ' の値を指定しなければなりません"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 表示できない文字かワイド文字を含んでいます"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 無効なフォントです"
-
-msgid "E597: can't select fontset"
-msgstr "E597: フォントセットを選択できません"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 無効なフォントセットです"
-
-msgid "E533: can't select wide font"
-msgstr "E533: ワイドフォントを選択できません"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 無効なワイドフォントです"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> の後に不正な文字があります"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: カンマが必要です"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' は空であるか %s を含む必要があります"
 
-msgid "E538: No mouse support"
-msgstr "E538: マウスはサポートされません"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 式が終了していません"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 要素が多過ぎます"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: グループが釣合いません"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: プレビューウィンドウが既に存在します"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: アラビア文字にはUTF-8が必要なので, ':set encoding=utf-8' してください"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 最低 %d の行数が必要です"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 最低 %d のカラム幅が必要です"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 未知のオプションです: %s"
@@ -4355,10 +4657,12 @@ msgstr "E355: 未知のオプションです: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: 数字が必要です: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4366,6 +4670,7 @@ msgstr ""
 "\n"
 "--- 端末コード ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4373,6 +4678,7 @@ msgstr ""
 "\n"
 "--- グローバルオプション値 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4380,6 +4686,7 @@ msgstr ""
 "\n"
 "--- ローカルオプション値 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4387,140 +4694,21 @@ msgstr ""
 "\n"
 "--- オプション ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp エラー"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': %s に対応する文字がありません"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': セミコロンの後に余分な文字があります: %s"
 
-msgid "cannot open "
-msgstr "開けません "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: ウィンドウを開けません!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "%s のバージョン %<PRId64> が必要です\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "NILを開けません:\n"
-
-msgid "Cannot create "
-msgstr "作成できません "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vimは %d で終了します\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "コンソールモードを変更できません?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: コンソールではない??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: -f オプションでシェルを実行できません"
-
-msgid "Cannot execute "
-msgstr "実行できません "
-
-msgid "shell "
-msgstr "シェル "
-
-msgid " returned\n"
-msgstr " 戻りました\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE が小さ過ぎます."
-
-msgid "I/O ERROR"
-msgstr "入出力エラー"
-
-msgid "Message"
-msgstr "メッセージ"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' が80ではないため, 外部コマンドを実行できません"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: プリンタの選択に失敗しました"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "%s へ (%s 上の)"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 未知のプリンタオプションです: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 印刷エラー: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "印刷しています: '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 文字セット名 \"%s\" は不正です (フォント名 \"%s\")"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: '%c' は不正な文字です (フォント名 \"%s\")"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 2重のシグナルのため, 終了します\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: 致命的シグナル %s を検知しました\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 致命的シグナルを検知しました\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X のエラーを検出しましたr\n"
-
-msgid "Testing the X display failed"
-msgstr "X display のチェックに失敗しました"
-
-msgid "Opening the X display timed out"
-msgstr "X display の open がタイムアウトしました"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"セキュリティコンテキストを取得できません "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"セキュリティコンテキストを設定できません "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4528,13 +4716,7 @@ msgstr ""
 "\n"
 "シェルを実行できません "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"sh シェルを実行できません\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4542,451 +4724,484 @@ msgstr ""
 "\n"
 "シェルが値を返しました "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"パイプを作成できません\n"
+"セキュリティコンテキストを取得できません "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"fork できません\n"
+"セキュリティコンテキストを設定できません "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"コマンドを中断しました\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP がICE接続を失いました"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "X display の open に失敗しました"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP がsave-yourself要求を処理しています"
-
-msgid "XSMP opening connection"
-msgstr "XSMP が接続を開始しています"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE接続が失敗したようです"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnectionが失敗しました: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: pathには \"%s\" というファイルがありません"
 
-msgid "At line"
-msgstr "行"
-
-msgid "Could not load vim32.dll!"
-msgstr "vim32.dll をロードできませんでした"
-
-msgid "VIM Error"
-msgstr "VIMエラー"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "DLLから関数ポインタを取得できませんでした"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "シェルがコード %d で終了しました"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: イベント %s を検知\n"
-
-msgid "close"
-msgstr "閉じる"
-
-msgid "logoff"
-msgstr "ログオフ"
-
-msgid "shutdown"
-msgstr "シャットダウン"
-
-msgid "E371: Command not found"
-msgstr "E371: コマンドがありません"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXEが $PATH の中に見つかりません.\n"
-"外部コマンドの終了後に一時停止をしません.\n"
-"詳細は  :help win32-vimrun  を参照してください."
-
-msgid "Vim Warning"
-msgstr "Vimの警告"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: フォーマット文字列に %%%c が多過ぎます"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: フォーマット文字列に予期せぬ %%%c がありました"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: フォーマット文字列に ] がありません"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: フォーマット文字列では %%%c はサポートされません"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: フォーマット文字列の前置に無効な %%%c があります"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: フォーマット文字列に無効な %%%c があります"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' にパターンが指定されていません"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: ディレクトリ名が無いか空です"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 要素がもうありません"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d of %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行が削除されました)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: quickfix スタックの末尾です"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: quickfix スタックの先頭です"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "エラー一覧 %d of %d; %d 個エラー"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 'buftype' オプションが設定されているので書込みません"
 
-msgid "Error file"
-msgstr "エラーファイル"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: ファイル名が無いか無効なパターンです"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "ファイル \"%s\" を開けません"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: バッファは読み込まれませんでした"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: 文字列かリストが必要です"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: 無効な項目です: %s%%[]"
 
 #
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ の後に ] がありません"
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: %s%%( が釣り合っていません"
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: %s( が釣り合っていません"
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: %s) が釣り合っていません"
 
 #
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( はココでは許可されていません"
 
 #
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 その他はココでは許可されていません"
 
 #
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: %s%%[ の後に ] がありません"
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] が空です"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: パターンが長過ぎます"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: \\z( が多過ぎます"
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: %s( が多過ぎます"
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: \\z( が釣り合っていません"
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: %s@ の後に不正な文字がありました"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: 複雑な %s{...} が多過ぎます"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61:%s* が入れ子になっています"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62:%s%c が入れ子になっています"
 
 #
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: \\_ の無効な使用方法です"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64:%s%c の後になにもありません"
 
 #
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: 不正な後方参照です"
 
 #
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: \\z の後に不正な文字がありました"
 
 #
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: %s%%[dxouU] の後に不正な文字がありました"
 
 #
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: %s%% の後に不正な文字がありました"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...} 内に文法エラーがあります"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部の部分該当:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
-"E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。"
-"正規表現エンジンは自動選択されます。"
+"E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。正規表現エンジンは自動選"
+"択されます。"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) 期待より早く正規表現の終端に到達しました"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA 正規表現) 位置が誤っています: %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) 期待より早く正規表現の終端に到達しました"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) 未知のオペレータです: '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) 未知のオペレータです: '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: 等価クラスを含むNFA構築に失敗しました!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) 未知のオペレータです: '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFA 正規表現) 繰り返しの制限回数を読込中にエラー"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (NFA 正規表現) 繰り返し の後に 繰り返し はできません!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA 正規表現) '(' が多過ぎます"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA 正規表現) \\z( が多過ぎます"
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA 正規表現) 終端記号がありません"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) スタックをポップできません!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
 msgstr ""
-"E875: (NFA 正規表現) (後置文字列をNFAに変換中に) "
-"スタックに残されたステートが多過ぎます"
+"E875: (NFA 正規表現) (後置文字列をNFAに変換中に) スタックに残されたステートが"
+"多過ぎます"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA 正規表現) NFA全体を保存するには空きスペースが足りません"
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) 現在横断中のブランチに十分なメモリを割り当てられません!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
-msgstr "NFA正規表現エンジン用のログファイルを書込用として開けません。"
-"ログは標準出力に出力します。"
+msgstr ""
+"NFA正規表現エンジン用のログファイルを書込用として開けません。ログは標準出力に"
+"出力します。"
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) ログファイル %s を開けません!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "NFA正規表現エンジン用のログファイルを書込用として開けません。"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " 仮想置換"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 置換"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反転"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 挿入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (挿入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (置換)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (仮想置換)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " ヘブライ"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " アラビア"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (言語)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (貼り付け)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ビジュアル"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ビジュアル 行"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ビジュアル 矩形"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " セレクト"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 行指向選択"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 矩形選択"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "記録中"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 無効な検索文字列です: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 上まで検索しましたが該当箇所はありません: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 下まで検索しましたが該当箇所はありません: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ';' のあとには '?' か '/' が期待されている"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (前に列挙した該当箇所を含む)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- インクルードされたファイル "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "見つかりません "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "パスに ----\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (既に列挙)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  見つかりません"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "インクルードされたファイルをスキャン中: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "インクルードされたファイルをスキャン中 %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 現在行に該当があります"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "全てのインクルードされたファイルが見つかりました"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "インクルードファイルはありません"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 定義を見つけられません"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: パターンを見つけられません"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Substitute "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4997,87 +5212,99 @@ msgstr ""
 "# 最後の %s検索パターン:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: スペルファイルの書式エラーです"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: スペルファイルが切取られているようです"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "%s (%d 行目) に続くテキスト: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "%s (%d 行目) の affix 名が長過ぎます: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr ""
 "E761: affixファイルの FOL, LOW もしくは UPP のフォーマットにエラーがあります"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL, LOW もしくは UPP の文字が範囲外です"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "単語ツリーを圧縮しています..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: スペルチェックは無効化されています"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"警告: 単語リスト \"%s_%s.spl\" および \"%s_ascii.spl\" は見つかりません"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "警告: 単語リスト \"%s.%s.spl\" および \"%s.ascii.spl\" は見つかりません"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "スペルファイル \"%s\" を読込中"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: スペルファイルではないようです"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 古いスペルファイルなので, アップデートしてください"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: より新しいバージョンの Vim 用のスペルファイルです"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: スペルファイルにサポートしていないセクションがあります"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "警告9: %s という範囲はサポートされていません"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "affix ファイル %s を読込中..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "%s (%d 行目) の単語を変換できませんでした: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "%s 内の次の変換はサポートされていません: %s から %s へ"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "%s 内の変換はサポートされていません"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 内の %d 行目の FLAG に無効な値があります: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 内の %d 行目にフラグの二重使用があります: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5086,6 +5313,7 @@ msgstr ""
 "%s の %d 行目の PFX 項目の後の COMPOUNDFORBIDFLAG の定義は誤った結果を生じる"
 "ことがあります"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5094,35 +5322,43 @@ msgstr ""
 "%s の %d 行目の PFX 項目の後の COMPOUNDPERMITFLAG の定義は誤った結果を生じる"
 "ことがあります"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "COMPOUNDRULES の値に誤りがあります. ファイル %s の %d 行目: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDWORDMAX の値に誤りがあります: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDMIN の値に誤りがあります: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDSYLMAX の値に誤りがあります: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s の %d 行目の CHECKCOMPOUNDPATTERN の値に誤りがあります: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "%s の %d 行目の 連続 affix ブロックのフラグの組合せに違いがあります: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s の %d 行目に 重複した affix を検出しました: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5131,270 +5367,334 @@ msgstr ""
 "%s の %d 行目の affix は BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
 "に使用してください: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s の %d 行目では Y か N が必要です: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s の %d 行目の 条件は壊れています: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s の %d 行目には REP(SAL) の回数が必要です"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s の %d 行目には MAP の回数が必要です"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s の %d 行目の MAP に重複した文字があります"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s の %d 行目に 認識できないか重複した項目があります: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s 行目に FOL/LOW/UPP がありません"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "SYLLABLE が指定されない COMPOUNDSYLMAX"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "遅延後置子が多過ぎます"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "複合フラグが多過ぎます"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "遅延後置子 と/もしくは 複合フラグが多過ぎます"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "SOFO%s 行が %s にありません"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "SAL行 と SOFO行 が %s で両方指定されています"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s の %d 行の フラグが数値ではありません: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s の %d 行目の フラグが不正です: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "値 %s は他の .aff ファイルで使用されたのと異なります"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "辞書ファイル %s をスキャン中..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s には単語数がありません"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "行 %6d, 単語 %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s の %d 行目で 重複単語が見つかりました: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "重複のうち最初の単語は %s の %d 行目です: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d 個の単語が見つかりました (%s 内)"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "非ASCII文字を含む %d 個の単語を無視しました (%s 内)"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "標準入力から読込み中 %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した /encoding= 行を無視しました: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 単語の後の /encoding= 行を無視しました: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した /regions= 行を無視しました: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s の %d 行目, 範囲指定が多過ぎます: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した / 行を無視しました: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s の %d 行目 無効な nr 領域です: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s の %d 行目 認識不能なフラグです: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "非ASCII文字を含む %d 個の単語を無視しました"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: メモリが足りないので、単語リストは不完全です"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "ノード %d 個(全 %d 個中) を圧縮しました; 残り %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "スペルファイルを逆読込中"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "音声畳込みを実行中..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "音声畳込み後の総単語数: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "総単語数: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "修正候補ファイル \"%s\" を書込み中..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "推定メモリ使用量: %d バイト"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 出力ファイル名には範囲名を含められません"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 範囲は 8 個までしかサポートされていません"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: 無効な範囲です: %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "警告: 複合フラグと NOBREAK が両方とも指定されました"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "スペルファイル %s を書込み中..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "実行しました!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "%s から単語が削除されました"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "%s に単語が追加されました"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 単語の文字がスペルファイルと異なります"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "残念ですが, 修正候補はありません"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "残念ですが, 修正候補は %<PRId64> 個しかありません"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "\"%.*s\" を次へ変換:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: スペル置換がまだ実行されていません"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 見つかりません: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: .sug ファイルではないようです: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: 古い .sug ファイルなので, アップデートしてください: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: より新しいバージョンの Vim 用の .sug ファイルです: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug ファイルが .spl ファイルと一致しません: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: .sug ファイルの読込中にエラーが発生しました: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: MAP エントリに重複文字が存在します"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "このバッファに定義された構文要素はありません"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 不正な引数です: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: そのような構文クラスタはありません: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C言語風コメントから同期中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "非同期"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同期開始 "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " 行前(トップ行よりも)"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5402,6 +5702,7 @@ msgstr ""
 "\n"
 "--- 構文同期要素 ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5409,6 +5710,7 @@ msgstr ""
 "\n"
 "要素上で同期中"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5416,212 +5718,272 @@ msgstr ""
 "\n"
 "--- 構文要素 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: そのような構文クラスタはありません: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; 該当 "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " 個の改行"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: この場所では引数containsは許可されていません"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: 無効なccharの値です"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: ここではグループは許可されません"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: %s の範囲要素が見つかりません"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: ファイル名が必要です"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: 構文の取り込み(include)が多過ぎます"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' がありません: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' がありません: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: 引数が足りません: 構文範囲 %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: 構文クラスタが多過ぎます"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: クラスタが指定されていません"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: パターン区切りが見つかりません: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: パターンのあとにゴミがあります: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 構文同期: 連続行パターンが2度指定されました"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 不正な引数です: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 等号がありません: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空の引数: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s はココでは許可されていません"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s は内容リストの先頭でなければならない"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 未知のグループ名: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 無効な :syntax のサブコマンド: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: syncolor.vim の再帰呼び出しを検出しました"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: ハイライトグループが見つかりません: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 引数が充分ではない: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 引数が多過ぎます: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: グループが設定されているのでハイライトリンクは無視されます"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 予期せぬ等号です: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 等号ががありません: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 引数がありません: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不正な値です: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 未知の前景色です"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 未知の背景色です"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: カラー名や番号を認識できません: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 終端コードが長過ぎます: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 不正な引数です: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 多くの異なるハイライト属性が使われ過ぎています"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: グループ名に印刷不可能な文字があります"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: グループ名に不正な文字があります"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: ハイライトと構文グループが多過ぎます"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: タグスタックの末尾です"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: タグスタックの先頭です"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 最初の該当タグを超えて戻ることはできません"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: タグが見つかりません: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "ファイル\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 該当タグが1つだけしかありません"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 最後に該当するタグを超えて進むことはできません"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "ファイル \"%s\" がありません"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "タグ %d (全%d%s)"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " かそれ以上"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  タグを異なるcaseで使用します!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: ファイル \"%s\" がありません"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5629,66 +5991,79 @@ msgstr ""
 "\n"
 "  # TO タグ        FROM 行    in file/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "タグファイル %s を検索中"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: タグファイルのパスが %s に切り捨てられました\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "タグファイル内の長い行を無視します"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: タグファイル \"%s\" のフォーマットにエラーがあります"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "直前の %<PRId64> バイト"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: タグファイルがソートされていません: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: タグファイルがありません"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: タグパターンを見つけられません"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: タグを見つけられないので単に推測します!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "重複したフィールド名: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' は未知です. 現行の組み込み端末は次のとおりです:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "省略値を次のように設定します '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: termcapファイルを開けません"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: terminfoに端末エントリを見つけられません"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: termcapに端末エントリを見つけられません"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcapに \"%s\" のエントリがありません"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 端末に \"cm\" 機能が必要です"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5696,244 +6071,169 @@ msgstr ""
 "\n"
 "--- 端末キー ---"
 
-msgid "new shell started\n"
-msgstr "新しいシェルを起動します\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 入力を読込み中のエラーにより終了します...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "空の選択領域のかわりにCUT_BUFFER0が使用されました"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: 予期せず行カウントが変わりました"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "可能なアンドゥはありません: とりあえず続けます"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: 書込み用にアンドゥファイルを開けません: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: アンドゥファイルが壊れています (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "'undodir'のディレクトリにアンドゥファイルを書き込めません"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "アンドゥファイルとして読み込めないので上書きしません: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "アンドゥファイルではないので上書きしません: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "対象がないのでアンドゥファイルの書き込みをスキップします"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "アンドゥファイル書き込み中: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: アンドゥファイルの書き込みエラーです: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "オーナーが異なるのでアンドゥファイルを読み込みません: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "アンドゥファイル読込中: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: アンドゥファイルを読込用として開けません: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: アンドゥファイルではありません: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: 非暗号化ファイルが暗号化されたアンドゥファイルを使ってます: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: 暗号化されたアンドゥファイルの解読に失敗しました: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: アンドゥファイルが暗号化されています: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: 互換性の無いアンドゥファイルです: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "ファイルの内容が変わっているため、アンドゥ情報を利用できません"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "アンドゥファイル %s の取込を完了"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "既に一番古い変更です"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "既に一番新しい変更です"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: アンドゥ番号 %<PRId64> は見つかりません"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行番号が間違っています"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "行 追加しました"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "行 追加しました"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "行 削除しました"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "行 削除しました"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "箇所変更しました"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "箇所変更しました"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "前方"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "後方"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "アンドゥ対象がありません"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "通番   変更数   変更時期           保存済"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> 秒経過しています"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo の直後に undojoin はできません"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: アンドゥリストが壊れています"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: アンドゥ行がありません"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 ビット GUI 版"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64 ビット GUI 版"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 ビット GUI 版"
-
-msgid " in Win32s mode"
-msgstr " in Win32s モード"
-
-msgid " with OLE support"
-msgstr " with OLE サポート"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 64 ビット コンソール 版"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 ビット コンソール 版"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 ビット 版"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 ビット MS-DOS 版"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 ビット MS-DOS 版"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS 版"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5941,6 +6241,7 @@ msgstr ""
 "\n"
 "適用済パッチ: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5948,9 +6249,11 @@ msgstr ""
 "\n"
 "追加拡張パッチ: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modified by "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5958,9 +6261,11 @@ msgstr ""
 "\n"
 "Compiled "
 
+#: ../version.c:649
 msgid "by "
 msgstr "by "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5968,837 +6273,1883 @@ msgstr ""
 "\n"
 "Huge 版 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Big 版 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"通常 版 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Small 版 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Tiny 版 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "without GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "with GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "with GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "with X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "with X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "with X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "with Photon GUI."
-
-msgid "with GUI."
-msgstr "with GUI."
-
-msgid "with Carbon GUI."
-msgstr "with Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "with Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "with (クラシック) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能の一覧 有効(+)/無効(-)\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "      システム vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        ユーザ vimrc: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "     第2ユーザ vimrc: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "     第3ユーザ vimrc: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         ユーザ exrc: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "      第2ユーザ exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "     システム gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       ユーザ gvimrc: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "    第2ユーザ gvimrc: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "    第3ユーザ gvimrc: \""
-
-msgid "    system menu file: \""
-msgstr "    システムメニュー: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       省略時の $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "省略時の $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "コンパイル: "
 
-msgid "Compiler: "
-msgstr "コンパイラ: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "リンク: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "デバッグビルド"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "version "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "by Bram Moolenaar 他."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim はオープンソースであり自由に配布可能です"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "ウガンダの恵まれない子供たちに援助を!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "詳細な情報は           :help iccf<Enter>      "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "終了するには           :q<Enter>              "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "バージョン情報は       :help version7<Enter>  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi互換モードで動作中"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "Vim推奨値にするには    :set nocp<Enter>       "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "詳細な情報は           :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "詳細はメニューの ヘルプ→孤児 を参照して下さい   "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "モード無で実行中, タイプした文字が挿入されます"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "メニューの 編集→全体設定→挿入(初心者)モード切替 "
-
-msgid "                              for two modes      "
-msgstr "                              でモード有に       "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "メニューの 編集→全体設定→Vi互換モード切替      "
-
-msgid "                              for Vim defaults   "
-msgstr "                              でVimとして動作    "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Vimの開発を応援してください!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Vimの登録ユーザになってください!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "詳細な情報は           :help sponsor<Enter>   "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "詳細な情報は           :help register<Enter>  "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "詳細はメニューの ヘルプ→スポンサー/登録 を参照して下さい   "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "   警告: Windows 95/98/Me を検出  "
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr " 詳細な情報は          :help windows95<Enter> "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "既にウィンドウは1つしかありません"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: プレビューウィンドウがありません"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: 左上と右下を同時に分割することはできません"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: 他のウィンドウが分割されている時には順回できません"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: 最後のウィンドウを閉じることはできません"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: autocmdウィンドウは閉じられません"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: autocmdウィンドウしか残らないため、ウィンドウは閉じられません"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: 他のウィンドウには変更があります"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: カーソルの下にファイル名がありません"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: pathには \"%s\" というファイルがありません"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() が空パスワードで呼び出されました"
 
-msgid "Edit with &multiple Vims"
-msgstr "複数のVimで編集する (&M)"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Edit with single &Vim"
-msgstr "1つのVimで編集する (&V)"
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish暗号のビッグ/リトルエンディアンが間違っています"
 
-msgid "Diff with Vim"
-msgstr "Vimで差分を表示する"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256のテストに失敗しました"
 
-msgid "Edit with &Vim"
-msgstr "Vimで編集する (&V)"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish暗号のテストに失敗しました"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "起動済のVimで編集する - "
+#~ msgid "Patch file"
+#~ msgstr "パッチファイル"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "選択したファイルをVimで編集する"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "決定(&O)\n"
+#~ "キャンセル(&C)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "プロセスの作成に失敗: gvimが環境変数PATH上にあるか確認してください!"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Vim サーバへの接続がありません"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll エラー"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: %s へ送ることができません"
 
-msgid "Path length too long!"
-msgstr "パスが長すぎます!"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: サーバの応答がありません"
 
-msgid "--No lines in buffer--"
-msgstr "--バッファに行がありません--"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: クライアントへ送ることができません"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: コマンドが中断されました"
+#~ msgid "Save As"
+#~ msgstr "別名で保存"
 
-msgid "E471: Argument required"
-msgstr "E471: 引数が必要です"
+#~ msgid "Edit File"
+#~ msgstr "ファイルを編集"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ の後は / か ? か & でなければなりません"
+# Added at 27-Jan-2004.
+#~ msgid " (NOT FOUND)"
+#~ msgstr "  (見つかりません)"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
+#~ msgid "Source Vim script"
+#~ msgstr "Vimスクリプトの取込み"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"
+#~ msgid "unknown"
+#~ msgstr "不明"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif がありません"
+#~ msgid "Edit File in new window"
+#~ msgstr "新しいウィンドウでファイルを編集します"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry がありません"
+#~ msgid "Append File"
+#~ msgstr "追加ファイル"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile がありません"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "ウィンドウ位置: X %d, Y %d"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor がありません"
+#~ msgid "Save Redirection"
+#~ msgstr "リダイレクトを保存します"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :while のない :endwhile があります"
+#~ msgid "Save View"
+#~ msgstr "ビューを保存します"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor のない :for があります"
+#~ msgid "Save Session"
+#~ msgstr "セッション情報を保存します"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: ファイルが存在します (! を追加で上書)"
+#~ msgid "Save Setup"
+#~ msgstr "設定を保存します"
 
-msgid "E472: Command failed"
-msgstr "E472: コマンドが失敗しました"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< は +eval 機能が無いと利用できません"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 未知のフォントセット: %s"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: このバージョンに合字はありません"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 未知のフォント: %s"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr " はデバイスです ('opendevice' オプションで回避できます)"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: フォント \"%s\" は固定幅ではありません"
+#~ msgid "Reading from stdin..."
+#~ msgstr "標準入力から読込み中..."
 
-msgid "E473: Internal error"
-msgstr "E473: 内部エラーです"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish暗号化]"
 
-msgid "Interrupted"
-msgstr "割込まれました"
+#~ msgid "[crypted]"
+#~ msgstr "[暗号化]"
 
-msgid "E14: Invalid address"
-msgstr "E14: 無効なアドレスです"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: ファイルが未知の方法で暗号化されています"
 
-msgid "E474: Invalid argument"
-msgstr "E474: 無効な引数です"
+# Added at 19-Jan-2004.
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeansは未変更のバッファを上書することは許可していません"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 無効な引数です: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeansバッファの一部を書き出すことはできません"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 無効な式です: %s"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "'opendevice' オプションによりデバイスへの書き込みはできません"
 
-msgid "E16: Invalid range"
-msgstr "E16: 無効な範囲です"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: リソースフォークが失われるかもしれません (! を追加で強制)"
 
-msgid "E476: Invalid command"
-msgstr "E476: 無効なコマンドです"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: GUI用のプロセスの起動に失敗しました"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" はディレクトリです"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: 子プロセスがGUIの起動に失敗しました"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: \"%s\"() のライブラリ呼出に失敗しました"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUIを開始できません"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: ライブラリの関数 %s をロードできませんでした"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: \"%s\"から読込むことができません"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: マークに無効な行番号が指定されていました"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 有効なフォントが見つからないので, GUIを開始できません"
 
-msgid "E20: Mark not set"
-msgstr "E20: マークは設定されていません"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' が無効です"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 'modifiable' がオフなので, 変更できません"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' に設定された値が無効です"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: スクリプトの入れ子が深過ぎます"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: %s の色を割り当てられません"
 
-msgid "E23: No alternate file"
-msgstr "E23: 副ファイルはありません"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "カーソルの位置にマッチはありません, 次を検索しています"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: そのような短縮入力はありません"
+#~ msgid "<cannot open> "
+#~ msgstr "<開けません> "
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! は許可されていません"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: フォント %s を取得できません"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUIは使用不可能です: コンパイル時に無効にされています"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 現在のディレクトリに戻れません"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: ヘブライ語は使用不可能です: コンパイル時に無効にされています\n"
+#~ msgid "Pathname:"
+#~ msgstr "パス名:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: ペルシア語は使用不可能です: コンパイル時に無効にされています\n"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 現在のディレクトリを取得できません"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: アラビア語は使用不可能です: コンパイル時に無効にされています\n"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: そのような名のハイライトグループはありません: %s"
+#~ msgid "Cancel"
+#~ msgstr "キャンセル"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: まだテキストが挿入されていません"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "スクロールバー: 画像を取得できませんでした."
 
-msgid "E30: No previous command line"
-msgstr "E30: 以前にコマンド行がありません"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim ダイアログ"
 
-msgid "E31: No such mapping"
-msgstr "E31: そのようなマッピングはありません"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: メッセージとコールバックのある BalloonEval を作成できません"
 
-msgid "E479: No match"
-msgstr "E479: 該当はありません"
+#~ msgid "Input _Methods"
+#~ msgstr "インプットメソッド"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 該当はありません: %s"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 検索と置換..."
 
-msgid "E32: No file name"
-msgstr "E32: ファイル名がありません"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 検索..."
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 正規表現置換がまだ実行されていません"
+#~ msgid "Find what:"
+#~ msgstr "検索文字列:"
 
-msgid "E34: No previous command"
-msgstr "E34: コマンドがまだ実行されていません"
+#~ msgid "Replace with:"
+#~ msgstr "置換文字列:"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: 正規表現がまだ実行されていません"
+#~ msgid "Match whole word only"
+#~ msgstr "正確に該当するものだけ"
 
-msgid "E481: No range allowed"
-msgstr "E481: 範囲指定は許可されていません"
+#~ msgid "Match case"
+#~ msgstr "大文字/小文字を区別する"
 
-msgid "E36: Not enough room"
-msgstr "E36: ウィンドウに十分な高さもしくは幅がありません"
+#~ msgid "Direction"
+#~ msgstr "方向"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: %s という名前の登録されたサーバはありません"
+#~ msgid "Up"
+#~ msgstr "上"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: ファイル %s を作成できません"
+#~ msgid "Down"
+#~ msgstr "下"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: 一時ファイルの名前を取得できません"
+#~ msgid "Find Next"
+#~ msgstr "次を検索"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: ファイル \"%s\" を開けません"
+#~ msgid "Replace"
+#~ msgstr "置換"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: ファイル %s を読込めません"
+#~ msgid "Replace All"
+#~ msgstr "全て置換"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: セッションマネージャから \"die\" 要求を受け取りました\n"
 
-msgid "E38: Null argument"
-msgstr "E38: 引数が空です"
+#~ msgid "Close"
+#~ msgstr "閉じる"
 
-msgid "E39: Number expected"
-msgstr "E39: 数値が要求されています"
+#~ msgid "New tab"
+#~ msgstr "新規タブページ"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: エラーファイル %s を開けません"
+#~ msgid "Open Tab..."
+#~ msgstr "タブページを開く..."
 
-msgid "E233: cannot open display"
-msgstr "E233: ディスプレイを開けません"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: メインウィンドウが不意に破壊されました\n"
 
-msgid "E41: Out of memory!"
-msgstr "E41: メモリが尽き果てました!"
+#~ msgid "&Filter"
+#~ msgstr "フィルタ(&F)"
 
-msgid "Pattern not found"
-msgstr "パターンは見つかりませんでした"
+#~ msgid "&Cancel"
+#~ msgstr "キャンセル(&C)"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: パターンは見つかりませんでした: %s"
+#~ msgid "Directories"
+#~ msgstr "ディレクトリ"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: 引数は正の値でなければなりません"
+#~ msgid "Filter"
+#~ msgstr "フィルタ"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 前のディレクトリに戻れません"
+#~ msgid "&Help"
+#~ msgstr "ヘルプ(&H)"
 
-msgid "E42: No Errors"
-msgstr "E42: エラーはありません"
+#~ msgid "Files"
+#~ msgstr "ファイル"
 
-msgid "E776: No location list"
-msgstr "E776: 場所リストはありません"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E43: Damaged match string"
-msgstr "E43: 該当文字列が破損しています"
+#~ msgid "Selection"
+#~ msgstr "選択"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 不正な正規表現プログラムです"
+#~ msgid "Find &Next"
+#~ msgstr "次を検索(&N)"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' オプションが設定されています (! を追加で上書き)"
+#~ msgid "&Replace"
+#~ msgstr "置換(&R)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 読取専用変数 \"%s\" には値を設定できません"
+#~ msgid "Replace &All"
+#~ msgstr "全て置換(&A)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: サンドボックスでは変数 \"%s\" に値を設定できません"
+#~ msgid "&Undo"
+#~ msgstr "アンドゥ(&U)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: エラーファイルの読込中にエラーが発生しました"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: タイトルが \"%s\" のウィンドウは見つかりません"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: サンドボックスでは許されません"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 引数はサポートされません: \"-%s\"; OLE版を使用してください."
 
-msgid "E523: Not allowed here"
-msgstr "E523: ここでは許可されません"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: MDIアプリの中ではウィンドウを開けません"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: スクリーンモードの設定には対応していません"
+#~ msgid "Close tab"
+#~ msgstr "タブページを閉じる"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: 無効なスクロール量です"
+#~ msgid "Open tab..."
+#~ msgstr "タブページを開く"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' オプションが空です"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "検索文字列 ('\\' を検索するには '\\\\')"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: sign のデータを読込めませんでした"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "検索・置換 ('\\' を検索するには '\\\\')"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: スワップファイルのクローズ時エラーです"
+#~ msgid "Not Used"
+#~ msgstr "使われません"
 
-msgid "E73: tag stack empty"
-msgstr "E73: タグスタックが空です"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "ディレクトリ\t*.nothing\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: コマンドが複雑過ぎます"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 色指定が正しくないのでエントリを割り当てられません"
 
-msgid "E75: Name too long"
-msgstr "E75: 名前が長過ぎます"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: 以下の文字セットのフォントがありません %s:"
 
-msgid "E76: Too many ["
-msgstr "E76: [ が多過ぎます"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: フォントセット名: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: ファイル名が多過ぎます"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "フォント '%s' は固定幅ではありません"
 
-msgid "E488: Trailing characters"
-msgstr "E488: 余分な文字が後ろにあります"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: フォントセット名: %s"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 未知のマーク"
+#~ msgid "Font0: %s"
+#~ msgstr "フォント0: %s"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: ワイルドカードを展開できません"
+#~ msgid "Font1: %s"
+#~ msgstr "フォント1: %s"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' は 'winminheight' より小さくできません"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' は 'winminwidth' より小さくできません"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "フォント0の幅: %<PRId64>"
 
-msgid "E80: Error while writing"
-msgstr "E80: 書込み中のエラー"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "フォント1の幅: %<PRId64>"
 
-msgid "Zero count"
-msgstr "ゼロカウント"
+#~ msgid "Invalid font specification"
+#~ msgstr "無効なフォント指定です"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: スクリプト以外で<SID>が使われました"
+#~ msgid "&Dismiss"
+#~ msgstr "却下する(&D)"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: 無効な式を受け取りました"
+#~ msgid "no specific match"
+#~ msgstr "マッチするものがありません"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: 領域が保護されているので, 変更できません"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - フォント選択"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans は読込専用ファイルを変更することを許しません"
+#~ msgid "Name:"
+#~ msgstr "名前:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 内部エラーです: %s"
+#~ msgid "Show size in Points"
+#~ msgstr "サイズをポイントで表示する"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
+#~ msgid "Encoding:"
+#~ msgstr "エンコード:"
 
-msgid "E749: empty buffer"
-msgstr "E749: バッファが空です"
+#~ msgid "Font:"
+#~ msgstr "フォント:"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 検索パターンか区切り記号が不正です"
+#~ msgid "Style:"
+#~ msgstr "スタイル:"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 同じ名前のファイルが他のバッファで読込まれています"
+#~ msgid "Size:"
+#~ msgstr "サイズ:"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: オプション '%s' は設定されていません"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ハングルオートマトンエラー"
 
-msgid "E850: Invalid register name"
-msgstr "E850: 無効なレジスタ名です"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat エラー"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "上まで検索したので下に戻ります"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: cscopeデータベース: %s を開くことができません"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "下まで検索したので上に戻ります"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: cscopeデータベースの情報を取得できません"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "暗号キーが必要です: \"%s\""
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Luaライブラリをロードできません."
 
-msgid "empty keys are not allowed"
-msgstr "空のキーは許可されていません"
+#~ msgid "cannot save undo information"
+#~ msgstr "アンドゥ情報が保存できません"
 
-msgid "dictionary is locked"
-msgstr "辞書はロックされています"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: このコマンドは無効です. MzScheme ライブラリをロードできません."
 
-msgid "list is locked"
-msgstr "リストはロックされています"
+#~ msgid "invalid expression"
+#~ msgstr "無効な式です"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "辞書にキー '%s' を追加するのに失敗しました"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "式はコンパイル時に無効にされています"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "インデックスは %s ではなく整数かスライスにしてください"
+#~ msgid "hidden option"
+#~ msgstr "隠しオプション"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "str() もしくは unicode() のインスタンスが期待されているのに %s でした"
+#~ msgid "unknown option"
+#~ msgstr "未知のオプションです"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "bytes() もしくは str() のインスタンスが期待されているのに %s でした"
+#~ msgid "window index is out of range"
+#~ msgstr "範囲外のウィンドウ番号です"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr "long() かそれへ変換可能なものが期待されているのに %s でした"
+#~ msgid "couldn't open buffer"
+#~ msgstr "バッファを開けません"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "int() かそれへ変換可能なものが期待されているのに %s でした"
+#~ msgid "cannot delete line"
+#~ msgstr "行を消せません"
 
-msgid "value is too large to fit into C int type"
-msgstr "C言語の int 型としては値が大き過ぎます"
+#~ msgid "cannot replace line"
+#~ msgstr "行を置換できません"
 
-msgid "value is too small to fit into C int type"
-msgstr "C言語の int 型としては値が小さ過ぎます"
+#~ msgid "cannot insert line"
+#~ msgstr "行を挿入できません"
 
-msgid "number must be greater then zero"
-msgstr "数値は 0 より大きくなければなりません"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "文字列には改行文字を含められません"
 
-msgid "number must be greater or equal to zero"
-msgstr "数値は 0 かそれ以上でなければなりません"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "Scheme値のVimへの変換エラー"
 
-msgid "can't delete OutputObject attributes"
-msgstr "OutputObject属性を消せません"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim エラー: ~a"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "無効な属性です: %s"
+#~ msgid "Vim error"
+#~ msgstr "Vim エラー"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: I/Oオブジェクトの初期化エラー"
+#~ msgid "buffer is invalid"
+#~ msgstr "バッファは無効です"
 
-msgid "failed to change directory"
-msgstr "辞書の変更に失敗しました"
+#~ msgid "window is invalid"
+#~ msgstr "ウィンドウは無効です"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "imp.find_module() が %s を返しました (期待値: 2 要素のタプル)"
+#~ msgid "linenr out of range"
+#~ msgstr "範囲外の行番号です"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "impl.find_module() が %d 要素のタプルを返しました (期待値: 2)"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "サンドボックスでは許されません"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "内部エラー: imp.find_module が NULL を含むタプルを返しました"
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: ライブラリ %s をロードできませんでした"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "vim.Dictionary属性は消せません"
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "このコマンドは無効です, ごめんなさい: Perlライブラリをロードできませんでし"
+#~ "た."
 
-msgid "cannot modify fixed dictionary"
-msgstr "固定された辞書は変更できません"
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: サンドボックスでは Safe モジュールを使用しないPerlスクリプトは禁じら"
+#~ "れています"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "属性 %s は設定できません"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: このVimでは :py3 を使った後に :python を使えません"
 
-msgid "hashtab changed during iteration"
-msgstr "イテレーション中に hashtab が変更されました"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: このコマンドは無効です,ごめんなさい: Pythonライブラリをロードできま"
+#~ "せんでした."
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "シーケンスの要素数には 2 が期待されていましたが %d でした"
+# Added at 07-Feb-2004.
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python を再帰的に実行することはできません"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "リストのコンストラクタはキーワード引数を受け付けません"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: このVimでは :python を使った後に :py3 を使えません"
 
-msgid "list index out of range"
-msgstr "リスト範囲外のインデックスです"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ は文字列のインスタンスでなければなりません"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "内部エラー: vimのリスト要素 %d の取得に失敗しました"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: このコマンドは無効です,ごめんなさい: Rubyライブラリをロードできませ"
+#~ "んでした."
 
-msgid "failed to add item to list"
-msgstr "リストへの要素追加に失敗しました"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: 予期せぬ return です"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "内部エラー: vimのリスト要素 %d はありません"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: 予期せぬ next です"
 
-msgid "internal error: failed to add item to list"
-msgstr "内部エラー: リストへの要素追加に失敗しました"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: 予期せぬ break です"
 
-msgid "cannot delete vim.List attributes"
-msgstr "vim.List 属性は消せません"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: 予期せぬ redo です"
 
-msgid "cannot modify fixed list"
-msgstr "固定されたリストは変更できません"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: rescue の外の retry です"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "無名関数 %s は存在しません"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: 取り扱われなかった例外があります"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "関数 %s がありません"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知のlongjmp状態: %d"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "関数のコンストラクタはキーワード引数を受け付けません"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "実装と定義を切り替える"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "関数 %s の実行に失敗しました"
+#~ msgid "Show base class of"
+#~ msgstr "次のクラスの基底を表示"
 
-msgid "unable to get option value"
-msgstr "オプションの値は取得できません"
+#~ msgid "Show overridden member function"
+#~ msgstr "オーバーライドされたメンバ関数を表示"
 
-msgid "internal error: unknown option type"
-msgstr "内部エラー: 未知のオプション型です"
+#~ msgid "Retrieve from file"
+#~ msgstr "ファイルから回復する"
 
-msgid "problem while switching windows"
-msgstr "ウィンドウを切換中に問題が発生しました"
+#~ msgid "Retrieve from project"
+#~ msgstr "プロジェクトから回復する"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "グローバルオプション %s の設定解除はできません"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "全てのプロジェクトから回復する"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "グローバルな値の無いオプション %s の設定解除はできません"
+#~ msgid "Retrieve"
+#~ msgstr "回復"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "削除されたタブを参照しようとしました"
+#~ msgid "Show source of"
+#~ msgstr "次のソースを表示する"
 
-msgid "no such tab page"
-msgstr "そのようなタブページはありません"
+#~ msgid "Find symbol"
+#~ msgstr "見つけたシンボル"
 
-msgid "attempt to refer to deleted window"
-msgstr "削除されたウィンドウを参照しようとしました"
+#~ msgid "Browse class"
+#~ msgstr "クラスを参照"
 
-msgid "readonly attribute: buffer"
-msgstr "読込専用属性: バッファー"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "階層でクラスを表示"
 
-msgid "cursor position outside buffer"
-msgstr "カーソル位置がバッファの外側です"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "限定された階層でクラスを表示"
 
-msgid "no such window"
-msgstr "そのようなウィンドウはありません"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref の参照先"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "削除されたバッファを参照しようとしました"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref が参照される"
 
-msgid "failed to rename buffer"
-msgstr "バッファ名の変更に失敗しました"
+#~ msgid "Xref has a"
+#~ msgstr "Xref が次のものをもっています"
 
-msgid "mark name must be a single character"
-msgstr "マーク名は1文字のアルファベットでなければなりません"
+#~ msgid "Xref used by"
+#~ msgstr "Xref が使用される"
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "vim.Bufferオブジェクトが期待されているのに %s でした"
+#~ msgid "Show docu of"
+#~ msgstr "次の文章を表示"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "指定されたバッファ %d への切り替えに失敗しました"
+#~ msgid "Generate docu for"
+#~ msgstr "次の文章を生成"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "vim.Windowオブジェクトが期待されているのに %s でした"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "SNiFF+に接続できません. 環境をチェックしてください(sniffemacs が $PATH に"
+#~ "なければなりません).\n"
 
-msgid "failed to find window in the current tab page"
-msgstr "現在のタブには指定されたウィンドウがありませんでした"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 読込中にエラーが発生しました. 切断しました"
 
-msgid "did not switch to the specified window"
-msgstr "指定されたウィンドウに切り替えませんでした"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "現在SNiFF+ の状態は「"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "vim.TabPageオブジェクトが期待されているのに %s でした"
+#~ msgid "not "
+#~ msgstr "未"
 
-msgid "did not switch to the specified tab page"
-msgstr "指定されたタブページに切り替えませんでした"
+#~ msgid "connected"
+#~ msgstr "接続」です"
 
-msgid "failed to run the code"
-msgstr "コードの実行に失敗しました"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 未知の SNiFF+ リクエストです: %s"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: 式評価は有効なpythonオブジェクトを返しませんでした"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: SNiFF+ への接続中のエラーです"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: 返されたpythonオブジェクトをvimの値に変換できませんでした"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ に接続されていません"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "%s vimの辞書型に変換できません"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: SNiFF+ バッファがありません"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "%s をvimの構造体に変換できません"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 書込み中にエラーが発生したので切断しました"
 
-msgid "internal error: NULL reference passed"
-msgstr "内部エラー: NULL参照が渡されました"
+#~ msgid "invalid buffer number"
+#~ msgstr "無効なバッファ番号です"
 
-msgid "internal error: invalid value type"
-msgstr "内部エラー: 無効な値型です"
+#~ msgid "not implemented yet"
+#~ msgstr "まだ実装されていません"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"パスフックの設定に失敗しました: sys.path_hooks がリストではありません\n"
-"すぐに下記を実施してください:\n"
-"- vim.path_hooks を sys.path_hooks へ追加\n"
-"- vim.VIM_SPECIAL_PATH を sys.path へ追加\n"
+#~ msgid "cannot set line(s)"
+#~ msgstr "行を設定できません"
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"パスの設定に失敗しました: sys.path がリストではありません\n"
-"すぐに vim.VIM_SPECIAL_PATH を sys.path に追加してください"
+#~ msgid "invalid mark name"
+#~ msgstr "無効なマーク名です"
+
+#~ msgid "mark not set"
+#~ msgstr "マークは設定されていません"
+
+#~ msgid "row %d column %d"
+#~ msgstr "行 %d 列 %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "行の挿入/追加をできません"
+
+#~ msgid "line number out of range"
+#~ msgstr "範囲外の行番号です"
+
+#~ msgid "unknown flag: "
+#~ msgstr "未知のフラグ: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "未知の vimOption です"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "キーボード割込み"
+
+#~ msgid "vim error"
+#~ msgstr "vim エラー"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "バッファ/ウィンドウ作成コマンドを作成できません: オブジェクトが消去されて"
+#~ "いました"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "コールバックコマンドを登録できません: バッファ/ウィンドウが既に消去されま"
+#~ "した"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL 致命的エラー: reflist 汚染!? vim-dev@vim.org に報告してください"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "コールバックコマンドを登録できません: バッファ/ウィンドウの参照が見つかり"
+#~ "ません"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: このコマンドは無効です,ごめんなさい: Tclライブラリをロードできません"
+#~ "でした."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 終了コード %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "行を取得できません"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "命令サーバの名前を登録できません"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 目的のプログラムへのコマンド送信に失敗しました"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 無効なサーバIDが使われました: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 実体の登録プロパティが不正です. 消去しました!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans はこのGUIでは利用できません\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "このVimにはdiff機能がありません(コンパイル時設定)."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' 使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "大小文字が無視される場合は大文字にするために / を前置してください"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tこのgvimをOLEとして登録する"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tgvimのOLE登録を解除する"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tGUIで起動する (\"gvim\" と同じ)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f or  --nofork\tフォアグラウンド: GUIを始めるときにforkしない"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tウィンドウを開くのに newcli を使用しない"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tI/Oに <device> を使用する"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t.gvimrcの代わりに <gvimrc> を使う"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t暗号化されたファイルを編集する"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tvimを指定した X サーバに接続する"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tXサーバに接続しない"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t可能ならばVimサーバで <files> を編集する"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  同上, サーバが無くても警告文を出力しない"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>\t--remote後 ファイルの編集が終わるのを待つ"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  同上, サーバが無くても警告文を出力しない"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <files>  --remoteでファイル1つにつき1つのタブ"
+#~ "ページを開く"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\tVimサーバに <keys> を送信して終了する"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\tサーバで <expr> を実行して結果を表示する"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVimサーバ名の一覧を表示して終了する"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\tVimサーバ <name> に送信/名前設定する"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(Motifバージョン):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(neXtawバージョン):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(Athenaバージョン):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t<display> でvimを実行する"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t最小化した状態でvimを起動する"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t背景色に <color> を使う(同義: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t前景色に <color> を使う(同義: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tテキスト表示に <font> を使う(同義: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t太字に <font> を使う"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <for>\t斜体字に <font> を使う"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t初期配置に <geom> を使う(同義: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t境界の幅を <width> にする(同義: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <width>  スクロールバーの幅を <width> にする(同義: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <height>\tメニューバーの高さを <height> にする(同義: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t反転映像を使用する(同義: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t反転映像を使用しない(同義: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t特定のリソースを使用する"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(GTK+バージョン):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t異なるGTK widgetでVimを開く"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tウィンドウIDを標準出力に出力する"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <親のタイトル>\tVimを親アプリケーションの中で起動する"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\t異なるWin32 widgetの内部にVimを開く"
+
+#~ msgid "No display"
+#~ msgstr "ディスプレイが見つかりません"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 送信に失敗しました.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 送信に失敗しました. ローカルでの実行を試みています\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d 個 (%d 個中) のファイルを編集しました"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "ディスプレイがありません: 式の送信に失敗しました.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 式の送信に失敗しました.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 無効なコードページです"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: ICの値を設定できません"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: インプットコンテキストの作成に失敗しました"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: インプットメソッドのオープンに失敗しました"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: IMの破壊コールバックを設定できませんでした"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: インプットメソッドはどんなスタイルもサポートしません"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: インプットメソッドは my preedit type をサポートしません"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: スワップファイルの暗号を更新中にエラーが発生しました"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s はこのバージョンのVimでサポートしていない形式で暗号化されています"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "スワップファイルは暗号化されています: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "新しい暗号キーを入力したあとにテキストファイルを保存していない場合は,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "新しい暗号キーを入力してください."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "暗号キーを変えたあとにテキストファイルを保存した場合は, テキストファイルと"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "スワップファイルに同じ暗号キーを使うためにenterだけを押してください."
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "スワップファイルから取得した暗号キーをテキストファイルに使います.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [このVimバージョンでは使用できません]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "このメニューを切り取る"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "ディレクトリ選択ダイアログ"
+
+#~ msgid "Save File dialog"
+#~ msgstr "ファイル保存ダイアログ"
+
+#~ msgid "Open File dialog"
+#~ msgstr "ファイル読込ダイアログ"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr ""
+#~ "E338: コンソールモードではファイルブラウザを使えません, ごめんなさい"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: ファイルを保存中...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 終了しました.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "エラー: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピー"
+#~ "ク時 %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 行が長くなり過ぎました"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 不正な 'mouseshape' です"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "暗号化用のキーを入力してください: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "もう一度同じキーを入力してください: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "キーが一致しません"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Netbeans #2 に接続できません"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Netbeans に接続できません"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: NetBeansの接続情報ファイルのアクセスモードに問題があります: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "Netbeans のソケットを読込み"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: NetBeansはこのGUIには対応していません"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: NetBeansは既に接続しています"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s は読込専用です (強制書込には ! を追加)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: 式評価機能が無効になっています"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "%<PRId64> 行を解放中"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: GUIでは 'term' を変更できません"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: GUIをスタートするには \":gui\" を使用してください"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: GTK+2 GUIでは変更できません"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 無効なフォントです"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: フォントセットを選択できません"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 無効なフォントセットです"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: ワイドフォントを選択できません"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 無効なワイドフォントです"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: マウスはサポートされません"
+
+#~ msgid "cannot open "
+#~ msgstr "開けません "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: ウィンドウを開けません!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "%s のバージョン %<PRId64> が必要です\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "NILを開けません:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "作成できません "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vimは %d で終了します\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "コンソールモードを変更できません?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: コンソールではない??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: -f オプションでシェルを実行できません"
+
+#~ msgid "Cannot execute "
+#~ msgstr "実行できません "
+
+#~ msgid "shell "
+#~ msgstr "シェル "
+
+#~ msgid " returned\n"
+#~ msgstr " 戻りました\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE が小さ過ぎます."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "入出力エラー"
+
+#~ msgid "Message"
+#~ msgstr "メッセージ"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' が80ではないため, 外部コマンドを実行できません"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: プリンタの選択に失敗しました"
+
+#~ msgid "to %s on %s"
+#~ msgstr "%s へ (%s 上の)"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 未知のプリンタオプションです: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 印刷エラー: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "印刷しています: '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 文字セット名 \"%s\" は不正です (フォント名 \"%s\")"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: '%c' は不正な文字です (フォント名 \"%s\")"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 2重のシグナルのため, 終了します\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: 致命的シグナル %s を検知しました\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 致命的シグナルを検知しました\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X のエラーを検出しましたr\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "X display のチェックに失敗しました"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "X display の open がタイムアウトしました"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "sh シェルを実行できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "パイプを作成できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "fork できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "コマンドを中断しました\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP がICE接続を失いました"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "X display の open に失敗しました"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP がsave-yourself要求を処理しています"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP が接続を開始しています"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE接続が失敗したようです"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnectionが失敗しました: %s"
+
+#~ msgid "At line"
+#~ msgstr "行"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "vim32.dll をロードできませんでした"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIMエラー"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "DLLから関数ポインタを取得できませんでした"
+
+#~ msgid "shell returned %d"
+#~ msgstr "シェルがコード %d で終了しました"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: イベント %s を検知\n"
+
+#~ msgid "close"
+#~ msgstr "閉じる"
+
+#~ msgid "logoff"
+#~ msgstr "ログオフ"
+
+#~ msgid "shutdown"
+#~ msgstr "シャットダウン"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: コマンドがありません"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXEが $PATH の中に見つかりません.\n"
+#~ "外部コマンドの終了後に一時停止をしません.\n"
+#~ "詳細は  :help win32-vimrun  を参照してください."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vimの警告"
+
+#~ msgid "Error file"
+#~ msgstr "エラーファイル"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: 等価クラスを含むNFA構築に失敗しました!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) 現在横断中のブランチに十分なメモリを割り当てられません!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "警告: 単語リスト \"%s_%s.spl\" および \"%s_ascii.spl\" は見つかりません"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "%s 内の変換はサポートされていません"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: メモリが足りないので、単語リストは不完全です"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: タグファイルのパスが %s に切り捨てられました\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "新しいシェルを起動します\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "空の選択領域のかわりにCUT_BUFFER0が使用されました"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "可能なアンドゥはありません: とりあえず続けます"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr ""
+#~ "E832: 非暗号化ファイルが暗号化されたアンドゥファイルを使ってます: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: 暗号化されたアンドゥファイルの解読に失敗しました: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: アンドゥファイルが暗号化されています: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 ビット GUI 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64 ビット GUI 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 ビット GUI 版"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " in Win32s モード"
+
+#~ msgid " with OLE support"
+#~ msgstr " with OLE サポート"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64 ビット コンソール 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 ビット コンソール 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 ビット 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 ビット MS-DOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 ビット MS-DOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "OpenVMS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Big 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "通常 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Small 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Tiny 版 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "with GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "with GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "with X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "with X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "with X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "with Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "with GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "with Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "with Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "with (クラシック) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "     システム gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       ユーザ gvimrc: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "    第2ユーザ gvimrc: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "    第3ユーザ gvimrc: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    システムメニュー: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "コンパイラ: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "詳細はメニューの ヘルプ→孤児 を参照して下さい   "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "モード無で実行中, タイプした文字が挿入されます"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "メニューの 編集→全体設定→挿入(初心者)モード切替 "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              でモード有に       "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "メニューの 編集→全体設定→Vi互換モード切替      "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              でVimとして動作    "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "   警告: Windows 95/98/Me を検出  "
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr " 詳細な情報は          :help windows95<Enter> "
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "複数のVimで編集する (&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "1つのVimで編集する (&V)"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Vimで差分を表示する"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Vimで編集する (&V)"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "起動済のVimで編集する - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "選択したファイルをVimで編集する"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "プロセスの作成に失敗: gvimが環境変数PATH上にあるか確認してください!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll エラー"
+
+#~ msgid "Path length too long!"
+#~ msgstr "パスが長すぎます!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 未知のフォントセット: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 未知のフォント: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: フォント \"%s\" は固定幅ではありません"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: ライブラリの関数 %s をロードできませんでした"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: ヘブライ語は使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: ペルシア語は使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: アラビア語は使用不可能です: コンパイル時に無効にされています\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: %s という名前の登録されたサーバはありません"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: ディスプレイを開けません"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 無効な式を受け取りました"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 領域が保護されているので, 変更できません"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans は読込専用ファイルを変更することを許しません"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "暗号キーが必要です: \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "空のキーは許可されていません"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "辞書はロックされています"
+
+#~ msgid "list is locked"
+#~ msgstr "リストはロックされています"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "辞書にキー '%s' を追加するのに失敗しました"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "インデックスは %s ではなく整数かスライスにしてください"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr ""
+#~ "str() もしくは unicode() のインスタンスが期待されているのに %s でした"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "bytes() もしくは str() のインスタンスが期待されているのに %s でした"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr "long() かそれへ変換可能なものが期待されているのに %s でした"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr "int() かそれへ変換可能なものが期待されているのに %s でした"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "C言語の int 型としては値が大き過ぎます"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "C言語の int 型としては値が小さ過ぎます"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "数値は 0 より大きくなければなりません"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "数値は 0 かそれ以上でなければなりません"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "OutputObject属性を消せません"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "無効な属性です: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: I/Oオブジェクトの初期化エラー"
+
+#~ msgid "failed to change directory"
+#~ msgstr "辞書の変更に失敗しました"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "imp.find_module() が %s を返しました (期待値: 2 要素のタプル)"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr "impl.find_module() が %d 要素のタプルを返しました (期待値: 2)"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "内部エラー: imp.find_module が NULL を含むタプルを返しました"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "vim.Dictionary属性は消せません"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "固定された辞書は変更できません"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "属性 %s は設定できません"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "イテレーション中に hashtab が変更されました"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr "シーケンスの要素数には 2 が期待されていましたが %d でした"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "リストのコンストラクタはキーワード引数を受け付けません"
+
+#~ msgid "list index out of range"
+#~ msgstr "リスト範囲外のインデックスです"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "内部エラー: vimのリスト要素 %d の取得に失敗しました"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "リストへの要素追加に失敗しました"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "内部エラー: vimのリスト要素 %d はありません"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "内部エラー: リストへの要素追加に失敗しました"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "vim.List 属性は消せません"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "固定されたリストは変更できません"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "無名関数 %s は存在しません"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "関数 %s がありません"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "関数のコンストラクタはキーワード引数を受け付けません"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "関数 %s の実行に失敗しました"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "ウィンドウを切換中に問題が発生しました"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "グローバルオプション %s の設定解除はできません"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "グローバルな値の無いオプション %s の設定解除はできません"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "削除されたタブを参照しようとしました"
+
+#~ msgid "no such tab page"
+#~ msgstr "そのようなタブページはありません"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "削除されたウィンドウを参照しようとしました"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "読込専用属性: バッファー"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "カーソル位置がバッファの外側です"
+
+#~ msgid "no such window"
+#~ msgstr "そのようなウィンドウはありません"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "削除されたバッファを参照しようとしました"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "バッファ名の変更に失敗しました"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "マーク名は1文字のアルファベットでなければなりません"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "vim.Bufferオブジェクトが期待されているのに %s でした"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "指定されたバッファ %d への切り替えに失敗しました"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "vim.Windowオブジェクトが期待されているのに %s でした"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "現在のタブには指定されたウィンドウがありませんでした"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "指定されたウィンドウに切り替えませんでした"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "vim.TabPageオブジェクトが期待されているのに %s でした"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "指定されたタブページに切り替えませんでした"
+
+#~ msgid "failed to run the code"
+#~ msgstr "コードの実行に失敗しました"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: 式評価は有効なpythonオブジェクトを返しませんでした"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: 返されたpythonオブジェクトをvimの値に変換できませんでした"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "%s vimの辞書型に変換できません"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "%s をvimの構造体に変換できません"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "内部エラー: NULL参照が渡されました"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "内部エラー: 無効な値型です"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "パスフックの設定に失敗しました: sys.path_hooks がリストではありません\n"
+#~ "すぐに下記を実施してください:\n"
+#~ "- vim.path_hooks を sys.path_hooks へ追加\n"
+#~ "- vim.VIM_SPECIAL_PATH を sys.path へ追加\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "パスの設定に失敗しました: sys.path がリストではありません\n"
+#~ "すぐに vim.VIM_SPECIAL_PATH を sys.path に追加してください"

--- a/src/nvim/po/ja.sjis.po
+++ b/src/nvim/po/ja.sjis.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-06 13:50+0900\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-07-06 15:00+0900\n"
 "Last-Translator: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
 "Language-Team: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
@@ -23,164 +23,204 @@ msgstr ""
 "Content-Type: text/plain; charset=cp932\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() が空パスワードで呼び出されました"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "オプションの値は取得できません"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "内部エラー: 未知のオプション型です"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish暗号のビッグ/リトルエンディアンが間違っています"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256のテストに失敗しました"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish暗号のテストに失敗しました"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[場所リスト]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Quickfixリスト]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: autocommandがコマンドの停止を引き起こしました"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: バッファを1つも作成できないので, 終了します..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: バッファを作成できないので, 他のを使用します..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 解放されたバッファはありません"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 削除されたバッファはありません"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 破棄されたバッファはありません"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 個のバッファが解放されました"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d 個のバッファが解放されました"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 個のバッファが削除されました"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d 個のバッファが削除されました"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 個のバッファが破棄されました"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d 個のバッファが破棄されました"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 最後のバッファは解放できません"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 変更されたバッファはありません"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: リスト表\示されるバッファはありません"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: バッファ %<PRId64> はありません"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 最後のバッファを越えて移動はできません"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 最初のバッファより前へは移動できません"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: バッファ %<PRId64> の変更は保存されていません (! で変更を破棄)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 最後のバッファは解放できません"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: ファイル名のリストが長過ぎます"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: バッファ %<PRId64> が見つかりません"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s に複数の該当がありました"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: %s に該当するバッファはありませんでした"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "行 %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: この名前のバッファは既にあります"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [変更あり]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未編集]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新ファイル]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[読込エラー]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[読専]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[読込専用]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 行 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64> (全体 %<PRId64>) --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[無名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ヘルプ"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[ヘルプ]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[プレビュー]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全て"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "末尾"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "先頭"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -188,9 +228,11 @@ msgstr ""
 "\n"
 "# バッファリスト:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[下書き]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -198,144 +240,200 @@ msgstr ""
 "\n"
 "--- サイン ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s のサイン:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  識別子=%d  名前=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: コロンがありません"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 不正なモードです"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 数値が必要です"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 不正なパーセンテージです"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: %<PRId64> 以上のバッファはdiffできません"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 一時ファイルの読込もしくは書込ができません"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 差分を作成できません "
 
-msgid "Patch file"
-msgstr "パッチファイル"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: patchの出力を読込めません"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: diffの出力を読込めません"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 現在のバッファは差分モードではありません"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: 差分モードである他のバッファは変更可能\です"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 差分モードである他のバッファはありません"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: 差分モードのバッファが2個以上あるので、どれを使うか特定できません"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: バッファ \"%s\" が見つかりません"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: バッファ \"%s\" は差分モードではありません"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 予\期せずバッファが変更変更されました"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 合字にEscapeは使用できません"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: キーマップファイルが見つかりません"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :source で取込むファイル以外では :loadkeymap を使えません"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: 空のキーマップエントリ"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " キーワード補完 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X モード (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 行(全体)補完 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr "ファイル名補完 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " タグ補完 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " パスパターン補完 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定義補完 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " 辞書補完 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " シソ\ーラス補完 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " コマンドライン補完 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " ユーザ定義補完 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 綴り修正候補 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "段落の最後にヒット"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: 補間関数がウィンドウを変更しました"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: 補完関数がテキストを削除しました"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary' オプションが空です"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus' オプションが空です"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "辞書をスキャン中: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (挿入) スクロール(^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (置換) スクロール (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "スキャン中: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "タグをスキャン中."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 追加中"
 
@@ -343,459 +441,574 @@ msgstr " 追加中"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 検索中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "始めに戻る"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "他の行の単語"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "唯一の該当"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "%d 番目の該当 (全該当 %d 個中)"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "%d 番目の該当"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: 予\期せぬ文字が :let にありました"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: リストのインデックスが範囲外です: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 未定義の変数です: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']' が見つかりません"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s の引数はリスト型でなければなりません"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s の引数はリスト型または辞書型でなければなりません"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: 辞書型に空のキーを使うことはできません"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: リスト型が必要です"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: 辞書型が必要です"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 関数の引数が多過ぎます: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: 辞書型にキーが存在しません: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 関数 %s は定義済です, 再定義するには ! を追加してください"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: 辞書型内にエントリが既に存在します"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: 関数参照型が要求されます"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: [:] を辞書型と組み合わせては使えません"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: 異なった型の変数です %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 未知の関数です: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 不正な変数名です: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: 浮動小数点数を文字列として扱っています"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: ターゲットがリスト型内の要素よりも少ないです"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: ターゲットがリスト型内の要素よりも多いです"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "リスト型の値に2つ以上の ; が検出されました"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: %s の値を一覧表\示できません"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: リスト型と辞書型以外はインデックス指定できません"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] は最後でなければいけません"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] にはリスト型の値が必要です"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: リスト型変数にターゲットよりも多い要素があります"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: リスト型変数に十\分な数の要素がありません"
 
 #
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for の後に \"in\" がありません"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: カッコ '(' がありません: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: その変数はありません: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: (アン)ロックするには変数の入れ子が深過ぎます"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' の後に ':' がありません"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: リスト型はリスト型としか比較できません"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: リスト型には無効な操作です"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: 辞書型は辞書型としか比較できません"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: 辞書型には無効な操作です"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: 関数参照型は関数参照型としか比較できません"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: 関数参照型には無効な操作です"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: '%' を浮動小数点数と組み合わせては使えません"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' が見つかりません"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: 関数参照型はインデックスできません"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: オプション名がありません: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 未知のオプションです: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 引用符 (\") がありません: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 引用符 (') がありません: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: リスト型にカンマがありません: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: リスト型の最後に ']' がありません: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: 辞書型にコロンがありません: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: 辞書型に重複キーがあります: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: 辞書型にカンマがありません: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: 辞書型の最後に '}' がありません: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 表\示するには変数の入れ子が深過ぎます"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: 関数の引数が多過ぎます: %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: 関数の無効な引数です: %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: 未知の関数です: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: 関数の引数が少な過ぎます: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: スクリプト以外で<SID>が使われました: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: 辞書用関数が呼ばれましたが辞書がありません: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: 数値か浮動小数点数が必要です"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "add() の引数"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 引数が多過ぎます"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() は挿入モードでしか利用できません"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: キーは既に存在します: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "extend() の引数"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "map() の引数"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "filter() の引数"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 行: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 未知の関数です: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"決定(&O)\n"
-"キャンセル(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() が inputsave() よりも多く呼ばれました"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "insert() の引数"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 範囲指定は許可されていません"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len() には無効な型です"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: ストライド(前進量)が 0 です"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 開始位置が終了位置を越えました"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<空>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Vim サーバへの接続がありません"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: %s へ送ることができません"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: サーバの応答がありません"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "remove() の引数"
 
 # Added at 10-Mar-2004.
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: シンボリックリンクが多過ぎます (循環している可能\性があります)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "reverse() の引数"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: クライアントへ送ることができません"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "sort() の引数"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "add() の引数"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: ソ\ートの比較関数が失敗しました"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: ソ\ートの比較関数が失敗しました"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(無効)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 一時ファイル書込中にエラーが発生しました"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: 浮動小数点数を数値として扱っています"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: 関数参照型を数値として扱っています。"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: リスト型を数値として扱っています"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 辞書型を数値として扱っています"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: 関数参照型を文字列として扱っています"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: リスト型を文字列として扱っています"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: 辞書型を文字列として扱っています"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 変数の型が一致しません: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: 変数 %s を削除できません"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: 関数参照型変数名は大文字で始まらなければなりません: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: 変数名が既存の関数名と衝突します: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 値がロックされています: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "不明"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: %s の値を変更できません"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: コピーを取るには変数の入れ子が深過ぎます"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: 未定義の関数です: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '(' がありません: %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: ここでは g: は使えません"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 不正な引数です: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: 引数名が重複しています: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction がありません"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: 関数名が変数名と衝突します: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: 関数 %s を再定義できません: 使用中です"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 関数名がスクリプトのファイル名と一致しません: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 関数名が要求されます"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 関数 %s を削除できません: 使用中です"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 関数呼出の入れ子数が 'maxfuncdepth' を超えました"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s を実行中です"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s が中断されました"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s が #%<PRId64> を返しました"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s が %s を返しました"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "%s の実行を継続中です"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: 関数外に :return がありました"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -803,6 +1016,7 @@ msgstr ""
 "\n"
 "# グローバル変数:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -810,82 +1024,104 @@ msgstr ""
 "\n"
 "\tLast set from "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "古いファイルはありません"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  16進数 %02x,  8進数 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 16進数 %04x, 8進数 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 16進数 %08x, 8進数 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 行をそれ自身には移動できません"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 行が移動されました"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> 行が移動されました"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> 行がフィルタ処理されました"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *フィルタ* autocommandは現在のバッファを変更してはいけません"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[最後の変更が保存されていません]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 行目: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: エラーが多過ぎるので, 以降はスキップします"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "viminfoファイル \"%s\"%s%s%s を読込み中 "
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 情報"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " マーク"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " 旧ファイル群"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失敗"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: viminfoファイルが書込みできません: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: viminfoファイル %s を保存できません!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "viminfoファイル \"%s\" を書込み中"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# この viminfo ファイルは Vim %s によって生成されました.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -893,40 +1129,47 @@ msgstr ""
 "# 変更する際には十\分注意してください!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# このファイルが書かれた時の 'encoding' の値\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "不正な先頭文字です"
 
-msgid "Save As"
-msgstr "別名で保存"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "ファイルを部分的に保存しますか?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: バッファを部分的に保存するには ! を使ってください"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "既存のファイル \"%s\" を上書きしますか?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "スワップファイル \"%s\" が存在します. 上書きを強制しますか?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: スワップファイルが存在します: %s (:silent! を追加で上書)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: バッファ %<PRId64> には名前がありません"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ファイルは保存されませんでした: 'write' オプションにより無効です"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -935,6 +1178,7 @@ msgstr ""
 "\"%s\" には 'readonly' オプションが設定されています.\n"
 "上書き強制をしますか?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -945,68 +1189,83 @@ msgstr ""
 "それでも恐らく書き込むことは可能\です.\n"
 "継続しますか?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" は読込専用です (強制書込には ! を追加)"
 
-msgid "Edit File"
-msgstr "ファイルを編集"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: autocommandが予\期せず新しいバッファ %s を削除しました"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 数ではない引数が :z に渡されました"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvimではシェルコマンドを使えません"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正規表\現は文字で区切ることができません"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "%s に置換しますか? (y/n/a/q/l/^E/^Y)"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(割込まれました) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 箇所該当しました"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 箇所置換しました"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> 箇所該当しました"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> 箇所置換しました"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " (計 1 行内)"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " (計 %<PRId64> 行内)"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global を再帰的には使えません"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: globalコマンドに正規表\現が指定されていません"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "パターンが全ての行で見つかりました: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "パターンは見つかりませんでした: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1016,265 +1275,335 @@ msgstr ""
 "# 最後に置換された文字列:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 慌てないでください"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 残念ですが '%s' のヘルプが %s にはありません"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 残念ですが %s にはヘルプがありません"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "残念ですがヘルプファイル \"%s\" が見つかりません"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: ディレクトリではありません: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 書込み用に %s を開けません"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 読込用に %s を開けません"
 
 # Added at 29-Apr-2004.
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 1つの言語のヘルプファイルに複数のエンコードが混在しています: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: タグ \"%s\" がファイル %s/%s に重複しています"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未知のsignコマンドです: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: sign名がありません"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: signの定義が多数見つかりました"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 無効なsignのテキストです: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 未知のsignです: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: signの番号がありません"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 無効なバッファ名です: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
-# Added at 27-Jan-2004.
-msgid " (NOT FOUND)"
-msgstr "  (見つかりません)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (非サポート)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[削除済]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "デバッグモードに入ります. 続けるには \"cont\" と入力してください."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "行 %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "ブレークポイント \"%s%s\" 行 %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: ブレークポイントが見つかりません: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "ブレークポイントが定義されていません"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  行 %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 初めに \":profile start {fname}\" を実行してください"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "変更を \"%s\" に保存しますか?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "無題"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: バッファ \"%s\" の変更は保存されていません"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "警告: 予\期せず他バッファへ移動しました (autocommands を調べてください)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 編集するファイルは1つしかありません"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 最初のファイルより前には行けません"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 最後のファイルを越えて後には行けません"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: そのコンパイラには対応していません: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "\"%s\" を \"%s\" から検索中"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "\"%s\" を検索中"
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "'runtimepath' の中には見つかりません: \"%s\""
 
-msgid "Source Vim script"
-msgstr "Vimスクリプトの取込み"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "ディレクトリは取込めません: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\" を取込めません"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "行 %<PRId64>: \"%s\" を取込めません"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" を取込中"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "行 %<PRId64>: %s を取込中"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "%s の取込を完了"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "モード行"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 引数"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 引数"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "環境変数"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "エラーハンドラ"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 警告: 行区切が不正です. ^M がないのでしょう"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding が取込スクリプト以外で使用されました"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish が取込スクリプト以外で使用されました"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "現在の %s言語: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 言語を \"%s\" に設定できません"
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Exモードに入ります. ノーマルに戻るには\"visual\"と入力してください."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: ファイルの終了位置"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: コマンドが再帰的過ぎます"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 例外が捕捉されませんでした: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "取込ファイルの最後です"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "関数の最後です"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: ユーザ定義コマンドのあいまいな使用です"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: エディタのコマンドではありません"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 逆さまの範囲が指定されました"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "逆さまの範囲が指定されました, 入替えますか?"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: w もしくは w>> を使用してください"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: このバージョンではこのコマンドは利用できません, ごめんなさい"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: ファイル名は 1 つにしてください"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "編集すべきファイルが 1 個ありますが, 終了しますか?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "編集すべきファイルがあと %d 個ありますが, 終了しますか?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 編集すべきファイルが 1 個あります"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 編集すべきファイルがあと %<PRId64> 個あります"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1282,293 +1611,339 @@ msgstr ""
 "\n"
 "    名前        引数 範囲  補完      定義"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "ユーザ定義コマンドが見つかりませんでした"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 属性は定義されていません"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 引数の数が無効です"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: カウントを2重指定することはできません"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: カウントの省略値が無効です"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -補完のための引数が必要です"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 無効な属性です: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 無効なコマンド名です"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: ユーザ定義コマンドは英大文字で始まらなければなりません"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: 予\約名なので, ユーザ定義コマンドに利用できません"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: そのユーザ定義コマンドはありません: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 無効な補完指定です: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 補完引数はカスタム補完でしか使用できません"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: カスタム補完には引数として関数が必要です"
 
-msgid "unknown"
-msgstr "不明"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: カラースキーム '%s' が見つかりません"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Vim 使いさん、やあ!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 最後のタブページを閉じることはできません"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "既にタブページは1つしかありません"
 
-msgid "Edit File in new window"
-msgstr "新しいウィンドウでファイルを編集します"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "タブページ %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "スワップファイルがありません"
 
-msgid "Append File"
-msgstr "追加ファイル"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: バッファが修正されているので, ディレクトリを変更できません (! を追加で"
 "上書)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 前のディレクトリはありません"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize には2つの数値の引数が必要です"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "ウィンドウ位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: このプラットホームにはウィンドウ位置の取得機能\は実装されていません"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos には2つの数値の引数が必要です"
 
-msgid "Save Redirection"
-msgstr "リダイレクトを保存します"
-
-msgid "Save View"
-msgstr "ビューを保存します"
-
-msgid "Save Session"
-msgstr "セッション情報を保存します"
-
-msgid "Save Setup"
-msgstr "設定を保存します"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: ディレクトリを作成できません: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" が存在します (上書するには ! を追加してください)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" を書込み用として開けません"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 引数は1文字の英字か引用符 (' か `) でなければいけません"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal の再帰利用が深くなり過ぎました"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< は +eval 機能\が無いと利用できません"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: '#'を置き換える副ファイルの名前がありません"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: \"<afile>\"を置き換えるautocommandのファイル名がありません"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: \"<abuf>\"を置き換えるautocommandバッファ番号がありません"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: \"<amatch>\"を置き換えるautocommandの該当名がありません"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: \"<sfile>\"を置き換える :source 対象ファイル名がありません"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: \"<slnum>\"を置き換える行番号がありません"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr ""
 "E499: '%' や '#' が無名ファイルなので \":p:h\" を伴わない使い方はできません"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 空文字列として評価されました"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: viminfoファイルを読込用として開けません"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: このバージョンに合字はありません"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 'Vim' で始まる例外は :throw できません"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "例外が発生しました: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "例外が収束しました: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "例外が破棄されました: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "例外が捕捉されました: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s により未決定状態が生じました"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s が再開しました"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s が破棄されました"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "例外"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "エラーと割込み"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "エラー"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "割込み"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if の入れ子が深過ぎます"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :if のない :endif があります"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :if のない :else があります"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :if のない :elseif があります"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 複数の :else があります"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :else の後に :elseif があります"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while や :for の入れ子が深過ぎます"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :while や :for のない :continue があります"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :while や :for のない :break があります"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :endfor を :while と組み合わせています"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :endwhile を :for と組み合わせています"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try の入れ子が深過ぎます"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :try のない :catch があります"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :finally の後に :catch があります"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :try のない :finally があります"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 複数の :finally があります"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :try のない :endtry です"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: 関数の外に :endfunction がありました"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 現在は他のバッファを編集することは許されません"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: 現在はバッファ情報を変更することは許されません"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "タグ名"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " ファイル種類\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "オプション 'history' がゼロです"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1577,230 +1952,303 @@ msgstr ""
 "\n"
 "# %s 項目の履歴 (新しいものから古いものへ):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "コマンドライン"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "検索文字列"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "式"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "入力行"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar がコマンド長を超えました"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: アクティブなウィンドウかバッファが削除されました"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: パスが長過ぎて補完できません"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: 無効なパスです: '**[数値]' はpathの最後か '%s' が続いてないといけませ"
+"ん."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpathには \"%s\" というファイルがありません"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: pathには \"%s\" というファイルがありません"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: cdpathにはこれ以上 \"%s\" というファイルがありません"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: パスにはこれ以上 \"%s\" というファイルがありません"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: autocommandがバッファかバッファ名を変更しました"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "不正なファイル名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr " はディレクトリです"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr " はファイルではありません"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr " はデバイスです ('opendevice' オプションで回避できます)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[新ファイル]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[新規ディレクトリ]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[ファイル過大]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[認可がありません]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre autocommand がファイルを読込不可にしました"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre autocommand は現在のバッファを変えられません"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 標準入力から読込中...\n"
 
-msgid "Reading from stdin..."
-msgstr "標準入力から読込み中..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 変換がファイルを読込不可にしました"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[FIFO/ソ\ケット]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[FIFO]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[ソ\ケット]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[キャラクタ・デバイス]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR無]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[長行分割]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未変換]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[変換済]"
 
-msgid "[blowfish]"
-msgstr "[blowfish暗号化]"
-
-msgid "[crypted]"
-msgstr "[暗号化]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[%<PRId64> 行目で変換エラー]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[%<PRId64> 行目の不正なバイト]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[読込エラー]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "変換に必要な一時ファイルが見つかりません"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert' による変換が失敗しました"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "'charconvert' の出力を読込めませんでした"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: ファイルが未知の方法で暗号化されています"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: acwriteバッファの該当するautocommandは存在しません"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 保存するバッファをautocommandが削除か解放しました"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: autocommandが予\期せぬ方法で行数を変更しました"
 
-# Added at 19-Jan-2004.
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeansは未変更のバッファを上書することは許可していません"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeansバッファの一部を書き出すことはできません"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "はファイルでも書込み可能\デバイスでもありません"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "'opendevice' オプションによりデバイスへの書き込みはできません"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "は読込専用です (強制書込には ! を追加)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: バックアップファイルを保存できません (! を追加で強制保存)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: バックアップファイルを閉じる際にエラーが発生しました (! を追加で強制)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: バックアップ用ファイルを読込めません (! を追加で強制読込)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: バックアップファイルを作れません (! を追加で強制作成)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: バックアップファイルを作れません (! を追加で強制作成)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: リソ\ースフォークが失われるかもしれません (! を追加で強制)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 保存用一時ファイルが見つかりません"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 変換できません (! を追加で変換せずに保存)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: リンクされたファイルに書込めません"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 書込み用にファイルを開けません"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: fsync に失敗しました"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 閉じることに失敗"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 書込みエラー, 変換失敗 (上書するには 'fenc' を空にしてください)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にしてくださ"
-"い)"
+"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にして"
+"ください)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 書込みエラー, (ファイルシステムが満杯?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 変換エラー"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "行 %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[デバイス]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 追加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 書込み"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: 原本ファイルを保存できません"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: 空の原本ファイルをtouchできません"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: バックアップファイルを消せません"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1808,110 +2256,134 @@ msgstr ""
 "\n"
 "警告: 原本ファイルが失われたか変更されました\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ファイルの保存に成功するまでエディタを終了しないでください!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dosフォーマット]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[macフォーマット]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unixフォーマット]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 文字"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 文字"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> 文字"
-
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[最終行が不完全]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 読込んだ後にファイルに変更がありました!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "本当に上書きしますか"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: \"%s\" を書込み中のエラーです"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: \"%s\" を閉じる時にエラーです"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: \"%s\" を読込中のエラーです"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: autocommand の FileChangedShell がバッファを削除しました"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: ファイル \"%s\" は既に存在しません"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: ファイル \"%s\" が変更されVimのバッファも変更されました"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "詳細は \":help W12\" を参照してください"
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: ファイル \"%s\" は編集開始後に変更されました"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "詳細は \":help W11\" を参照してください"
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: ファイル \"%s\" のモードが編集開始後に変更されました"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "詳細は \":help W16\" を参照してください"
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: ファイル \"%s\" は編集開始後に作成されました"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1919,39 +2391,48 @@ msgstr ""
 "&OK\n"
 "ファイル読込(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: \"%s\" をリロードする準備ができませんでした"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\" はリロードできませんでした"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--削除済--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "autocommand: %s <バッファ=%d> が自動的に削除されます"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: そのグループはありません: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * の後に不正な文字がありました: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: そのようなイベントはありません: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: そのようなグループもしくはイベントはありません: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1959,536 +2440,760 @@ msgstr ""
 "\n"
 "--- Auto-Commands ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <バッファ=%d>: 無効なバッファ番号です "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 全てのイベントに対してのautocommandは実行できません"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "該当するautocommandは存在しません"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocommandの入れ子が深過ぎます"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto commands for \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s を実行しています"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { がありません."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } がありません."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 折畳みがありません"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 現在の 'foldmethod' では折畳みを作成できません"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 現在の 'foldmethod' では折畳みを削除できません"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld 行が折畳まれました "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 読込バッファへ追加"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 再帰的マッピング"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s というグローバル短縮入力は既に存在します"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s というグローバルマッピングは既に存在します"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s という短縮入力は既に存在します"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s というマッピングは既に存在します"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "短縮入力は見つかりませんでした"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "マッピングは見つかりませんでした"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 不正なモード"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: GUI用のプロセスの起動に失敗しました"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--バッファに行がありません--"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: 子プロセスがGUIの起動に失敗しました"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: コマンドが中断されました"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUIを開始できません"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 引数が必要です"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: \"%s\"から読込むことができません"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ の後は / か ? か & でなければなりません"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 有効なフォントが見つからないので, GUIを開始できません"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' が無効です"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' に設定された値が無効です"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: %s の色を割り当てられません"
-
-msgid "No match at cursor, finding next"
-msgstr "カーソ\ルの位置にマッチはありません, 次を検索しています"
-
-msgid "<cannot open> "
-msgstr "<開けません> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: フォント %s を取得できません"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 現在のディレクトリに戻れません"
-
-msgid "Pathname:"
-msgstr "パス名:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 現在のディレクトリを取得できません"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "キャンセル"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "スクロールバー: 画像を取得できませんでした."
-
-msgid "Vim dialog"
-msgstr "Vim ダイアログ"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: メッセージとコールバックのある BalloonEval を作成できません"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"はい(&Y)\n"
-"いいえ(&N)\n"
-"キャンセル(&C)"
+"E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"
 
-msgid "Input _Methods"
-msgstr "インプットメソ\ッド"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif がありません"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 検索と置換..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry がありません"
 
-msgid "VIM - Search..."
-msgstr "VIM - 検索..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile がありません"
 
-msgid "Find what:"
-msgstr "検索文字列:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor がありません"
 
-msgid "Replace with:"
-msgstr "置換文字列:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :while のない :endwhile があります"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "正確に該当するものだけ"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor のない :for があります"
 
-#. match case button
-msgid "Match case"
-msgstr "大文字/小文字を区別する"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: ファイルが存在します (! を追加で上書)"
 
-msgid "Direction"
-msgstr "方向"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: コマンドが失敗しました"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "上"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 内部エラーです"
 
-msgid "Down"
-msgstr "下"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "割込まれました"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "次を検索"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 無効なアドレスです"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "置換"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 無効な引数です"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "全て置換"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: セッションマネージャから \"die\" 要求を受け取りました\n"
-
-msgid "Close"
-msgstr "閉じる"
-
-msgid "New tab"
-msgstr "新規タブページ"
-
-msgid "Open Tab..."
-msgstr "タブページを開く..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: メインウィンドウが不意に破壊されました\n"
-
-msgid "&Filter"
-msgstr "フィルタ(&F)"
-
-msgid "&Cancel"
-msgstr "キャンセル(&C)"
-
-msgid "Directories"
-msgstr "ディレクトリ"
-
-msgid "Filter"
-msgstr "フィルタ"
-
-msgid "&Help"
-msgstr "ヘルプ(&H)"
-
-msgid "Files"
-msgstr "ファイル"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "選択"
-
-msgid "Find &Next"
-msgstr "次を検索(&N)"
-
-msgid "&Replace"
-msgstr "置換(&R)"
-
-msgid "Replace &All"
-msgstr "全て置換(&A)"
-
-msgid "&Undo"
-msgstr "アンドゥ(&U)"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: タイトルが \"%s\" のウィンドウは見つかりません"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 無効な引数です: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 引数はサポートされません: \"-%s\"; OLE版を使用してください."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 無効な式です: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: MDIアプリの中ではウィンドウを開けません"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 無効な範囲です"
 
-msgid "Close tab"
-msgstr "タブページを閉じる"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 無効なコマンドです"
 
-msgid "Open tab..."
-msgstr "タブページを開く"
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "検索文字列 ('\\' を検索するには '\\\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "検索・置換 ('\\' を検索するには '\\\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "使われません"
-
-msgid "Directory\t*.nothing\n"
-msgstr "ディレクトリ\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 色指定が正しくないのでエントリを割り当てられません"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: 以下の文字セットのフォントがありません %s:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" はディレクトリです"
 
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 無効なスクロール量です"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
+msgstr ""
+
+#: ../globals.h:1022
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: フォントセット名: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "フォント '%s' は固定幅ではありません"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: \"%s\"() のライブラリ呼出に失敗しました"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: マークに無効な行番号が指定されていました"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: マークは設定されていません"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 'modifiable' がオフなので, 変更できません"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: スクリプトの入れ子が深過ぎます"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 副ファイルはありません"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: そのような短縮入力はありません"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! は許可されていません"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUIは使用不可能\です: コンパイル時に無効にされています"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: フォントセット名: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: そのような名のハイライトグループはありません: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: まだテキストが挿入されていません"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 以前にコマンド行がありません"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: そのようなマッピングはありません"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 該当はありません"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font0: %s"
-msgstr "フォント0: %s"
+msgid "E480: No match: %s"
+msgstr "E480: 該当はありません: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ファイル名がありません"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 正規表\現置換がまだ実行されていません"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: コマンドがまだ実行されていません"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 正規表\現がまだ実行されていません"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 範囲指定は許可されていません"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: ウィンドウに十\分な高さもしくは幅がありません"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font1: %s"
-msgstr "フォント1: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: ファイル %s を作成できません"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 一時ファイルの名前を取得できません"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
+msgid "E484: Can't open file %s"
+msgstr "E484: ファイル \"%s\" を開けません"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "フォント0の幅: %<PRId64>"
+msgid "E485: Can't read file %s"
+msgstr "E485: ファイル %s を読込めません"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[最後の変更が保存されていません]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 引数が空です"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 数値が要求されています"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "フォント1の幅: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: エラーファイル %s を開けません"
 
-msgid "Invalid font specification"
-msgstr "無効なフォント指定です"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: メモリが尽き果てました!"
 
-msgid "&Dismiss"
-msgstr "却下する(&D)"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "パターンは見つかりませんでした"
 
-msgid "no specific match"
-msgstr "マッチするものがありません"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: パターンは見つかりませんでした: %s"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - フォント選択"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 引数は正の値でなければなりません"
 
-msgid "Name:"
-msgstr "名前:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 前のディレクトリに戻れません"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "サイズをポイントで表\示する"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: エラーはありません"
 
-msgid "Encoding:"
-msgstr "エンコード:"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 場所リストはありません"
 
-msgid "Font:"
-msgstr "フォント:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 該当文字列が破損しています"
 
-msgid "Style:"
-msgstr "スタイル:"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 不正な正規表\現プログラムです"
 
-msgid "Size:"
-msgstr "サイズ:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' オプションが設定されています (! を追加で上書き)"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ハングルオートマトンエラー"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 読取専用変数 \"%s\" には値を設定できません"
 
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: サンドボックスでは変数 \"%s\" に値を設定できません"
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: エラーファイルの読込中にエラーが発生しました"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: サンドボックスでは許されません"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: ここでは許可されません"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: スクリーンモードの設定には対応していません"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 無効なスクロール量です"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' オプションが空です"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: sign のデータを読込めませんでした"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: スワップファイルのクローズ時エラーです"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: タグスタックが空です"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: コマンドが複雑過ぎます"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名前が長過ぎます"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [ が多過ぎます"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: ファイル名が多過ぎます"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 余分な文字が後ろにあります"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 未知のマーク"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: ワイルドカードを展開できません"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' は 'winminheight' より小さくできません"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' は 'winminwidth' より小さくできません"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 書込み中のエラー"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "ゼロカウント"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: スクリプト以外で<SID>が使われました"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 内部エラーです: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: バッファが空です"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 検索パターンか区切り記号が不正です"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 同じ名前のファイルが他のバッファで読込まれています"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: オプション '%s' は設定されていません"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: 無効なレジスタ名です"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "上まで検索したので下に戻ります"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "下まで検索したので上に戻ります"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: コロンがありません"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 不正な構\文要素です"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 数値が必要です"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "%d ページ"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "印刷するテキストがありません"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "印刷中: ページ %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " コピー %d (全 %d 中)"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "印刷しました: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "印刷が中止されました"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: PostScript出力ファイルの書込みエラーです"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: ファイル \"%s\" を開けません"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: PostScriptのリソ\ースファイル \"%s\" を読込めません"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: ファイル \"%s\" は PostScript リソ\ースファイルではありません"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: ファイル \"%s\" は対応していない PostScript リソ\ースファイルです"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: リソ\ースファイル \"%s\" はバージョンが異なります"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 互換性の無いマルチバイトエンコーディングと文字セットです"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: マルチバイトエンコーディングでは printmbcharset を空にできません"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr ""
 "E675: マルチバイト文字を印刷するためのデフォルトフォントが指定されていません"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript出力用のファイルを開けません"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: ファイル \"%s\" を開けません"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: PostScriptのリソ\ースファイル \"prolog.ps\" が見つかりません"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: PostScriptのリソ\ースファイル \"cidfont.ps\" が見つかりません"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: PostScriptのリソ\ースファイル \"%s.ps\" が見つかりません"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: 印刷エンコード \"%s\" へ変換できません"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "プリンタに送信中..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScriptファイルの印刷に失敗しました"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "印刷ジョブを送信しました."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "新データベースを追加"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "パターンのクエリーを追加"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "このメッセージを表\示する"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "接続を終了する"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "全ての接続を再初期化する"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "接続を表\示する"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 使用方法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "このcscopeコマンドは分割ウィンドウではサポートされません.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 使用法: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: タグが見つかりません"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) エラー: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat エラー"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s はディレクトリ及び有効なcscopeのデータベースではありません"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "cscopeデータベース %s を追加"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: cscopeの接続 %<PRId64> を読込み中のエラーです"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知のcscope検索型です"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscopeパイプを作成できませんでした"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: cscopeの起動準備(fork)に失敗しました"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection への setpgid に失敗しました"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection の実行に失敗しました"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: to_fp の fdopen に失敗しました"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fr_fp の fdopen に失敗しました"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: cscopeプロセスを起動できませんでした"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: cscope接続に失敗しました"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: 無効な cscopequickfix フラグ %c の %c です"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: cscopeクエリー %s of %s に該当がありませんでした"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscopeコマンド:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (使用法: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2510,32 +3215,31 @@ msgstr ""
 "       s: このCシンボルを探す\n"
 "       t: このテキスト文字列を探す\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: cscopeデータベース: %s を開くことができません"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: cscopeデータベースの情報を取得できません"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重複するcscopeデータベースは追加されませんでした"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope接続 %s が見つかりませんでした"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope接続 %s が閉じられました"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches で致命的なエラーです"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope タグ: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2543,377 +3247,87 @@ msgstr ""
 "\n"
 "   #   行番号"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "ファイル名 / 文脈 / 行\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: cscopeエラー: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "全てのcscopeデータベースをリセットします"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "cscope接続がありません\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    データベース名                      prepend パス\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Luaライブラリをロードできません."
-
-msgid "cannot save undo information"
-msgstr "アンドゥ情報が保存できません"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr "E815: このコマンドは無効です. MzScheme ライブラリをロードできません."
-
-msgid "invalid expression"
-msgstr "無効な式です"
-
-msgid "expressions disabled at compile time"
-msgstr "式はコンパイル時に無効にされています"
-
-msgid "hidden option"
-msgstr "隠しオプション"
-
-msgid "unknown option"
-msgstr "未知のオプションです"
-
-msgid "window index is out of range"
-msgstr "範囲外のウィンドウ番号です"
-
-msgid "couldn't open buffer"
-msgstr "バッファを開けません"
-
-msgid "cannot delete line"
-msgstr "行を消せません"
-
-msgid "cannot replace line"
-msgstr "行を置換できません"
-
-msgid "cannot insert line"
-msgstr "行を挿入できません"
-
-msgid "string cannot contain newlines"
-msgstr "文字列には改行文字を含められません"
-
-msgid "error converting Scheme values to Vim"
-msgstr "Scheme値のVimへの変換エラー"
-
-msgid "Vim error: ~a"
-msgstr "Vim エラー: ~a"
-
-msgid "Vim error"
-msgstr "Vim エラー"
-
-msgid "buffer is invalid"
-msgstr "バッファは無効です"
-
-msgid "window is invalid"
-msgstr "ウィンドウは無効です"
-
-msgid "linenr out of range"
-msgstr "範囲外の行番号です"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "サンドボックスでは許されません"
-
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: ライブラリ %s をロードできませんでした"
-
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"このコマンドは無効です, ごめんなさい: Perlライブラリをロードできませんでした."
-
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: サンドボックスでは Safe モジュールを使用しないPerlスクリプトは禁じられ"
-"ています"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: このVimでは :py3 を使った後に :python を使えません"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: このコマンドは無効です,ごめんなさい: Pythonライブラリをロードできません"
-"でした."
-
-# Added at 07-Feb-2004.
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python を再帰的に実行することはできません"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: このVimでは :python を使った後に :py3 を使えません"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ は文字列のインスタンスでなければなりません"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: このコマンドは無効です,ごめんなさい: Rubyライブラリをロードできませんで"
-"した."
-
-msgid "E267: unexpected return"
-msgstr "E267: 予\期せぬ return です"
-
-msgid "E268: unexpected next"
-msgstr "E268: 予\期せぬ next です"
-
-msgid "E269: unexpected break"
-msgstr "E269: 予\期せぬ break です"
-
-msgid "E270: unexpected redo"
-msgstr "E270: 予\期せぬ redo です"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: rescue の外の retry です"
-
-msgid "E272: unhandled exception"
-msgstr "E272: 取り扱われなかった例外があります"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知のlongjmp状態: %d"
-
-msgid "Toggle implementation/definition"
-msgstr "実装と定義を切り替える"
-
-msgid "Show base class of"
-msgstr "次のクラスの基底を表\示"
-
-msgid "Show overridden member function"
-msgstr "オーバーライドされたメンバ関数を表\示"
-
-msgid "Retrieve from file"
-msgstr "ファイルから回復する"
-
-msgid "Retrieve from project"
-msgstr "プロジェクトから回復する"
-
-msgid "Retrieve from all projects"
-msgstr "全てのプロジェクトから回復する"
-
-msgid "Retrieve"
-msgstr "回復"
-
-msgid "Show source of"
-msgstr "次のソ\ースを表\示する"
-
-msgid "Find symbol"
-msgstr "見つけたシンボル"
-
-msgid "Browse class"
-msgstr "クラスを参照"
-
-msgid "Show class in hierarchy"
-msgstr "階層でクラスを表\示"
-
-msgid "Show class in restricted hierarchy"
-msgstr "限定された階層でクラスを表\示"
-
-msgid "Xref refers to"
-msgstr "Xref の参照先"
-
-msgid "Xref referred by"
-msgstr "Xref が参照される"
-
-msgid "Xref has a"
-msgstr "Xref が次のものをもっています"
-
-msgid "Xref used by"
-msgstr "Xref が使用される"
-
-msgid "Show docu of"
-msgstr "次の文章を表\示"
-
-msgid "Generate docu for"
-msgstr "次の文章を生成"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"SNiFF+に接続できません. 環境をチェックしてください(sniffemacs が $PATH になけ"
-"ればなりません).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 読込中にエラーが発生しました. 切断しました"
-
-msgid "SNiFF+ is currently "
-msgstr "現在SNiFF+ の状態は「"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "接続」です"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 未知の SNiFF+ リクエストです: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: SNiFF+ への接続中のエラーです"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ に接続されていません"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: SNiFF+ バッファがありません"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 書込み中にエラーが発生したので切断しました"
-
-msgid "invalid buffer number"
-msgstr "無効なバッファ番号です"
-
-msgid "not implemented yet"
-msgstr "まだ実装されていません"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "行を設定できません"
-
-msgid "invalid mark name"
-msgstr "無効なマーク名です"
-
-msgid "mark not set"
-msgstr "マークは設定されていません"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "行 %d 列 %d"
-
-msgid "cannot insert/append line"
-msgstr "行の挿入/追加をできません"
-
-msgid "line number out of range"
-msgstr "範囲外の行番号です"
-
-msgid "unknown flag: "
-msgstr "未知のフラグ: "
-
-msgid "unknown vimOption"
-msgstr "未知の vimOption です"
-
-msgid "keyboard interrupt"
-msgstr "キーボード割込み"
-
-msgid "vim error"
-msgstr "vim エラー"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr ""
-"バッファ/ウィンドウ作成コマンドを作成できません: オブジェクトが消去されていま"
-"した"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"コールバックコマンドを登録できません: バッファ/ウィンドウが既に消去されました"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL 致命的エラー: reflist 汚染!? vim-dev@vim.org に報告してください"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"コールバックコマンドを登録できません: バッファ/ウィンドウの参照が見つかりませ"
-"ん"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: このコマンドは無効です,ごめんなさい: Tclライブラリをロードできませんで"
-"した."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 終了コード %d"
-
-msgid "cannot get line"
-msgstr "行を取得できません"
-
-msgid "Unable to register a command server name"
-msgstr "命令サーバの名前を登録できません"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: 目的のプログラムへのコマンド送信に失敗しました"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 無効なサーバIDが使われました: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 実体の登録プロパティが不正です. 消去しました!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "未知のオプション引数です"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "編集引数が多過ぎます"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "引数がありません"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "オプション引数の後にゴミがあります"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "\"+command\", \"-c command\", \"--cmd command\" の引数が多過ぎます"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "無効な引数です: "
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d 個のファイルが編集を控えています\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans はこのGUIでは利用できません\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "このVimにはdiff機能\がありません(コンパイル時設定)."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' 使用不可能\です: コンパイル時に無効にされています\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "スクリプトファイルを再び開いてみます: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "読込用として開けません"
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "スクリプト出力用を開けません"
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 端末への出力ではありません\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 警告: 端末からの入力ではありません\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "vimrc前のコマンドライン"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: \"%s\"から読込むことができません"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2921,18 +3335,23 @@ msgstr ""
 "\n"
 "より詳細な情報は: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[ファイル..]    あるファイルを編集する"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               標準入力からテキストを読込む"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t タグ         タグが定義されたところから編集する"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  最初のエラーで編集する"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2942,9 +3361,11 @@ msgstr ""
 "\n"
 "使用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [引数] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2952,13 +3373,7 @@ msgstr ""
 "\n"
 "   もしくは:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"大小文字が無視される場合は大文字にするために / を前置してください"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2968,315 +3383,189 @@ msgstr ""
 "\n"
 "引数:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tこのあとにはファイル名だけ"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tワイルドカードを展開しない"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tこのgvimをOLEとして登録する"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tgvimのOLE登録を解除する"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tGUIで起動する (\"gvim\" と同じ)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f or  --nofork\tフォアグラウンド: GUIを始めるときにforkしない"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tViモード (\"vi\" と同じ)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tExモード (\"ex\" と同じ)"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\t改良Exモード"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tサイレント(バッチ)モード (\"ex\" 専用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\t差分モード (\"vidiff\" と同じ)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tイージーモード (\"evim\" と同じ, モード無)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t読込専用モード (\"view\" と同じ)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t制限モード (\"rvim\" と同じ)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t変更 (ファイル保存時) をできないようにする"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tテキストの編集を行なえないようにする"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tバイナリモード"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLispモード"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVi互換モード: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tVi非互換モード: 'nocompatible"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][fname]\t\tログ出力設定 [レベル N] [ログファイル名 fname]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tデバッグモード"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tスワップファイルを使用せずメモリだけ"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tスワップファイルを列挙し終了"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (ファイル名)\tクラッシュしたセッションを復帰"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t-rと同じ"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tウィンドウを開くのに newcli を使用しない"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tI/Oに <device> を使用する"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tアラビア語モードで起動する"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tヘブライ語モードで起動する"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tペルシア語モードで起動する"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t端末を <terminal> に設定する"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t.vimrcの代わりに <vimrc> を使う"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t.gvimrcの代わりに <gvimrc> を使う"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tプラグインスクリプトをロードしない"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tN 個タブページを開く(省略値: ファイルにつき1個)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tN 個ウィンドウを開く(省略値: ファイルにつき1個)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t-oと同じだが垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tファイルの最後からはじめる"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t<lnum> 行からはじめる"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\tvimrcをロードする前に <command> を実行する"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t最初のファイルをロード後 <command> を実行する"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t最初のファイルをロード後ファイル <session> を取込む"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tファイル <scriptin> からノーマルコマンドを読込む"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t入力した全コマンドをファイル <scriptout> に追加する"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t入力した全コマンドをファイル <scriptout> に保存する"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t暗号化されたファイルを編集する"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tvimを指定した X サーバに接続する"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tXサーバに接続しない"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t可能\ならばVimサーバで <files> を編集する"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  同上, サーバが無くても警告文を出力しない"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>\t--remote後 ファイルの編集が終わるのを待つ"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  同上, サーバが無くても警告文を出力しない"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <files>  --remoteでファイル1つにつき1つのタブ"
-"ページを開く"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\tVimサーバに <keys> を送信して終了する"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\tサーバで <expr> を実行して結果を表\示する"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVimサーバ名の一覧を表\示して終了する"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\tVimサーバ <name> に送信/名前設定する"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <file>\t起動にかかった時間の詳細を <file> へ出力する"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t.viminfoの代わりに <viminfo> を使う"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h or  --help\tヘルプ(このメッセージ)を表\示し終了する"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tバージョン情報を表\示し終了する"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(Motifバージョン):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(neXtawバージョン):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(Athenaバージョン):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t<display> でvimを実行する"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t最小化した状態でvimを起動する"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t背景色に <color> を使う(同義: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t前景色に <color> を使う(同義: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tテキスト表\示に <font> を使う(同義: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t太字に <font> を使う"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <for>\t斜体字に <font> を使う"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t初期配置に <geom> を使う(同義: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t境界の幅を <width> にする(同義: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <width>  スクロールバーの幅を <width> にする(同義: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\tメニューバーの高さを <height> にする(同義: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t反転映像を使用する(同義: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t反転映像を使用しない(同義: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t特定のリソ\ースを使用する"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvimによって解釈される引数(GTK+バージョン):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t異なるGTK widgetでVimを開く"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tウィンドウIDを標準出力に出力する"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <親のタイトル>\tVimを親アプリケーションの中で起動する"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\t異なるWin32 widgetの内部にVimを開く"
-
-msgid "No display"
-msgstr "ディスプレイが見つかりません"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 送信に失敗しました.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 送信に失敗しました. ローカルでの実行を試みています\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d 個 (%d 個中) のファイルを編集しました"
-
-msgid "No display: Send expression failed.\n"
-msgstr "ディスプレイがありません: 式の送信に失敗しました.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 式の送信に失敗しました.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "マークが設定されていません"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\" に該当するマークがありません"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3285,6 +3574,7 @@ msgstr ""
 "mark   行   列 ファイル/テキスト"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3293,6 +3583,7 @@ msgstr ""
 " jump   行   列 ファイル/テキスト"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3300,6 +3591,7 @@ msgstr ""
 "\n"
 "変更   行    列  テキスト"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3308,6 +3600,7 @@ msgstr ""
 "# ファイルマーク:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3315,6 +3608,7 @@ msgstr ""
 "\n"
 "# ジャンプリスト (新しいものが先):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3322,88 +3616,84 @@ msgstr ""
 "\n"
 "# ファイル内マークの履歴 (新しいものから古いもの):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>' が見つかりません"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 無効なコードページです"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: ICの値を設定できません"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: インプットコンテキストの作成に失敗しました"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: インプットメソ\ッドのオープンに失敗しました"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: IMの破壊コールバックを設定できませんでした"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: インプットメソ\ッドはどんなスタイルもサポートしません"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: インプットメソ\ッドは my preedit type をサポートしません"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: ブロックがロックされていません"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: スワップファイル読込時にシークエラーです"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: スワップファイルの読込みエラーです"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: スワップファイル書込み時にシークエラーです"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: スワップファイルの書込みエラーです"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: スワップファイルが既に存在します (symlinkによる攻撃?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: ブロック 0 を取得できません?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: ブロック 1 を取得できません?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: ブロック 2 を取得できません?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: スワップファイルの暗号を更新中にエラーが発生しました"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: おっと, スワップファイルが失われました!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: スワップファイルの名前を変えられません"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: \"%s\" のスワップファイルを開けないのでリカバリは不可能\です"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): ブロック 0 を取得できませんでした??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: %s にはスワップファイルが見つかりません"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "使用するスワップファイルの番号を入力してください(0 で終了): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s を開けません"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "ブロック 0 を読込めません "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3411,22 +3701,28 @@ msgstr ""
 "\n"
 "恐らく変更がされていないかVimがスワップファイルを更新していません."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " Vimのこのバージョンでは使用できません.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Vimのバージョン3.0を使用してください.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s はVimのスワップファイルではないようです"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " このコンピュータでは使用できません.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "このファイルは次の場所で作られました "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3434,104 +3730,85 @@ msgstr ""
 ",\n"
 "もしくはファイルが損傷しています."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr ""
-"E833: %s はこのバージョンのVimでサポートしていない形式で暗号化されています"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " は損傷しています (ページサイズが最小値を下回っています).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "スワップファイル \"%s\" を使用中"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原本ファイル \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原本ファイルが変更されています"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "スワップファイルは暗号化されています: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"新しい暗号キーを入力したあとにテキストファイルを保存していない場合は,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"新しい暗号キーを入力してください."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"暗号キーを変えたあとにテキストファイルを保存した場合は, テキストファイルと"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"スワップファイルに同じ暗号キーを使うためにenterだけを押してください."
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: %s からブロック 1 を読込めません"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???多くの行が失われています"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???行数が間違っています"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???ブロックが空です"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???行が失われています"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ブロック 1 のIDが間違っています(%s が.swpファイルでない?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???ブロックがありません"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? ここから ???END までの行が破壊されているようです"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? ここから ???END までの行が挿入か削除されたようです"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: リカバリが割込まれました"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: リカバリの最中にエラーが検出されました; ???で始まる行を参照してください"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "詳細は \":help E312\" を参照してください"
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "リカバリが終了しました. 全てが正しいかチェックしてください."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3539,12 +3816,15 @@ msgstr ""
 "\n"
 "(変更をチェックするために, このファイルを別の名前で保存した上で\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "原本ファイルとの diff を実行すると良いでしょう)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "復元完了. バッファの内容はファイルと同じになりました."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3554,43 +3834,52 @@ msgstr ""
 "それから.swpファイルを削除してください\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "スワップファイルから取得した暗号キーをテキストファイルに使います.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "スワップファイルが複数見つかりました:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   現在のディレクトリ:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   ある名前を使用中:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   ディレクトリ "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- なし --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            所有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   日付: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             日付: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [from Vim version 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [Vimのスワップファイルではないようです]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "        ファイル名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3598,12 +3887,15 @@ msgstr ""
 "\n"
 "          変更状態: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "あり"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "なし"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3611,9 +3903,11 @@ msgstr ""
 "\n"
 "          ユーザ名: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   ホスト名: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3621,6 +3915,7 @@ msgstr ""
 "\n"
 "          ホスト名: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3628,16 +3923,11 @@ msgstr ""
 "\n"
 "        プロセスID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (まだ実行中)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [このVimバージョンでは使用できません]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3645,75 +3935,97 @@ msgstr ""
 "\n"
 "         [このコンピュータでは使用できません]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [読込めません]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [開けません]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: スワップファイルが無いので維持できません"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "ファイルが維持されます"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 維持に失敗しました"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 無効なlnumです: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 行 %<PRId64> を見つけられません"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ポインタブロックのIDが間違っています 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx は 0 であるべきです"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新されたブロックが多過ぎるかも?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: ポインタブロックのIDが間違っています 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "ブロック 1 は消された?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 行 %<PRId64> が見つかりません"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: ポインタブロックのIDが間違っています"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count がゼロです"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行番号が範囲外です: %<PRId64> 超えています"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: ブロック %<PRId64> の行カウントが間違っています"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "スタックサイズが増えます"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: ポインタブロックのIDが間違っています 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: \"%s\" のシンボリックリンクがループになっています"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3721,14 +4033,15 @@ msgstr ""
 "\n"
 "次の名前でスワップファイルを見つけました \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "次のファイルを開いている最中 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      スワップファイルよりも新しいです!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3740,15 +4053,19 @@ msgstr ""
 "    この場合には, 変更をした際に最終的に, 同じファイルの異なる\n"
 "    2つのインスタンスができてしまうことに注意してください."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  終了するか, 注意しながら続けてください.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) このファイルの編集セッションがクラッシュした.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    この場合には \":recover\" か \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3756,9 +4073,11 @@ msgstr ""
 "\"\n"
 "    を使用して変更をリカバーします(\":help recovery\" を参照).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    既にこれを行なったのならば, スワップファイル \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3766,18 +4085,23 @@ msgstr ""
 "\"\n"
 "    を消せばこのメッセージを回避できます.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "スワップファイル \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" が既にあります!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "スワップファイルが既に存在します!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3791,6 +4115,7 @@ msgstr ""
 "終了する(&Q)\n"
 "中止する(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3806,34 +4131,56 @@ msgstr ""
 "終了する(&Q)\n"
 "中止する(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: スワップファイルが多数見つかりました"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: メニューアイテムのパスの部分がサブメニューではありません"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: メニューは他のモードにだけあります"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: \"%s\" というメニューはありません"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: メニュー名が空です"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: メニューパスはサブメニューを生じるべきではありません"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: メニューバーには直接メニューアイテムを追加できません"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 区切りはメニューパスの一部ではありません"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3841,60 +4188,73 @@ msgstr ""
 "\n"
 "--- メニュー ---"
 
-msgid "Tear off this menu"
-msgstr "このメニューを切り取る"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: メニューパスはメニューアイテムを生じなければいけません"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: メニューが見つかりません: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s にはメニューが定義されていません"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: メニューパスはサブメニューを生じなければいけません"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: メニューが見つかりません - メニュー名を確認してください"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "%s の処理中にエラーが検出されました:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "行 %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 無効なレジスタ名: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "日本語メッセージ翻訳/監修: 村岡 太郎 <koron.kaoriya@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "割込み: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "続けるにはENTERを押すかコマンドを入力してください"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 行 %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 継続 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: 画面/ページ/行 下, b/u/k: 上, q: 終了 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "質問"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3902,6 +4262,17 @@ msgstr ""
 "はい(&Y)\n"
 "いいえ(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"はい(&Y)\n"
+"いいえ(&N)\n"
+"キャンセル(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3915,272 +4286,175 @@ msgstr ""
 "全て放棄(&D)\n"
 "キャンセル(&C)"
 
-msgid "Select Directory dialog"
-msgstr "ディレクトリ選択ダイアログ"
-
-msgid "Save File dialog"
-msgstr "ファイル保存ダイアログ"
-
-msgid "Open File dialog"
-msgstr "ファイル読込ダイアログ"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: コンソ\ールモードではファイルブラウザを使えません, ごめんなさい"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() の引数が不十\分です"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: printf() の引数には浮動少数点数が期待されています"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf() の引数が多過ぎます"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 警告: 読込専用ファイルを変更します"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "番号と<Enter>を入力するかマウスでクリックしてください (空でキャンセル): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "番号と<Enter>を入力してください (空でキャンセル): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 行 追加しました"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 行 削除しました"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> 行 追加しました"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> 行 削除しました"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (割込まれました)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "ビーッ!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: ファイルを保存中...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 終了しました.\n"
-
-msgid "ERROR: "
-msgstr "エラー: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピーク時 %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 行が長くなり過ぎました"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "実行のためにシェルを呼出し中: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: コロンがありません"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 不正なモードです"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 不正な 'mouseshape' です"
-
-msgid "E548: digit expected"
-msgstr "E548: 数値が必要です"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 不正なパーセンテージです"
-
-msgid "Enter encryption key: "
-msgstr "暗号化用のキーを入力してください: "
-
-msgid "Enter same key again: "
-msgstr "もう一度同じキーを入力してください: "
-
-msgid "Keys don't match!"
-msgstr "キーが一致しません"
-
-msgid "E854: path too long for completion"
-msgstr "E854: パスが長過ぎて補完できません"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: 無効なパスです: '**[数値]' はpathの最後か '%s' が続いてないといけませ"
-"ん."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpathには \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: pathには \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: cdpathにはこれ以上 \"%s\" というファイルがありません"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: パスにはこれ以上 \"%s\" というファイルがありません"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Netbeans #2 に接続できません"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Netbeans に接続できません"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: NetBeansの接続情報ファイルのアクセスモードに問題があります: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "Netbeans のソ\ケットを読込み"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: NetBeansはこのGUIには対応していません"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: NetBeansは既に接続しています"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s は読込専用です (強制書込には ! を追加)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: カーソ\ルの位置には識別子がありません"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' オプションが空です"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: 式評価機能\が無効になっています"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "警告: 使用している端末はハイライトできません"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: カーソ\ルの位置には文字列がありません"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 現在の 'foldmethod' では折畳みを消去できません"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 変更リストが空です"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 変更リストの先頭"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 行が %s で 1 回処理されました"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 行が %s で %d 回処理されました"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行が %s で 1 回処理されました"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行が %s で %d 回処理されました"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> 行がインデントされます... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 行をインデントしました "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> 行をインデントしました "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: まだレジスタを使用していません"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "ヤンクできません; とにかく消去"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 行が変更されました"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> 行が変更されました"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "%<PRId64> 行を解放中"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "1 行のブロックがヤンクされました"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 行がヤンクされました"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "%<PRId64> 行のブロックがヤンクされました"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> 行がヤンクされました"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: レジスタ %s には何もありません"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4188,9 +4462,11 @@ msgstr ""
 "\n"
 "--- レジスタ ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "不正なレジスタ名"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4198,160 +4474,182 @@ msgstr ""
 "\n"
 "# レジスタ:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 列; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> バイト"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト %<PRId64> / %<PRId64>"
-
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 %<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
+"選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / "
+"%<PRId64> バイト"
 
+#: ../ops.c:5105
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / "
+"%<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト "
+"%<PRId64> / %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 "
+"%<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=%N ページ"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Vim を使ってくれてありがとう"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 未知のオプションです"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: オプションはサポートされていません"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: modeline では許可されません"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: キーコードが設定されていません"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = の後には数字が必要です"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: termcap 内に見つかりません"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正な文字です <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' には空文字列を設定できません"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: GUIでは 'term' を変更できません"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: GUIをスタートするには \":gui\" を使用してください"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' と 'patchmode' が同じです"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: 'listchars'の値に矛盾があります"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: 'fillchars'の値に矛盾があります"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: GTK+2 GUIでは変更できません"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: コロンがありません"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 文字列の長さがゼロです"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> の後に数字がありません"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: カンマがありません"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: ' の値を指定しなければなりません"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 表\示できない文字かワイド文字を含んでいます"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 無効なフォントです"
-
-msgid "E597: can't select fontset"
-msgstr "E597: フォントセットを選択できません"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 無効なフォントセットです"
-
-msgid "E533: can't select wide font"
-msgstr "E533: ワイドフォントを選択できません"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 無効なワイドフォントです"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> の後に不正な文字があります"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: カンマが必要です"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' は空であるか %s を含む必要があります"
 
-msgid "E538: No mouse support"
-msgstr "E538: マウスはサポートされません"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 式が終了していません"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 要素が多過ぎます"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: グループが釣合いません"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: プレビューウィンドウが既に存在します"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: アラビア文字にはUTF-8が必要なので, ':set encoding=utf-8' してください"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 最低 %d の行数が必要です"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 最低 %d のカラム幅が必要です"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 未知のオプションです: %s"
@@ -4359,10 +4657,12 @@ msgstr "E355: 未知のオプションです: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: 数字が必要です: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4370,6 +4670,7 @@ msgstr ""
 "\n"
 "--- 端末コード ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4377,6 +4678,7 @@ msgstr ""
 "\n"
 "--- グローバルオプション値 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4384,6 +4686,7 @@ msgstr ""
 "\n"
 "--- ローカルオプション値 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4391,140 +4694,21 @@ msgstr ""
 "\n"
 "--- オプション ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp エラー"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': %s に対応する文字がありません"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': セミコロンの後に余分な文字があります: %s"
 
-msgid "cannot open "
-msgstr "開けません "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: ウィンドウを開けません!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "%s のバージョン %<PRId64> が必要です\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "NILを開けません:\n"
-
-msgid "Cannot create "
-msgstr "作成できません "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vimは %d で終了します\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "コンソ\ールモードを変更できません?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: コンソ\ールではない??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: -f オプションでシェルを実行できません"
-
-msgid "Cannot execute "
-msgstr "実行できません "
-
-msgid "shell "
-msgstr "シェル "
-
-msgid " returned\n"
-msgstr " 戻りました\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE が小さ過ぎます."
-
-msgid "I/O ERROR"
-msgstr "入出力エラー"
-
-msgid "Message"
-msgstr "メッセージ"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' が80ではないため, 外部コマンドを実行できません"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: プリンタの選択に失敗しました"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "%s へ (%s 上の)"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 未知のプリンタオプションです: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 印刷エラー: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "印刷しています: '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 文字セット名 \"%s\" は不正です (フォント名 \"%s\")"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: '%c' は不正な文字です (フォント名 \"%s\")"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 2重のシグナルのため, 終了します\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: 致命的シグナル %s を検知しました\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 致命的シグナルを検知しました\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X のエラーを検出しましたr\n"
-
-msgid "Testing the X display failed"
-msgstr "X display のチェックに失敗しました"
-
-msgid "Opening the X display timed out"
-msgstr "X display の open がタイムアウトしました"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"セキュリティコンテキストを取得できません "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"セキュリティコンテキストを設定できません "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4532,13 +4716,7 @@ msgstr ""
 "\n"
 "シェルを実行できません "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"sh シェルを実行できません\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4546,451 +4724,484 @@ msgstr ""
 "\n"
 "シェルが値を返しました "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"パイプを作成できません\n"
+"セキュリティコンテキストを取得できません "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"fork できません\n"
+"セキュリティコンテキストを設定できません "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"コマンドを中断しました\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP がICE接続を失いました"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "X display の open に失敗しました"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP がsave-yourself要求を処理しています"
-
-msgid "XSMP opening connection"
-msgstr "XSMP が接続を開始しています"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE接続が失敗したようです"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnectionが失敗しました: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: pathには \"%s\" というファイルがありません"
 
-msgid "At line"
-msgstr "行"
-
-msgid "Could not load vim32.dll!"
-msgstr "vim32.dll をロードできませんでした"
-
-msgid "VIM Error"
-msgstr "VIMエラー"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "DLLから関数ポインタを取得できませんでした"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "シェルがコード %d で終了しました"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: イベント %s を検知\n"
-
-msgid "close"
-msgstr "閉じる"
-
-msgid "logoff"
-msgstr "ログオフ"
-
-msgid "shutdown"
-msgstr "シャットダウン"
-
-msgid "E371: Command not found"
-msgstr "E371: コマンドがありません"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXEが $PATH の中に見つかりません.\n"
-"外部コマンドの終了後に一時停止をしません.\n"
-"詳細は  :help win32-vimrun  を参照してください."
-
-msgid "Vim Warning"
-msgstr "Vimの警告"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: フォーマット文字列に %%%c が多過ぎます"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: フォーマット文字列に予\期せぬ %%%c がありました"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: フォーマット文字列に ] がありません"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: フォーマット文字列では %%%c はサポートされません"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: フォーマット文字列の前置に無効な %%%c があります"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: フォーマット文字列に無効な %%%c があります"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' にパターンが指定されていません"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: ディレクトリ名が無いか空です"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 要素がもうありません"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d of %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行が削除されました)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: quickfix スタックの末尾です"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: quickfix スタックの先頭です"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "エラー一覧 %d of %d; %d 個エラー"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 'buftype' オプションが設定されているので書込みません"
 
-msgid "Error file"
-msgstr "エラーファイル"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: ファイル名が無いか無効なパターンです"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "ファイル \"%s\" を開けません"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: バッファは読み込まれませんでした"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: 文字列かリストが必要です"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: 無効な項目です: %s%%[]"
 
 #
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ の後に ] がありません"
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: %s%%( が釣り合っていません"
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: %s( が釣り合っていません"
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: %s) が釣り合っていません"
 
 #
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( はココでは許可されていません"
 
 #
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 その他はココでは許可されていません"
 
 #
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: %s%%[ の後に ] がありません"
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] が空です"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: パターンが長過ぎます"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: \\z( が多過ぎます"
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: %s( が多過ぎます"
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: \\z( が釣り合っていません"
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: %s@ の後に不正な文字がありました"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: 複雑な %s{...} が多過ぎます"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61:%s* が入れ子になっています"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62:%s%c が入れ子になっています"
 
 #
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: \\_ の無効な使用方法です"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64:%s%c の後になにもありません"
 
 #
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: 不正な後方参照です"
 
 #
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: \\z の後に不正な文字がありました"
 
 #
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: %s%%[dxouU] の後に不正な文字がありました"
 
 #
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: %s%% の後に不正な文字がありました"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...} 内に文法エラーがあります"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部の部分該当:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
-"E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。"
-"正規表\現エンジンは自動選択されます。"
+"E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。正規表\現エンジンは自動選"
+"択されます。"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) 期待より早く正規表\現の終端に到達しました"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA 正規表\現) 位置が誤っています: %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) 期待より早く正規表\現の終端に到達しました"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) 未知のオペレータです: '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) 未知のオペレータです: '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: 等価クラスを含むNFA構\築に失敗しました!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) 未知のオペレータです: '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFA 正規表\現) 繰り返しの制限回数を読込中にエラー"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (NFA 正規表\現) 繰り返し の後に 繰り返し はできません!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA 正規表\現) '(' が多過ぎます"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA 正規表\現) \\z( が多過ぎます"
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA 正規表\現) 終端記号がありません"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) スタックをポップできません!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
 msgstr ""
-"E875: (NFA 正規表\現) (後置文字列をNFAに変換中に) "
-"スタックに残されたステートが多過ぎます"
+"E875: (NFA 正規表\現) (後置文字列をNFAに変換中に) スタックに残されたステートが"
+"多過ぎます"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA 正規表\現) NFA全体を保存するには空きスペースが足りません"
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) 現在横断中のブランチに十\分なメモリを割り当てられません!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
-msgstr "NFA正規表\現エンジン用のログファイルを書込用として開けません。"
-"ログは標準出力に出力します。"
+msgstr ""
+"NFA正規表\現エンジン用のログファイルを書込用として開けません。ログは標準出力に"
+"出力します。"
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) ログファイル %s を開けません!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "NFA正規表\現エンジン用のログファイルを書込用として開けません。"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " 仮想置換"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 置換"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反転"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 挿入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (挿入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (置換)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (仮想置換)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " ヘブライ"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " アラビア"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (言語)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (貼\り付け)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ビジュアル"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ビジュアル 行"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ビジュアル 矩形"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " セレクト"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 行指向選択"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 矩形選択"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "記録中"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 無効な検索文字列です: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 上まで検索しましたが該当箇所はありません: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 下まで検索しましたが該当箇所はありません: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ';' のあとには '?' か '/' が期待されている"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (前に列挙した該当箇所を含む)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- インクルードされたファイル "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "見つかりません "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "パスに ----\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (既に列挙)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  見つかりません"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "インクルードされたファイルをスキャン中: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "インクルードされたファイルをスキャン中 %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 現在行に該当があります"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "全てのインクルードされたファイルが見つかりました"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "インクルードファイルはありません"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 定義を見つけられません"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: パターンを見つけられません"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Substitute "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5001,87 +5212,99 @@ msgstr ""
 "# 最後の %s検索パターン:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: スペルファイルの書式エラーです"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: スペルファイルが切取られているようです"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "%s (%d 行目) に続くテキスト: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "%s (%d 行目) の affix 名が長過ぎます: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr ""
 "E761: affixファイルの FOL, LOW もしくは UPP のフォーマットにエラーがあります"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL, LOW もしくは UPP の文字が範囲外です"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "単語ツリーを圧縮しています..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: スペルチェックは無効化されています"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"警告: 単語リスト \"%s_%s.spl\" および \"%s_ascii.spl\" は見つかりません"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "警告: 単語リスト \"%s.%s.spl\" および \"%s.ascii.spl\" は見つかりません"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "スペルファイル \"%s\" を読込中"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: スペルファイルではないようです"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 古いスペルファイルなので, アップデートしてください"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: より新しいバージョンの Vim 用のスペルファイルです"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: スペルファイルにサポートしていないセクションがあります"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "警告9: %s という範囲はサポートされていません"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "affix ファイル %s を読込中..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "%s (%d 行目) の単語を変換できませんでした: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "%s 内の次の変換はサポートされていません: %s から %s へ"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "%s 内の変換はサポートされていません"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 内の %d 行目の FLAG に無効な値があります: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 内の %d 行目にフラグの二重使用があります: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5090,6 +5313,7 @@ msgstr ""
 "%s の %d 行目の PFX 項目の後の COMPOUNDFORBIDFLAG の定義は誤った結果を生じる"
 "ことがあります"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5098,35 +5322,43 @@ msgstr ""
 "%s の %d 行目の PFX 項目の後の COMPOUNDPERMITFLAG の定義は誤った結果を生じる"
 "ことがあります"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "COMPOUNDRULES の値に誤りがあります. ファイル %s の %d 行目: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDWORDMAX の値に誤りがあります: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDMIN の値に誤りがあります: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s の %d 行目の COMPOUNDSYLMAX の値に誤りがあります: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s の %d 行目の CHECKCOMPOUNDPATTERN の値に誤りがあります: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "%s の %d 行目の 連続 affix ブロックのフラグの組合せに違いがあります: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s の %d 行目に 重複した affix を検出しました: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5135,270 +5367,334 @@ msgstr ""
 "%s の %d 行目の affix は BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
 "に使用してください: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s の %d 行目では Y か N が必要です: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s の %d 行目の 条件は壊れています: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s の %d 行目には REP(SAL) の回数が必要です"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s の %d 行目には MAP の回数が必要です"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s の %d 行目の MAP に重複した文字があります"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s の %d 行目に 認識できないか重複した項目があります: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s 行目に FOL/LOW/UPP がありません"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "SYLLABLE が指定されない COMPOUNDSYLMAX"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "遅延後置子が多過ぎます"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "複合フラグが多過ぎます"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "遅延後置子 と/もしくは 複合フラグが多過ぎます"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "SOFO%s 行が %s にありません"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "SAL行 と SOFO行 が %s で両方指定されています"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s の %d 行の フラグが数値ではありません: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s の %d 行目の フラグが不正です: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "値 %s は他の .aff ファイルで使用されたのと異なります"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "辞書ファイル %s をスキャン中..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s には単語数がありません"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "行 %6d, 単語 %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s の %d 行目で 重複単語が見つかりました: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "重複のうち最初の単語は %s の %d 行目です: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d 個の単語が見つかりました (%s 内)"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "非ASCII文字を含む %d 個の単語を無視しました (%s 内)"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "標準入力から読込み中 %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した /encoding= 行を無視しました: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 単語の後の /encoding= 行を無視しました: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した /regions= 行を無視しました: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s の %d 行目, 範囲指定が多過ぎます: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s の %d 行目の 重複した / 行を無視しました: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s の %d 行目 無効な nr 領域です: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s の %d 行目 認識不能\なフラグです: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "非ASCII文字を含む %d 個の単語を無視しました"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: メモリが足りないので、単語リストは不完全です"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "ノード %d 個(全 %d 個中) を圧縮しました; 残り %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "スペルファイルを逆読込中"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "音声畳込みを実行中..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "音声畳込み後の総単語数: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "総単語数: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "修正候補ファイル \"%s\" を書込み中..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "推定メモリ使用量: %d バイト"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 出力ファイル名には範囲名を含められません"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 範囲は 8 個までしかサポートされていません"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: 無効な範囲です: %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "警告: 複合フラグと NOBREAK が両方とも指定されました"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "スペルファイル %s を書込み中..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "実行しました!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "%s から単語が削除されました"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "%s に単語が追加されました"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 単語の文字がスペルファイルと異なります"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "残念ですが, 修正候補はありません"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "残念ですが, 修正候補は %<PRId64> 個しかありません"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "\"%.*s\" を次へ変換:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: スペル置換がまだ実行されていません"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 見つかりません: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: .sug ファイルではないようです: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: 古い .sug ファイルなので, アップデートしてください: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: より新しいバージョンの Vim 用の .sug ファイルです: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug ファイルが .spl ファイルと一致しません: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: .sug ファイルの読込中にエラーが発生しました: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: MAP エントリに重複文字が存在します"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "このバッファに定義された構\文要素はありません"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 不正な引数です: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: そのような構\文クラスタはありません: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C言語風コメントから同期中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "非同期"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同期開始 "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " 行前(トップ行よりも)"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5406,6 +5702,7 @@ msgstr ""
 "\n"
 "--- 構\文同期要素 ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5413,6 +5710,7 @@ msgstr ""
 "\n"
 "要素上で同期中"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5420,212 +5718,272 @@ msgstr ""
 "\n"
 "--- 構\文要素 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: そのような構\文クラスタはありません: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; 該当 "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " 個の改行"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: この場所では引数containsは許可されていません"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: 無効なccharの値です"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: ここではグループは許可されません"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: %s の範囲要素が見つかりません"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: ファイル名が必要です"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: 構\文の取り込み(include)が多過ぎます"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' がありません: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' がありません: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: 引数が足りません: 構\文範囲 %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: 構\文クラスタが多過ぎます"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: クラスタが指定されていません"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: パターン区切りが見つかりません: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: パターンのあとにゴミがあります: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 構\文同期: 連続行パターンが2度指定されました"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 不正な引数です: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 等号がありません: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空の引数: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s はココでは許可されていません"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s は内容リストの先頭でなければならない"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 未知のグループ名: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 無効な :syntax のサブコマンド: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: syncolor.vim の再帰呼び出しを検出しました"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: ハイライトグループが見つかりません: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 引数が充分ではない: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 引数が多過ぎます: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: グループが設定されているのでハイライトリンクは無視されます"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 予\期せぬ等号です: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 等号ががありません: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 引数がありません: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不正な値です: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 未知の前景色です"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 未知の背景色です"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: カラー名や番号を認識できません: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 終端コードが長過ぎます: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 不正な引数です: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 多くの異なるハイライト属性が使われ過ぎています"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: グループ名に印刷不可能\な文字があります"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: グループ名に不正な文字があります"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: ハイライトと構\文グループが多過ぎます"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: タグスタックの末尾です"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: タグスタックの先頭です"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 最初の該当タグを超えて戻ることはできません"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: タグが見つかりません: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "ファイル\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 該当タグが1つだけしかありません"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 最後に該当するタグを超えて進むことはできません"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "ファイル \"%s\" がありません"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "タグ %d (全%d%s)"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " かそれ以上"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  タグを異なるcaseで使用します!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: ファイル \"%s\" がありません"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5633,66 +5991,79 @@ msgstr ""
 "\n"
 "  # TO タグ        FROM 行    in file/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "タグファイル %s を検索中"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: タグファイルのパスが %s に切り捨てられました\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "タグファイル内の長い行を無視します"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: タグファイル \"%s\" のフォーマットにエラーがあります"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "直前の %<PRId64> バイト"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: タグファイルがソ\ートされていません: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: タグファイルがありません"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: タグパターンを見つけられません"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: タグを見つけられないので単に推測します!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "重複したフィールド名: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' は未知です. 現行の組み込み端末は次のとおりです:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "省略値を次のように設定します '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: termcapファイルを開けません"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: terminfoに端末エントリを見つけられません"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: termcapに端末エントリを見つけられません"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcapに \"%s\" のエントリがありません"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 端末に \"cm\" 機能\が必要です"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5700,244 +6071,169 @@ msgstr ""
 "\n"
 "--- 端末キー ---"
 
-msgid "new shell started\n"
-msgstr "新しいシェルを起動します\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 入力を読込み中のエラーにより終了します...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "空の選択領域のかわりにCUT_BUFFER0が使用されました"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: 予\期せず行カウントが変わりました"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "可能\なアンドゥはありません: とりあえず続けます"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: 書込み用にアンドゥファイルを開けません: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: アンドゥファイルが壊れています (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "'undodir'のディレクトリにアンドゥファイルを書き込めません"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "アンドゥファイルとして読み込めないので上書きしません: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "アンドゥファイルではないので上書きしません: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "対象がないのでアンドゥファイルの書き込みをスキップします"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "アンドゥファイル書き込み中: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: アンドゥファイルの書き込みエラーです: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "オーナーが異なるのでアンドゥファイルを読み込みません: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "アンドゥファイル読込中: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: アンドゥファイルを読込用として開けません: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: アンドゥファイルではありません: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: 非暗号化ファイルが暗号化されたアンドゥファイルを使ってます: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: 暗号化されたアンドゥファイルの解読に失敗しました: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: アンドゥファイルが暗号化されています: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: 互換性の無いアンドゥファイルです: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "ファイルの内容が変わっているため、アンドゥ情報を利用できません"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "アンドゥファイル %s の取込を完了"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "既に一番古い変更です"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "既に一番新しい変更です"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: アンドゥ番号 %<PRId64> は見つかりません"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行番号が間違っています"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "行 追加しました"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "行 追加しました"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "行 削除しました"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "行 削除しました"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "箇所変更しました"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "箇所変更しました"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "前方"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "後方"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "アンドゥ対象がありません"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "通番   変更数   変更時期           保存済"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> 秒経過しています"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo の直後に undojoin はできません"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: アンドゥリストが壊れています"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: アンドゥ行がありません"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 ビット GUI 版"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64 ビット GUI 版"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 ビット GUI 版"
-
-msgid " in Win32s mode"
-msgstr " in Win32s モード"
-
-msgid " with OLE support"
-msgstr " with OLE サポート"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 64 ビット コンソ\ール 版"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 ビット コンソ\ール 版"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 ビット 版"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 ビット MS-DOS 版"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 ビット MS-DOS 版"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS 版"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5945,6 +6241,7 @@ msgstr ""
 "\n"
 "適用済パッチ: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5952,9 +6249,11 @@ msgstr ""
 "\n"
 "追加拡張パッチ: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modified by "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5962,9 +6261,11 @@ msgstr ""
 "\n"
 "Compiled "
 
+#: ../version.c:649
 msgid "by "
 msgstr "by "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5972,837 +6273,1883 @@ msgstr ""
 "\n"
 "Huge 版 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Big 版 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"通常 版 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Small 版 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Tiny 版 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "without GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "with GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "with GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "with X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "with X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "with X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "with Photon GUI."
-
-msgid "with GUI."
-msgstr "with GUI."
-
-msgid "with Carbon GUI."
-msgstr "with Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "with Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "with (クラシック) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  機能\の一覧 有効(+)/無効(-)\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "      システム vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        ユーザ vimrc: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "     第2ユーザ vimrc: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "     第3ユーザ vimrc: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         ユーザ exrc: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "      第2ユーザ exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "     システム gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       ユーザ gvimrc: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "    第2ユーザ gvimrc: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "    第3ユーザ gvimrc: \""
-
-msgid "    system menu file: \""
-msgstr "    システムメニュー: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       省略時の $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "省略時の $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "コンパイル: "
 
-msgid "Compiler: "
-msgstr "コンパイラ: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "リンク: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "デバッグビルド"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "version "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "by Bram Moolenaar 他."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim はオープンソ\ースであり自由に配布可能\です"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "ウガンダの恵まれない子供たちに援助を!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "詳細な情報は           :help iccf<Enter>      "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "終了するには           :q<Enter>              "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "オンラインヘルプは     :help<Enter> か <F1>   "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "バージョン情報は       :help version7<Enter>  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi互換モードで動作中"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "Vim推奨値にするには    :set nocp<Enter>       "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "詳細な情報は           :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "詳細はメニューの ヘルプ→孤児 を参照して下さい   "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "モード無で実行中, タイプした文字が挿入されます"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "メニューの 編集→全体設定→挿入(初心者)モード切替 "
-
-msgid "                              for two modes      "
-msgstr "                              でモード有に       "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "メニューの 編集→全体設定→Vi互換モード切替      "
-
-msgid "                              for Vim defaults   "
-msgstr "                              でVimとして動作    "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Vimの開発を応援してください!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Vimの登録ユーザになってください!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "詳細な情報は           :help sponsor<Enter>   "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "詳細な情報は           :help register<Enter>  "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "詳細はメニューの ヘルプ→スポンサー/登録 を参照して下さい   "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "   警告: Windows 95/98/Me を検出  "
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr " 詳細な情報は          :help windows95<Enter> "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "既にウィンドウは1つしかありません"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: プレビューウィンドウがありません"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: 左上と右下を同時に分割することはできません"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: 他のウィンドウが分割されている時には順回できません"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: 最後のウィンドウを閉じることはできません"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: autocmdウィンドウは閉じられません"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: autocmdウィンドウしか残らないため、ウィンドウは閉じられません"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: 他のウィンドウには変更があります"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: カーソ\ルの下にファイル名がありません"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: pathには \"%s\" というファイルがありません"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() が空パスワードで呼び出されました"
 
-msgid "Edit with &multiple Vims"
-msgstr "複数のVimで編集する (&M)"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Edit with single &Vim"
-msgstr "1つのVimで編集する (&V)"
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish暗号のビッグ/リトルエンディアンが間違っています"
 
-msgid "Diff with Vim"
-msgstr "Vimで差分を表\示する"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256のテストに失敗しました"
 
-msgid "Edit with &Vim"
-msgstr "Vimで編集する (&V)"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish暗号のテストに失敗しました"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "起動済のVimで編集する - "
+#~ msgid "Patch file"
+#~ msgstr "パッチファイル"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "選択したファイルをVimで編集する"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "決定(&O)\n"
+#~ "キャンセル(&C)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "プロセスの作成に失敗: gvimが環境変数PATH上にあるか確認してください!"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Vim サーバへの接続がありません"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll エラー"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: %s へ送ることができません"
 
-msgid "Path length too long!"
-msgstr "パスが長すぎます!"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: サーバの応答がありません"
 
-msgid "--No lines in buffer--"
-msgstr "--バッファに行がありません--"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: クライアントへ送ることができません"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: コマンドが中断されました"
+#~ msgid "Save As"
+#~ msgstr "別名で保存"
 
-msgid "E471: Argument required"
-msgstr "E471: 引数が必要です"
+#~ msgid "Edit File"
+#~ msgstr "ファイルを編集"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ の後は / か ? か & でなければなりません"
+# Added at 27-Jan-2004.
+#~ msgid " (NOT FOUND)"
+#~ msgstr "  (見つかりません)"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
+#~ msgid "Source Vim script"
+#~ msgstr "Vimスクリプトの取込み"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"
+#~ msgid "unknown"
+#~ msgstr "不明"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif がありません"
+#~ msgid "Edit File in new window"
+#~ msgstr "新しいウィンドウでファイルを編集します"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry がありません"
+#~ msgid "Append File"
+#~ msgstr "追加ファイル"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile がありません"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "ウィンドウ位置: X %d, Y %d"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor がありません"
+#~ msgid "Save Redirection"
+#~ msgstr "リダイレクトを保存します"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :while のない :endwhile があります"
+#~ msgid "Save View"
+#~ msgstr "ビューを保存します"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor のない :for があります"
+#~ msgid "Save Session"
+#~ msgstr "セッション情報を保存します"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: ファイルが存在します (! を追加で上書)"
+#~ msgid "Save Setup"
+#~ msgstr "設定を保存します"
 
-msgid "E472: Command failed"
-msgstr "E472: コマンドが失敗しました"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< は +eval 機能\が無いと利用できません"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 未知のフォントセット: %s"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: このバージョンに合字はありません"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 未知のフォント: %s"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr " はデバイスです ('opendevice' オプションで回避できます)"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: フォント \"%s\" は固定幅ではありません"
+#~ msgid "Reading from stdin..."
+#~ msgstr "標準入力から読込み中..."
 
-msgid "E473: Internal error"
-msgstr "E473: 内部エラーです"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish暗号化]"
 
-msgid "Interrupted"
-msgstr "割込まれました"
+#~ msgid "[crypted]"
+#~ msgstr "[暗号化]"
 
-msgid "E14: Invalid address"
-msgstr "E14: 無効なアドレスです"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: ファイルが未知の方法で暗号化されています"
 
-msgid "E474: Invalid argument"
-msgstr "E474: 無効な引数です"
+# Added at 19-Jan-2004.
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeansは未変更のバッファを上書することは許可していません"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 無効な引数です: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeansバッファの一部を書き出すことはできません"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 無効な式です: %s"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "'opendevice' オプションによりデバイスへの書き込みはできません"
 
-msgid "E16: Invalid range"
-msgstr "E16: 無効な範囲です"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: リソ\ースフォークが失われるかもしれません (! を追加で強制)"
 
-msgid "E476: Invalid command"
-msgstr "E476: 無効なコマンドです"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: GUI用のプロセスの起動に失敗しました"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" はディレクトリです"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: 子プロセスがGUIの起動に失敗しました"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: \"%s\"() のライブラリ呼出に失敗しました"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUIを開始できません"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: ライブラリの関数 %s をロードできませんでした"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: \"%s\"から読込むことができません"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: マークに無効な行番号が指定されていました"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 有効なフォントが見つからないので, GUIを開始できません"
 
-msgid "E20: Mark not set"
-msgstr "E20: マークは設定されていません"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' が無効です"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 'modifiable' がオフなので, 変更できません"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' に設定された値が無効です"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: スクリプトの入れ子が深過ぎます"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: %s の色を割り当てられません"
 
-msgid "E23: No alternate file"
-msgstr "E23: 副ファイルはありません"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "カーソ\ルの位置にマッチはありません, 次を検索しています"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: そのような短縮入力はありません"
+#~ msgid "<cannot open> "
+#~ msgstr "<開けません> "
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! は許可されていません"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: フォント %s を取得できません"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUIは使用不可能\です: コンパイル時に無効にされています"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 現在のディレクトリに戻れません"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: ヘブライ語は使用不可能\です: コンパイル時に無効にされています\n"
+#~ msgid "Pathname:"
+#~ msgstr "パス名:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: ペルシア語は使用不可能\です: コンパイル時に無効にされています\n"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 現在のディレクトリを取得できません"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: アラビア語は使用不可能\です: コンパイル時に無効にされています\n"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: そのような名のハイライトグループはありません: %s"
+#~ msgid "Cancel"
+#~ msgstr "キャンセル"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: まだテキストが挿入されていません"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "スクロールバー: 画像を取得できませんでした."
 
-msgid "E30: No previous command line"
-msgstr "E30: 以前にコマンド行がありません"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim ダイアログ"
 
-msgid "E31: No such mapping"
-msgstr "E31: そのようなマッピングはありません"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: メッセージとコールバックのある BalloonEval を作成できません"
 
-msgid "E479: No match"
-msgstr "E479: 該当はありません"
+#~ msgid "Input _Methods"
+#~ msgstr "インプットメソ\ッド"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 該当はありません: %s"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 検索と置換..."
 
-msgid "E32: No file name"
-msgstr "E32: ファイル名がありません"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 検索..."
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 正規表\現置換がまだ実行されていません"
+#~ msgid "Find what:"
+#~ msgstr "検索文字列:"
 
-msgid "E34: No previous command"
-msgstr "E34: コマンドがまだ実行されていません"
+#~ msgid "Replace with:"
+#~ msgstr "置換文字列:"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: 正規表\現がまだ実行されていません"
+#~ msgid "Match whole word only"
+#~ msgstr "正確に該当するものだけ"
 
-msgid "E481: No range allowed"
-msgstr "E481: 範囲指定は許可されていません"
+#~ msgid "Match case"
+#~ msgstr "大文字/小文字を区別する"
 
-msgid "E36: Not enough room"
-msgstr "E36: ウィンドウに十\分な高さもしくは幅がありません"
+#~ msgid "Direction"
+#~ msgstr "方向"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: %s という名前の登録されたサーバはありません"
+#~ msgid "Up"
+#~ msgstr "上"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: ファイル %s を作成できません"
+#~ msgid "Down"
+#~ msgstr "下"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: 一時ファイルの名前を取得できません"
+#~ msgid "Find Next"
+#~ msgstr "次を検索"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: ファイル \"%s\" を開けません"
+#~ msgid "Replace"
+#~ msgstr "置換"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: ファイル %s を読込めません"
+#~ msgid "Replace All"
+#~ msgstr "全て置換"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: セッションマネージャから \"die\" 要求を受け取りました\n"
 
-msgid "E38: Null argument"
-msgstr "E38: 引数が空です"
+#~ msgid "Close"
+#~ msgstr "閉じる"
 
-msgid "E39: Number expected"
-msgstr "E39: 数値が要求されています"
+#~ msgid "New tab"
+#~ msgstr "新規タブページ"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: エラーファイル %s を開けません"
+#~ msgid "Open Tab..."
+#~ msgstr "タブページを開く..."
 
-msgid "E233: cannot open display"
-msgstr "E233: ディスプレイを開けません"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: メインウィンドウが不意に破壊されました\n"
 
-msgid "E41: Out of memory!"
-msgstr "E41: メモリが尽き果てました!"
+#~ msgid "&Filter"
+#~ msgstr "フィルタ(&F)"
 
-msgid "Pattern not found"
-msgstr "パターンは見つかりませんでした"
+#~ msgid "&Cancel"
+#~ msgstr "キャンセル(&C)"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: パターンは見つかりませんでした: %s"
+#~ msgid "Directories"
+#~ msgstr "ディレクトリ"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: 引数は正の値でなければなりません"
+#~ msgid "Filter"
+#~ msgstr "フィルタ"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 前のディレクトリに戻れません"
+#~ msgid "&Help"
+#~ msgstr "ヘルプ(&H)"
 
-msgid "E42: No Errors"
-msgstr "E42: エラーはありません"
+#~ msgid "Files"
+#~ msgstr "ファイル"
 
-msgid "E776: No location list"
-msgstr "E776: 場所リストはありません"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E43: Damaged match string"
-msgstr "E43: 該当文字列が破損しています"
+#~ msgid "Selection"
+#~ msgstr "選択"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 不正な正規表\現プログラムです"
+#~ msgid "Find &Next"
+#~ msgstr "次を検索(&N)"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' オプションが設定されています (! を追加で上書き)"
+#~ msgid "&Replace"
+#~ msgstr "置換(&R)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 読取専用変数 \"%s\" には値を設定できません"
+#~ msgid "Replace &All"
+#~ msgstr "全て置換(&A)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: サンドボックスでは変数 \"%s\" に値を設定できません"
+#~ msgid "&Undo"
+#~ msgstr "アンドゥ(&U)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: エラーファイルの読込中にエラーが発生しました"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: タイトルが \"%s\" のウィンドウは見つかりません"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: サンドボックスでは許されません"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 引数はサポートされません: \"-%s\"; OLE版を使用してください."
 
-msgid "E523: Not allowed here"
-msgstr "E523: ここでは許可されません"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: MDIアプリの中ではウィンドウを開けません"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: スクリーンモードの設定には対応していません"
+#~ msgid "Close tab"
+#~ msgstr "タブページを閉じる"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: 無効なスクロール量です"
+#~ msgid "Open tab..."
+#~ msgstr "タブページを開く"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' オプションが空です"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "検索文字列 ('\\' を検索するには '\\\\')"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: sign のデータを読込めませんでした"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "検索・置換 ('\\' を検索するには '\\\\')"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: スワップファイルのクローズ時エラーです"
+#~ msgid "Not Used"
+#~ msgstr "使われません"
 
-msgid "E73: tag stack empty"
-msgstr "E73: タグスタックが空です"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "ディレクトリ\t*.nothing\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: コマンドが複雑過ぎます"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 色指定が正しくないのでエントリを割り当てられません"
 
-msgid "E75: Name too long"
-msgstr "E75: 名前が長過ぎます"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: 以下の文字セットのフォントがありません %s:"
 
-msgid "E76: Too many ["
-msgstr "E76: [ が多過ぎます"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: フォントセット名: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: ファイル名が多過ぎます"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "フォント '%s' は固定幅ではありません"
 
-msgid "E488: Trailing characters"
-msgstr "E488: 余分な文字が後ろにあります"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: フォントセット名: %s"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 未知のマーク"
+#~ msgid "Font0: %s"
+#~ msgstr "フォント0: %s"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: ワイルドカードを展開できません"
+#~ msgid "Font1: %s"
+#~ msgstr "フォント1: %s"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' は 'winminheight' より小さくできません"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' は 'winminwidth' より小さくできません"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "フォント0の幅: %<PRId64>"
 
-msgid "E80: Error while writing"
-msgstr "E80: 書込み中のエラー"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "フォント1の幅: %<PRId64>"
 
-msgid "Zero count"
-msgstr "ゼロカウント"
+#~ msgid "Invalid font specification"
+#~ msgstr "無効なフォント指定です"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: スクリプト以外で<SID>が使われました"
+#~ msgid "&Dismiss"
+#~ msgstr "却下する(&D)"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: 無効な式を受け取りました"
+#~ msgid "no specific match"
+#~ msgstr "マッチするものがありません"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: 領域が保護されているので, 変更できません"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - フォント選択"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans は読込専用ファイルを変更することを許しません"
+#~ msgid "Name:"
+#~ msgstr "名前:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 内部エラーです: %s"
+#~ msgid "Show size in Points"
+#~ msgstr "サイズをポイントで表\示する"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
+#~ msgid "Encoding:"
+#~ msgstr "エンコード:"
 
-msgid "E749: empty buffer"
-msgstr "E749: バッファが空です"
+#~ msgid "Font:"
+#~ msgstr "フォント:"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 検索パターンか区切り記号が不正です"
+#~ msgid "Style:"
+#~ msgstr "スタイル:"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 同じ名前のファイルが他のバッファで読込まれています"
+#~ msgid "Size:"
+#~ msgstr "サイズ:"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: オプション '%s' は設定されていません"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ハングルオートマトンエラー"
 
-msgid "E850: Invalid register name"
-msgstr "E850: 無効なレジスタ名です"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat エラー"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "上まで検索したので下に戻ります"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: cscopeデータベース: %s を開くことができません"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "下まで検索したので上に戻ります"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: cscopeデータベースの情報を取得できません"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "暗号キーが必要です: \"%s\""
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Luaライブラリをロードできません."
 
-msgid "empty keys are not allowed"
-msgstr "空のキーは許可されていません"
+#~ msgid "cannot save undo information"
+#~ msgstr "アンドゥ情報が保存できません"
 
-msgid "dictionary is locked"
-msgstr "辞書はロックされています"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: このコマンドは無効です. MzScheme ライブラリをロードできません."
 
-msgid "list is locked"
-msgstr "リストはロックされています"
+#~ msgid "invalid expression"
+#~ msgstr "無効な式です"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "辞書にキー '%s' を追加するのに失敗しました"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "式はコンパイル時に無効にされています"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "インデックスは %s ではなく整数かスライスにしてください"
+#~ msgid "hidden option"
+#~ msgstr "隠しオプション"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "str() もしくは unicode() のインスタンスが期待されているのに %s でした"
+#~ msgid "unknown option"
+#~ msgstr "未知のオプションです"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "bytes() もしくは str() のインスタンスが期待されているのに %s でした"
+#~ msgid "window index is out of range"
+#~ msgstr "範囲外のウィンドウ番号です"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr "long() かそれへ変換可能\なものが期待されているのに %s でした"
+#~ msgid "couldn't open buffer"
+#~ msgstr "バッファを開けません"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "int() かそれへ変換可能\なものが期待されているのに %s でした"
+#~ msgid "cannot delete line"
+#~ msgstr "行を消せません"
 
-msgid "value is too large to fit into C int type"
-msgstr "C言語の int 型としては値が大き過ぎます"
+#~ msgid "cannot replace line"
+#~ msgstr "行を置換できません"
 
-msgid "value is too small to fit into C int type"
-msgstr "C言語の int 型としては値が小さ過ぎます"
+#~ msgid "cannot insert line"
+#~ msgstr "行を挿入できません"
 
-msgid "number must be greater then zero"
-msgstr "数値は 0 より大きくなければなりません"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "文字列には改行文字を含められません"
 
-msgid "number must be greater or equal to zero"
-msgstr "数値は 0 かそれ以上でなければなりません"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "Scheme値のVimへの変換エラー"
 
-msgid "can't delete OutputObject attributes"
-msgstr "OutputObject属性を消せません"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim エラー: ~a"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "無効な属性です: %s"
+#~ msgid "Vim error"
+#~ msgstr "Vim エラー"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: I/Oオブジェクトの初期化エラー"
+#~ msgid "buffer is invalid"
+#~ msgstr "バッファは無効です"
 
-msgid "failed to change directory"
-msgstr "辞書の変更に失敗しました"
+#~ msgid "window is invalid"
+#~ msgstr "ウィンドウは無効です"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "imp.find_module() が %s を返しました (期待値: 2 要素のタプル)"
+#~ msgid "linenr out of range"
+#~ msgstr "範囲外の行番号です"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "impl.find_module() が %d 要素のタプルを返しました (期待値: 2)"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "サンドボックスでは許されません"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "内部エラー: imp.find_module が NULL を含むタプルを返しました"
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: ライブラリ %s をロードできませんでした"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "vim.Dictionary属性は消せません"
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "このコマンドは無効です, ごめんなさい: Perlライブラリをロードできませんでし"
+#~ "た."
 
-msgid "cannot modify fixed dictionary"
-msgstr "固定された辞書は変更できません"
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: サンドボックスでは Safe モジュールを使用しないPerlスクリプトは禁じら"
+#~ "れています"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "属性 %s は設定できません"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: このVimでは :py3 を使った後に :python を使えません"
 
-msgid "hashtab changed during iteration"
-msgstr "イテレーション中に hashtab が変更されました"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: このコマンドは無効です,ごめんなさい: Pythonライブラリをロードできま"
+#~ "せんでした."
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "シーケンスの要素数には 2 が期待されていましたが %d でした"
+# Added at 07-Feb-2004.
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python を再帰的に実行することはできません"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "リストのコンストラクタはキーワード引数を受け付けません"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: このVimでは :python を使った後に :py3 を使えません"
 
-msgid "list index out of range"
-msgstr "リスト範囲外のインデックスです"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ は文字列のインスタンスでなければなりません"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "内部エラー: vimのリスト要素 %d の取得に失敗しました"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: このコマンドは無効です,ごめんなさい: Rubyライブラリをロードできませ"
+#~ "んでした."
 
-msgid "failed to add item to list"
-msgstr "リストへの要素追加に失敗しました"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: 予\期せぬ return です"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "内部エラー: vimのリスト要素 %d はありません"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: 予\期せぬ next です"
 
-msgid "internal error: failed to add item to list"
-msgstr "内部エラー: リストへの要素追加に失敗しました"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: 予\期せぬ break です"
 
-msgid "cannot delete vim.List attributes"
-msgstr "vim.List 属性は消せません"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: 予\期せぬ redo です"
 
-msgid "cannot modify fixed list"
-msgstr "固定されたリストは変更できません"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: rescue の外の retry です"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "無名関数 %s は存在しません"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: 取り扱われなかった例外があります"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "関数 %s がありません"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知のlongjmp状態: %d"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "関数のコンストラクタはキーワード引数を受け付けません"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "実装と定義を切り替える"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "関数 %s の実行に失敗しました"
+#~ msgid "Show base class of"
+#~ msgstr "次のクラスの基底を表\示"
 
-msgid "unable to get option value"
-msgstr "オプションの値は取得できません"
+#~ msgid "Show overridden member function"
+#~ msgstr "オーバーライドされたメンバ関数を表\示"
 
-msgid "internal error: unknown option type"
-msgstr "内部エラー: 未知のオプション型です"
+#~ msgid "Retrieve from file"
+#~ msgstr "ファイルから回復する"
 
-msgid "problem while switching windows"
-msgstr "ウィンドウを切換中に問題が発生しました"
+#~ msgid "Retrieve from project"
+#~ msgstr "プロジェクトから回復する"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "グローバルオプション %s の設定解除はできません"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "全てのプロジェクトから回復する"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "グローバルな値の無いオプション %s の設定解除はできません"
+#~ msgid "Retrieve"
+#~ msgstr "回復"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "削除されたタブを参照しようとしました"
+#~ msgid "Show source of"
+#~ msgstr "次のソ\ースを表\示する"
 
-msgid "no such tab page"
-msgstr "そのようなタブページはありません"
+#~ msgid "Find symbol"
+#~ msgstr "見つけたシンボル"
 
-msgid "attempt to refer to deleted window"
-msgstr "削除されたウィンドウを参照しようとしました"
+#~ msgid "Browse class"
+#~ msgstr "クラスを参照"
 
-msgid "readonly attribute: buffer"
-msgstr "読込専用属性: バッファー"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "階層でクラスを表\示"
 
-msgid "cursor position outside buffer"
-msgstr "カーソ\ル位置がバッファの外側です"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "限定された階層でクラスを表\示"
 
-msgid "no such window"
-msgstr "そのようなウィンドウはありません"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref の参照先"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "削除されたバッファを参照しようとしました"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref が参照される"
 
-msgid "failed to rename buffer"
-msgstr "バッファ名の変更に失敗しました"
+#~ msgid "Xref has a"
+#~ msgstr "Xref が次のものをもっています"
 
-msgid "mark name must be a single character"
-msgstr "マーク名は1文字のアルファベットでなければなりません"
+#~ msgid "Xref used by"
+#~ msgstr "Xref が使用される"
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "vim.Bufferオブジェクトが期待されているのに %s でした"
+#~ msgid "Show docu of"
+#~ msgstr "次の文章を表\示"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "指定されたバッファ %d への切り替えに失敗しました"
+#~ msgid "Generate docu for"
+#~ msgstr "次の文章を生成"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "vim.Windowオブジェクトが期待されているのに %s でした"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "SNiFF+に接続できません. 環境をチェックしてください(sniffemacs が $PATH に"
+#~ "なければなりません).\n"
 
-msgid "failed to find window in the current tab page"
-msgstr "現在のタブには指定されたウィンドウがありませんでした"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 読込中にエラーが発生しました. 切断しました"
 
-msgid "did not switch to the specified window"
-msgstr "指定されたウィンドウに切り替えませんでした"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "現在SNiFF+ の状態は「"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "vim.TabPageオブジェクトが期待されているのに %s でした"
+#~ msgid "not "
+#~ msgstr "未"
 
-msgid "did not switch to the specified tab page"
-msgstr "指定されたタブページに切り替えませんでした"
+#~ msgid "connected"
+#~ msgstr "接続」です"
 
-msgid "failed to run the code"
-msgstr "コードの実行に失敗しました"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 未知の SNiFF+ リクエストです: %s"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: 式評価は有効なpythonオブジェクトを返しませんでした"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: SNiFF+ への接続中のエラーです"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: 返されたpythonオブジェクトをvimの値に変換できませんでした"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ に接続されていません"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "%s vimの辞書型に変換できません"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: SNiFF+ バッファがありません"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "%s をvimの構\造体に変換できません"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 書込み中にエラーが発生したので切断しました"
 
-msgid "internal error: NULL reference passed"
-msgstr "内部エラー: NULL参照が渡されました"
+#~ msgid "invalid buffer number"
+#~ msgstr "無効なバッファ番号です"
 
-msgid "internal error: invalid value type"
-msgstr "内部エラー: 無効な値型です"
+#~ msgid "not implemented yet"
+#~ msgstr "まだ実装されていません"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"パスフックの設定に失敗しました: sys.path_hooks がリストではありません\n"
-"すぐに下記を実施してください:\n"
-"- vim.path_hooks を sys.path_hooks へ追加\n"
-"- vim.VIM_SPECIAL_PATH を sys.path へ追加\n"
+#~ msgid "cannot set line(s)"
+#~ msgstr "行を設定できません"
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"パスの設定に失敗しました: sys.path がリストではありません\n"
-"すぐに vim.VIM_SPECIAL_PATH を sys.path に追加してください"
+#~ msgid "invalid mark name"
+#~ msgstr "無効なマーク名です"
+
+#~ msgid "mark not set"
+#~ msgstr "マークは設定されていません"
+
+#~ msgid "row %d column %d"
+#~ msgstr "行 %d 列 %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "行の挿入/追加をできません"
+
+#~ msgid "line number out of range"
+#~ msgstr "範囲外の行番号です"
+
+#~ msgid "unknown flag: "
+#~ msgstr "未知のフラグ: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "未知の vimOption です"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "キーボード割込み"
+
+#~ msgid "vim error"
+#~ msgstr "vim エラー"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "バッファ/ウィンドウ作成コマンドを作成できません: オブジェクトが消去されて"
+#~ "いました"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "コールバックコマンドを登録できません: バッファ/ウィンドウが既に消去されま"
+#~ "した"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL 致命的エラー: reflist 汚染!? vim-dev@vim.org に報告してください"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "コールバックコマンドを登録できません: バッファ/ウィンドウの参照が見つかり"
+#~ "ません"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: このコマンドは無効です,ごめんなさい: Tclライブラリをロードできません"
+#~ "でした."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 終了コード %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "行を取得できません"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "命令サーバの名前を登録できません"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 目的のプログラムへのコマンド送信に失敗しました"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 無効なサーバIDが使われました: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 実体の登録プロパティが不正です. 消去しました!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans はこのGUIでは利用できません\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "このVimにはdiff機能\がありません(コンパイル時設定)."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' 使用不可能\です: コンパイル時に無効にされています\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "大小文字が無視される場合は大文字にするために / を前置してください"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tこのgvimをOLEとして登録する"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tgvimのOLE登録を解除する"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tGUIで起動する (\"gvim\" と同じ)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f or  --nofork\tフォアグラウンド: GUIを始めるときにforkしない"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tウィンドウを開くのに newcli を使用しない"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tI/Oに <device> を使用する"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t.gvimrcの代わりに <gvimrc> を使う"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t暗号化されたファイルを編集する"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tvimを指定した X サーバに接続する"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tXサーバに接続しない"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t可能\ならばVimサーバで <files> を編集する"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  同上, サーバが無くても警告文を出力しない"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>\t--remote後 ファイルの編集が終わるのを待つ"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  同上, サーバが無くても警告文を出力しない"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <files>  --remoteでファイル1つにつき1つのタブ"
+#~ "ページを開く"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\tVimサーバに <keys> を送信して終了する"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\tサーバで <expr> を実行して結果を表\示する"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVimサーバ名の一覧を表\示して終了する"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\tVimサーバ <name> に送信/名前設定する"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(Motifバージョン):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(neXtawバージョン):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(Athenaバージョン):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t<display> でvimを実行する"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t最小化した状態でvimを起動する"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t背景色に <color> を使う(同義: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t前景色に <color> を使う(同義: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tテキスト表\示に <font> を使う(同義: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t太字に <font> を使う"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <for>\t斜体字に <font> を使う"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t初期配置に <geom> を使う(同義: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t境界の幅を <width> にする(同義: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <width>  スクロールバーの幅を <width> にする(同義: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <height>\tメニューバーの高さを <height> にする(同義: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t反転映像を使用する(同義: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t反転映像を使用しない(同義: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t特定のリソ\ースを使用する"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvimによって解釈される引数(GTK+バージョン):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t<display> でvimを実行する(同義: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\tメインウィンドウを識別する一意な役割(role)を設定する"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t異なるGTK widgetでVimを開く"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tウィンドウIDを標準出力に出力する"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <親のタイトル>\tVimを親アプリケーションの中で起動する"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\t異なるWin32 widgetの内部にVimを開く"
+
+#~ msgid "No display"
+#~ msgstr "ディスプレイが見つかりません"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 送信に失敗しました.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 送信に失敗しました. ローカルでの実行を試みています\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d 個 (%d 個中) のファイルを編集しました"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "ディスプレイがありません: 式の送信に失敗しました.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 式の送信に失敗しました.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 無効なコードページです"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: ICの値を設定できません"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: インプットコンテキストの作成に失敗しました"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: インプットメソ\ッドのオープンに失敗しました"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: IMの破壊コールバックを設定できませんでした"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: インプットメソ\ッドはどんなスタイルもサポートしません"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: インプットメソ\ッドは my preedit type をサポートしません"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: スワップファイルの暗号を更新中にエラーが発生しました"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s はこのバージョンのVimでサポートしていない形式で暗号化されています"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "スワップファイルは暗号化されています: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "新しい暗号キーを入力したあとにテキストファイルを保存していない場合は,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "新しい暗号キーを入力してください."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "暗号キーを変えたあとにテキストファイルを保存した場合は, テキストファイルと"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "スワップファイルに同じ暗号キーを使うためにenterだけを押してください."
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "スワップファイルから取得した暗号キーをテキストファイルに使います.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [このVimバージョンでは使用できません]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "このメニューを切り取る"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "ディレクトリ選択ダイアログ"
+
+#~ msgid "Save File dialog"
+#~ msgstr "ファイル保存ダイアログ"
+
+#~ msgid "Open File dialog"
+#~ msgstr "ファイル読込ダイアログ"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr ""
+#~ "E338: コンソ\ールモードではファイルブラウザを使えません, ごめんなさい"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: ファイルを保存中...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 終了しました.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "エラー: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピー"
+#~ "ク時 %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 行が長くなり過ぎました"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 不正な 'mouseshape' です"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "暗号化用のキーを入力してください: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "もう一度同じキーを入力してください: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "キーが一致しません"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Netbeans #2 に接続できません"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Netbeans に接続できません"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: NetBeansの接続情報ファイルのアクセスモードに問題があります: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "Netbeans のソ\ケットを読込み"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: NetBeansはこのGUIには対応していません"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: NetBeansは既に接続しています"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s は読込専用です (強制書込には ! を追加)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: 式評価機能\が無効になっています"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "%<PRId64> 行を解放中"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: GUIでは 'term' を変更できません"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: GUIをスタートするには \":gui\" を使用してください"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: GTK+2 GUIでは変更できません"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 無効なフォントです"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: フォントセットを選択できません"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 無効なフォントセットです"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: ワイドフォントを選択できません"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 無効なワイドフォントです"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: マウスはサポートされません"
+
+#~ msgid "cannot open "
+#~ msgstr "開けません "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: ウィンドウを開けません!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "%s のバージョン %<PRId64> が必要です\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "NILを開けません:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "作成できません "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vimは %d で終了します\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "コンソ\ールモードを変更できません?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: コンソ\ールではない??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: -f オプションでシェルを実行できません"
+
+#~ msgid "Cannot execute "
+#~ msgstr "実行できません "
+
+#~ msgid "shell "
+#~ msgstr "シェル "
+
+#~ msgid " returned\n"
+#~ msgstr " 戻りました\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE が小さ過ぎます."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "入出力エラー"
+
+#~ msgid "Message"
+#~ msgstr "メッセージ"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' が80ではないため, 外部コマンドを実行できません"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: プリンタの選択に失敗しました"
+
+#~ msgid "to %s on %s"
+#~ msgstr "%s へ (%s 上の)"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 未知のプリンタオプションです: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 印刷エラー: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "印刷しています: '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 文字セット名 \"%s\" は不正です (フォント名 \"%s\")"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: '%c' は不正な文字です (フォント名 \"%s\")"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 2重のシグナルのため, 終了します\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: 致命的シグナル %s を検知しました\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 致命的シグナルを検知しました\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X のエラーを検出しましたr\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "X display のチェックに失敗しました"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "X display の open がタイムアウトしました"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "sh シェルを実行できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "パイプを作成できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "fork できません\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "コマンドを中断しました\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP がICE接続を失いました"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "X display の open に失敗しました"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP がsave-yourself要求を処理しています"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP が接続を開始しています"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE接続が失敗したようです"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnectionが失敗しました: %s"
+
+#~ msgid "At line"
+#~ msgstr "行"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "vim32.dll をロードできませんでした"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIMエラー"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "DLLから関数ポインタを取得できませんでした"
+
+#~ msgid "shell returned %d"
+#~ msgstr "シェルがコード %d で終了しました"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: イベント %s を検知\n"
+
+#~ msgid "close"
+#~ msgstr "閉じる"
+
+#~ msgid "logoff"
+#~ msgstr "ログオフ"
+
+#~ msgid "shutdown"
+#~ msgstr "シャットダウン"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: コマンドがありません"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXEが $PATH の中に見つかりません.\n"
+#~ "外部コマンドの終了後に一時停止をしません.\n"
+#~ "詳細は  :help win32-vimrun  を参照してください."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vimの警告"
+
+#~ msgid "Error file"
+#~ msgstr "エラーファイル"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: 等価クラスを含むNFA構\築に失敗しました!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) 現在横断中のブランチに十\分なメモリを割り当てられません!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "警告: 単語リスト \"%s_%s.spl\" および \"%s_ascii.spl\" は見つかりません"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "%s 内の変換はサポートされていません"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: メモリが足りないので、単語リストは不完全です"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: タグファイルのパスが %s に切り捨てられました\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "新しいシェルを起動します\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "空の選択領域のかわりにCUT_BUFFER0が使用されました"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "可能\なアンドゥはありません: とりあえず続けます"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr ""
+#~ "E832: 非暗号化ファイルが暗号化されたアンドゥファイルを使ってます: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: 暗号化されたアンドゥファイルの解読に失敗しました: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: アンドゥファイルが暗号化されています: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 ビット GUI 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64 ビット GUI 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 ビット GUI 版"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " in Win32s モード"
+
+#~ msgid " with OLE support"
+#~ msgstr " with OLE サポート"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64 ビット コンソ\ール 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 ビット コンソ\ール 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 ビット 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 ビット MS-DOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 ビット MS-DOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "OpenVMS 版"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Big 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "通常 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Small 版 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Tiny 版 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "with GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "with GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "with X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "with X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "with X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "with Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "with GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "with Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "with Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "with (クラシック) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "     システム gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       ユーザ gvimrc: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "    第2ユーザ gvimrc: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "    第3ユーザ gvimrc: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    システムメニュー: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "コンパイラ: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "詳細はメニューの ヘルプ→孤児 を参照して下さい   "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "モード無で実行中, タイプした文字が挿入されます"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "メニューの 編集→全体設定→挿入(初心者)モード切替 "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              でモード有に       "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "メニューの 編集→全体設定→Vi互換モード切替      "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              でVimとして動作    "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "   警告: Windows 95/98/Me を検出  "
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr " 詳細な情報は          :help windows95<Enter> "
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "複数のVimで編集する (&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "1つのVimで編集する (&V)"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Vimで差分を表\示する"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Vimで編集する (&V)"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "起動済のVimで編集する - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "選択したファイルをVimで編集する"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "プロセスの作成に失敗: gvimが環境変数PATH上にあるか確認してください!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll エラー"
+
+#~ msgid "Path length too long!"
+#~ msgstr "パスが長すぎます!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 未知のフォントセット: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 未知のフォント: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: フォント \"%s\" は固定幅ではありません"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: ライブラリの関数 %s をロードできませんでした"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: ヘブライ語は使用不可能\です: コンパイル時に無効にされています\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: ペルシア語は使用不可能\です: コンパイル時に無効にされています\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: アラビア語は使用不可能\です: コンパイル時に無効にされています\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: %s という名前の登録されたサーバはありません"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: ディスプレイを開けません"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 無効な式を受け取りました"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 領域が保護されているので, 変更できません"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans は読込専用ファイルを変更することを許しません"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "暗号キーが必要です: \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "空のキーは許可されていません"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "辞書はロックされています"
+
+#~ msgid "list is locked"
+#~ msgstr "リストはロックされています"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "辞書にキー '%s' を追加するのに失敗しました"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "インデックスは %s ではなく整数かスライスにしてください"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr ""
+#~ "str() もしくは unicode() のインスタンスが期待されているのに %s でした"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "bytes() もしくは str() のインスタンスが期待されているのに %s でした"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr "long() かそれへ変換可能\なものが期待されているのに %s でした"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr "int() かそれへ変換可能\なものが期待されているのに %s でした"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "C言語の int 型としては値が大き過ぎます"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "C言語の int 型としては値が小さ過ぎます"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "数値は 0 より大きくなければなりません"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "数値は 0 かそれ以上でなければなりません"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "OutputObject属性を消せません"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "無効な属性です: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: I/Oオブジェクトの初期化エラー"
+
+#~ msgid "failed to change directory"
+#~ msgstr "辞書の変更に失敗しました"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "imp.find_module() が %s を返しました (期待値: 2 要素のタプル)"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr "impl.find_module() が %d 要素のタプルを返しました (期待値: 2)"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "内部エラー: imp.find_module が NULL を含むタプルを返しました"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "vim.Dictionary属性は消せません"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "固定された辞書は変更できません"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "属性 %s は設定できません"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "イテレーション中に hashtab が変更されました"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr "シーケンスの要素数には 2 が期待されていましたが %d でした"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "リストのコンストラクタはキーワード引数を受け付けません"
+
+#~ msgid "list index out of range"
+#~ msgstr "リスト範囲外のインデックスです"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "内部エラー: vimのリスト要素 %d の取得に失敗しました"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "リストへの要素追加に失敗しました"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "内部エラー: vimのリスト要素 %d はありません"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "内部エラー: リストへの要素追加に失敗しました"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "vim.List 属性は消せません"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "固定されたリストは変更できません"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "無名関数 %s は存在しません"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "関数 %s がありません"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "関数のコンストラクタはキーワード引数を受け付けません"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "関数 %s の実行に失敗しました"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "ウィンドウを切換中に問題が発生しました"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "グローバルオプション %s の設定解除はできません"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "グローバルな値の無いオプション %s の設定解除はできません"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "削除されたタブを参照しようとしました"
+
+#~ msgid "no such tab page"
+#~ msgstr "そのようなタブページはありません"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "削除されたウィンドウを参照しようとしました"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "読込専用属性: バッファー"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "カーソ\ル位置がバッファの外側です"
+
+#~ msgid "no such window"
+#~ msgstr "そのようなウィンドウはありません"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "削除されたバッファを参照しようとしました"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "バッファ名の変更に失敗しました"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "マーク名は1文字のアルファベットでなければなりません"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "vim.Bufferオブジェクトが期待されているのに %s でした"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "指定されたバッファ %d への切り替えに失敗しました"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "vim.Windowオブジェクトが期待されているのに %s でした"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "現在のタブには指定されたウィンドウがありませんでした"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "指定されたウィンドウに切り替えませんでした"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "vim.TabPageオブジェクトが期待されているのに %s でした"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "指定されたタブページに切り替えませんでした"
+
+#~ msgid "failed to run the code"
+#~ msgstr "コードの実行に失敗しました"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: 式評価は有効なpythonオブジェクトを返しませんでした"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: 返されたpythonオブジェクトをvimの値に変換できませんでした"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "%s vimの辞書型に変換できません"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "%s をvimの構\造体に変換できません"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "内部エラー: NULL参照が渡されました"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "内部エラー: 無効な値型です"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "パスフックの設定に失敗しました: sys.path_hooks がリストではありません\n"
+#~ "すぐに下記を実施してください:\n"
+#~ "- vim.path_hooks を sys.path_hooks へ追加\n"
+#~ "- vim.VIM_SPECIAL_PATH を sys.path へ追加\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "パスの設定に失敗しました: sys.path がリストではありません\n"
+#~ "すぐに vim.VIM_SPECIAL_PATH を sys.path に追加してください"

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -6,168 +6,216 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-02-16 16:18+0900\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-02-18 09:49+0900\n"
 "Last-Translator: SungHyun Nam <goweol@gmail.com>\n"
 "Language-Team: GTP Korean <gnome-kr-translation@gnome.or.kr>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: 빈 비밀번호로 bf_key_init() 함수가 불려졌습니다"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "옵션 인자 뒤에 쓰레기 값"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish big/little endian use wrong"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256 시험이 실패했습니다."
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish 시험이 실패했습니다."
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[위치 목록]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Quickfix 목록]"
 
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: Autocommand가 버퍼나 버퍼이름을 바꾸었습니다"
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: 버퍼를 할당할 수 없어서 끝냅니다..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: 버퍼를 할당할 수 없어서 다른 걸 사용합니다..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 내려진 버퍼가 없습니다"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 지워진 버퍼가 없습니다"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 완전히 지워진 버퍼가 없습니다"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "버퍼 한 개가 내려졌습니다"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "버퍼 %d 개가 내려졌습니다"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "버퍼 한 개가 지워졌습니다"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "버퍼 %d 개가 지워졌습니다"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "버퍼 한 개가 완전히 지워졌습니다"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "버퍼 %d개가 완전히 지워졌습니다"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 마지막 버퍼를 내릴 수 없습니다"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 바뀐 버퍼를 찾을 수 없습니다"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: 나열된 버퍼가 없습니다"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: 버퍼 %<PRId64>이(가) 존재하지 않습니다"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 마지막 버퍼입니다"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 첫 번째 버퍼입니다"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: 버퍼 %<PRId64>을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려면 ! 더하"
-"기)"
+"E89: 버퍼 %<PRId64>을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려"
+"면 ! 더하기)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 마지막 버퍼를 내릴 수 없습니다"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 경고: 파일 이름 목록이 넘쳤습니다"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: 버퍼 %<PRId64>을(를) 찾을 수 없습니다"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s을(를) 하나 이상 찾았습니다"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: %s와 맞는 버퍼가 없습니다"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "%<PRId64> 줄"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 이 이름을 가진 버퍼가 이미 있습니다"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [바뀜]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[고치지 않았음]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[새 파일]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[읽기 에러]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[읽기 전용]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[읽기 전용]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 줄 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 줄 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "%<PRId64> / %<PRId64> 줄 --%d%%-- 칸 "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[이름 없음]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "도움말"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[도움말]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[미리 보기]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "모두"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "바닥"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "꼭대기"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -175,9 +223,11 @@ msgstr ""
 "\n"
 "# 버퍼 목록:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Scratch]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -185,144 +235,200 @@ msgstr ""
 "\n"
 "--- 기호 ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s에 대한 기호:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    줄=%<PRId64>  id=%d  이름=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: 콜론이 없습니다"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 이상한 모드"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 숫자가 필요합니다"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 이상한 백분율"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: %<PRId64>개 이상의 버퍼에 대해서는 diff를 할 수 없습니다"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 임시 파일을 읽거나 쓸 수 없습니다"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: diff를 만들 수 없습니다"
 
-msgid "Patch file"
-msgstr "패키 파일"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: patch 결과를 읽을 수 없습니다"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: diff 출력을 읽을 수 없습니다"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 현재 버퍼는 diff 상태가 아닙니다"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: 수정 가능한 diff 상태 버퍼는 없습니다"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 다른 버퍼중에 diff 상태인 게 없습니다"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: 두개 이상의 버퍼가 diff 상태여서 어떤 것을 써야할 지 알 수 없습니다"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: \"%s\" 버퍼를 찾을 수 없습니다"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: \"%s\" 버퍼는 diff 상태가 아닙니다"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 버퍼가 모르는 사이에 바뀌었습니다"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: digraph에는 Escape을 쓸 수 없습니다"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: 키맵 파일을 찾을 수 없습니다"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: 불러들인 파일에서 :loadkeymap을 사용하지 않았습니다"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: 키맵 엔트리가 비어있음"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " 낱말 완성 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X 모드 (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 전체 줄 완성 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " 파일 이름 완성 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " 태그 완성 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " 경로 패턴 완성 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 정의 완성 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dictionary 완성 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " 백과사전 완성 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " 명령행 완성 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " 사용자 정의 완성 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni 완성 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 단어 제안 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 낱말 로컬 완성 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "단락의 마지막 만남"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Completion 기능이 창을 바꾸었습니다"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Completion 기능이 문자열을 지웠습니다"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary' 옵션이 비었습니다"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus' 옵션이 비었습니다"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "사전 찾는 중: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (끼워넣기) 스크롤 (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (바꿈) 스크롤 (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "찾는 중: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "태그 찾는 중."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 더하기"
 
@@ -330,426 +436,581 @@ msgstr " 더하기"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 찾는 중..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "원래대로 복구"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "다른 줄에 낱말"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "The only match"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "match %d of %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "match %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: ':let'에 모르는 글자"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: 목록 번호가 범위를 벗어남: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 정의 안 된 변수: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']'이 없습니다"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s 인자는 List이어야 합니다"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s 인자는 List 혹은 Dictionary여야 합니다"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Dictionary에 빈 키를 쓸 수 없습니다"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: List가 필요합니다"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Dictionary가 필요합니다"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 함수에 너무 많은 인자 넘김: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Dictionary에 키가 없음: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 함수 %s이(가) 이미 있습니다, 바꾸려면 !을 더하세요"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: 이미 Dictionary 항목이 있습니다"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref가 필요합니다"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Dictionary에 [:]을 사용할 수 없습니다"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: %s=에 대한 잘못된 변수형"
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 모르는 함수: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 비정상적인 변수 명: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Float를 String으로 사용"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: List 항목보다 적은 대상"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: List 항목보다 많은 대상"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "변수 목록에 중복된 ;"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: %s 변수 목록을 나열할 수 없습니다"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: List나 Dictionary만 색인할 수 있습니다"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:]은 마지막에 위치해야 합니다"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:]은 List 값이 필요합니다"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: List 값이 대상보다 많은 항목을 가지고 있습니다"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: List 값이 충분한 항목을 가지고 있지 않습니다"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for 뒤에 \"in\"가 없습니다"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: 괄호 없음: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: 이런 변수 없음: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: 잠금(해제)하기에 변수가 너무 깊이 중첩되었습니다"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' 뒤에 ':'이 없습니다"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: List는 List와만 비교할 수 있습니다"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: List에 대한 잘못된 동작"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Dictionary는 Dictionary와만 비교할 수 있습니다"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Dictionary에 대한 잘못된 동작"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref는 Funcref와만 비교할 수 있습니다"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Funcrefs에 대한 잘못된 동작"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Float에 '%'는 사용할 수 없습니다"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')'가 없습니다"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Funcref를 색인할 수 없습니다"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: 옵션 이름 없음: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 모르는 옵션: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 따옴표 없음: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 따옴표 없음: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: List에 콤마 누락: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: List 끝에 ']' 누락: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Dictionary에 콜론 누락: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Dictionary에 중복된 키: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Dictionary에 콤마 누락: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Dictionary 끝에 '}' 누락: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 변수가 표시하기에 너무 깊이 중첩되었습니다"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: 함수 %s에 너무 많은 인자가 전달되었습니다"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: 함수 %s(으)로 잘못된 인자가 넘겨졌습니다"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: 모르는 함수: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: 함수에 적은 인자 넘김: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: 스크립트 콘텍스트 밖에서 <SID> 사용: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Dictionary없이 사전함수가 불려짐: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Number 혹은 Float가 필요합니다"
 
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 너무 많은 인자"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete()은 입력 모드에서만 사용될 수 있습니다"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "확인(&O)"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: 키가 이미 존재함: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd 인자"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 줄: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 모르는 함수: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"확인(&O)\n"
-"취소(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore()가 inputsave()보다 많이 불려졌습니다"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 범위가 허용되지 않습니다"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len()에 잘못된 형"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Stride가 0"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 시작위치가 끝을 지나침"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<비어있음>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Vim 서버에 연결되어 있지 않습니다"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd 인자"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: %s(으)로 보낼 수 없습니다"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: 서버의 응답을 읽을 수 없습니다"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: 너무 많은 심볼릭 링크 (반복순환?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: 클라이언트로 보낼 수 없습니다"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c 인자"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: 정렬 비교 기능이 실패했습니다"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: 정렬 비교 기능이 실패했습니다"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(잘못되었습니다)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 임시 파일 쓰기 에러"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float를 Number로 사용"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref를 Number로 사용"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: List를 Number로 사용"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Dictionary를 Number로 사용"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref를 String으로 사용"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: List를 String으로 사용"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Dictionary를 String으로 사용"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Float를 String으로 사용"
-
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funcref 변수명은 대문자로 시작해야 함: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: 변수명이 이미 있는 함수명과 충돌: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 변수 형 다름: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: 변수 %s를 삭제할 수 없습니다"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funcref 변수명은 대문자로 시작해야 함: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: 변수명이 이미 있는 함수명과 충돌: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 값이 잠겨있음: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "모름"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: %s 값을 바꿀 수 없습니다"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: 복사하기에 변수가 너무 깊게 중첩되었습니다"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: 정의 안 된 함수: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '('가 없음: %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: IC 값을 설정할 수 없습니다"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 잘못된 인자: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "중복된 필드 명: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction이 없습니다"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: 함수명이 변수명과 충돌: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: 함수 %s을(를) 다시 정의할 수 없습니다: 사용중입니다"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 함수명이 스크립트 파일명과 다름: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 함수 이름이 필요합니다"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 함수 이름은 대문자로 시작하거나 콜론을 포함해야 함: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 함수 이름은 대문자로 시작하거나 콜론을 포함해야 함: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 함수 %s을(를) 지울 수 없습니다: 사용중입니다"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 함수를 부른 깊이가 'maxfuncdepth'보다 큽니다"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s 부르는 중"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s이(가) 중지되었습니다"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s이(가) #%<PRId64>을(를) 돌려주었습니다"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s이(가) %s을(를) 돌려주었습니다"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "%s에서 계속"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return이 함수 안에 있지 않습니다"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -757,6 +1018,7 @@ msgstr ""
 "\n"
 "# 전역 변수:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -764,82 +1026,104 @@ msgstr ""
 "\n"
 "\tLast set from "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "old 파일이 없습니다"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  십육진 %02x,  팔진 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d,  십육진 %04x,  팔진 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d,  십육진 %08x,  팔진 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 줄을 그 자신으로 이동하려고 했습니다"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 줄 옮겨졌습니다"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> 줄 옮겨졌습니다"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> 줄을 걸렀습니다"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 자동명령은 현재 버퍼를 바꾸어서는 안 됩니다"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[마지막으로 고친 뒤 저장 안 함]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: 줄에 %s: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: 너무 많은 에러, 나머지 건너뜀"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "viminfo 파일 \"%s\"%s%s%s을(를) 읽는 중"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 인포"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " 마크"
 
-#~ msgid " oldfiles"
-#~ msgstr ""
+#: ../ex_cmds.c:1462
+msgid " oldfiles"
+msgstr ""
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 실패"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo 파일의 쓰기 권한이 없습니다: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Viminfo 파일 %s을(를) 쓸 수 없습니다!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Viminfo 파일 \"%s\"을(를) 쓰는 중"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# 이 viminfo 파일은 빔이 만든 것입니다 Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -847,40 +1131,47 @@ msgstr ""
 "# 조심만 한다면 고칠 수도 있습니다!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# 이 파일이 저장되었을 때의 'encoding'의 값\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "이상한 시작 글자"
 
-msgid "Save As"
-msgstr "다른 이름으로 저장"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "파일 일부만 저장할까요?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: 버퍼 일부만 쓰려면 !을 사용하십시오"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "이미 있는 \"%s\" 파일을 덮어쓸까요?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "스왑 파일 \"%s\"가 있습니다, 덮어쓸까요?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 스왑 파일 있음: %s (덮어쓰려면 :silent! 사용)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: 버퍼 %<PRId64>의 파일 이름이 없습니다"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 파일이 써지지 않음: 'write' 옵션에 의해 쓸 수가 없습니다"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -889,6 +1180,7 @@ msgstr ""
 "'readonly' 옵션이 \"%s\"에 대해 설정되어 있습니다.\n"
 "그래도 쓰기를 원하십니까?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -899,64 +1191,83 @@ msgstr ""
 "그래도 쓰기가 가능할 지도 모릅니다.\n"
 "한 번 써 볼까요?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\"는 읽기 전용입니다 (덮어쓰려면 ! 더하기)"
 
-msgid "Edit File"
-msgstr "파일 고치기"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autocommand가 뜻 밖에 새 버퍼 %s을(를) 지웠습니다"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 숫자가 아닌 인자가 :z에 주어졌습니다"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim에서는 쉘 명령을 사용할 수 없습니다"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 정규표현식은 글자로 구분될 수 없습니다"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "%s(으)로 바꿈 (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(중단되었습니다) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1개 찾아짐"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1개 바꿨음"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64>개 찾아짐"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64>개 바꿨음"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " 한 줄에서"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " %<PRId64> 줄에서"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global은 재귀 호출 될 수 없습니다"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: global에서 정규표현식이 빠졌습니다"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "여러 줄에서 패턴을 찾았습니다: %s"
 
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "패턴을 찾을 수 없습니다"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -966,263 +1277,334 @@ msgstr ""
 "# 마지막으로 바꾼 문자열:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 당황하지 마십시오!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 미안합니다, 도움말 '%s'이(가) %s에 대해 없습니다"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 미안합니다, %s에 대한 도움말이 없습니다"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "미안합니다, 도움말 파일 \"%s\"을(를) 찾을 수 없습니다"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: 디렉토리가 아님: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 쓰기 위한 %s을(를) 열 수 없습니다"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 읽기 위한 %s을(를) 열 수 없습니다"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 한 언어내에서 여러 인코딩 사용: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: \"%s\" 태그가 %s/%s 파일에서 중복되었습니다"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 모르는 sign 명령: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: sign 이름이 없습니다"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: 너무 많은 sign이 정의되어 있습니다"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 잘못된 sign 텍스트: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 모르는 sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: sign 번호가 없습니다"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 잘못된 버퍼 이름: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 잘못된 sign ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (못 찾았음)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (지원되지 않음)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[지워졌습니다]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "디버그 상태로 들어감.  계속하려면 \"cont\"를 입력하십시오."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "%<PRId64> 줄: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "명령: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "중지점: \"%s%s\" %<PRId64> 줄"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 중지점을 찾을 수 없습니다: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "중지점이 정의되어 있지 않습니다"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  %<PRId64> 줄"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 먼저 \":profile start {fname}\"을 사용하세요"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "\"%s\"에 바뀐 내용을 저장할까요?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "제목 없음"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: 버퍼 \"%s\"에 나중에 바뀐 내용이 써지지 않았습니다"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "경고: 뜻 밖에 다른 버퍼로 들어갔습니다 (autocommand를 확인하십시오)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 고칠 파일이 하나 밖에 없습니다"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 첫 번째 파일 이전으로는 갈 수 없습니다"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 마지막 파일 뒤로는 갈 수 없습니다"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: 컴파일러가 지원되지 않음: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "\"%s\"을(를) \"%s\"에서 찾는 중"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "\"%s\"을(를) 찾는 중"
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "'runtimepath'에서 찾을 수 없음: \"%s\""
 
-msgid "Source Vim script"
-msgstr "빔 스크립트 로드"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "디렉토리는 source할 수 없음: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\"을(를) 불러 들일 수 없습니다"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "%<PRId64> 줄: \"%s\"을(를) 불러 들일 수 없습니다"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\"을(를) 불러들이는 중"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "%<PRId64> 줄: \"%s\" 불러들이는 중"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "%s 불러들이기 끝"
 
-#~ msgid "modeline"
-#~ msgstr ""
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr ""
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 인자"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 인자"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "환경 변수"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "에러 핸들러"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 경고: 잘못된 줄 구분자. ^M이 없는 것 같습니다"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding이 불러들인 파일 밖에서 사용되었습니다"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish가 불러들인 파일 밖에서 사용되었습니다"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "현재 %s언어: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 언어를 \"%s\"(으)로 설정할 수 없습니다"
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Ex 상태로 전환.  Normal 상태로 가려면 \"visual\"을 입력하십시오."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: 파일의 마지막입니다"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: 명령이 너무 많이 다시 반복되었습니다"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 예외가 발생하지 않았습니다: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "불러들인 파일의 마지막"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "함수의 마지막"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: 사용자 정의 명령을 모호하게 사용하고 있습니다"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: 편집기 명령이 아닙니다"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 반대 영역이 주어졌습니다"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "반대 영역이 주어졌습니다, 뒤집을까요"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: w나 w>>를 사용하십시오"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: 미안합니다, 그 명령은 현재 판에서 사용할 수 없습니다"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: 오로지 하나의 파일 이름만 사용 가능합니다"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "고칠 파일이 한 개 더 있습니다. 그래도 끝낼까요?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "고칠 파일이 %d 개 더 있습니다. 그래도 끝낼까요?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 고칠 파일이 한 개 더 있습니다"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 고칠 파일이 %<PRId64> 개 더 있습니다"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 명령이 이미 존재합니다: 바꾸려면 !을 더하세요"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1230,289 +1612,335 @@ msgstr ""
 "\n"
 "    이름        인자 범위  완성      정의"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "사용자 정의 명령을 찾을 수 없습니다"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 명시된 속성이 없습니다"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 잘못된 인자 갯수"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: 카운트는 두 번 이상 명시될 수 없습니다"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: 잘못된 기본 카운트 값"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete에 인자가 필요합니다"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 잘못된 속성: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 잘못된 명령 이름"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: 사용자 정의 명령은 대문자로 시작해야 합니다"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: 예약된 이름, 사용자 정의 명령으로 사용될 수 없습니다"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: 그런 사용자 정의 명령 없음: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 잘못된 끝내기 값: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 완성 인자는 사용자 완성에서만 허용됩니다"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: 사용자 완성은 함수 인자가 필요합니다"
 
-msgid "unknown"
-msgstr "모름"
-
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: 색 스킴 %s을(를) 찾을 수 없습니다"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "빔 사용자님, 환영합니다!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 마지막 탭을 닫을 수 없습니다"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "이미 하나의 탭만 있습니다"
 
-msgid "Edit File in new window"
-msgstr "새 창에서 파일 고치기"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "탭 페이지 %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "스왑 파일이 없습니다"
 
-msgid "Append File"
-msgstr "파일 추가"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: 디렉토리를 바꿀 수 없는 데, 버퍼는 수정됨 (덮어쓰려면 ! 더하기)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 이전 디렉토리가 없습니다"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 모름"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize는 두개의 인자가 필요합니다"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "창 위치: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: 이 플랫폼에 대한 창 위치 얻는 기능을 구현되지 않았습니다"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos에는 두개의 인자가 필요합니다"
 
-msgid "Save Redirection"
-msgstr "리디렉션 저장"
-
-msgid "Save View"
-msgstr "보기 저장"
-
-msgid "Save Session"
-msgstr "세션 저장"
-
-msgid "Save Setup"
-msgstr "설정 저장"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: 디렉토리 생성 실패: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\"이(가) 존재합니다 (덮어쓰려면 ! 더하기)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: 쓰기 위한 \"%s\"을(를) 열 수 없습니다"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 인자는 글자나 앞/뒤 인용 부호여야 합니다"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal의 재귀 호출이 너무 많이 생겼습니다"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #<는 +eval 기능이 포함되어야 사용할 수 있습니다"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: '#'에 대해 치환할 교체 파일 이름이 없습니다"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: \"<afile>\"에 대해 치환할 자동명령 파일 이름이 없습니다"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: \"<abuf>\"에 대해 치환할 자동명령 버퍼 번호가 없습니다"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: \"<amatch>\"에 대해 치환할 자동명령 매치 이름이 없습니다"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: \"<sfile>\"에 대해 치환할 :source 파일 이름이 없습니다"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: \"<slnum>\"에 사용될 줄 번호가 없습니다"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%'나 '#'에 대한 빈 파일 이름, 오로지 \":p:h\"와만 동작합니다"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 빈 문자열에서 값을 구하려고 합니다"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: 읽을 viminfo 파일을 열 수 없습니다"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: 이 판에는 digraph가 없습니다"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 'Vim' 접두사로 예외를 :throw할 수 없습니다"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "예외 thrown: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "예외 종료됨: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "예외 버려짐: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, %<PRId64> 줄"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "예외 발생: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s이(가) pending 되었습니다"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s이(가) 재개 되었습니다"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s이(가) 버려졌습니다"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "예외"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "에러와 인터럽트"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "에러"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "인터럽트"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if가 너무 깊게 중첩되었습니다"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :if없이 :endif가 있습니다"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :if없이 :else가 있습니다"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :if없이 :elseif가 있습니다"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 여러개의 :else가 있습니다"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :else 뒤에 :elseif가 있습니다"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for가 너무 깊게 중첩되었습니다"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :while 혹은 :for없이 :continue가 있습니다"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :while 혹은 :for없이 :break가 있습니다"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :while에 :endfor가 사용되었습니다"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :for에 :endwhile이 사용되었습니다"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try가 너무 깊게 중첩되었습니다"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :try없이 :catch가 있습니다"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :finally 뒤에 :catch가 있습니다"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :try없이 :finally가 있습니다"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 여러개의 :finally가 있습니다"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :try없이 :endtry가 있습니다"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction이 function 내에 없습니다"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 지금은 다른 버퍼를 편집할 수 없습니다"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: 지금은 버퍼 정보를 바꿀 수 없습니다"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "태그이름"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " kind file\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history' 옵션이 0입니다"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1521,226 +1949,301 @@ msgstr ""
 "\n"
 "# %s 히스토리 (새것부터 오래된 것 순):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "명령 줄"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "찾을 문자열"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "표현"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "입력 줄"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar가 명령 길이를 벗어났습니다"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: 활성된 창이나 버퍼가 지워졌습니다"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: 잘못된 경로: '**[번호]'는 경로의 마지막에 위치하거나 '%s' 뒤에 있어야 "
+"합니다."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath에서 \"%s\" 디렉토리를 찾을 수 없습니다"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: path에서 \"%s\" 파일을 찾을 수 없습니다"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: cdpath에서 더 이상의 \"%s\" 디렉토리를 찾을 수 없습니다"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: path에서 더 이상의 \"%s\" 파일을 찾을 수 없습니다"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autocommand가 버퍼나 버퍼이름을 바꾸었습니다"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "잘못된 파일 이름"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "은(는) 디렉토리입니다"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "은(는) 파일이 아닙니다"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "은(는) 장치가 아닙니다 ('opendevice' 옵션으로 막힘)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[새 파일]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[새 디렉토리]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[파일이 너무 큼]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[허용 안 됩니다]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre 자동명령이 파일을 읽지 못하게 만들었습니다"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre 자동명령은 현재 버퍼를 바꾸면 안 됩니다"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "빔: 표준입력에서 읽는 중...\n"
 
-msgid "Reading from stdin..."
-msgstr "표준입력에서 읽는 중..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 변환된 파일을 읽을 수가 없습니다!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[피포/소켓]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[피포]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[소켓]"
 
-#~ msgid "[character special]"
-#~ msgstr ""
+#. or character special
+#: ../fileio.c:1801
+msgid "[character special]"
+msgstr ""
 
-msgid "[RO]"
-msgstr "[읽기 전용]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR 없음]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[긴 줄 잘림]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[변환 안 됩니다]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[변환 되었습니다]"
 
-msgid "[crypted]"
-msgstr "[암호화 되었습니다]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[%<PRId64> 줄에서 변환 에러]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[%<PRId64> 줄에 잘못된 바이트]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[읽기 에러]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "변환하기 위한 임시 파일을 찾을 수 없습니다"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert'를 사용한 변환이 실패했습니다"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "'charconvert'의 출력결과를 읽을 수 없습니다"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: 파일이 모르는 방법으로 암호화되어 있습니다"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: acwrite 버퍼에 대한 autocommand를 찾을 수 없습니다"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 쓸 버퍼를 자동명령이 지우거나 닫았습니다"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autocommand가 잘못된 방법으로 줄을 바꾸었습니다"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans에서는 바뀌지 않은 버퍼를 쓸 수 없습니다"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeans 버퍼에 대해서는 부분 저장을 할 수 없습니다"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "파일 혹은 쓸 수 있는 장치가 아닙니다"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "장치 쓰기가 'opendevice' 옵션으로 막힘"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "읽기 전용입니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: 백업파일을 쓸 수 없습니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: 백업파일 닫기 에러 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: 백업할 파일을 읽을 수 없습니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: 백업파일을 만들 수 없습니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: 백업파일을 만들 수 없습니다 (덮어쓰려면 ! 더하기)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: The resource fork will be lost (덮어쓰려면 ! 더하기)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 쓸 임시 파일을 찾을 수 없습니다"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 변환할 수 없습니다 (변환 없이 저장하려면 ! 더하기)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: 쓸 연결된 파일을 열 수 없습니다"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 쓸 파일을 열 수 없습니다"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync가 실패했습니다"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 닫기가 실패했습니다"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 쓰기 에러, 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
-msgstr "E513: 쓰기 에러, %<PRId64> 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
+msgstr ""
+"E513: 쓰기 에러, %<PRId64> 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 쓰기 에러 (파일 시스템이 꽉찼나요?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 변환 에러"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "%<PRId64> 줄에서;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[장치]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[새로운]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 더했습니다"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 저장 했습니다"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: 패치 상태: 원래 파일을 저장할 수 없습니다"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: 패치 상태: 빈 원래 파일을 만들 수 없습니다"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: 백업 파일을 지울 수 없습니다"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1748,76 +2251,96 @@ msgstr ""
 "\n"
 "경고: 원래 파일이 없어졌거나 깨졌을 수 있습니다\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "파일이 성공적으로 저장될 때까지 편집기를 끝내지 마십시오!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[도스]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[도스 형식]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[맥]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[맥 형식]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[유닉스]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[유닉스 형식]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 줄, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 줄, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 글자"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 글자"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[불완전한 마지막 줄]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "경고: 파일이 읽은 뒤에 바뀌었습니다!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "정말로 쓰기를 원하십니까"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: \"%s\"에 쓰기 에러"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: \"%s\" 닫기 에러"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: \"%s\" 읽기 에러"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell 자동명령이 버퍼를 지웠습니다"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: 파일 \"%s\"을(를) 더 이상 사용할 수 없습니다"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1825,30 +2348,38 @@ msgid ""
 msgstr ""
 "W12: 경고: 파일 \"%s\"이(가) 바뀌었고 마찬가지로 빔의 버퍼도 바뀌었습니다"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "더 많은 정보를 보려면 \":help W12\"을 입력하세요."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 경고: 파일 \"%s\"이(가) 고치기 시작한 뒤에 바뀌었습니다"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "더 많은 정보를 보려면 \":help W11\"을 입력하세요."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 경고: 파일 \"%s\"의 상태가 고치기 시작한 뒤에 바뀌었습니다"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "더 많은 정보를 보려면 \":help W16\"을 입력하세요."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 경고: 파일 \"%s\"이(가) 고치기 시작한 뒤에 만들었습니다"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "경고"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1856,39 +2387,48 @@ msgstr ""
 "확인(&O)\n"
 "파일 불러오기(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: \"%s\"의 재로드를 준비할 수 없습니다"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\"을(를) 다시 로드할 수 없습니다"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--지워짐--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "autocommand 자동삭제: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: 이런 그룹 없음: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * 뒤에 이상한 글자: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: 그런 이벤트 없음: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: 그런 그룹이나 이벤트 없음: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1896,531 +2436,761 @@ msgstr ""
 "\n"
 "--- 자동-명령 ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: 잘못된 버퍼 번호"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: ALL 이벤트에 대해 자동명령을 실행할 수 없습니다"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "맞는 자동명령이 없습니다"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: 자동명령이 너무 깊게 중첩되었습니다"
 
+#: ../fileio.c:7143
 #, c-format
-#~ msgid "%s Auto commands for \"%s\""
-#~ msgstr ""
+msgid "%s Auto commands for \"%s\""
+msgstr ""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s 실행중"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "자동명령 %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: {가 없습니다."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: }가 없습니다."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: fold가 없습니다"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 현재의 'foldmethod'으로 접기를 만들 수 없습니다"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 현재의 'foldmethod'으로 접기를 지울 수 없습니다"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld 줄 접힘 "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 읽혀진 버퍼에 더하기"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 재귀 맵핑"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s 전역 약어가 이미 존재합니다"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s 전역 매핑이 이미 존재합니다"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s 약어가 이미 존재합니다"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s 매핑이 이미 존재합니다"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "약어를 찾을 수 없습니다"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "맵핑을 찾을 수 없습니다"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 이상한 상태"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUI를 시작할 수 없습니다"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--버퍼에 줄 없음--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: \"%s\"에서 읽을 수 없습니다"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: 명령이 중지되었습니다"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 쓸만한 글꼴을 찾을 수 없어서 GUI를 실행할 수 없습니다"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 인자가 필요합니다"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide'가 이상합니다"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: /, ? 혹은 &는 \\ 뒤에 와야 합니다"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' 값이 이상합니다"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 명령줄 창에 잘못됨; <CR> 실행, CTRL-C 끝내기"
 
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: 색 %s을(를) 할당할 수 없습니다"
-
-#~ msgid "No match at cursor, finding next"
-#~ msgstr ""
-
-msgid "<cannot open> "
-msgstr "<열 수 없음> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: 글꼴 %s을(를) 얻을 수 없습니다"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 현재 디렉토리로 돌아갈 수 없습니다"
-
-msgid "Pathname:"
-msgstr "경로 이름:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 현재 디렉토리를 얻을 수 없습니다"
-
-msgid "OK"
-msgstr "확인"
-
-msgid "Cancel"
-msgstr "취소"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "스크롤바 위젯: 썸 픽스맵의 지오미트리를 얻을 수 없습니다."
-
-msgid "Vim dialog"
-msgstr "빔 대화상자"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: 메시지와 콜백 모두를 사용해서는 BalloonEval을 만들 수 없습니다"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"예(&Y)\n"
-"아니오(&N)\n"
-"취소(&C)"
+"E12: 현재 디렉토리 또는 태그 찾기에서 exrc/vimrc에서의 명령은 허용 안 됩니다"
 
-msgid "Input _Methods"
-msgstr "입력 방법(_M)"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif가 없습니다"
 
-msgid "VIM - Search and Replace..."
-msgstr "빔 - 찾아서 바꾸기..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry가 없습니다"
 
-msgid "VIM - Search..."
-msgstr "빔 - 찾기..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile이 없습니다"
 
-msgid "Find what:"
-msgstr "무얼 찾을까요:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor 누락"
 
-msgid "Replace with:"
-msgstr "바꿀 문자열:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :while없이 :endwhile이 있습니다"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "똑같은 낱말만"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :for 없는 :endfor"
 
-#. match case button
-#~ msgid "Match case"
-#~ msgstr ""
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 파일이 있습니다 (덮어쓰려면 ! 사용)"
 
-msgid "Direction"
-msgstr "방향"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: 명령이 실패했습니다"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "위로"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 내부 에러"
 
-msgid "Down"
-msgstr "아래로"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "중단되었습니다"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "다음 찾기"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 잘못된 주소"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "바꾸기"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 잘못된 인자"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "모두 바꾸기"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "빔: 세션 관리자로부터 \"die\" 요청을 받았습니다\n"
-
-msgid "Close"
-msgstr "닫기"
-
-msgid "New tab"
-msgstr "새 탭"
-
-msgid "Open Tab..."
-msgstr "탭 열기..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "빔: 메인 창이 죽게 될 것입니다\n"
-
-msgid "&Filter"
-msgstr "거르개(&F)"
-
-msgid "&Cancel"
-msgstr "취소(&C)"
-
-msgid "Directories"
-msgstr "디렉토리"
-
-msgid "Filter"
-msgstr "거르개"
-
-msgid "&Help"
-msgstr "도움말(&H)"
-
-msgid "Files"
-msgstr "파일"
-
-msgid "&OK"
-msgstr "확인(&O)"
-
-msgid "Selection"
-msgstr "고르기"
-
-msgid "Find &Next"
-msgstr "다음 찾기(&N)"
-
-msgid "&Replace"
-msgstr "바꾸기(&R)"
-
-msgid "Replace &All"
-msgstr "모두 바꾸기(&A)"
-
-msgid "&Undo"
-msgstr "취소(&U)"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: 창 제목 \"%s\"을(를) 찾을 수 없습니다"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 잘못된 인자: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 지원되지 않는 인자: \"-%s\": OLE 판을 사용하십시오."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 잘못된 표현식: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: MDI 응용프로그램 안에서 창을 열 수 없습니다"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 잘못된 범위"
 
-msgid "Close tab"
-msgstr "탭 닫기"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 잘못된 명령"
 
-msgid "Open tab..."
-msgstr "탭 열기..."
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\"은(는) 디렉토리입니다"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "문자열 찾기 ('\\'를 찾으려면 '\\\\' 사용)"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 스크롤 크기가 잘못되었습니다"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "문자열 찾아 바꾸기 ('\\'를 찾으려면 '\\\\' 사용)"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "사용 않됨"
-
-msgid "Directory\t*.nothing\n"
-msgstr "디렉토리\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"빔 E458: 색상맵 엔트리를 할당할 수 없습니다, 몇몇 색이 잘못될 수 있습니다"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: 다음 글자셋의 글꼴이 글꼴셋 %s에 없습니다:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: 글꼴셋 이름: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "글꼴 '%s'은(는) 고정넓이가 아닙니다"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: 글꼴셋 이름: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "글꼴0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "글꼴1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "글꼴%<PRId64> 너비가 글꼴0의 두배가 아닙니다\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "글꼴0 너비: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"글꼴1 너비: %<PRId64>\n"
-"\n"
 
-#~ msgid "Invalid font specification"
-#~ msgstr ""
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 라이브러리 \"%s()\" 부르기 실패"
 
-#~ msgid "&Dismiss"
-#~ msgstr ""
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 마크가 잘못된 줄 번호를 가지고 있습니다"
 
-#~ msgid "no specific match"
-#~ msgstr ""
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 마크가 설정되어 있지 않습니다"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - 글꼴 선택기"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 바꿀 수 없음, 'modifiable'이 꺼져있습니다"
 
-msgid "Name:"
-msgstr "이름:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 스크립트가 너무 깊게 중첩되었습니다"
 
-#. create toggle button
-#~ msgid "Show size in Points"
-#~ msgstr ""
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 다른 파일이 없습니다"
 
-msgid "Encoding:"
-msgstr "인코딩:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: 그런 약어는 없습니다"
 
-msgid "Font:"
-msgstr "글꼴:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: !은 허용되지 않습니다"
 
-msgid "Style:"
-msgstr "스타일:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다"
 
-msgid "Size:"
-msgstr "크기:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 이런 하이라이트 그룹 이름은 없습니다: %s"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: 한글 오토마타 에러"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: 입력된 텍스트가 아직 없습니다"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 이전 명령 줄이 없습니다"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: 그런 맵핑이 없습니다"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 맞지 않습니다"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 맞지 않음: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: 파일 이름이 없습니다"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 이전 바꾸기 정규 표현식이 없습니다"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: 이전 명령이 없습니다"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 이전 정규표현식이 없습니다"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 범위는 허용되지 않습니다"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: 빈 공간이 충분하지 않습니다"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: %s 파일을 만들 수 없습니다"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 임시 파일 이름을 얻을 수 없습니다"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: %s 파일을 열 수 없습니다"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: %s 파일을 읽을 수 없습니다"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 마지막으로 고친 뒤 저장되지 않았습니다 (무시하려면 ! 더하기)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[마지막으로 고친 뒤 저장 안 함]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 널 인자"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 숫자가 필요합니다"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 에러파일 %s을(를) 열 수 없습니다"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: 메모리가 바닥났습니다!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "패턴을 찾을 수 없습니다"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 패턴을 찾을 수 없습니다: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 인자는 양수이어야 합니다"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 이전 디렉토리로 갈 수 없습니다"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: 에러 없음"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 위치 목록 없음"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 깨진 맞는 문자열"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 깨진 정규표현식 프로그램"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' 옵션이 설정되어 있습니다 (덮어쓰려면 ! 더하기)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 읽기 전용 변수 \"%s\"을(를) 바꿀 수 없습니다"
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: sandbox 안에서는 변수를 설정할 수 없음: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 에러파일 읽는 도중에 에러"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: sandbox에서는 허용되지 않습니다"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: 여기에서 허용되지 않습니다"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 스크린 상태 설정은 지원되지 않습니다"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 스크롤 크기가 잘못되었습니다"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' 옵션이 비었습니다"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: sign 자료를 읽을 수 없습니다"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: 스왑 파일을 닫을 수 없습니다"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: 태그 스택이 비었습니다"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: 명령이 너무 복잡합니다"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 이름이 너무 깁니다"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [가 너무 많습니다"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: 파일 이름이 너무 많습니다"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 끝에 문자가 더 있습니다"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 모르는 마크"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 만능 글자를 확장할 수 없습니다"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight'는 'winminheight'보다 커야 합니다"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth'는 'winminwidth'보다 커야 합니다"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 쓰는 중에 에러"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Zero count"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: 스크립트 콘텍스트 밖에서 <SID> 사용"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 내부 에러: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: 패턴이 'maxmempattern'보다 많은 메모리를 사용합니다"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: 빈 버퍼"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 잘못된 찾기 패턴 혹은 구분자"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 파일이 다른 버퍼에 로딩되어 있습니다"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: 옵션 '%s'이(가) 설정되어 있지 않습니다"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 잘못된 레지스터 이름: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "처음까지 찾았음, 끝에서 계속"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "끝까지 찾았음, 처음부터 계속"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: 콜론이 없습니다"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 이상한 컴포넌트"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 숫자가 필요합니다"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "페이지 %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "인쇄될 텍스트가 없습니다"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "페이지 %d 인쇄중 (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " 복사 %d / %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "인쇄됨: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "인쇄가 취소되었습니다."
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: 포스트스크립트 출력파일에 쓸 수 없습니다."
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: \"%s\" 파일을 열 수 없습니다"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: 포스트스크립트 리소스 파일 \"%s\"을(를) 읽을 수 없습니다"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: 파일 \"%s\"은(는) 포스트스크립트 리소스 파일이 아닙니다"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: 파일 \"%s\"은(는) 지원되는 포스트스크립트 리소스 파일이 아닙니다"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" 리소스 파일은 버전이 잘못되었습니다"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 호환되지 않는 다중문자 인코딩과 문자셋."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset는 다중문자 인코딩에서 반드시 설정되어야 합니다."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: 다중문자 인쇄를 위한 글꼴이 설정되어 있지 않습니다"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: 포스트스크립트 출력파일을 열 수 없습니다"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: \"%s\" 파일을 열 수 없습니다"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: 포스트스크립트 리소스 파일 \"prolog.ps\"를 찾을 수 없습니다"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: 포스트스크립트 리소스 파일 \"cidfont.ps\"를 찾을 수 없습니다"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: 포스트스크립트 리소스 파일 \"%s.ps\"를 찾을 수 없습니다"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: \"%s\" 인쇄 인코딩으로 변환할 수 없습니다"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "프린터로 보내는 중..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: 포스트스크립트 파일을 인쇄할 수 없습니다"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "인쇄작업이 끝났습니다."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "새 데이터베이스 더하기"
 
-#~ msgid "Query for a pattern"
-#~ msgstr ""
+#: ../if_cscope.c:87
+msgid "Query for a pattern"
+msgstr ""
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "이 메시지 보이기"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "연결 끊기"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "모든 연결 다시 초기화"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "연결 보여주기"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 사용법: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "이 cscope 명령은 창 나누기를 지원하지 않습니다.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 사용법: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: 태그를 찾을 수 없습니다"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) 에러: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat 에러"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s은(는) 디렉토리도 혹은 cscope 데이터베이스가 아닙니다"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "cscope 데이터베이스 %s에 더했습니다."
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: cscope 연결 %<PRId64> 읽기 에러"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 모르는 cscope 찾기 형식"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscope 파이프를 만들 수 없습니다"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: cscope를 fork할 수 없습니다"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection 실행이 실패했습니다"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection 실행이 실패했습니다"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: to_fp에 대한 fdopen 실패"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fr_fp에 대한 fdopen 실패"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: cscope 프로세스를 spawn할 수 없습니다"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: cscope 연결이 없습니다"
 
+#: ../if_cscope.c:1009
 #, c-format
-#~ msgid "E469: invalid cscopequickfix flag %c for %c"
-#~ msgstr ""
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr ""
 
+#: ../if_cscope.c:1058
 #, c-format
-#~ msgid "E259: no matches found for cscope query %s of %s"
-#~ msgstr ""
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr ""
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope 명령:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (사용법: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2442,32 +3212,31 @@ msgstr ""
 "       s: 이 C 심볼 찾기\n"
 "       t: 이 문자열 찾기\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: cscope 데이터베이스를 열 수 없음: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: cscope 데이터베이스 정보를 얻을 수 없습니다"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 중복된 cscope 데이터베이스는 더해지지 않았습니다"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope 연결 %s을(를) 찾을 수 없습니다"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope 연결 %s이(가) 닫혔습니다"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches에 심각한 에러"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope 태그: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2475,377 +3244,87 @@ msgstr ""
 "\n"
 "   #   줄"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "파일 이름 / 콘텍스트 / 줄\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope 에러: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "모든 cscope 데이터베이스 리셋"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "cscope 연결이 없습니다\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    데이터베이스 이름                   prepend path\n"
 
-#~ msgid "Lua library cannot be loaded."
-#~ msgstr ""
-
-msgid "cannot save undo information"
-msgstr "undo 정보를 저장할 수 없습니다"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: 미안합니다, 이 명령은 사용할 수 없습니다, MzScheme 라이브러리를 로딩할 "
-"수 없습니다."
-
-msgid "invalid expression"
-msgstr "잘못된 표현식"
-
-msgid "expressions disabled at compile time"
-msgstr "표현식을 지원하지 않도록 컴파일 되었습니다"
-
-#~ msgid "hidden option"
-#~ msgstr ""
-
-msgid "unknown option"
-msgstr "모르는 옵션"
-
-msgid "window index is out of range"
-msgstr "창 번호가 범위를 벗어났습니다"
-
-msgid "couldn't open buffer"
-msgstr "버퍼를 열 수 없었습니다"
-
-msgid "cannot delete line"
-msgstr "줄을 지울 수 없습니다"
-
-msgid "cannot replace line"
-msgstr "줄을 바꿀 수 없습니다"
-
-msgid "cannot insert line"
-msgstr "줄을 끼워넣을 수 없습니다"
-
-msgid "string cannot contain newlines"
-msgstr "문자열은 newline을 포함할 수 없습니다"
-
-msgid "Vim error: ~a"
-msgstr "Vim 에러: ~a"
-
-msgid "Vim error"
-msgstr "Vim 에러"
-
-msgid "buffer is invalid"
-msgstr "버퍼가 이상합니다"
-
-msgid "window is invalid"
-msgstr "창이 이상합니다"
-
-msgid "linenr out of range"
-msgstr "줄 번호가 범위를 벗어났습니다"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "Vim sandbox에서는 허용되지 않습니다"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: 이 Vim은 :py3을 사용한 후에 :python을 사용할 수 없습니다"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: 미안합니다, 이 명령은 사용할 수 없습니다, 파이썬 라이브러리를 로딩할 "
-"수 없습니다."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python을 재귀호출할 수 없습니다"
-
-msgid "can't delete OutputObject attributes"
-msgstr "OutputObject 속성을 지울 수 없습니다"
-
-msgid "softspace must be an integer"
-msgstr "softspace는 정수여야만 합니다"
-
-msgid "invalid attribute"
-msgstr "잘못된 속성"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<%p에 버퍼 객체 (삭제됨)>"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: 이 Vim은 :python을 사용한 후에 :py3을 사용할 수 없습니다"
-
-#~ msgid "E265: $_ must be an instance of String"
-#~ msgstr ""
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: 미안합니다, 이 명령은 사용할 수 없습니다, 루비 라이브러리를 로딩할 수 "
-"없습니다."
-
-msgid "E267: unexpected return"
-msgstr "E267: 뜻밖의 return"
-
-msgid "E268: unexpected next"
-msgstr "E268: 뜻밖의 next"
-
-msgid "E269: unexpected break"
-msgstr "E269: 뜻밖의 break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: 뜻밖의 redo"
-
-#~ msgid "E271: retry outside of rescue clause"
-#~ msgstr ""
-
-msgid "E272: unhandled exception"
-msgstr "E272: 처리않된 예외"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 모르는 longjmp 상태 %d"
-
-msgid "Toggle implementation/definition"
-msgstr "토글 구현/정의"
-
-msgid "Show base class of"
-msgstr "...의 기본 클래스 보여주기"
-
-#~ msgid "Show overridden member function"
-#~ msgstr ""
-
-#~ msgid "Retrieve from file"
-#~ msgstr ""
-
-#~ msgid "Retrieve from project"
-#~ msgstr ""
-
-#~ msgid "Retrieve from all projects"
-#~ msgstr ""
-
-#~ msgid "Retrieve"
-#~ msgstr ""
-
-#~ msgid "Show source of"
-#~ msgstr ""
-
-#~ msgid "Find symbol"
-#~ msgstr ""
-
-#~ msgid "Browse class"
-#~ msgstr ""
-
-#~ msgid "Show class in hierarchy"
-#~ msgstr ""
-
-#~ msgid "Show class in restricted hierarchy"
-#~ msgstr ""
-
-#~ msgid "Xref refers to"
-#~ msgstr ""
-
-#~ msgid "Xref referred by"
-#~ msgstr ""
-
-#~ msgid "Xref has a"
-#~ msgstr ""
-
-#~ msgid "Xref used by"
-#~ msgstr ""
-
-#~ msgid "Show docu of"
-#~ msgstr ""
-
-#~ msgid "Generate docu for"
-#~ msgstr ""
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"SNiFF+로 연결할 수 없습니다. 환경을 확인하십시오 (sniffemacs가 $PATH에서 찾아"
-"져야 합니다).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 읽는 중 에러. 끊김"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ is currently "
-
-msgid "not "
-msgstr "not "
-
-msgid "connected"
-msgstr "connected"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 모르는 SNiFF+ 요청: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: SNiFF+에 연결 에러"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SniFF+가 연결되지 않았습니다"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: SniFF+ 버퍼가 아닙니다"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 쓰는 도중 에러. 끊겼습니다"
-
-msgid "invalid buffer number"
-msgstr "잘못된 버퍼 번호"
-
-msgid "not implemented yet"
-msgstr "아직 구현되지 않았습니다"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "줄을 설정할 수 없습니다"
-
-msgid "invalid mark name"
-msgstr "잘못된 마크 이름"
-
-msgid "mark not set"
-msgstr "마크가 설정되지 않았습니다"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "행 %d 열 %d"
-
-msgid "cannot insert/append line"
-msgstr "줄을 끼워넣거나 더할 수 없습니다"
-
-msgid "line number out of range"
-msgstr "줄 번호가 범위를 벗어났습니다"
-
-msgid "unknown flag: "
-msgstr "모르는 플래그: "
-
-msgid "unknown vimOption"
-msgstr "모르는 빔 옵션"
-
-msgid "keyboard interrupt"
-msgstr "키보드 인터럽트"
-
-msgid "vim error"
-msgstr "빔 에러"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "버퍼/창 명령을 만들 수 없습니다: 객체가 지워집니다"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창이 이미 지워졌습니다"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL 심각한 에러: reflist가 깨졌나!? 이 문제를 vim-dev@vim.org로 알려주"
-"십시오"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창 참조를 찾을 수 없습니다"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: 미안합니다, 이 명령은 사용할 수 없습니다, Tcl 라이브러리를 로딩할 수 없"
-"습니다."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL 에러: 끝내기 코드가 정수가 아닌가!? 이 문제를 vim-dev@vim.org로 알"
-"려주십시오"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 종료 코드 %d"
-
-msgid "cannot get line"
-msgstr "줄을 얻을 수 없습니다"
-
-msgid "Unable to register a command server name"
-msgstr "명령 서버 이름을 등록할 수 없습니다"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: 대상프로그램으로 명령 보내기가 실패했습니다"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 잘못된 서버 id 사용됨: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: 빔 인스턴스 레지스트리 속성이 잘못되어 있습니다. 지웠습니다!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "모르는 옵션 인자"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "너무 많은 편집 인자"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "뒤에 인자가 없음"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "옵션 인자 뒤에 쓰레기 값"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "너무 많은 \"+command\" \"-c command\" 혹은 \"--cmd command\" 인자"
 
-#~ msgid "Invalid argument for"
-#~ msgstr ""
+#: ../main.c:154
+msgid "Invalid argument for"
+msgstr ""
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d 파일을 고치기\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "이 GUI는 netbeans를 지원하지 않습니다\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "이 빔은 diff 기능 없이 컴파일 되었습니다."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb'는 사용할 수 없음: 컴파일할 때 포함되지 않음\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "스크립트 파일을 다시 열려고 시도: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "읽기 위해 열 수 없음: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "스크립트 출력을 열 수 없음: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: 에러: NetBeans에서 gvim 시작 실패\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "빔: 경고: 터미널로 출력할 수 없습니다\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "빔: 경고: 터미널로 부터 입력받을 수 없습니다\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc 명령 행"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: \"%s\"에서 읽을 수 없습니다"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2853,18 +3332,23 @@ msgstr ""
 "\n"
 "더 많은 정보를 원하시면: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[파일 ..]       주어진 파일 고치기"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               표준입력에서 텍스트 읽기"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          태그가 정의된 위치에서 파일 고치기"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [에러파일]   첫 번째 에러가 난 파일 고치기"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2874,9 +3358,11 @@ msgstr ""
 "\n"
 "사용법:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [인자] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2884,11 +3370,7 @@ msgstr ""
 "\n"
 "   혹은:"
 
-#~ msgid ""
-#~ "\n"
-#~ "Where case is ignored prepend / to make flag upper case"
-#~ msgstr ""
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2898,321 +3380,189 @@ msgstr ""
 "\n"
 "인자:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t이 뒤에는 파일 이름만"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t와일드카드를 확장하지 않음"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\t이 gvim OLE에 등록"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tgvim을 OLE에서 등록취소"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tGUI로 실행 (\"gvim\"과 같음)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f 혹은 --nofork\t포그라운드: GUI로 시작할 때 fork하지 말 것"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi 상태 (\"vi\"와 같음)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx 상태 (\"ex\"와 같음)"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t조용한 (배치) 상태 (\"ex\"만)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff 상태 (\"vimdiff\"와 같음)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\t쉬운 상태 (\"evim\"과 같음, modeless)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t읽기 전용 상태 (\"view\"와 같음)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t제한된 상태 (\"rvim\"과 같음)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t수정(파일 쓰기)이 허용되지 않음"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t텍스트 수정이 허용되지 않음"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t이진 상태"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\t리스프 상태"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVi 호환: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tVi와 호환되지 않음: 'nocompatible'"
 
-#~ msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
-#~ msgstr ""
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t디버깅 상태"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t스왑 파일 없이 메모리만 사용"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t스왑 파일 목록을 표시한 뒤 끝내기"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (파일 이름과 함께)\t파손되었던 세션 복구"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t-r과 같음"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t창을 열 때 newcli 사용하지 않음"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <장치>\t\tI/O에 <장치> 사용"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tArabic 모드로 시작"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tHebrew 모드로 시작"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tFarsi 모드로 시작"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t터미널 종류를 <terminal>로 설정"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t.vimrc 대신 <vimrc>를 사용"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t.gvimrc 대신 <gvimrc>를 사용"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t플러그인 스크립트를 불러들이지 않음"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tN개의 탭 열기 (기본: 파일별로 하나)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tN개의 창 열기 (기본: 파일별로 하나)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t-o와 같지만 창을 수직으로 나누기"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t파일 마지막에서 시작"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t<lnum> 줄에서 시작"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <명령>\tvimrc 파일을 읽기 전에 <명령>을 실행"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <명령>\t\t첫째 파일을 읽은 뒤 <명령>을 실행"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <세션>\t\t첫째 파일을 읽은 뒤 <세션> 파일 불러 들이기"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t<scriptin> 파일에서 Normal 상태 명령 읽기"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t모든 입력된 명령을 <scriptout> 파일에 추가"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t모든 입력된 명령을 <scriptout> 파일에 저장"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t암호화된 파일 고치기"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t빔을 특정 X-서버와 연결"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tX 서버에 연결하지 않음"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t가능하면 빔 서버에서 <files> 편집"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  같음, 서버가 없다고 불평하지 않음"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  --remote와 같지만 다 고칠 때까지 기다립니다"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  같음, 서버가 없다고 불평하지 않음"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <files>  --remote와 같지만 파일별로 탭 페이지 사"
-"용"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t빔 서버로 <keys>를 보내고 끝내기"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t빔 서버에서 <expr> 실행하고 결과 출력"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t사용 가능한 빔 서버 이름을 표시하고 끝내기"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t빔 서버 <name>이 되거나 서버로 보내기"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <file>\tstartup timing 메시지를 <file>에 저장"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t.viminfo 대신 <viminfo>를 사용"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h 혹은 --help\t도움말(이 메시지)을 출력한 뒤 끝내기"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t판 정보를 출력한 뒤 끝내기"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim이 알고 있는 인자 (모티프 판):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim이 알고 있는 인자 (neXtaw 판):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim이 알고 있는 인자 (아테나 판):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t빔을 <display>에서 실행"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t아이콘 상태로 빔 시작"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t바탕 색으로 <color> 사용 (also: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t일반 색에 <color> 사용 (also: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\t일반 텍스트에 <font> 사용 (also: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t굵은 텍스트에 <font> 사용"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t기울임 텍스트에 <font> 사용"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t초기 지오미트리에 <geom> 사용 (also: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t가장자리 넓이에 <width> 사용 (also: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width>  스크롤바 넓이에 <width> 사용 (also: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t메뉴바 높이에 <height> 사용 (also: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t반전 비디오 사용 (also: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t반전 비디오 사용 안 함 (also: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t명시된 리소스 설정"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim이 알고있는 인자 (RISC OS 판):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <숫자>\t칸에서 창 초기 너비"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <숫자>\t줄에서 창 초기 높이"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim이 알고있는 인자 (GTK+ 판):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t빔을 <display>에서 실행 (also: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t메인 창 구분을 위해 유일한 역할 설정"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t빔을 다른 GTK 위젯 안에서 열음"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\tVim을 부모 응용 프로그램 내에서 열기"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\t다른 win32 위젯 안에서 Vim 열기"
-
-msgid "No display"
-msgstr "디스플레이가 없습니다"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 보내기가 실패하였습니다.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 보내기 실패. 로컬에서 실행됩니다\n"
-
-#, c-format
-#~ msgid "%d of %d edited"
-#~ msgstr ""
-
-msgid "No display: Send expression failed.\n"
-msgstr "디스플레이 없음: 표현식 보내기가 실패했습니다.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 표현식 보내기가 실패했습니다.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "설정된 마크가 없습니다"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\"에 맞는 마크가 없습니다"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3221,6 +3571,7 @@ msgstr ""
 "마크 라인  col 파일/텍스트"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3229,11 +3580,13 @@ msgstr ""
 " 점프 라인  col 파일/텍스트"
 
 #. Highlight title
-#~ msgid ""
-#~ "\n"
-#~ "change line  col text"
-#~ msgstr ""
+#: ../mark.c:831
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3242,6 +3595,7 @@ msgstr ""
 "# 파일 마크:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3249,6 +3603,7 @@ msgstr ""
 "\n"
 "# 점프목록 (새것이 먼저):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3256,88 +3611,84 @@ msgstr ""
 "\n"
 "# 파일내의 마크 히스토리 (새것부터 오래된 순):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>'이 없습니다"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 정상적인 코드페이지가 아닙니다"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: IC 값을 설정할 수 없습니다"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: 입력 콘텍스트를 만들 수 없습니다"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: 입력 방식을 열다가 실패했습니다"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 경고: IM에 파괴 콜백을 설정할 수 없습니다"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 입력 방식이 어떤 형식도 지원하지 않습니다"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 입력 방식이 내 preedit 형식을 지원하지 않습니다"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: 구역이 잠궈지지 않았습니다"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: 스왑 파일을 읽기 위해 특정 위치로 갈 수 없습니다"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: 스왑 파일을 읽을 수 없습니다"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: 스왑 파일을 쓰기 위해 특정 위치로 갈 수 없습니다"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: 스왑 파일을 쓸 수 없습니다"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: 스왑 파일이 이미 존재합니다 (symlink 공격?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: 구역 번호 0을 얻지 못했나요?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: 구역 번호 1을 얻지 못했나요?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: 구역 번호 2를 얻지 못했나요?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: 스왑 파일을 암호화할 수 없습니다"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: 으윽, 스왑 파일을 잃어버렸습니다!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: 스왑 파일 이름을 바꿀 수 없습니다"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: \"%s\"의 스왑 파일을 열 수 없어서 복구는 불가능합니다"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): 구역 0을 얻지 못했나요??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: %s의 스왑 파일을 찾을 수 없습니다"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "사용할 스왑 파일 번호를 입력하십시오 (0은 끝내기): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s을(를) 열 수 없습니다"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Unable to read block 0 from "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3345,124 +3696,111 @@ msgstr ""
 "\n"
 "어떤 수정도 없었거나 빔이 스왑 파일을 갱신하지 않은 것 같습니다."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " cannot be used with this version of Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "빔 3.0 판을 사용하십시오.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s은(는) 빔 스왑 파일이 아닌 것 같습니다"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " 이 컴퓨터에서는 사용될 수 없습니다.\n"
 
-#~ msgid "The file was created on "
-#~ msgstr ""
-
-#~ msgid ""
-#~ ",\n"
-#~ "or the file has been damaged."
-#~ msgstr ""
-
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
+#: ../memline.c:924
+msgid "The file was created on "
 msgstr ""
-"E833: %s이(가) 암호화되어 있는 데, 이 Vim은 암호화를 지원하지 않습니다"
 
-#~ msgid " has been damaged (page size is smaller than minimum value).\n"
-#~ msgstr ""
+#: ../memline.c:928
+msgid ""
+",\n"
+"or the file has been damaged."
+msgstr ""
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "스왑 파일 \"%s\"을(를) 사용합니다"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "원래 파일 \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 경고: 원래 파일이 바뀌었습니다"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "스왑 파일이 암호화됨: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"새로운 암호 키를 입력했는 데, 파일을 저장하지 않았었다면,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"새로운 암호 키를 입력하세요."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"암호 키를 바꾼 후에 파일을 저장했었다면 같은 키로 텍스트 파일과"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"스왑파일을 저장하려면 엔터를 누르세요"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: %s의 구역 1을 읽을 수 없습니다"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???많은 줄을 잃어버림"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???줄 번호가 잘못되었습니다"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???빈 구역"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???줄을 잃어버림"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: 구역 1의 ID가 잘못되었습니다 (%s이(가) .swp 파일이 아닌가?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???구역 잃어버림"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? 여기부터 ???끝까지의 줄이 섞였습니다"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? 여기부터 ???끝까지의 줄이 끼워지거나 지워져 버린 것 같습니다"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???끝"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: 복구 중단되었습니다"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: 복구 도중 에러 생겼습니다; ???로 시작하는 줄을 찾아보십시오"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "더 많은 정보를 보려면 \":help E312\"를 입력하세요."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "복구가 끝났습니다. 모든 게 정상인 지 확인해 보셔야만 합니다."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3470,12 +3808,15 @@ msgstr ""
 "\n"
 "(어쩌면 다른 이름으로 저장하고 싶으실 지도 모르겠습니다\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "그리고 바뀐 내용을 확인하려면 원래 파일에 대해 diff를 실행하세요)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "복구가 끝났습니다. 버퍼의 내용이 파일 내용과 같습니다."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3485,43 +3826,52 @@ msgstr ""
 "이제 .swp 파일을 지우셔도 됩니다.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "텍스트 파일에 스왑파일에서 가져온 암호 키를 사용합니다.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "스왑 파일을 찾았음:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   현재 디렉토리에:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   명시된 이름을 사용:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   In directory "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- 없음 --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          소유자: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   날짜: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             날짜: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [빔 3.0 판의 것]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [빔 스왑 파일로 보이지 않습니다]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         파일 이름: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3529,12 +3879,15 @@ msgstr ""
 "\n"
 "          수정: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "예"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "아니오"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3542,9 +3895,11 @@ msgstr ""
 "\n"
 "         사용자 이름: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "  호스트 이름: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3552,6 +3907,7 @@ msgstr ""
 "\n"
 "         호스트 이름: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3559,16 +3915,11 @@ msgstr ""
 "\n"
 "        프로세스 ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (아직 실행중)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [빔 이번 판에서는 사용할 수 없음]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3576,75 +3927,97 @@ msgstr ""
 "\n"
 "         [이 컴퓨터에서는 사용할 수 없음]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [읽을 수 없음]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [열 수 없음]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: 보존할 수 없습니다, 스왑 파일이 없습니다"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "파일이 보존되었습니다"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 파일 보존을 실패했습니다"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 잘못된 lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: %<PRId64> 줄을 찾을 수 없습니다"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 잘못된 포인터 구역 id 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx는 0여야만 합니다"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 너무 많은 구역이 갱신되었나요?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: 잘못된 포인터 구역 id 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "구역 1이 지워졌나요?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: %<PRId64> 줄을 찾을 수 없습니다"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: 잘못된 포인터 구역 id"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count가 0입니다"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 줄 번호가 범위를 벗어났습니다: 마지막에서 %<PRId64> 만큼"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: 구역 %<PRId64>의 줄 갯수가 틀렸습니다"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "스택 크기 증가"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: 잘못된 포인터 구역 id 2"
 
+#: ../memline.c:3070
 #, c-format
-#~ msgid "E773: Symlink loop for \"%s\""
-#~ msgstr ""
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 주목"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3652,38 +4025,44 @@ msgstr ""
 "\n"
 "Found a swap file by the name \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "While opening file \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NEWER than swap file!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 다른 프로그램이 같은 파일을 고치고 있는중일 수 있습니다.\n"
 "    만약 그렇다면 같은 파일을 두 개의 프로그램에서 고치지\n"
 "    않도록 조심하시기 바랍니다.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    끝내거나 위험을 감수하시려면 계속하십시오.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 파일을 고치다가 죽었었습니다.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    만약 그렇다면 \":recover\" 혹은 \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3691,9 +4070,11 @@ msgstr ""
 "\"\n"
 "    을 사용하여 복구하십시오 (\":help recovery\" 참고).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    이미 복구하셨었다면 스왑파일 \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3701,18 +4082,23 @@ msgstr ""
 "\"\n"
 "    을(를) 지우셔야 이 메시지가 사라집니다.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "스왑 파일 \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\"이 이미 존재합니다!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "빔 - 주목"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "스왑 파일이 이미 존재합니다!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3726,6 +4112,7 @@ msgstr ""
 "끝내기(&Q)\n"
 "버리기(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3741,34 +4128,56 @@ msgstr ""
 "끝내기(&Q)\n"
 "버리기(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: 너무 많은 스왑 파일이 발견되었습니다"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 메모리 부족!  (%<PRIu64> 바이트를 할당)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: 메뉴 항목 경로의 부분이 하위 메뉴가 아닙니다"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: 메뉴가 다른 모드에서만 존재합니다"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: \"%s\" 메뉴 없음"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: 메뉴 이름 없음"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: 하위 메뉴 앞에는 메뉴 경로가 붙을 수 없습니다"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: 메뉴바에 곧바로 메뉴 항목을 더할 수는 없습니다"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 구분자는 메뉴 경로의 부분이 될 수 없습니다"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3776,60 +4185,73 @@ msgstr ""
 "\n"
 "--- 메뉴 ---"
 
-msgid "Tear off this menu"
-msgstr "이 메뉴를 떼어냄"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: 메뉴 항목 앞에는 메뉴 경로가 있어야 합니다"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: 메뉴를 찾을 수 없습니다: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s 모드에 대한 메뉴가 정의되어 있지 않습니다"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: 하위 메뉴 앞에 메뉴 경로가 있어야 합니다"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: 메뉴를 찾을 수 없음 - 메뉴 이름을 확인하십시오"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "%s 수행중 에러 발견:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "%4ld 줄:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 잘못된 레지스터 이름: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "메시지 관리자: Bram Moolenaar <Bram@vim.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "중단: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "계속하려면 엔터 혹은 명령을 입력하십시오"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 줄 %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 더 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: 화면/페이지/라인 아래로, b/u/k: 위로, q: 종료 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "질문"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3837,6 +4259,17 @@ msgstr ""
 "예(&Y)\n"
 "아니오(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"예(&Y)\n"
+"아니오(&N)\n"
+"취소(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3850,262 +4283,174 @@ msgstr ""
 "모두 버림(&D)\n"
 "취소(&C)"
 
-msgid "Select Directory dialog"
-msgstr "디렉토리 선택 대화상자"
-
-msgid "Save File dialog"
-msgstr "파일 저장 대화상자"
-
-msgid "Open File dialog"
-msgstr "파일 열기 대화상자"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: 미안합니다, 콘솔 상태에는 파일 브라우저가 없습니다"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf()에 넘어온 인자 갯수가 부족"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: printf()에 예상못한 Float 인자"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf()에 너무 많은 인자 넘어옴"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 경고: 읽기 전용 파일을 고치고 있습니다"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "숫자 입력후 <엔터>나 마우스 클릭 (숫자없으면 취소): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "숫자 입력후 <엔터> (숫자없으면 취소): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "한 줄 이상"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "한 줄 이하"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> 보다 많은 줄"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> 보다 적은 줄"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (중단되었습니다)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "삑!"
 
-msgid "Vim: preserving files...\n"
-msgstr "빔: 파일 보존중...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "빔: 끌났습니다.\n"
-
-msgid "ERROR: "
-msgstr "에러: "
-
-#, c-format
-#~ msgid ""
-#~ "\n"
-#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-#~ msgstr ""
-
-#, c-format
-#~ msgid ""
-#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-#~ "\n"
-#~ msgstr ""
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 줄이 너무 길어졌습니다"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 메모리 부족!  (%<PRIu64> 바이트를 할당)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "실행하려고 쉘 부름: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: 콜론이 없습니다"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 이상한 모드"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 이상한 마우스모양"
-
-msgid "E548: digit expected"
-msgstr "E548: 숫자가 필요합니다"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 이상한 백분율"
-
-msgid "Enter encryption key: "
-msgstr "암호 키 입력: "
-
-msgid "Enter same key again: "
-msgstr "같은 키를 다시 입력: "
-
-msgid "Keys don't match!"
-msgstr "키가 맞지 않습니다!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: 잘못된 경로: '**[번호]'는 경로의 마지막에 위치하거나 '%s' 뒤에 있어야 "
-"합니다."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath에서 \"%s\" 디렉토리를 찾을 수 없습니다"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: path에서 \"%s\" 파일을 찾을 수 없습니다"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: cdpath에서 더 이상의 \"%s\" 디렉토리를 찾을 수 없습니다"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: path에서 더 이상의 \"%s\" 파일을 찾을 수 없습니다"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Netbeans #2에 연결할 수 없습니다"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Netbeans에 연결할 수 없습니다"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans 연결 정보 파일이 접근 모드가 잘못됨: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "Netbeans 소켓에서 읽기"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: 버퍼 %<PRId64>에 대한 NetBeans 연결을 잃어버렸습니다"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: 이 GUI는 netbeans를 지원하지 않습니다"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans가 이미 연결되어 있습니다"
-
-msgid "E505: "
-msgstr "E505: "
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: 커서 밑에 식별자가 없습니다"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc'가 비어있습니다"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval 기능이 빠져있습니다"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "경고: 터미널이 비쥬얼 상태를 표시할 수 없습니다"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: 커서 밑에 문자열이 없습니다"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 현재의 'foldmethod'으로 접기를 지울 수 없습니다"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: changelist가 비었습니다"
 
-#~ msgid "E662: At start of changelist"
-#~ msgstr ""
+#: ../normal.c:5899
+msgid "E662: At start of changelist"
+msgstr ""
 
-#~ msgid "E663: At end of changelist"
-#~ msgstr ""
+#: ../normal.c:5901
+msgid "E663: At end of changelist"
+msgstr ""
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "VIM을 마치려면  :quit<Enter>  입력"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 line %sed 1 time"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 line %sed %d times"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> lines %sed 1 time"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> lines %sed %d times"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> lines to indent... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 line indented "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> lines indented "
 
-#~ msgid "E748: No previously used register"
-#~ msgstr ""
+#: ../ops.c:938
+msgid "E748: No previously used register"
+msgstr ""
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "cannot yank; delete anyway"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 line changed"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> lines changed"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "freeing %<PRId64> lines"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "block of 1 line yanked"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 line yanked"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "block of %<PRId64> lines yanked"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> lines yanked"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: %s 레지스터에 아무 것도 없습니다"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4113,9 +4458,11 @@ msgstr ""
 "\n"
 "--- 레지스터 ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "이상한 레지스터 이름"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4123,159 +4470,181 @@ msgstr ""
 "\n"
 "# 레지스터:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 모르는 레지스터 형식 %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 열; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 바이트"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 문자; %<PRId64> of %<PRId64> 바이"
-"트"
+"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; "
+"%<PRId64> of %<PRId64> 바이트"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 바이트 %<PRId64> of %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 문자 %<PRId64> of %<PRId64>; 바이트 %<PRId64> "
-"of %<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; "
+"%<PRId64> of %<PRId64> 문자; %<PRId64> of %<PRId64> 바이트"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 바이"
+"트 %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 문자 "
+"%<PRId64> of %<PRId64>; 바이트 %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=페이지 %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "빔을 날게 해 주셔서 고맙습니다"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 모르는 옵션"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: 지원되지 않는 옵션입니다"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: 모드라인에서 사용될 수 없습니다"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = 뒤에 숫자가 필요합니다"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: termcap에서 찾을 수 없습니다"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 이상한 글자 <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term'을 빈 문자열로 설정할 수 없습니다"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: GUI에서는 term을 바꿀 수 없습니다"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: GUI를 시작하려면 \":gui\"를 사용하십시오"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext'와 'patchmode'가 동일합니다"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: 'listchars' 값과 충돌이 발생합니다"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: 'fillchars' 값과 충돌이 발생합니다"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: GTK+ 2 GUI에서는 바뀔 수 없습니다"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: 콜론이 없습니다"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 빈 문자열입니다"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> 뒤에 숫자가 없습니다"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: 콤마가 없습니다"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: ' 값을 명시해 주셔야 합니다"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 출력할 수 없는, 혹은 와이드 문자를 포함하고 있습니다"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 잘못된 글꼴(들)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: 글꼴셋을 고를 수 없습니다"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 잘못된 글꼴셋"
-
-msgid "E533: can't select wide font"
-msgstr "E533: 와이드 글꼴을 고를 수 없습니다"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 잘못된 와이드 글꼴"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> 뒤에 이상한 글자"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: 콤마가 필요합니다"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring'은 비거나 %s을(를) 포함해야 합니다"
 
-msgid "E538: No mouse support"
-msgstr "E538: 마우스를 지원하지 않습니다"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 닫히지 않은 표현식 배열"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 너무 많은 항목"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: 균형이 안 잡힌 그룹"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: 미리 보기 창이 이미 존재합니다"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic은 UTF-8 인코딩 필요, ':set encoding=utf-8' 하세요"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 적어도 %d 줄이 필요합니다"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 적어도 %d 칸이 필요합니다"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 모르는 옵션: %s"
@@ -4283,10 +4652,12 @@ msgstr "E355: 모르는 옵션: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: 숫자가 필요: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4294,6 +4665,7 @@ msgstr ""
 "\n"
 "--- 터미널 코드 ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4301,6 +4673,7 @@ msgstr ""
 "\n"
 "--- 전역 옵션 값 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4308,6 +4681,7 @@ msgstr ""
 "\n"
 "--- 지역 옵션 값 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4315,140 +4689,21 @@ msgstr ""
 "\n"
 "--- 옵션 ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp 에러"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': %s에 대한 맞는 글자가 없습니다"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': 세미콜론 뒤에 글자가 더 있음: %s"
 
-msgid "cannot open "
-msgstr "cannot open "
-
-msgid "VIM: Can't open window!\n"
-msgstr "빔: 창을 열 수 없습니다!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "아미가도스 2.04나 더 높은 판이 필요합니다\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Need %s version %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "NIL을 열 수 없음:\n"
-
-msgid "Cannot create "
-msgstr "Cannot create "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "빔이 %d 값으로 끝냅니다\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "콘솔 상태를 바꿀 수 없습니다 ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: 콘솔이 아닌가??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: -f 옵션이 사용된 경우 쉘을 실행할 수 없습니다"
-
-msgid "Cannot execute "
-msgstr "Cannot execute "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " returned\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE가 너무 작습니다."
-
-msgid "I/O ERROR"
-msgstr "I/O 에러"
-
-msgid "Message"
-msgstr "메시지"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns'이 80이 아니어서, 외부 명령을 실행할 수 없습니다"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: 프린터를 고르지 못했습니다"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "to %s on %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 모르는 프린터 글꼴: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 인쇄 에러: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "'%s' 인쇄중"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 잘못된 글자셋 이름 \"%s\"이(가) 글꼴 이름 \"%s\"에 있습니다"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: 잘못된 글자 '%c'이(가) 글꼴 이름 \"%s\"에 있습니다"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "빔: 같은 시그널 두 번, 끝냅니다\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "빔: %s 시그널을 잡았습니다\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "빔: 죽을 시그널을 잡았습니다\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "X 디스플레이를 여는 데 %<PRId64> msec이 걸렸습니다"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"빔: X 에러가 생겼습니다\n"
-
-msgid "Testing the X display failed"
-msgstr "X 디스플레이 시험이 실패했습니다"
-
-msgid "Opening the X display timed out"
-msgstr "X 디스플레이를 열다가 시간이 초과되었습니다"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Could not get security context for "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Could not set security context for "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4456,13 +4711,7 @@ msgstr ""
 "\n"
 "Cannot execute shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"쉘 sh를 실행할 수 없습니다\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4470,367 +4719,471 @@ msgstr ""
 "\n"
 "shell returned "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"파이프를 만들 수 없습니다\n"
+"Could not get security context for "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"자식 프로세스를 만들 수 없습니다\n"
+"Could not set security context for "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"명령이 끝마쳐졌습니다\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP가 ICE 연결을 잃어버렸습니다"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "X 디스플레이 열기가 실패했습니다"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP가 save-yourself 요청을 실행하고 있습니다"
-
-msgid "XSMP opening connection"
-msgstr "XSMP가 연결을 여는 중입니다"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP가 ICE 연결 감시를 실패했습니다"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection 실패: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: path에서 \"%s\" 파일을 찾을 수 없습니다"
 
-msgid "At line"
-msgstr "At line"
-
-msgid "Could not load vim32.dll!"
-msgstr "vim32.dll을 불러 들일 수 없습니다!"
-
-msgid "VIM Error"
-msgstr "빔 에러"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "함수 포인터를 DLL로 바꿀 수 없습니다!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "쉘이 %d을(를) 돌려주었습니다"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "빔: %s 이벤트를 잡았습니다\n"
-
-msgid "close"
-msgstr "닫기"
-
-msgid "logoff"
-msgstr "로그아웃"
-
-msgid "shutdown"
-msgstr "셧다운"
-
-msgid "E371: Command not found"
-msgstr "E371: 명령을 찾을 수 없습니다"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE를 $PATH에서 찾을 수 없습니다.\n"
-"외부 명령이 끝난 뒤 멈출 수 없습니다.\n"
-"다 많은 정보를 보시려면 :help win32-vimrun을 보십시오."
-
-msgid "Vim Warning"
-msgstr "빔 경고"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: 형식 문자열에 %%%c이(가) 너무 많습니다"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: 형식 문자열에 %%%c이(가) 잘못되었습니다"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: 형식 문자열에 ]가 없습니다"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: 형식 문자열에 지원되지 않는 %%%c이(가) 있습니다"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: 형식 문자열 서두에 잘못된 %%%c이(가) 있습니다"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: 형식 문자열에 잘못된 %%%c이(가) 있습니다"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat'이 어떤 패턴도 포함하고 있지 않습니다"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: 빠졌거나 빈 디렉토리 이름"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 더 이상의 항목이 없습니다"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d of %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (줄을 지웠음)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: 퀵픽스 스택의 바닥입니다"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: 퀵픽스 스택의 꼭대기입니다"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "error list %d of %d; %d errors"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 쓸 수 없음, 'buftype' 옵션이 설정되어 있습니다"
 
-msgid "Error file"
-msgstr "에러 파일"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: 파일명 누락 혹은 잘못된 패턴"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "\"%s\" 파일을 열 수 없습니다"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: 버퍼가 로드되지 않았습니다"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: String이나 List가 있어야 함"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: %s%%[]에 잘못된 항목"
 
-msgid "E339: Pattern too long"
-msgstr "E339: 패턴이 너무 깁니다"
-
-msgid "E50: Too many \\z("
-msgstr "E50: \\z(가 너무 많습니다"
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: %s(가 너무 많습니다"
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: 맞지 않는 \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: 맞지 않는 %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: 맞지 않는 %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: 맞지 않는 %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: %s@ 뒤에 잘못된 문자"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: %s{...}s가 너무 많음"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Nested %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Nested %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: \\_를 잘 못 사용"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 뒤에 아무것도 없습니다"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: 이상한 후위 참조"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z(는 여기에서 허용되지 않습니다"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 등은 여기에서 허용되지 않습니다"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: \\z 뒤에 이상한 문자"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: %s%%[ 뒤에 ]가 없습니다"
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: 빈 %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: %s%%[dxouU] 뒤에 이상한 문자"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: %s%% 뒤에 이상한 문자"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ 뒤에 ]가 없습니다"
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: 맞지 않는 %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: 맞지 않는 %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: 맞지 않는 %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z(는 여기에서 허용되지 않습니다"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 등은 여기에서 허용되지 않습니다"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ 뒤에 ]가 없습니다"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: 빈 %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: 패턴이 너무 깁니다"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: \\z(가 너무 많습니다"
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: %s(가 너무 많습니다"
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: 맞지 않는 \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: %s@ 뒤에 잘못된 문자"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: %s{...}s가 너무 많음"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Nested %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Nested %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: \\_를 잘 못 사용"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 뒤에 아무것도 없습니다"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: 이상한 후위 참조"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: \\z 뒤에 이상한 문자"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: %s%%[dxouU] 뒤에 이상한 문자"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: %s%% 뒤에 이상한 문자"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...}에 구문 에러"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "외부 submatches:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: \\z(가 너무 많습니다"
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E828: 쓰기 위해 undo을 열 수 없습니다: %s"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " 선택치환"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 바꾸기"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 반대"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 끼워넣기"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (끼워넣기)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (바꾸기)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (선택치환)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " 헤브루"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " 아라비아"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (언어)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (붙이기)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " 비주얼"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " 비주얼 라인"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " 비주얼 블록"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " 고르기"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 라인 고르기"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 블록 고르기"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "기록중"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 잘못된 찾기 문자열: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 처음까지 맞는 문자열이 없습니다: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 끝까지 맞는 문자열이 없습니다: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ';' 뒤에는 '?'나 '/'가 와야 합니다"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (이전에 맞았던 목록 포함)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Included files "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "not found "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "in path ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Already listed)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  못 찾았음"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "포함된 파일 찾는 중: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "포함된 파일 %s 찾는 중"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 맞는 게 현재 줄에 있습니다"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "모든 포함된 파일을 찾았습니다"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "포함된 파일이 없습니다"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 정의를 찾을 수 없습니다"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: 패턴을 찾을 수 없습니다"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Substitute "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4841,84 +5194,97 @@ msgstr ""
 "# Last %sSearch Pattern:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: spell 파일 형식 에러"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: 잘린 spell 파일"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Trailing text in %s line %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affix name too long in %s line %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: affix 파일 FOL, LOW 혹은 UPP에 형식 에러"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL, LOW 혹은 UPP의 문자가 범위를 벗어남"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "단어 트리 압축중..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: 맞춤법 검사가 활성화되어 있지 않습니다"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr "경고: 단어 목록 \"%s_%s.spl\" 혹은 \"%s_ascii.spl\"을 찾을 수 없습니다"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "경고: 단어 목록 \"%s.%s.spl\" 혹은 \"%s.ascii.spl\"을 찾을 수 없습니다"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "spell 파일 \"%s\"을(를) 읽고 있습니다"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: spell 파일이 아닌 것 같습니다"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 오래된 spell 파일, 갱신이 필요합니다"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Spell 파일이 새 버젼의 Vim용입니다"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: spell 파일에 지원되지 않는 섹션"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "경고: %s 영역은 지원되지 않습니다"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "affix 파일 %s 읽는 중"
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "%s 라인 %d에 있는 단어 변환 실패: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "%s의 변환이 지원되지 않습니다: %s에서 %s로"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "%s의 변환이 지원되지 않습니다"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 라인 %d에 FLAG에 대한 잘못된 값: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 라인 %d에 플래그가 사용된 후 FLAG: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -4927,6 +5293,7 @@ msgstr ""
 "%s 라인 %d에 PFX 뒤에 COMPOUNDFORBIDFLAG을 정의한 것은 잘못된 결과를 초래할 "
 "수 있습니다"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -4935,34 +5302,42 @@ msgstr ""
 "%s 라인 %d에 PFX 뒤에 COMPOUNDPERMITFLAG을 정의한 것은 잘못된 결과를 초래할 "
 "수 있습니다"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDRULES 값: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDWORDMAX 값: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDMIN 값: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDSYLMAX 값: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 CHECKCOMPOUNDPATTERN 값: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "%s 라인 %d에 연속된 affix 블록에 다른 결합 플래그: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s 라인 %d에 중복된 affix: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -4971,270 +5346,334 @@ msgstr ""
 "%s 라인 %d에 BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST에 대해서도 "
 "affix가 사용됨: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s 라인 %d에 Y나 N이 기대됨: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s 라인 %d가 망가진 상태: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s 라인 %d에 REP(SAL) 카운트가 기대됨"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s 라인 %d에 MAP 카운트가 기대됨"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s 라인 %d의 MAP에 중복된 문자"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s 라인 %d에 모르는 혹은 중복된 항목: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s에 FOL/LOW/UPP이 누락된 라인"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX이 SYLLABLE없이 사용됨"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "postponed 접두사가 너무 많습니다"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "compound 플래그가 너무 많습니다"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "postponed 접두사와(나) compound 플래그가 너무 많습니다"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "SOFO%s가 누락된 라인이 %s에 있습니다"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "%s에 SAL과 SOFO 라인이 둘 다 있습니다"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s 라인 %d에 숫자가 아닌 플래그: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 플래그: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s 값이 다른 .aff 파일에서 사용된 것과 다릅니다"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "사전 파일 %s 읽는 중 ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s에 단어 카운트가 없습니다"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "라인 %6d, 단어 %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s 라인 %d에 중복된 단어: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "%s 라인 %d에 처음 중복된 단어: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d개의 중복된 단어가 %s에 있습니다"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "무시된 %d개의 아스키문자열이 아닌 단어가 %s에 있습니다"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "단어 파일 %s 읽는 중 ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 중복된 /encoding= 라인 무시됨: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 단어 뒤의 /encoding= 라인 무시됨: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 중복된 /regions= 라인 무시됨: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s 라인 %d에 너무 많은 영역: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 / 라인 무시됨: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 영역 번호: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s 라인 %d에 모르는 플래그: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "아스키 문자열이 아닌 %d개의 단어가 무시되었습니다"
 
-#~ msgid "E845: Insufficient memory, word list will be incomplete"
-#~ msgstr ""
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "%d/%d 노드가 압축됨; %d (%d%%)가 남음"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "맞춤법 파일을 읽는 중..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "soundfold 수행중..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "soundfold 수행 후의 단어 수: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "총 단어 수: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "%s 제안 파일을 쓰는 중 ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "추정된 런타임 메모리 사용량: %d 바이트"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 생성 파일명은 영역 이름과 달라야 합니다"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 최대 8개의 영역이 지원됩니다"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: %s에 잘못된 영역"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "경고: compound와 NOBREAK 둘 다 명시됨"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "spell 파일 %s 쓰는 중 ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "끝!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile'에 %<PRId64> 항목이 없습니다"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "%s에서 단어 삭제됨"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "%s에 단어 추가됨"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 단어가 spell 파일 간에 다릅니다"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "죄송, 제안할 게 없습니다"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "죄송, %<PRId64>개만 제안"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Change \"%.*s\" to:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: 철자가 바뀐적이 없습니다"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 찾을 수 없음: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: .sug 파일이 아닌 것 같음: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: 오래된 .sug 파일, 갱신 필요: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug 파일이 새 버젼의 Vim용임: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug 파일이 .spl 파일과 맞지 않음: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: .sug 파일 읽기 에러: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: MAP 항목에 중복된 문자"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "이 버퍼에 대해 정의된 구문 항목이 없습니다"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 잘못된 인자: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 이런 구문 클러스터는 없습니다: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "이 버퍼에 대해 정의된 구문 항목이 없습니다"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C-형식 주석문에 동기맞춤"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "동기맞춤 없음"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "syncing starts "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " lines before top line"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5242,6 +5681,7 @@ msgstr ""
 "\n"
 "--- Syntax sync 항목들 ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5249,6 +5689,7 @@ msgstr ""
 "\n"
 "syncing on items"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5256,198 +5697,273 @@ msgstr ""
 "\n"
 "--- Syntax 항목 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 이런 구문 클러스터는 없습니다: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; match "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " line breaks"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: contains 인자는 여기에 쓸 수 없습니다"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: 잘못된 cchar 값"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here는 여기에서 사용될 수 없습니다"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: %s에 대한 region 항목을 찾지 못했습니다"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: 파일이름이 필요합니다"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 파일 이름이 너무 많습니다"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' 누락: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' 누락: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: 충분치 않은 인자: 구문 영역 %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 이런 구문 클러스터는 없습니다: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: 클러스터가 명시되지 않았습니다"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: 패턴 구분자를 찾을 수 없습니다: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: 패턴 뒤에 쓰레기: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: 줄 연속 패턴이 두 번 사용되었습니다"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 비정상적인 인자: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 이퀄 기호가 빠졌음: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 빈 인자: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s은(는) 여기에서 허용되지 않습니다"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s은(는) contains 목록의 첫 번째여야 합니다"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 모르는 그룹 이름: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 잘못된 :syntax 하위 명령: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: syncolor.vim 반복 로딩"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: 하이라이트 그룹을 찾을 수 없습니다: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 충분치 않은 인자: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 너무 많은 인자: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: group이 설정값이 있습니다, highlight link 무시됨"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 뜻밖의 이퀄 기호: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 이퀄 기호가 빠졌음: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 인자가 빠졌음: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 비정상적인 값: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 모르는 FG 색상"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 모르는 BG 색상"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: 색 이름이나 숫자를 인식할 수 없음: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 터미널 코드가 너무 김: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 잘못된 인자: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 너무 많은 다른 하이라이트 속성이 사용되고 있습니다"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 그룹 이름에 출력할 수 없는 문자가 있습니다"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: 그룹 이름에 이상한 문자"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: 태그 스택의 끝입니다"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: 태그 스택의 처음입니다"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 첫 번째 맞는 태그 이전으로는 갈 수 없습니다"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: 태그를 찾을 수 없음: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "파일\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 맞는 태그가 하나 밖에 없습니다"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 마지막 맞는 태그 뒤로는 갈 수 없습니다"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "파일 \"%s\"이(가) 존재하지 않습니다"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d of %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " or more"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Using tag with different case!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: 파일 \"%s\"이(가) 존재하지 않습니다"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5455,66 +5971,79 @@ msgstr ""
 "\n"
 "  # TO tag         FROM line  in file/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "태그 파일 %s 찾는 중"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: %s에 대한 태그 파일 경로가 잘렸습니다\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr "태그 파일의 너무 긴 라인을 무시합니다"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: 태그 파일 \"%s\"에 형식 에러가 있습니다"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Before byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: 태그 파일이 정렬되어 있지 않음: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: 태그 파일이 없습니다"
 
-msgid "Ignoring long line in tags file"
-msgstr "태그 파일의 너무 긴 라인을 무시합니다"
-
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: 태그 패턴을 찾을 수 없습니다"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: 태그를 찾을 수 없지만 이거 같습니다!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "중복된 필드 명: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' not known. Available builtin terminals are:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "defaulting to '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: termcap 파일을 열 수 없습니다"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: 터미널 항목을 terminfo에서 찾을 수 없습니다"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: 터미널 항목을 termcap에서 찾을 수 없습니다"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap에 \"%s\" 항목이 없습니다"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 터미널이 \"cm\" 기능을 지원해야 합니다"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5522,251 +6051,169 @@ msgstr ""
 "\n"
 "--- 터미널 키 ---"
 
-msgid "new shell started\n"
-msgstr "새 쉘이 시작되었습니다\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "빔: 입력 읽는 중 에러, 끝내는중...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "빈 고르기 대신 CUT_BUFFER0을 사용했습니다"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: 줄 갯수가 모르는 사이에 바뀌었습니다"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "취소 불가능; 어쨌든 계속합니다"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: 쓰기 위해 undo을 열 수 없습니다: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: 깨진 undo 파일 (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "'undodir'에 있는 어떤 디렉토리에도 undo 파일을 쓸 수 없습니다"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "읽을 수가 없어서 undo 파일에 덮어쓸 수 없습니다: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "undo 파일이 아니어서 덮어쓸 수 없습니다: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "undo할 내용이 없어서 undo 파일 저장을 건너뜁니다"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "undo 파일 쓰는 중: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: undo 파일 쓰기 에러: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "소유자가 달라서 undo 파일을 읽지 않습니다: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "undo 파일 읽는 중: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: 읽기 위해 undo 파일을 열 수 없습니다: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: undo 파일이 아닙니다: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: 암호화되지 않은 파일이 암호화된 undo 파일을 가지고 있습니다: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Undo 파일을 해독할 수 없습니다: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Undo 파일이 암호화되었습니다: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: 호환되지 않는 undo 파일: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "파일 내용이 바뀌어서, undo 정보를 사용할 수 없습니다"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "undo 파일 %s을(를) 읽어들였습니다"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "더 이상의 수정이 없었습니다"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "더 이상의 수정은 없었습니다"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Undo 번호 %<PRId64>를 찾을 수 없습니다"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 잘못된 줄 번호"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "more line"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "more lines"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "line less"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "fewer lines"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "change"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "changes"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "before"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "after"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "취소할 게 없습니다"
 
-#~ msgid "number changes  when               saved"
-#~ msgstr ""
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> seconds ago"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo 뒤에 undojoin은 할 수 없습니다"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: undo 목록이 깨졌습니다"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: undo 줄이 없습니다"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 비트 GUI 판"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64비트 GUI 버젼"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32비트 GUI 버젼"
-
-msgid " in Win32s mode"
-msgstr " Win32s 상태"
-
-msgid " with OLE support"
-msgstr " OLE 지원"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 64비트 콘솔 버젼"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32비트 콘솔 버젼"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16비트 버젼"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32비트 MS-DOS 버젼"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16비트 MS-DOS 버젼"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (유닉스) 버젼"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 버젼"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 버젼"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS 버젼"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS 버젼"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5774,6 +6221,7 @@ msgstr ""
 "\n"
 "포함된 패치: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5781,9 +6229,11 @@ msgstr ""
 "\n"
 "별도의 패치: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modified by "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5791,9 +6241,11 @@ msgstr ""
 "\n"
 "Compiled "
 
+#: ../version.c:649
 msgid "by "
 msgstr "by "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5801,643 +6253,1604 @@ msgstr ""
 "\n"
 "Huge 버젼 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Big 버젼 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normal 버젼 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Small 버젼 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Tiny 버젼 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "GUI 없음."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "Photon GUI."
-
-msgid "with GUI."
-msgstr "GUI."
-
-msgid "with Carbon GUI."
-msgstr "Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "(클래식) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  기능 (+: 포함됨, -: 포함 안 됨):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "        시스템 vimrc 파일: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        사용자 vimrc 파일: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 사용자 두 번째 vimrc 파일: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 사용자 세 번째 vimrc 파일: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         사용자 exrc 파일: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  사용자 두 번째 exrc 파일: \""
 
-msgid "  system gvimrc file: \""
-msgstr "       시스템 gvimrc 파일: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       사용자 gvimrc 파일: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "사용자 두 번째 gvimrc 파일: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "사용자 세 번째 gvimrc 파일: \""
-
-msgid "    system menu file: \""
-msgstr "    시스템 메뉴 파일: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  fall-back for $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " f-b for $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "컴파일: "
 
-msgid "Compiler: "
-msgstr "컴파일러: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "링크: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  디버그 빌드"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "빔 - 향상된 Vi"
 
+#: ../version.c:769
 msgid "version "
 msgstr "판 "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "by Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "빔은 소스가 열려 있고 공짜로 배포됩니다"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "우간다에 사는 가난한 아이를 도와주세요!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "이에 대한 정보를 보려면    :help iccf<엔터>       입력"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "끝내려면                   :q<엔터>               입력"
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "온라인 도움말을 보려면     :help<엔터> 또는 <F1>  입력"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "판 정보를 보려면           :help version7<엔터>   입력"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi 호환 상태로 실행중입니다"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "빔 기본값을 사용하려면     :set nocp<엔터>        입력"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "이에 대한 정보를 보려면    :help cp-default<엔터> 입력"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "이에 대한 정보를 보려면    메뉴에서 도움말->고아  선택"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "모드없이 수행중이며, 입력된 문자는 삽입됩니다"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "메뉴에서 편집->전역 설정->삽입 모드 토글을 선택하시면 "
-
-msgid "                              for two modes      "
-msgstr "                         두 모드를 사용할 수 있습니다 "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "메뉴에서 편집->전역 설정->Vi 호환 토글을 선택하시면   "
-
-msgid "                              for Vim defaults   "
-msgstr "                          Vim이 기본값으로 동작합니다 "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "빔 개발을 후원해 주세요!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "빔 사용자로 등록하세요!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "이에 대한 정보를 보려면    :help sponsor<엔터>    입력"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "이에 대한 정보를 보려면    :help register<엔터>   입력"
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "이에 대한 정보를 보려면    메뉴 도움말->Sponsor/Register"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "경고: 윈도우즈 95/98/ME를 찾았음"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "이에 대한 정보를 보려면    :help windows95<엔터>  입력"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "이미 하나의 창만 있습니다"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: 미리 보기 창이 없습니다"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: 위 왼쪽과 아래 오른쪽을 동시에 나눌 수 없습니다"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: 다른 창이 나눠졌을 때에는 회전할 수 없습니다"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: 마지막 창을 닫을 수 없습니다"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: autocmd 창을 닫을 수 없습니다"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: 창을 닫을 수 없음, autocmd 창만 남음"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: 다른 창이 바뀌었습니다"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: 커서 밑에 파일 이름이 없습니다"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: path에서 \"%s\" 파일을 찾을 수 없습니다"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: 빈 비밀번호로 bf_key_init() 함수가 불려졌습니다"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: %s 라이브러리를 로드할 수 없습니다"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"미안합니다, 이 명령은 사용할 수 없습니다, Perl 라이브러리를 로딩할 수 없습니"
-"다."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish big/little endian use wrong"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Safe 모듈없이는 sandbox에서 Perl evaluation이 제한됩니다"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256 시험이 실패했습니다."
 
-msgid "Edit with &multiple Vims"
-msgstr "여러 빔으로 편집(&M)"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish 시험이 실패했습니다."
 
-msgid "Edit with single &Vim"
-msgstr "하나의 빔으로만 편집(&V)"
+#~ msgid "Patch file"
+#~ msgstr "패키 파일"
 
-msgid "Diff with Vim"
-msgstr "빔으로 Diff"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "확인(&O)\n"
+#~ "취소(&C)"
 
-msgid "Edit with &Vim"
-msgstr "빔으로 편집(&V)"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Vim 서버에 연결되어 있지 않습니다"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "하나의 빔으로만 편집 - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: %s(으)로 보낼 수 없습니다"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "선택된 파일(들)을 빔으로 편집"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 서버의 응답을 읽을 수 없습니다"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "프로세스 생성 에러: gvim이 path에 있는 지 확인하세요!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 클라이언트로 보낼 수 없습니다"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll 에러"
+#~ msgid "Save As"
+#~ msgstr "다른 이름으로 저장"
 
-msgid "Path length too long!"
-msgstr "경로가 너무 깁니다"
+#~ msgid "Edit File"
+#~ msgstr "파일 고치기"
 
-msgid "--No lines in buffer--"
-msgstr "--버퍼에 줄 없음--"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (못 찾았음)"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: 명령이 중지되었습니다"
+#~ msgid "Source Vim script"
+#~ msgstr "빔 스크립트 로드"
 
-msgid "E471: Argument required"
-msgstr "E471: 인자가 필요합니다"
+#~ msgid "unknown"
+#~ msgstr "모름"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: /, ? 혹은 &는 \\ 뒤에 와야 합니다"
+#~ msgid "Edit File in new window"
+#~ msgstr "새 창에서 파일 고치기"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 명령줄 창에 잘못됨; <CR> 실행, CTRL-C 끝내기"
+#~ msgid "Append File"
+#~ msgstr "파일 추가"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: 현재 디렉토리 또는 태그 찾기에서 exrc/vimrc에서의 명령은 허용 안 됩니다"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "창 위치: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif가 없습니다"
+#~ msgid "Save Redirection"
+#~ msgstr "리디렉션 저장"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry가 없습니다"
+#~ msgid "Save View"
+#~ msgstr "보기 저장"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile이 없습니다"
+#~ msgid "Save Session"
+#~ msgstr "세션 저장"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor 누락"
+#~ msgid "Save Setup"
+#~ msgstr "설정 저장"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :while없이 :endwhile이 있습니다"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #<는 +eval 기능이 포함되어야 사용할 수 있습니다"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :for 없는 :endfor"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 이 판에는 digraph가 없습니다"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 파일이 있습니다 (덮어쓰려면 ! 사용)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "은(는) 장치가 아닙니다 ('opendevice' 옵션으로 막힘)"
 
-msgid "E472: Command failed"
-msgstr "E472: 명령이 실패했습니다"
+#~ msgid "Reading from stdin..."
+#~ msgstr "표준입력에서 읽는 중..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 모르는 글꼴셋: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[암호화 되었습니다]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 모르는 글꼴: %s"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: 파일이 모르는 방법으로 암호화되어 있습니다"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: 글꼴 \"%s\"은(는) 고정넓이가 아닙니다"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans에서는 바뀌지 않은 버퍼를 쓸 수 없습니다"
 
-msgid "E473: Internal error"
-msgstr "E473: 내부 에러"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeans 버퍼에 대해서는 부분 저장을 할 수 없습니다"
 
-msgid "Interrupted"
-msgstr "중단되었습니다"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "장치 쓰기가 'opendevice' 옵션으로 막힘"
 
-msgid "E14: Invalid address"
-msgstr "E14: 잘못된 주소"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: The resource fork will be lost (덮어쓰려면 ! 더하기)"
 
-msgid "E474: Invalid argument"
-msgstr "E474: 잘못된 인자"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUI를 시작할 수 없습니다"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 잘못된 인자: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: \"%s\"에서 읽을 수 없습니다"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 잘못된 표현식: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 쓸만한 글꼴을 찾을 수 없어서 GUI를 실행할 수 없습니다"
 
-msgid "E16: Invalid range"
-msgstr "E16: 잘못된 범위"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide'가 이상합니다"
 
-msgid "E476: Invalid command"
-msgstr "E476: 잘못된 명령"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 값이 이상합니다"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\"은(는) 디렉토리입니다"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: 색 %s을(를) 할당할 수 없습니다"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 라이브러리 \"%s()\" 부르기 실패"
+#~ msgid "<cannot open> "
+#~ msgstr "<열 수 없음> "
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: %s 라이브러리 함수를 로드할 수 없습니다"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 글꼴 %s을(를) 얻을 수 없습니다"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 마크가 잘못된 줄 번호를 가지고 있습니다"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 현재 디렉토리로 돌아갈 수 없습니다"
 
-msgid "E20: Mark not set"
-msgstr "E20: 마크가 설정되어 있지 않습니다"
+#~ msgid "Pathname:"
+#~ msgstr "경로 이름:"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 바꿀 수 없음, 'modifiable'이 꺼져있습니다"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 현재 디렉토리를 얻을 수 없습니다"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 스크립트가 너무 깊게 중첩되었습니다"
+#~ msgid "OK"
+#~ msgstr "확인"
 
-msgid "E23: No alternate file"
-msgstr "E23: 다른 파일이 없습니다"
+#~ msgid "Cancel"
+#~ msgstr "취소"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: 그런 약어는 없습니다"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "스크롤바 위젯: 썸 픽스맵의 지오미트리를 얻을 수 없습니다."
 
-msgid "E477: No ! allowed"
-msgstr "E477: !은 허용되지 않습니다"
+#~ msgid "Vim dialog"
+#~ msgstr "빔 대화상자"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: 메시지와 콜백 모두를 사용해서는 BalloonEval을 만들 수 없습니다"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebrew는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+#~ msgid "Input _Methods"
+#~ msgstr "입력 방법(_M)"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "빔 - 찾아서 바꾸기..."
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabic은 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+#~ msgid "VIM - Search..."
+#~ msgstr "빔 - 찾기..."
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 이런 하이라이트 그룹 이름은 없습니다: %s"
+#~ msgid "Find what:"
+#~ msgstr "무얼 찾을까요:"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: 입력된 텍스트가 아직 없습니다"
+#~ msgid "Replace with:"
+#~ msgstr "바꿀 문자열:"
 
-msgid "E30: No previous command line"
-msgstr "E30: 이전 명령 줄이 없습니다"
+#~ msgid "Match whole word only"
+#~ msgstr "똑같은 낱말만"
 
-msgid "E31: No such mapping"
-msgstr "E31: 그런 맵핑이 없습니다"
+#~ msgid "Direction"
+#~ msgstr "방향"
 
-msgid "E479: No match"
-msgstr "E479: 맞지 않습니다"
+#~ msgid "Up"
+#~ msgstr "위로"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 맞지 않음: %s"
+#~ msgid "Down"
+#~ msgstr "아래로"
 
-msgid "E32: No file name"
-msgstr "E32: 파일 이름이 없습니다"
+#~ msgid "Find Next"
+#~ msgstr "다음 찾기"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 이전 바꾸기 정규 표현식이 없습니다"
+#~ msgid "Replace"
+#~ msgstr "바꾸기"
 
-msgid "E34: No previous command"
-msgstr "E34: 이전 명령이 없습니다"
+#~ msgid "Replace All"
+#~ msgstr "모두 바꾸기"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: 이전 정규표현식이 없습니다"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "빔: 세션 관리자로부터 \"die\" 요청을 받았습니다\n"
 
-msgid "E481: No range allowed"
-msgstr "E481: 범위는 허용되지 않습니다"
+#~ msgid "Close"
+#~ msgstr "닫기"
 
-msgid "E36: Not enough room"
-msgstr "E36: 빈 공간이 충분하지 않습니다"
+#~ msgid "New tab"
+#~ msgstr "새 탭"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: \"%s\"은(는) 등록된 서버명이 아닙니다"
+#~ msgid "Open Tab..."
+#~ msgstr "탭 열기..."
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: %s 파일을 만들 수 없습니다"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "빔: 메인 창이 죽게 될 것입니다\n"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: 임시 파일 이름을 얻을 수 없습니다"
+#~ msgid "&Filter"
+#~ msgstr "거르개(&F)"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: %s 파일을 열 수 없습니다"
+#~ msgid "&Cancel"
+#~ msgstr "취소(&C)"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: %s 파일을 읽을 수 없습니다"
+#~ msgid "Directories"
+#~ msgstr "디렉토리"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 마지막으로 고친 뒤 저장되지 않았습니다 (무시하려면 ! 더하기)"
+#~ msgid "Filter"
+#~ msgstr "거르개"
 
-msgid "E38: Null argument"
-msgstr "E38: 널 인자"
+#~ msgid "&Help"
+#~ msgstr "도움말(&H)"
 
-msgid "E39: Number expected"
-msgstr "E39: 숫자가 필요합니다"
+#~ msgid "Files"
+#~ msgstr "파일"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 에러파일 %s을(를) 열 수 없습니다"
+#~ msgid "&OK"
+#~ msgstr "확인(&O)"
 
-msgid "E233: cannot open display"
-msgstr "E233: 디스플레이를 열 수 없습니다"
+#~ msgid "Selection"
+#~ msgstr "고르기"
 
-msgid "E41: Out of memory!"
-msgstr "E41: 메모리가 바닥났습니다!"
+#~ msgid "Find &Next"
+#~ msgstr "다음 찾기(&N)"
 
-msgid "Pattern not found"
-msgstr "패턴을 찾을 수 없습니다"
+#~ msgid "&Replace"
+#~ msgstr "바꾸기(&R)"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 패턴을 찾을 수 없습니다: %s"
+#~ msgid "Replace &All"
+#~ msgstr "모두 바꾸기(&A)"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: 인자는 양수이어야 합니다"
+#~ msgid "&Undo"
+#~ msgstr "취소(&U)"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 이전 디렉토리로 갈 수 없습니다"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: 창 제목 \"%s\"을(를) 찾을 수 없습니다"
 
-msgid "E42: No Errors"
-msgstr "E42: 에러 없음"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 지원되지 않는 인자: \"-%s\": OLE 판을 사용하십시오."
 
-msgid "E776: No location list"
-msgstr "E776: 위치 목록 없음"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: MDI 응용프로그램 안에서 창을 열 수 없습니다"
 
-msgid "E43: Damaged match string"
-msgstr "E43: 깨진 맞는 문자열"
+#~ msgid "Close tab"
+#~ msgstr "탭 닫기"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 깨진 정규표현식 프로그램"
+#~ msgid "Open tab..."
+#~ msgstr "탭 열기..."
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' 옵션이 설정되어 있습니다 (덮어쓰려면 ! 더하기)"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "문자열 찾기 ('\\'를 찾으려면 '\\\\' 사용)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 읽기 전용 변수 \"%s\"을(를) 바꿀 수 없습니다"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "문자열 찾아 바꾸기 ('\\'를 찾으려면 '\\\\' 사용)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: sandbox 안에서는 변수를 설정할 수 없음: \"%s\""
+#~ msgid "Not Used"
+#~ msgstr "사용 않됨"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 에러파일 읽는 도중에 에러"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "디렉토리\t*.nothing\n"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: sandbox에서는 허용되지 않습니다"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "빔 E458: 색상맵 엔트리를 할당할 수 없습니다, 몇몇 색이 잘못될 수 있습니다"
 
-msgid "E523: Not allowed here"
-msgstr "E523: 여기에서 허용되지 않습니다"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: 다음 글자셋의 글꼴이 글꼴셋 %s에 없습니다:"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 스크린 상태 설정은 지원되지 않습니다"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: 글꼴셋 이름: %s"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: 스크롤 크기가 잘못되었습니다"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "글꼴 '%s'은(는) 고정넓이가 아닙니다"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' 옵션이 비었습니다"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: 글꼴셋 이름: %s\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: sign 자료를 읽을 수 없습니다"
+#~ msgid "Font0: %s\n"
+#~ msgstr "글꼴0: %s\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: 스왑 파일을 닫을 수 없습니다"
+#~ msgid "Font1: %s\n"
+#~ msgstr "글꼴1: %s\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: 태그 스택이 비었습니다"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "글꼴%<PRId64> 너비가 글꼴0의 두배가 아닙니다\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: 명령이 너무 복잡합니다"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "글꼴0 너비: %<PRId64>\n"
 
-msgid "E75: Name too long"
-msgstr "E75: 이름이 너무 깁니다"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "글꼴1 너비: %<PRId64>\n"
+#~ "\n"
 
-msgid "E76: Too many ["
-msgstr "E76: [가 너무 많습니다"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - 글꼴 선택기"
 
-msgid "E77: Too many file names"
-msgstr "E77: 파일 이름이 너무 많습니다"
+#~ msgid "Name:"
+#~ msgstr "이름:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: 끝에 문자가 더 있습니다"
+#~ msgid "Encoding:"
+#~ msgstr "인코딩:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 모르는 마크"
+#~ msgid "Font:"
+#~ msgstr "글꼴:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 만능 글자를 확장할 수 없습니다"
+#~ msgid "Style:"
+#~ msgstr "스타일:"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight'는 'winminheight'보다 커야 합니다"
+#~ msgid "Size:"
+#~ msgstr "크기:"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth'는 'winminwidth'보다 커야 합니다"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: 한글 오토마타 에러"
 
-msgid "E80: Error while writing"
-msgstr "E80: 쓰는 중에 에러"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 에러"
 
-msgid "Zero count"
-msgstr "Zero count"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: cscope 데이터베이스를 열 수 없음: %s"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: 스크립트 콘텍스트 밖에서 <SID> 사용"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: cscope 데이터베이스 정보를 얻을 수 없습니다"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: 잘못된 표현식이 받아졌습니다"
+#~ msgid "cannot save undo information"
+#~ msgstr "undo 정보를 저장할 수 없습니다"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: 영역이 보호되고 있어서 수정할 수 없습니다"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: 미안합니다, 이 명령은 사용할 수 없습니다, MzScheme 라이브러리를 로딩"
+#~ "할 수 없습니다."
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans는 읽기 전용 파일을 바꿀 수 없습니다"
+#~ msgid "invalid expression"
+#~ msgstr "잘못된 표현식"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 내부 에러: %s"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "표현식을 지원하지 않도록 컴파일 되었습니다"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: 패턴이 'maxmempattern'보다 많은 메모리를 사용합니다"
+#~ msgid "unknown option"
+#~ msgstr "모르는 옵션"
 
-msgid "E749: empty buffer"
-msgstr "E749: 빈 버퍼"
+#~ msgid "window index is out of range"
+#~ msgstr "창 번호가 범위를 벗어났습니다"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 잘못된 찾기 패턴 혹은 구분자"
+#~ msgid "couldn't open buffer"
+#~ msgstr "버퍼를 열 수 없었습니다"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 파일이 다른 버퍼에 로딩되어 있습니다"
+#~ msgid "cannot delete line"
+#~ msgstr "줄을 지울 수 없습니다"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: 옵션 '%s'이(가) 설정되어 있지 않습니다"
+#~ msgid "cannot replace line"
+#~ msgstr "줄을 바꿀 수 없습니다"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "처음까지 찾았음, 끝에서 계속"
+#~ msgid "cannot insert line"
+#~ msgstr "줄을 끼워넣을 수 없습니다"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "끝까지 찾았음, 처음부터 계속"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "문자열은 newline을 포함할 수 없습니다"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "\"%s\"에 대한 암호 키가 필요합니다"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim 에러: ~a"
 
-msgid "writelines() requires list of strings"
-msgstr "writelines()는 문자열 목록이 필요합니다"
+#~ msgid "Vim error"
+#~ msgstr "Vim 에러"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: 파이썬: I/O 객체 초기화중 에러가 생겼습니다"
+#~ msgid "buffer is invalid"
+#~ msgstr "버퍼가 이상합니다"
 
-msgid "no such buffer"
-msgstr "그런 버퍼는 없습니다"
+#~ msgid "window is invalid"
+#~ msgstr "창이 이상합니다"
 
-msgid "attempt to refer to deleted window"
-msgstr "지워진 창을 참조하려고 하였습니다"
+#~ msgid "linenr out of range"
+#~ msgstr "줄 번호가 범위를 벗어났습니다"
 
-msgid "readonly attribute"
-msgstr "읽기 전용 속성"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "Vim sandbox에서는 허용되지 않습니다"
 
-msgid "cursor position outside buffer"
-msgstr "퍼서 위치가 버퍼 밖에 있습니다"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: 이 Vim은 :py3을 사용한 후에 :python을 사용할 수 없습니다"
 
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<%p에 창 객체 (삭제됨)>"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: 미안합니다, 이 명령은 사용할 수 없습니다, 파이썬 라이브러리를 로딩"
+#~ "할 수 없습니다."
 
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<%p에 창 객체 (모름)>"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python을 재귀호출할 수 없습니다"
 
-#, c-format
-msgid "<window %d>"
-msgstr "<창 %d>"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "OutputObject 속성을 지울 수 없습니다"
 
-msgid "no such window"
-msgstr "그런 창은 없습니다"
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace는 정수여야만 합니다"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "지워진 버퍼를 참조하려고 하였습니다"
+#~ msgid "invalid attribute"
+#~ msgstr "잘못된 속성"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<%p에 버퍼 객체 (삭제됨)>"
+
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: 이 Vim은 :python을 사용한 후에 :py3을 사용할 수 없습니다"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: 미안합니다, 이 명령은 사용할 수 없습니다, 루비 라이브러리를 로딩할 "
+#~ "수 없습니다."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: 뜻밖의 return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: 뜻밖의 next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: 뜻밖의 break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: 뜻밖의 redo"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: 처리않된 예외"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 모르는 longjmp 상태 %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "토글 구현/정의"
+
+#~ msgid "Show base class of"
+#~ msgstr "...의 기본 클래스 보여주기"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "SNiFF+로 연결할 수 없습니다. 환경을 확인하십시오 (sniffemacs가 $PATH에서 "
+#~ "찾아져야 합니다).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 읽는 중 에러. 끊김"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ is currently "
+
+#~ msgid "not "
+#~ msgstr "not "
+
+#~ msgid "connected"
+#~ msgstr "connected"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 모르는 SNiFF+ 요청: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: SNiFF+에 연결 에러"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SniFF+가 연결되지 않았습니다"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: SniFF+ 버퍼가 아닙니다"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 쓰는 도중 에러. 끊겼습니다"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "잘못된 버퍼 번호"
+
+#~ msgid "not implemented yet"
+#~ msgstr "아직 구현되지 않았습니다"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "줄을 설정할 수 없습니다"
+
+#~ msgid "invalid mark name"
+#~ msgstr "잘못된 마크 이름"
+
+#~ msgid "mark not set"
+#~ msgstr "마크가 설정되지 않았습니다"
+
+#~ msgid "row %d column %d"
+#~ msgstr "행 %d 열 %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "줄을 끼워넣거나 더할 수 없습니다"
+
+#~ msgid "line number out of range"
+#~ msgstr "줄 번호가 범위를 벗어났습니다"
+
+#~ msgid "unknown flag: "
+#~ msgstr "모르는 플래그: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "모르는 빔 옵션"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "키보드 인터럽트"
+
+#~ msgid "vim error"
+#~ msgstr "빔 에러"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "버퍼/창 명령을 만들 수 없습니다: 객체가 지워집니다"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창이 이미 지워졌습니다"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL 심각한 에러: reflist가 깨졌나!? 이 문제를 vim-dev@vim.org로 알려"
+#~ "주십시오"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창 참조를 찾을 수 없습니다"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: 미안합니다, 이 명령은 사용할 수 없습니다, Tcl 라이브러리를 로딩할 "
+#~ "수 없습니다."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL 에러: 끝내기 코드가 정수가 아닌가!? 이 문제를 vim-dev@vim.org로 "
+#~ "알려주십시오"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 종료 코드 %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "줄을 얻을 수 없습니다"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "명령 서버 이름을 등록할 수 없습니다"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 대상프로그램으로 명령 보내기가 실패했습니다"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 잘못된 서버 id 사용됨: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: 빔 인스턴스 레지스트리 속성이 잘못되어 있습니다. 지웠습니다!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "이 GUI는 netbeans를 지원하지 않습니다\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "이 빔은 diff 기능 없이 컴파일 되었습니다."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb'는 사용할 수 없음: 컴파일할 때 포함되지 않음\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: 에러: NetBeans에서 gvim 시작 실패\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t이 gvim OLE에 등록"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tgvim을 OLE에서 등록취소"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tGUI로 실행 (\"gvim\"과 같음)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f 혹은 --nofork\t포그라운드: GUI로 시작할 때 fork하지 말 것"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t창을 열 때 newcli 사용하지 않음"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <장치>\t\tI/O에 <장치> 사용"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t.gvimrc 대신 <gvimrc>를 사용"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t암호화된 파일 고치기"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t빔을 특정 X-서버와 연결"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tX 서버에 연결하지 않음"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t가능하면 빔 서버에서 <files> 편집"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  같음, 서버가 없다고 불평하지 않음"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  --remote와 같지만 다 고칠 때까지 기다립니다"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  같음, 서버가 없다고 불평하지 않음"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <files>  --remote와 같지만 파일별로 탭 페이"
+#~ "지 사용"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t빔 서버로 <keys>를 보내고 끝내기"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t빔 서버에서 <expr> 실행하고 결과 출력"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t사용 가능한 빔 서버 이름을 표시하고 끝내기"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t빔 서버 <name>이 되거나 서버로 보내기"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고 있는 인자 (모티프 판):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고 있는 인자 (neXtaw 판):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고 있는 인자 (아테나 판):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t빔을 <display>에서 실행"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t아이콘 상태로 빔 시작"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t바탕 색으로 <color> 사용 (also: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t일반 색에 <color> 사용 (also: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\t일반 텍스트에 <font> 사용 (also: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t굵은 텍스트에 <font> 사용"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t기울임 텍스트에 <font> 사용"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t초기 지오미트리에 <geom> 사용 (also: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t가장자리 넓이에 <width> 사용 (also: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width>  스크롤바 넓이에 <width> 사용 (also: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t메뉴바 높이에 <height> 사용 (also: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t반전 비디오 사용 (also: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t반전 비디오 사용 안 함 (also: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t명시된 리소스 설정"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고있는 인자 (RISC OS 판):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <숫자>\t칸에서 창 초기 너비"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <숫자>\t줄에서 창 초기 높이"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고있는 인자 (GTK+ 판):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t빔을 <display>에서 실행 (also: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t메인 창 구분을 위해 유일한 역할 설정"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t빔을 다른 GTK 위젯 안에서 열음"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\tVim을 부모 응용 프로그램 내에서 열기"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\t다른 win32 위젯 안에서 Vim 열기"
+
+#~ msgid "No display"
+#~ msgstr "디스플레이가 없습니다"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 보내기가 실패하였습니다.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 보내기 실패. 로컬에서 실행됩니다\n"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "디스플레이 없음: 표현식 보내기가 실패했습니다.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 표현식 보내기가 실패했습니다.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 정상적인 코드페이지가 아닙니다"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: 입력 콘텍스트를 만들 수 없습니다"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: 입력 방식을 열다가 실패했습니다"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 경고: IM에 파괴 콜백을 설정할 수 없습니다"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 입력 방식이 어떤 형식도 지원하지 않습니다"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 입력 방식이 내 preedit 형식을 지원하지 않습니다"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: 스왑 파일을 암호화할 수 없습니다"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s이(가) 암호화되어 있는 데, 이 Vim은 암호화를 지원하지 않습니다"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "스왑 파일이 암호화됨: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "새로운 암호 키를 입력했는 데, 파일을 저장하지 않았었다면,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "새로운 암호 키를 입력하세요."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "암호 키를 바꾼 후에 파일을 저장했었다면 같은 키로 텍스트 파일과"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "스왑파일을 저장하려면 엔터를 누르세요"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "텍스트 파일에 스왑파일에서 가져온 암호 키를 사용합니다.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [빔 이번 판에서는 사용할 수 없음]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "이 메뉴를 떼어냄"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "디렉토리 선택 대화상자"
+
+#~ msgid "Save File dialog"
+#~ msgstr "파일 저장 대화상자"
+
+#~ msgid "Open File dialog"
+#~ msgstr "파일 열기 대화상자"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: 미안합니다, 콘솔 상태에는 파일 브라우저가 없습니다"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "빔: 파일 보존중...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "빔: 끌났습니다.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "에러: "
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 줄이 너무 길어졌습니다"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 이상한 마우스모양"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "암호 키 입력: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "같은 키를 다시 입력: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "키가 맞지 않습니다!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Netbeans #2에 연결할 수 없습니다"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Netbeans에 연결할 수 없습니다"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 연결 정보 파일이 접근 모드가 잘못됨: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "Netbeans 소켓에서 읽기"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 버퍼 %<PRId64>에 대한 NetBeans 연결을 잃어버렸습니다"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: 이 GUI는 netbeans를 지원하지 않습니다"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans가 이미 연결되어 있습니다"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval 기능이 빠져있습니다"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "freeing %<PRId64> lines"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: GUI에서는 term을 바꿀 수 없습니다"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: GUI를 시작하려면 \":gui\"를 사용하십시오"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: GTK+ 2 GUI에서는 바뀔 수 없습니다"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 잘못된 글꼴(들)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 글꼴셋을 고를 수 없습니다"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 잘못된 글꼴셋"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: 와이드 글꼴을 고를 수 없습니다"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 잘못된 와이드 글꼴"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: 마우스를 지원하지 않습니다"
+
+#~ msgid "cannot open "
+#~ msgstr "cannot open "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "빔: 창을 열 수 없습니다!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "아미가도스 2.04나 더 높은 판이 필요합니다\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Need %s version %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "NIL을 열 수 없음:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Cannot create "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "빔이 %d 값으로 끝냅니다\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "콘솔 상태를 바꿀 수 없습니다 ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 콘솔이 아닌가??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: -f 옵션이 사용된 경우 쉘을 실행할 수 없습니다"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Cannot execute "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " returned\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE가 너무 작습니다."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 에러"
+
+#~ msgid "Message"
+#~ msgstr "메시지"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns'이 80이 아니어서, 외부 명령을 실행할 수 없습니다"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: 프린터를 고르지 못했습니다"
+
+#~ msgid "to %s on %s"
+#~ msgstr "to %s on %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 모르는 프린터 글꼴: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 인쇄 에러: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "'%s' 인쇄중"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 잘못된 글자셋 이름 \"%s\"이(가) 글꼴 이름 \"%s\"에 있습니다"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 잘못된 글자 '%c'이(가) 글꼴 이름 \"%s\"에 있습니다"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "빔: 같은 시그널 두 번, 끝냅니다\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "빔: %s 시그널을 잡았습니다\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "빔: 죽을 시그널을 잡았습니다\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "X 디스플레이를 여는 데 %<PRId64> msec이 걸렸습니다"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "빔: X 에러가 생겼습니다\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "X 디스플레이 시험이 실패했습니다"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "X 디스플레이를 열다가 시간이 초과되었습니다"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "쉘 sh를 실행할 수 없습니다\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "파이프를 만들 수 없습니다\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "자식 프로세스를 만들 수 없습니다\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "명령이 끝마쳐졌습니다\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP가 ICE 연결을 잃어버렸습니다"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "X 디스플레이 열기가 실패했습니다"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP가 save-yourself 요청을 실행하고 있습니다"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP가 연결을 여는 중입니다"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP가 ICE 연결 감시를 실패했습니다"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection 실패: %s"
+
+#~ msgid "At line"
+#~ msgstr "At line"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "vim32.dll을 불러 들일 수 없습니다!"
+
+#~ msgid "VIM Error"
+#~ msgstr "빔 에러"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "함수 포인터를 DLL로 바꿀 수 없습니다!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "쉘이 %d을(를) 돌려주었습니다"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "빔: %s 이벤트를 잡았습니다\n"
+
+#~ msgid "close"
+#~ msgstr "닫기"
+
+#~ msgid "logoff"
+#~ msgstr "로그아웃"
+
+#~ msgid "shutdown"
+#~ msgstr "셧다운"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 명령을 찾을 수 없습니다"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE를 $PATH에서 찾을 수 없습니다.\n"
+#~ "외부 명령이 끝난 뒤 멈출 수 없습니다.\n"
+#~ "다 많은 정보를 보시려면 :help win32-vimrun을 보십시오."
+
+#~ msgid "Vim Warning"
+#~ msgstr "빔 경고"
+
+#~ msgid "Error file"
+#~ msgstr "에러 파일"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "경고: 단어 목록 \"%s_%s.spl\" 혹은 \"%s_ascii.spl\"을 찾을 수 없습니다"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "%s의 변환이 지원되지 않습니다"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: %s에 대한 태그 파일 경로가 잘렸습니다\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "새 쉘이 시작되었습니다\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "빈 고르기 대신 CUT_BUFFER0을 사용했습니다"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "취소 불가능; 어쨌든 계속합니다"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr ""
+#~ "E832: 암호화되지 않은 파일이 암호화된 undo 파일을 가지고 있습니다: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Undo 파일을 해독할 수 없습니다: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Undo 파일이 암호화되었습니다: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 비트 GUI 판"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64비트 GUI 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32비트 GUI 버젼"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " Win32s 상태"
+
+#~ msgid " with OLE support"
+#~ msgstr " OLE 지원"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64비트 콘솔 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32비트 콘솔 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16비트 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32비트 MS-DOS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16비트 MS-DOS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (유닉스) 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "OpenVMS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Big 버젼 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normal 버젼 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Small 버젼 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Tiny 버젼 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "(클래식) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "       시스템 gvimrc 파일: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       사용자 gvimrc 파일: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "사용자 두 번째 gvimrc 파일: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "사용자 세 번째 gvimrc 파일: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    시스템 메뉴 파일: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "컴파일러: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "이에 대한 정보를 보려면    메뉴에서 도움말->고아  선택"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "모드없이 수행중이며, 입력된 문자는 삽입됩니다"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "메뉴에서 편집->전역 설정->삽입 모드 토글을 선택하시면 "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                         두 모드를 사용할 수 있습니다 "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "메뉴에서 편집->전역 설정->Vi 호환 토글을 선택하시면   "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                          Vim이 기본값으로 동작합니다 "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "경고: 윈도우즈 95/98/ME를 찾았음"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "이에 대한 정보를 보려면    :help windows95<엔터>  입력"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: %s 라이브러리를 로드할 수 없습니다"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "미안합니다, 이 명령은 사용할 수 없습니다, Perl 라이브러리를 로딩할 수 없습"
+#~ "니다."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: Safe 모듈없이는 sandbox에서 Perl evaluation이 제한됩니다"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "여러 빔으로 편집(&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "하나의 빔으로만 편집(&V)"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "빔으로 Diff"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "빔으로 편집(&V)"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "하나의 빔으로만 편집 - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "선택된 파일(들)을 빔으로 편집"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "프로세스 생성 에러: gvim이 path에 있는 지 확인하세요!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 에러"
+
+#~ msgid "Path length too long!"
+#~ msgstr "경로가 너무 깁니다"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 모르는 글꼴셋: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 모르는 글꼴: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: 글꼴 \"%s\"은(는) 고정넓이가 아닙니다"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: %s 라이브러리 함수를 로드할 수 없습니다"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hebrew는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsi는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabic은 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: \"%s\"은(는) 등록된 서버명이 아닙니다"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: 디스플레이를 열 수 없습니다"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 잘못된 표현식이 받아졌습니다"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 영역이 보호되고 있어서 수정할 수 없습니다"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans는 읽기 전용 파일을 바꿀 수 없습니다"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "\"%s\"에 대한 암호 키가 필요합니다"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines()는 문자열 목록이 필요합니다"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: 파이썬: I/O 객체 초기화중 에러가 생겼습니다"
+
+#~ msgid "no such buffer"
+#~ msgstr "그런 버퍼는 없습니다"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "지워진 창을 참조하려고 하였습니다"
+
+#~ msgid "readonly attribute"
+#~ msgstr "읽기 전용 속성"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "퍼서 위치가 버퍼 밖에 있습니다"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<%p에 창 객체 (삭제됨)>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<%p에 창 객체 (모름)>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<창 %d>"
+
+#~ msgid "no such window"
+#~ msgstr "그런 창은 없습니다"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "지워진 버퍼를 참조하려고 하였습니다"

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -1779,10 +1779,6 @@ msgstr "%<PRId64> 줄, "
 msgid "1 character"
 msgstr "1 글자"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> 글자"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/ko.po
+++ b/src/nvim/po/ko.po
@@ -1779,10 +1779,6 @@ msgstr "%<PRId64> 줄, "
 msgid "1 character"
 msgstr "1 글자"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> 글자"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/ko.po
+++ b/src/nvim/po/ko.po
@@ -6,168 +6,216 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-02-16 16:18+0900\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-02-18 09:49+0900\n"
 "Last-Translator: SungHyun Nam <goweol@gmail.com>\n"
 "Language-Team: GTP Korean <gnome-kr-translation@gnome.or.kr>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=euc-kr\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: 빈 비밀번호로 bf_key_init() 함수가 불려졌습니다"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "옵션 인자 뒤에 쓰레기 값"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish big/little endian use wrong"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256 시험이 실패했습니다."
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish 시험이 실패했습니다."
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[위치 목록]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Quickfix 목록]"
 
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: Autocommand가 버퍼나 버퍼이름을 바꾸었습니다"
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: 버퍼를 할당할 수 없어서 끝냅니다..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: 버퍼를 할당할 수 없어서 다른 걸 사용합니다..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 내려진 버퍼가 없습니다"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 지워진 버퍼가 없습니다"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 완전히 지워진 버퍼가 없습니다"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "버퍼 한 개가 내려졌습니다"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "버퍼 %d 개가 내려졌습니다"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "버퍼 한 개가 지워졌습니다"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "버퍼 %d 개가 지워졌습니다"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "버퍼 한 개가 완전히 지워졌습니다"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "버퍼 %d개가 완전히 지워졌습니다"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 마지막 버퍼를 내릴 수 없습니다"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 바뀐 버퍼를 찾을 수 없습니다"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: 나열된 버퍼가 없습니다"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: 버퍼 %<PRId64>이(가) 존재하지 않습니다"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 마지막 버퍼입니다"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 첫 번째 버퍼입니다"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: 버퍼 %<PRId64>을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려면 ! 더하"
-"기)"
+"E89: 버퍼 %<PRId64>을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려"
+"면 ! 더하기)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 마지막 버퍼를 내릴 수 없습니다"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 경고: 파일 이름 목록이 넘쳤습니다"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: 버퍼 %<PRId64>을(를) 찾을 수 없습니다"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s을(를) 하나 이상 찾았습니다"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: %s와 맞는 버퍼가 없습니다"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "%<PRId64> 줄"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 이 이름을 가진 버퍼가 이미 있습니다"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [바뀜]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[고치지 않았음]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[새 파일]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[읽기 에러]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[읽기 전용]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[읽기 전용]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 줄 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 줄 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "%<PRId64> / %<PRId64> 줄 --%d%%-- 칸 "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[이름 없음]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "도움말"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[도움말]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[미리 보기]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "모두"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "바닥"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "꼭대기"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -175,9 +223,11 @@ msgstr ""
 "\n"
 "# 버퍼 목록:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Scratch]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -185,144 +235,200 @@ msgstr ""
 "\n"
 "--- 기호 ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s에 대한 기호:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    줄=%<PRId64>  id=%d  이름=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: 콜론이 없습니다"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 이상한 모드"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 숫자가 필요합니다"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 이상한 백분율"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: %<PRId64>개 이상의 버퍼에 대해서는 diff를 할 수 없습니다"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 임시 파일을 읽거나 쓸 수 없습니다"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: diff를 만들 수 없습니다"
 
-msgid "Patch file"
-msgstr "패키 파일"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: patch 결과를 읽을 수 없습니다"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: diff 출력을 읽을 수 없습니다"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 현재 버퍼는 diff 상태가 아닙니다"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: 수정 가능한 diff 상태 버퍼는 없습니다"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 다른 버퍼중에 diff 상태인 게 없습니다"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: 두개 이상의 버퍼가 diff 상태여서 어떤 것을 써야할 지 알 수 없습니다"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: \"%s\" 버퍼를 찾을 수 없습니다"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: \"%s\" 버퍼는 diff 상태가 아닙니다"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 버퍼가 모르는 사이에 바뀌었습니다"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: digraph에는 Escape을 쓸 수 없습니다"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: 키맵 파일을 찾을 수 없습니다"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: 불러들인 파일에서 :loadkeymap을 사용하지 않았습니다"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: 키맵 엔트리가 비어있음"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " 낱말 완성 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X 모드 (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 전체 줄 완성 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " 파일 이름 완성 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " 태그 완성 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " 경로 패턴 완성 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 정의 완성 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dictionary 완성 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " 백과사전 완성 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " 명령행 완성 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " 사용자 정의 완성 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni 완성 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 단어 제안 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 낱말 로컬 완성 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "단락의 마지막 만남"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Completion 기능이 창을 바꾸었습니다"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Completion 기능이 문자열을 지웠습니다"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary' 옵션이 비었습니다"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus' 옵션이 비었습니다"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "사전 찾는 중: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (끼워넣기) 스크롤 (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (바꿈) 스크롤 (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "찾는 중: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "태그 찾는 중."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 더하기"
 
@@ -330,426 +436,581 @@ msgstr " 더하기"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 찾는 중..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "원래대로 복구"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "다른 줄에 낱말"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "The only match"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "match %d of %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "match %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: ':let'에 모르는 글자"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: 목록 번호가 범위를 벗어남: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 정의 안 된 변수: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']'이 없습니다"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s 인자는 List이어야 합니다"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s 인자는 List 혹은 Dictionary여야 합니다"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Dictionary에 빈 키를 쓸 수 없습니다"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: List가 필요합니다"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Dictionary가 필요합니다"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 함수에 너무 많은 인자 넘김: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Dictionary에 키가 없음: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 함수 %s이(가) 이미 있습니다, 바꾸려면 !을 더하세요"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: 이미 Dictionary 항목이 있습니다"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref가 필요합니다"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Dictionary에 [:]을 사용할 수 없습니다"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: %s=에 대한 잘못된 변수형"
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 모르는 함수: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 비정상적인 변수 명: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Float를 String으로 사용"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: List 항목보다 적은 대상"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: List 항목보다 많은 대상"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "변수 목록에 중복된 ;"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: %s 변수 목록을 나열할 수 없습니다"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: List나 Dictionary만 색인할 수 있습니다"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:]은 마지막에 위치해야 합니다"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:]은 List 값이 필요합니다"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: List 값이 대상보다 많은 항목을 가지고 있습니다"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: List 값이 충분한 항목을 가지고 있지 않습니다"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for 뒤에 \"in\"가 없습니다"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: 괄호 없음: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: 이런 변수 없음: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: 잠금(해제)하기에 변수가 너무 깊이 중첩되었습니다"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' 뒤에 ':'이 없습니다"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: List는 List와만 비교할 수 있습니다"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: List에 대한 잘못된 동작"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Dictionary는 Dictionary와만 비교할 수 있습니다"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Dictionary에 대한 잘못된 동작"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref는 Funcref와만 비교할 수 있습니다"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Funcrefs에 대한 잘못된 동작"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Float에 '%'는 사용할 수 없습니다"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')'가 없습니다"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Funcref를 색인할 수 없습니다"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: 옵션 이름 없음: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 모르는 옵션: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 따옴표 없음: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 따옴표 없음: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: List에 콤마 누락: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: List 끝에 ']' 누락: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Dictionary에 콜론 누락: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Dictionary에 중복된 키: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Dictionary에 콤마 누락: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Dictionary 끝에 '}' 누락: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 변수가 표시하기에 너무 깊이 중첩되었습니다"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: 함수 %s에 너무 많은 인자가 전달되었습니다"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: 함수 %s(으)로 잘못된 인자가 넘겨졌습니다"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: 모르는 함수: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: 함수에 적은 인자 넘김: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: 스크립트 콘텍스트 밖에서 <SID> 사용: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Dictionary없이 사전함수가 불려짐: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Number 혹은 Float가 필요합니다"
 
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 너무 많은 인자"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete()은 입력 모드에서만 사용될 수 있습니다"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "확인(&O)"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: 키가 이미 존재함: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd 인자"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 줄: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 모르는 함수: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"확인(&O)\n"
-"취소(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore()가 inputsave()보다 많이 불려졌습니다"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 범위가 허용되지 않습니다"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len()에 잘못된 형"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Stride가 0"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 시작위치가 끝을 지나침"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<비어있음>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Vim 서버에 연결되어 있지 않습니다"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd 인자"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: %s(으)로 보낼 수 없습니다"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: 서버의 응답을 읽을 수 없습니다"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: 너무 많은 심볼릭 링크 (반복순환?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: 클라이언트로 보낼 수 없습니다"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c 인자"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c 인자"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: 정렬 비교 기능이 실패했습니다"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: 정렬 비교 기능이 실패했습니다"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(잘못되었습니다)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 임시 파일 쓰기 에러"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float를 Number로 사용"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref를 Number로 사용"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: List를 Number로 사용"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Dictionary를 Number로 사용"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref를 String으로 사용"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: List를 String으로 사용"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Dictionary를 String으로 사용"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Float를 String으로 사용"
-
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funcref 변수명은 대문자로 시작해야 함: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: 변수명이 이미 있는 함수명과 충돌: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 변수 형 다름: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: 변수 %s를 삭제할 수 없습니다"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funcref 변수명은 대문자로 시작해야 함: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: 변수명이 이미 있는 함수명과 충돌: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 값이 잠겨있음: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "모름"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: %s 값을 바꿀 수 없습니다"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: 복사하기에 변수가 너무 깊게 중첩되었습니다"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: 정의 안 된 함수: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '('가 없음: %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: IC 값을 설정할 수 없습니다"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 잘못된 인자: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "중복된 필드 명: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction이 없습니다"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: 함수명이 변수명과 충돌: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: 함수 %s을(를) 다시 정의할 수 없습니다: 사용중입니다"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 함수명이 스크립트 파일명과 다름: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 함수 이름이 필요합니다"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 함수 이름은 대문자로 시작하거나 콜론을 포함해야 함: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 함수 이름은 대문자로 시작하거나 콜론을 포함해야 함: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 함수 %s을(를) 지울 수 없습니다: 사용중입니다"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 함수를 부른 깊이가 'maxfuncdepth'보다 큽니다"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s 부르는 중"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s이(가) 중지되었습니다"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s이(가) #%<PRId64>을(를) 돌려주었습니다"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s이(가) %s을(를) 돌려주었습니다"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "%s에서 계속"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return이 함수 안에 있지 않습니다"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -757,6 +1018,7 @@ msgstr ""
 "\n"
 "# 전역 변수:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -764,82 +1026,104 @@ msgstr ""
 "\n"
 "\tLast set from "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "old 파일이 없습니다"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  십육진 %02x,  팔진 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d,  십육진 %04x,  팔진 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d,  십육진 %08x,  팔진 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 줄을 그 자신으로 이동하려고 했습니다"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 줄 옮겨졌습니다"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> 줄 옮겨졌습니다"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> 줄을 걸렀습니다"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 자동명령은 현재 버퍼를 바꾸어서는 안 됩니다"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[마지막으로 고친 뒤 저장 안 함]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: 줄에 %s: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: 너무 많은 에러, 나머지 건너뜀"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "viminfo 파일 \"%s\"%s%s%s을(를) 읽는 중"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 인포"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " 마크"
 
-#~ msgid " oldfiles"
-#~ msgstr ""
+#: ../ex_cmds.c:1462
+msgid " oldfiles"
+msgstr ""
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 실패"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo 파일의 쓰기 권한이 없습니다: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Viminfo 파일 %s을(를) 쓸 수 없습니다!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Viminfo 파일 \"%s\"을(를) 쓰는 중"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# 이 viminfo 파일은 빔이 만든 것입니다 Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -847,40 +1131,47 @@ msgstr ""
 "# 조심만 한다면 고칠 수도 있습니다!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# 이 파일이 저장되었을 때의 'encoding'의 값\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "이상한 시작 글자"
 
-msgid "Save As"
-msgstr "다른 이름으로 저장"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "파일 일부만 저장할까요?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: 버퍼 일부만 쓰려면 !을 사용하십시오"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "이미 있는 \"%s\" 파일을 덮어쓸까요?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "스왑 파일 \"%s\"가 있습니다, 덮어쓸까요?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 스왑 파일 있음: %s (덮어쓰려면 :silent! 사용)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: 버퍼 %<PRId64>의 파일 이름이 없습니다"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 파일이 써지지 않음: 'write' 옵션에 의해 쓸 수가 없습니다"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -889,6 +1180,7 @@ msgstr ""
 "'readonly' 옵션이 \"%s\"에 대해 설정되어 있습니다.\n"
 "그래도 쓰기를 원하십니까?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -899,64 +1191,83 @@ msgstr ""
 "그래도 쓰기가 가능할 지도 모릅니다.\n"
 "한 번 써 볼까요?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\"는 읽기 전용입니다 (덮어쓰려면 ! 더하기)"
 
-msgid "Edit File"
-msgstr "파일 고치기"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autocommand가 뜻 밖에 새 버퍼 %s을(를) 지웠습니다"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 숫자가 아닌 인자가 :z에 주어졌습니다"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim에서는 쉘 명령을 사용할 수 없습니다"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 정규표현식은 글자로 구분될 수 없습니다"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "%s(으)로 바꿈 (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(중단되었습니다) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1개 찾아짐"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1개 바꿨음"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64>개 찾아짐"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64>개 바꿨음"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " 한 줄에서"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " %<PRId64> 줄에서"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global은 재귀 호출 될 수 없습니다"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: global에서 정규표현식이 빠졌습니다"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "여러 줄에서 패턴을 찾았습니다: %s"
 
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "패턴을 찾을 수 없습니다"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -966,263 +1277,334 @@ msgstr ""
 "# 마지막으로 바꾼 문자열:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 당황하지 마십시오!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 미안합니다, 도움말 '%s'이(가) %s에 대해 없습니다"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 미안합니다, %s에 대한 도움말이 없습니다"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "미안합니다, 도움말 파일 \"%s\"을(를) 찾을 수 없습니다"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: 디렉토리가 아님: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 쓰기 위한 %s을(를) 열 수 없습니다"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 읽기 위한 %s을(를) 열 수 없습니다"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 한 언어내에서 여러 인코딩 사용: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: \"%s\" 태그가 %s/%s 파일에서 중복되었습니다"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 모르는 sign 명령: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: sign 이름이 없습니다"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: 너무 많은 sign이 정의되어 있습니다"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 잘못된 sign 텍스트: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 모르는 sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: sign 번호가 없습니다"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 잘못된 버퍼 이름: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 잘못된 sign ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (못 찾았음)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (지원되지 않음)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[지워졌습니다]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "디버그 상태로 들어감.  계속하려면 \"cont\"를 입력하십시오."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "%<PRId64> 줄: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "명령: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "중지점: \"%s%s\" %<PRId64> 줄"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 중지점을 찾을 수 없습니다: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "중지점이 정의되어 있지 않습니다"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  %<PRId64> 줄"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 먼저 \":profile start {fname}\"을 사용하세요"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "\"%s\"에 바뀐 내용을 저장할까요?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "제목 없음"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: 버퍼 \"%s\"에 나중에 바뀐 내용이 써지지 않았습니다"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "경고: 뜻 밖에 다른 버퍼로 들어갔습니다 (autocommand를 확인하십시오)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 고칠 파일이 하나 밖에 없습니다"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 첫 번째 파일 이전으로는 갈 수 없습니다"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 마지막 파일 뒤로는 갈 수 없습니다"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: 컴파일러가 지원되지 않음: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "\"%s\"을(를) \"%s\"에서 찾는 중"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "\"%s\"을(를) 찾는 중"
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "'runtimepath'에서 찾을 수 없음: \"%s\""
 
-msgid "Source Vim script"
-msgstr "빔 스크립트 로드"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "디렉토리는 source할 수 없음: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\"을(를) 불러 들일 수 없습니다"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "%<PRId64> 줄: \"%s\"을(를) 불러 들일 수 없습니다"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\"을(를) 불러들이는 중"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "%<PRId64> 줄: \"%s\" 불러들이는 중"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "%s 불러들이기 끝"
 
-#~ msgid "modeline"
-#~ msgstr ""
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr ""
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 인자"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 인자"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "환경 변수"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "에러 핸들러"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 경고: 잘못된 줄 구분자. ^M이 없는 것 같습니다"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding이 불러들인 파일 밖에서 사용되었습니다"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish가 불러들인 파일 밖에서 사용되었습니다"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "현재 %s언어: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 언어를 \"%s\"(으)로 설정할 수 없습니다"
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Ex 상태로 전환.  Normal 상태로 가려면 \"visual\"을 입력하십시오."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: 파일의 마지막입니다"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: 명령이 너무 많이 다시 반복되었습니다"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 예외가 발생하지 않았습니다: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "불러들인 파일의 마지막"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "함수의 마지막"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: 사용자 정의 명령을 모호하게 사용하고 있습니다"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: 편집기 명령이 아닙니다"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 반대 영역이 주어졌습니다"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "반대 영역이 주어졌습니다, 뒤집을까요"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: w나 w>>를 사용하십시오"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: 미안합니다, 그 명령은 현재 판에서 사용할 수 없습니다"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: 오로지 하나의 파일 이름만 사용 가능합니다"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "고칠 파일이 한 개 더 있습니다. 그래도 끝낼까요?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "고칠 파일이 %d 개 더 있습니다. 그래도 끝낼까요?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 고칠 파일이 한 개 더 있습니다"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 고칠 파일이 %<PRId64> 개 더 있습니다"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 명령이 이미 존재합니다: 바꾸려면 !을 더하세요"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1230,289 +1612,335 @@ msgstr ""
 "\n"
 "    이름        인자 범위  완성      정의"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "사용자 정의 명령을 찾을 수 없습니다"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 명시된 속성이 없습니다"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 잘못된 인자 갯수"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: 카운트는 두 번 이상 명시될 수 없습니다"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: 잘못된 기본 카운트 값"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete에 인자가 필요합니다"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 잘못된 속성: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 잘못된 명령 이름"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: 사용자 정의 명령은 대문자로 시작해야 합니다"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: 예약된 이름, 사용자 정의 명령으로 사용될 수 없습니다"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: 그런 사용자 정의 명령 없음: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 잘못된 끝내기 값: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 완성 인자는 사용자 완성에서만 허용됩니다"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: 사용자 완성은 함수 인자가 필요합니다"
 
-msgid "unknown"
-msgstr "모름"
-
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: 색 스킴 %s을(를) 찾을 수 없습니다"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "빔 사용자님, 환영합니다!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 마지막 탭을 닫을 수 없습니다"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "이미 하나의 탭만 있습니다"
 
-msgid "Edit File in new window"
-msgstr "새 창에서 파일 고치기"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "탭 페이지 %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "스왑 파일이 없습니다"
 
-msgid "Append File"
-msgstr "파일 추가"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: 디렉토리를 바꿀 수 없는 데, 버퍼는 수정됨 (덮어쓰려면 ! 더하기)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 이전 디렉토리가 없습니다"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 모름"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize는 두개의 인자가 필요합니다"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "창 위치: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: 이 플랫폼에 대한 창 위치 얻는 기능을 구현되지 않았습니다"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos에는 두개의 인자가 필요합니다"
 
-msgid "Save Redirection"
-msgstr "리디렉션 저장"
-
-msgid "Save View"
-msgstr "보기 저장"
-
-msgid "Save Session"
-msgstr "세션 저장"
-
-msgid "Save Setup"
-msgstr "설정 저장"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: 디렉토리 생성 실패: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\"이(가) 존재합니다 (덮어쓰려면 ! 더하기)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: 쓰기 위한 \"%s\"을(를) 열 수 없습니다"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 인자는 글자나 앞/뒤 인용 부호여야 합니다"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal의 재귀 호출이 너무 많이 생겼습니다"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #<는 +eval 기능이 포함되어야 사용할 수 있습니다"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: '#'에 대해 치환할 교체 파일 이름이 없습니다"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: \"<afile>\"에 대해 치환할 자동명령 파일 이름이 없습니다"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: \"<abuf>\"에 대해 치환할 자동명령 버퍼 번호가 없습니다"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: \"<amatch>\"에 대해 치환할 자동명령 매치 이름이 없습니다"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: \"<sfile>\"에 대해 치환할 :source 파일 이름이 없습니다"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: \"<slnum>\"에 사용될 줄 번호가 없습니다"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%'나 '#'에 대한 빈 파일 이름, 오로지 \":p:h\"와만 동작합니다"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 빈 문자열에서 값을 구하려고 합니다"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: 읽을 viminfo 파일을 열 수 없습니다"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: 이 판에는 digraph가 없습니다"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 'Vim' 접두사로 예외를 :throw할 수 없습니다"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "예외 thrown: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "예외 종료됨: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "예외 버려짐: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, %<PRId64> 줄"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "예외 발생: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s이(가) pending 되었습니다"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s이(가) 재개 되었습니다"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s이(가) 버려졌습니다"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "예외"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "에러와 인터럽트"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "에러"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "인터럽트"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if가 너무 깊게 중첩되었습니다"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :if없이 :endif가 있습니다"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :if없이 :else가 있습니다"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :if없이 :elseif가 있습니다"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 여러개의 :else가 있습니다"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :else 뒤에 :elseif가 있습니다"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for가 너무 깊게 중첩되었습니다"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :while 혹은 :for없이 :continue가 있습니다"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :while 혹은 :for없이 :break가 있습니다"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :while에 :endfor가 사용되었습니다"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :for에 :endwhile이 사용되었습니다"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try가 너무 깊게 중첩되었습니다"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :try없이 :catch가 있습니다"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :finally 뒤에 :catch가 있습니다"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :try없이 :finally가 있습니다"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 여러개의 :finally가 있습니다"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :try없이 :endtry가 있습니다"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction이 function 내에 없습니다"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 지금은 다른 버퍼를 편집할 수 없습니다"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: 지금은 버퍼 정보를 바꿀 수 없습니다"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "태그이름"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " kind file\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history' 옵션이 0입니다"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1521,226 +1949,301 @@ msgstr ""
 "\n"
 "# %s 히스토리 (새것부터 오래된 것 순):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "명령 줄"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "찾을 문자열"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "표현"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "입력 줄"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar가 명령 길이를 벗어났습니다"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: 활성된 창이나 버퍼가 지워졌습니다"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: 잘못된 경로: '**[번호]'는 경로의 마지막에 위치하거나 '%s' 뒤에 있어야 "
+"합니다."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath에서 \"%s\" 디렉토리를 찾을 수 없습니다"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: path에서 \"%s\" 파일을 찾을 수 없습니다"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: cdpath에서 더 이상의 \"%s\" 디렉토리를 찾을 수 없습니다"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: path에서 더 이상의 \"%s\" 파일을 찾을 수 없습니다"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autocommand가 버퍼나 버퍼이름을 바꾸었습니다"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "잘못된 파일 이름"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "은(는) 디렉토리입니다"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "은(는) 파일이 아닙니다"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "은(는) 장치가 아닙니다 ('opendevice' 옵션으로 막힘)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[새 파일]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[새 디렉토리]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[파일이 너무 큼]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[허용 안 됩니다]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre 자동명령이 파일을 읽지 못하게 만들었습니다"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre 자동명령은 현재 버퍼를 바꾸면 안 됩니다"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "빔: 표준입력에서 읽는 중...\n"
 
-msgid "Reading from stdin..."
-msgstr "표준입력에서 읽는 중..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 변환된 파일을 읽을 수가 없습니다!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[피포/소켓]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[피포]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[소켓]"
 
-#~ msgid "[character special]"
-#~ msgstr ""
+#. or character special
+#: ../fileio.c:1801
+msgid "[character special]"
+msgstr ""
 
-msgid "[RO]"
-msgstr "[읽기 전용]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR 없음]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[긴 줄 잘림]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[변환 안 됩니다]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[변환 되었습니다]"
 
-msgid "[crypted]"
-msgstr "[암호화 되었습니다]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[%<PRId64> 줄에서 변환 에러]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[%<PRId64> 줄에 잘못된 바이트]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[읽기 에러]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "변환하기 위한 임시 파일을 찾을 수 없습니다"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert'를 사용한 변환이 실패했습니다"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "'charconvert'의 출력결과를 읽을 수 없습니다"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: 파일이 모르는 방법으로 암호화되어 있습니다"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: acwrite 버퍼에 대한 autocommand를 찾을 수 없습니다"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 쓸 버퍼를 자동명령이 지우거나 닫았습니다"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autocommand가 잘못된 방법으로 줄을 바꾸었습니다"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans에서는 바뀌지 않은 버퍼를 쓸 수 없습니다"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeans 버퍼에 대해서는 부분 저장을 할 수 없습니다"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "파일 혹은 쓸 수 있는 장치가 아닙니다"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "장치 쓰기가 'opendevice' 옵션으로 막힘"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "읽기 전용입니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: 백업파일을 쓸 수 없습니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: 백업파일 닫기 에러 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: 백업할 파일을 읽을 수 없습니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: 백업파일을 만들 수 없습니다 (덮어쓰려면 ! 더하기)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: 백업파일을 만들 수 없습니다 (덮어쓰려면 ! 더하기)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: The resource fork will be lost (덮어쓰려면 ! 더하기)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 쓸 임시 파일을 찾을 수 없습니다"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 변환할 수 없습니다 (변환 없이 저장하려면 ! 더하기)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: 쓸 연결된 파일을 열 수 없습니다"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 쓸 파일을 열 수 없습니다"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync가 실패했습니다"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 닫기가 실패했습니다"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 쓰기 에러, 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
-msgstr "E513: 쓰기 에러, %<PRId64> 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
+msgstr ""
+"E513: 쓰기 에러, %<PRId64> 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 쓰기 에러 (파일 시스템이 꽉찼나요?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 변환 에러"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "%<PRId64> 줄에서;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[장치]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[새로운]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 더했습니다"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 저장 했습니다"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: 패치 상태: 원래 파일을 저장할 수 없습니다"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: 패치 상태: 빈 원래 파일을 만들 수 없습니다"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: 백업 파일을 지울 수 없습니다"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1748,76 +2251,96 @@ msgstr ""
 "\n"
 "경고: 원래 파일이 없어졌거나 깨졌을 수 있습니다\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "파일이 성공적으로 저장될 때까지 편집기를 끝내지 마십시오!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[도스]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[도스 형식]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[맥]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[맥 형식]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[유닉스]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[유닉스 형식]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 줄, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 줄, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 글자"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 글자"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[불완전한 마지막 줄]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "경고: 파일이 읽은 뒤에 바뀌었습니다!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "정말로 쓰기를 원하십니까"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: \"%s\"에 쓰기 에러"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: \"%s\" 닫기 에러"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: \"%s\" 읽기 에러"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell 자동명령이 버퍼를 지웠습니다"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: 파일 \"%s\"을(를) 더 이상 사용할 수 없습니다"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1825,30 +2348,38 @@ msgid ""
 msgstr ""
 "W12: 경고: 파일 \"%s\"이(가) 바뀌었고 마찬가지로 빔의 버퍼도 바뀌었습니다"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "더 많은 정보를 보려면 \":help W12\"을 입력하세요."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 경고: 파일 \"%s\"이(가) 고치기 시작한 뒤에 바뀌었습니다"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "더 많은 정보를 보려면 \":help W11\"을 입력하세요."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 경고: 파일 \"%s\"의 상태가 고치기 시작한 뒤에 바뀌었습니다"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "더 많은 정보를 보려면 \":help W16\"을 입력하세요."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 경고: 파일 \"%s\"이(가) 고치기 시작한 뒤에 만들었습니다"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "경고"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1856,39 +2387,48 @@ msgstr ""
 "확인(&O)\n"
 "파일 불러오기(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: \"%s\"의 재로드를 준비할 수 없습니다"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\"을(를) 다시 로드할 수 없습니다"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--지워짐--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "autocommand 자동삭제: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: 이런 그룹 없음: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * 뒤에 이상한 글자: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: 그런 이벤트 없음: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: 그런 그룹이나 이벤트 없음: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1896,531 +2436,761 @@ msgstr ""
 "\n"
 "--- 자동-명령 ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: 잘못된 버퍼 번호"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: ALL 이벤트에 대해 자동명령을 실행할 수 없습니다"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "맞는 자동명령이 없습니다"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: 자동명령이 너무 깊게 중첩되었습니다"
 
+#: ../fileio.c:7143
 #, c-format
-#~ msgid "%s Auto commands for \"%s\""
-#~ msgstr ""
+msgid "%s Auto commands for \"%s\""
+msgstr ""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s 실행중"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "자동명령 %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: {가 없습니다."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: }가 없습니다."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: fold가 없습니다"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 현재의 'foldmethod'으로 접기를 만들 수 없습니다"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 현재의 'foldmethod'으로 접기를 지울 수 없습니다"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld 줄 접힘 "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 읽혀진 버퍼에 더하기"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 재귀 맵핑"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s 전역 약어가 이미 존재합니다"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s 전역 매핑이 이미 존재합니다"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s 약어가 이미 존재합니다"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s 매핑이 이미 존재합니다"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "약어를 찾을 수 없습니다"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "맵핑을 찾을 수 없습니다"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 이상한 상태"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: GUI를 시작할 수 없습니다"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--버퍼에 줄 없음--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: \"%s\"에서 읽을 수 없습니다"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: 명령이 중지되었습니다"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 쓸만한 글꼴을 찾을 수 없어서 GUI를 실행할 수 없습니다"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 인자가 필요합니다"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide'가 이상합니다"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: /, ? 혹은 &는 \\ 뒤에 와야 합니다"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' 값이 이상합니다"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 명령줄 창에 잘못됨; <CR> 실행, CTRL-C 끝내기"
 
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: 색 %s을(를) 할당할 수 없습니다"
-
-#~ msgid "No match at cursor, finding next"
-#~ msgstr ""
-
-msgid "<cannot open> "
-msgstr "<열 수 없음> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: 글꼴 %s을(를) 얻을 수 없습니다"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 현재 디렉토리로 돌아갈 수 없습니다"
-
-msgid "Pathname:"
-msgstr "경로 이름:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 현재 디렉토리를 얻을 수 없습니다"
-
-msgid "OK"
-msgstr "확인"
-
-msgid "Cancel"
-msgstr "취소"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "스크롤바 위젯: 썸 픽스맵의 지오미트리를 얻을 수 없습니다."
-
-msgid "Vim dialog"
-msgstr "빔 대화상자"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: 메시지와 콜백 모두를 사용해서는 BalloonEval을 만들 수 없습니다"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"예(&Y)\n"
-"아니오(&N)\n"
-"취소(&C)"
+"E12: 현재 디렉토리 또는 태그 찾기에서 exrc/vimrc에서의 명령은 허용 안 됩니다"
 
-msgid "Input _Methods"
-msgstr "입력 방법(_M)"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif가 없습니다"
 
-msgid "VIM - Search and Replace..."
-msgstr "빔 - 찾아서 바꾸기..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry가 없습니다"
 
-msgid "VIM - Search..."
-msgstr "빔 - 찾기..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile이 없습니다"
 
-msgid "Find what:"
-msgstr "무얼 찾을까요:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor 누락"
 
-msgid "Replace with:"
-msgstr "바꿀 문자열:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :while없이 :endwhile이 있습니다"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "똑같은 낱말만"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :for 없는 :endfor"
 
-#. match case button
-#~ msgid "Match case"
-#~ msgstr ""
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 파일이 있습니다 (덮어쓰려면 ! 사용)"
 
-msgid "Direction"
-msgstr "방향"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: 명령이 실패했습니다"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "위로"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 내부 에러"
 
-msgid "Down"
-msgstr "아래로"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "중단되었습니다"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "다음 찾기"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 잘못된 주소"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "바꾸기"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 잘못된 인자"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "모두 바꾸기"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "빔: 세션 관리자로부터 \"die\" 요청을 받았습니다\n"
-
-msgid "Close"
-msgstr "닫기"
-
-msgid "New tab"
-msgstr "새 탭"
-
-msgid "Open Tab..."
-msgstr "탭 열기..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "빔: 메인 창이 죽게 될 것입니다\n"
-
-msgid "&Filter"
-msgstr "거르개(&F)"
-
-msgid "&Cancel"
-msgstr "취소(&C)"
-
-msgid "Directories"
-msgstr "디렉토리"
-
-msgid "Filter"
-msgstr "거르개"
-
-msgid "&Help"
-msgstr "도움말(&H)"
-
-msgid "Files"
-msgstr "파일"
-
-msgid "&OK"
-msgstr "확인(&O)"
-
-msgid "Selection"
-msgstr "고르기"
-
-msgid "Find &Next"
-msgstr "다음 찾기(&N)"
-
-msgid "&Replace"
-msgstr "바꾸기(&R)"
-
-msgid "Replace &All"
-msgstr "모두 바꾸기(&A)"
-
-msgid "&Undo"
-msgstr "취소(&U)"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: 창 제목 \"%s\"을(를) 찾을 수 없습니다"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 잘못된 인자: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 지원되지 않는 인자: \"-%s\": OLE 판을 사용하십시오."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 잘못된 표현식: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: MDI 응용프로그램 안에서 창을 열 수 없습니다"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 잘못된 범위"
 
-msgid "Close tab"
-msgstr "탭 닫기"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 잘못된 명령"
 
-msgid "Open tab..."
-msgstr "탭 열기..."
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\"은(는) 디렉토리입니다"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "문자열 찾기 ('\\'를 찾으려면 '\\\\' 사용)"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 스크롤 크기가 잘못되었습니다"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "문자열 찾아 바꾸기 ('\\'를 찾으려면 '\\\\' 사용)"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "사용 않됨"
-
-msgid "Directory\t*.nothing\n"
-msgstr "디렉토리\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"빔 E458: 색상맵 엔트리를 할당할 수 없습니다, 몇몇 색이 잘못될 수 있습니다"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: 다음 글자셋의 글꼴이 글꼴셋 %s에 없습니다:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: 글꼴셋 이름: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "글꼴 '%s'은(는) 고정넓이가 아닙니다"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: 글꼴셋 이름: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "글꼴0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "글꼴1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "글꼴%<PRId64> 너비가 글꼴0의 두배가 아닙니다\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "글꼴0 너비: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"글꼴1 너비: %<PRId64>\n"
-"\n"
 
-#~ msgid "Invalid font specification"
-#~ msgstr ""
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 라이브러리 \"%s()\" 부르기 실패"
 
-#~ msgid "&Dismiss"
-#~ msgstr ""
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 마크가 잘못된 줄 번호를 가지고 있습니다"
 
-#~ msgid "no specific match"
-#~ msgstr ""
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 마크가 설정되어 있지 않습니다"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - 글꼴 선택기"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 바꿀 수 없음, 'modifiable'이 꺼져있습니다"
 
-msgid "Name:"
-msgstr "이름:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 스크립트가 너무 깊게 중첩되었습니다"
 
-#. create toggle button
-#~ msgid "Show size in Points"
-#~ msgstr ""
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 다른 파일이 없습니다"
 
-msgid "Encoding:"
-msgstr "인코딩:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: 그런 약어는 없습니다"
 
-msgid "Font:"
-msgstr "글꼴:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: !은 허용되지 않습니다"
 
-msgid "Style:"
-msgstr "스타일:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다"
 
-msgid "Size:"
-msgstr "크기:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 이런 하이라이트 그룹 이름은 없습니다: %s"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: 한글 오토마타 에러"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: 입력된 텍스트가 아직 없습니다"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 이전 명령 줄이 없습니다"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: 그런 맵핑이 없습니다"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 맞지 않습니다"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 맞지 않음: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: 파일 이름이 없습니다"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 이전 바꾸기 정규 표현식이 없습니다"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: 이전 명령이 없습니다"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 이전 정규표현식이 없습니다"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 범위는 허용되지 않습니다"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: 빈 공간이 충분하지 않습니다"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: %s 파일을 만들 수 없습니다"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 임시 파일 이름을 얻을 수 없습니다"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: %s 파일을 열 수 없습니다"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: %s 파일을 읽을 수 없습니다"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 마지막으로 고친 뒤 저장되지 않았습니다 (무시하려면 ! 더하기)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[마지막으로 고친 뒤 저장 안 함]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 널 인자"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 숫자가 필요합니다"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 에러파일 %s을(를) 열 수 없습니다"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: 메모리가 바닥났습니다!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "패턴을 찾을 수 없습니다"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 패턴을 찾을 수 없습니다: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 인자는 양수이어야 합니다"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 이전 디렉토리로 갈 수 없습니다"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: 에러 없음"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 위치 목록 없음"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 깨진 맞는 문자열"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 깨진 정규표현식 프로그램"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' 옵션이 설정되어 있습니다 (덮어쓰려면 ! 더하기)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 읽기 전용 변수 \"%s\"을(를) 바꿀 수 없습니다"
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: sandbox 안에서는 변수를 설정할 수 없음: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 에러파일 읽는 도중에 에러"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: sandbox에서는 허용되지 않습니다"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: 여기에서 허용되지 않습니다"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 스크린 상태 설정은 지원되지 않습니다"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 스크롤 크기가 잘못되었습니다"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' 옵션이 비었습니다"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: sign 자료를 읽을 수 없습니다"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: 스왑 파일을 닫을 수 없습니다"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: 태그 스택이 비었습니다"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: 명령이 너무 복잡합니다"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 이름이 너무 깁니다"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [가 너무 많습니다"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: 파일 이름이 너무 많습니다"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 끝에 문자가 더 있습니다"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 모르는 마크"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 만능 글자를 확장할 수 없습니다"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight'는 'winminheight'보다 커야 합니다"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth'는 'winminwidth'보다 커야 합니다"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 쓰는 중에 에러"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Zero count"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: 스크립트 콘텍스트 밖에서 <SID> 사용"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 내부 에러: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: 패턴이 'maxmempattern'보다 많은 메모리를 사용합니다"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: 빈 버퍼"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 잘못된 찾기 패턴 혹은 구분자"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 파일이 다른 버퍼에 로딩되어 있습니다"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: 옵션 '%s'이(가) 설정되어 있지 않습니다"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 잘못된 레지스터 이름: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "처음까지 찾았음, 끝에서 계속"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "끝까지 찾았음, 처음부터 계속"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: 콜론이 없습니다"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 이상한 컴포넌트"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 숫자가 필요합니다"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "페이지 %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "인쇄될 텍스트가 없습니다"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "페이지 %d 인쇄중 (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " 복사 %d / %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "인쇄됨: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "인쇄가 취소되었습니다."
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: 포스트스크립트 출력파일에 쓸 수 없습니다."
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: \"%s\" 파일을 열 수 없습니다"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: 포스트스크립트 리소스 파일 \"%s\"을(를) 읽을 수 없습니다"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: 파일 \"%s\"은(는) 포스트스크립트 리소스 파일이 아닙니다"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: 파일 \"%s\"은(는) 지원되는 포스트스크립트 리소스 파일이 아닙니다"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" 리소스 파일은 버전이 잘못되었습니다"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 호환되지 않는 다중문자 인코딩과 문자셋."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset는 다중문자 인코딩에서 반드시 설정되어야 합니다."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: 다중문자 인쇄를 위한 글꼴이 설정되어 있지 않습니다"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: 포스트스크립트 출력파일을 열 수 없습니다"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: \"%s\" 파일을 열 수 없습니다"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: 포스트스크립트 리소스 파일 \"prolog.ps\"를 찾을 수 없습니다"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: 포스트스크립트 리소스 파일 \"cidfont.ps\"를 찾을 수 없습니다"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: 포스트스크립트 리소스 파일 \"%s.ps\"를 찾을 수 없습니다"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: \"%s\" 인쇄 인코딩으로 변환할 수 없습니다"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "프린터로 보내는 중..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: 포스트스크립트 파일을 인쇄할 수 없습니다"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "인쇄작업이 끝났습니다."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "새 데이터베이스 더하기"
 
-#~ msgid "Query for a pattern"
-#~ msgstr ""
+#: ../if_cscope.c:87
+msgid "Query for a pattern"
+msgstr ""
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "이 메시지 보이기"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "연결 끊기"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "모든 연결 다시 초기화"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "연결 보여주기"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 사용법: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "이 cscope 명령은 창 나누기를 지원하지 않습니다.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 사용법: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: 태그를 찾을 수 없습니다"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) 에러: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat 에러"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s은(는) 디렉토리도 혹은 cscope 데이터베이스가 아닙니다"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "cscope 데이터베이스 %s에 더했습니다."
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: cscope 연결 %<PRId64> 읽기 에러"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 모르는 cscope 찾기 형식"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscope 파이프를 만들 수 없습니다"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: cscope를 fork할 수 없습니다"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection 실행이 실패했습니다"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection 실행이 실패했습니다"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: to_fp에 대한 fdopen 실패"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fr_fp에 대한 fdopen 실패"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: cscope 프로세스를 spawn할 수 없습니다"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: cscope 연결이 없습니다"
 
+#: ../if_cscope.c:1009
 #, c-format
-#~ msgid "E469: invalid cscopequickfix flag %c for %c"
-#~ msgstr ""
+msgid "E469: invalid cscopequickfix flag %c for %c"
+msgstr ""
 
+#: ../if_cscope.c:1058
 #, c-format
-#~ msgid "E259: no matches found for cscope query %s of %s"
-#~ msgstr ""
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr ""
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope 명령:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (사용법: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2442,32 +3212,31 @@ msgstr ""
 "       s: 이 C 심볼 찾기\n"
 "       t: 이 문자열 찾기\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: cscope 데이터베이스를 열 수 없음: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: cscope 데이터베이스 정보를 얻을 수 없습니다"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 중복된 cscope 데이터베이스는 더해지지 않았습니다"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope 연결 %s을(를) 찾을 수 없습니다"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope 연결 %s이(가) 닫혔습니다"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches에 심각한 에러"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope 태그: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2475,377 +3244,87 @@ msgstr ""
 "\n"
 "   #   줄"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "파일 이름 / 콘텍스트 / 줄\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope 에러: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "모든 cscope 데이터베이스 리셋"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "cscope 연결이 없습니다\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    데이터베이스 이름                   prepend path\n"
 
-#~ msgid "Lua library cannot be loaded."
-#~ msgstr ""
-
-msgid "cannot save undo information"
-msgstr "undo 정보를 저장할 수 없습니다"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: 미안합니다, 이 명령은 사용할 수 없습니다, MzScheme 라이브러리를 로딩할 "
-"수 없습니다."
-
-msgid "invalid expression"
-msgstr "잘못된 표현식"
-
-msgid "expressions disabled at compile time"
-msgstr "표현식을 지원하지 않도록 컴파일 되었습니다"
-
-#~ msgid "hidden option"
-#~ msgstr ""
-
-msgid "unknown option"
-msgstr "모르는 옵션"
-
-msgid "window index is out of range"
-msgstr "창 번호가 범위를 벗어났습니다"
-
-msgid "couldn't open buffer"
-msgstr "버퍼를 열 수 없었습니다"
-
-msgid "cannot delete line"
-msgstr "줄을 지울 수 없습니다"
-
-msgid "cannot replace line"
-msgstr "줄을 바꿀 수 없습니다"
-
-msgid "cannot insert line"
-msgstr "줄을 끼워넣을 수 없습니다"
-
-msgid "string cannot contain newlines"
-msgstr "문자열은 newline을 포함할 수 없습니다"
-
-msgid "Vim error: ~a"
-msgstr "Vim 에러: ~a"
-
-msgid "Vim error"
-msgstr "Vim 에러"
-
-msgid "buffer is invalid"
-msgstr "버퍼가 이상합니다"
-
-msgid "window is invalid"
-msgstr "창이 이상합니다"
-
-msgid "linenr out of range"
-msgstr "줄 번호가 범위를 벗어났습니다"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "Vim sandbox에서는 허용되지 않습니다"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: 이 Vim은 :py3을 사용한 후에 :python을 사용할 수 없습니다"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: 미안합니다, 이 명령은 사용할 수 없습니다, 파이썬 라이브러리를 로딩할 "
-"수 없습니다."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python을 재귀호출할 수 없습니다"
-
-msgid "can't delete OutputObject attributes"
-msgstr "OutputObject 속성을 지울 수 없습니다"
-
-msgid "softspace must be an integer"
-msgstr "softspace는 정수여야만 합니다"
-
-msgid "invalid attribute"
-msgstr "잘못된 속성"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<%p에 버퍼 객체 (삭제됨)>"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: 이 Vim은 :python을 사용한 후에 :py3을 사용할 수 없습니다"
-
-#~ msgid "E265: $_ must be an instance of String"
-#~ msgstr ""
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: 미안합니다, 이 명령은 사용할 수 없습니다, 루비 라이브러리를 로딩할 수 "
-"없습니다."
-
-msgid "E267: unexpected return"
-msgstr "E267: 뜻밖의 return"
-
-msgid "E268: unexpected next"
-msgstr "E268: 뜻밖의 next"
-
-msgid "E269: unexpected break"
-msgstr "E269: 뜻밖의 break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: 뜻밖의 redo"
-
-#~ msgid "E271: retry outside of rescue clause"
-#~ msgstr ""
-
-msgid "E272: unhandled exception"
-msgstr "E272: 처리않된 예외"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 모르는 longjmp 상태 %d"
-
-msgid "Toggle implementation/definition"
-msgstr "토글 구현/정의"
-
-msgid "Show base class of"
-msgstr "...의 기본 클래스 보여주기"
-
-#~ msgid "Show overridden member function"
-#~ msgstr ""
-
-#~ msgid "Retrieve from file"
-#~ msgstr ""
-
-#~ msgid "Retrieve from project"
-#~ msgstr ""
-
-#~ msgid "Retrieve from all projects"
-#~ msgstr ""
-
-#~ msgid "Retrieve"
-#~ msgstr ""
-
-#~ msgid "Show source of"
-#~ msgstr ""
-
-#~ msgid "Find symbol"
-#~ msgstr ""
-
-#~ msgid "Browse class"
-#~ msgstr ""
-
-#~ msgid "Show class in hierarchy"
-#~ msgstr ""
-
-#~ msgid "Show class in restricted hierarchy"
-#~ msgstr ""
-
-#~ msgid "Xref refers to"
-#~ msgstr ""
-
-#~ msgid "Xref referred by"
-#~ msgstr ""
-
-#~ msgid "Xref has a"
-#~ msgstr ""
-
-#~ msgid "Xref used by"
-#~ msgstr ""
-
-#~ msgid "Show docu of"
-#~ msgstr ""
-
-#~ msgid "Generate docu for"
-#~ msgstr ""
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"SNiFF+로 연결할 수 없습니다. 환경을 확인하십시오 (sniffemacs가 $PATH에서 찾아"
-"져야 합니다).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 읽는 중 에러. 끊김"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ is currently "
-
-msgid "not "
-msgstr "not "
-
-msgid "connected"
-msgstr "connected"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 모르는 SNiFF+ 요청: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: SNiFF+에 연결 에러"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SniFF+가 연결되지 않았습니다"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: SniFF+ 버퍼가 아닙니다"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 쓰는 도중 에러. 끊겼습니다"
-
-msgid "invalid buffer number"
-msgstr "잘못된 버퍼 번호"
-
-msgid "not implemented yet"
-msgstr "아직 구현되지 않았습니다"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "줄을 설정할 수 없습니다"
-
-msgid "invalid mark name"
-msgstr "잘못된 마크 이름"
-
-msgid "mark not set"
-msgstr "마크가 설정되지 않았습니다"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "행 %d 열 %d"
-
-msgid "cannot insert/append line"
-msgstr "줄을 끼워넣거나 더할 수 없습니다"
-
-msgid "line number out of range"
-msgstr "줄 번호가 범위를 벗어났습니다"
-
-msgid "unknown flag: "
-msgstr "모르는 플래그: "
-
-msgid "unknown vimOption"
-msgstr "모르는 빔 옵션"
-
-msgid "keyboard interrupt"
-msgstr "키보드 인터럽트"
-
-msgid "vim error"
-msgstr "빔 에러"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "버퍼/창 명령을 만들 수 없습니다: 객체가 지워집니다"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창이 이미 지워졌습니다"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL 심각한 에러: reflist가 깨졌나!? 이 문제를 vim-dev@vim.org로 알려주"
-"십시오"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창 참조를 찾을 수 없습니다"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: 미안합니다, 이 명령은 사용할 수 없습니다, Tcl 라이브러리를 로딩할 수 없"
-"습니다."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL 에러: 끝내기 코드가 정수가 아닌가!? 이 문제를 vim-dev@vim.org로 알"
-"려주십시오"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 종료 코드 %d"
-
-msgid "cannot get line"
-msgstr "줄을 얻을 수 없습니다"
-
-msgid "Unable to register a command server name"
-msgstr "명령 서버 이름을 등록할 수 없습니다"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: 대상프로그램으로 명령 보내기가 실패했습니다"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 잘못된 서버 id 사용됨: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: 빔 인스턴스 레지스트리 속성이 잘못되어 있습니다. 지웠습니다!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "모르는 옵션 인자"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "너무 많은 편집 인자"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "뒤에 인자가 없음"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "옵션 인자 뒤에 쓰레기 값"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "너무 많은 \"+command\" \"-c command\" 혹은 \"--cmd command\" 인자"
 
-#~ msgid "Invalid argument for"
-#~ msgstr ""
+#: ../main.c:154
+msgid "Invalid argument for"
+msgstr ""
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d 파일을 고치기\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "이 GUI는 netbeans를 지원하지 않습니다\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "이 빔은 diff 기능 없이 컴파일 되었습니다."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb'는 사용할 수 없음: 컴파일할 때 포함되지 않음\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "스크립트 파일을 다시 열려고 시도: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "읽기 위해 열 수 없음: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "스크립트 출력을 열 수 없음: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: 에러: NetBeans에서 gvim 시작 실패\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "빔: 경고: 터미널로 출력할 수 없습니다\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "빔: 경고: 터미널로 부터 입력받을 수 없습니다\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc 명령 행"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: \"%s\"에서 읽을 수 없습니다"
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2853,18 +3332,23 @@ msgstr ""
 "\n"
 "더 많은 정보를 원하시면: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[파일 ..]       주어진 파일 고치기"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               표준입력에서 텍스트 읽기"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          태그가 정의된 위치에서 파일 고치기"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [에러파일]   첫 번째 에러가 난 파일 고치기"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2874,9 +3358,11 @@ msgstr ""
 "\n"
 "사용법:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [인자] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2884,11 +3370,7 @@ msgstr ""
 "\n"
 "   혹은:"
 
-#~ msgid ""
-#~ "\n"
-#~ "Where case is ignored prepend / to make flag upper case"
-#~ msgstr ""
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2898,321 +3380,189 @@ msgstr ""
 "\n"
 "인자:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t이 뒤에는 파일 이름만"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t와일드카드를 확장하지 않음"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\t이 gvim OLE에 등록"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tgvim을 OLE에서 등록취소"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tGUI로 실행 (\"gvim\"과 같음)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f 혹은 --nofork\t포그라운드: GUI로 시작할 때 fork하지 말 것"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi 상태 (\"vi\"와 같음)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx 상태 (\"ex\"와 같음)"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t조용한 (배치) 상태 (\"ex\"만)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff 상태 (\"vimdiff\"와 같음)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\t쉬운 상태 (\"evim\"과 같음, modeless)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t읽기 전용 상태 (\"view\"와 같음)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t제한된 상태 (\"rvim\"과 같음)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t수정(파일 쓰기)이 허용되지 않음"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t텍스트 수정이 허용되지 않음"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t이진 상태"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\t리스프 상태"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tVi 호환: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tVi와 호환되지 않음: 'nocompatible'"
 
-#~ msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
-#~ msgstr ""
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t디버깅 상태"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t스왑 파일 없이 메모리만 사용"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t스왑 파일 목록을 표시한 뒤 끝내기"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (파일 이름과 함께)\t파손되었던 세션 복구"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t-r과 같음"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t창을 열 때 newcli 사용하지 않음"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <장치>\t\tI/O에 <장치> 사용"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tArabic 모드로 시작"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tHebrew 모드로 시작"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tFarsi 모드로 시작"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t터미널 종류를 <terminal>로 설정"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t.vimrc 대신 <vimrc>를 사용"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t.gvimrc 대신 <gvimrc>를 사용"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t플러그인 스크립트를 불러들이지 않음"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tN개의 탭 열기 (기본: 파일별로 하나)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tN개의 창 열기 (기본: 파일별로 하나)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t-o와 같지만 창을 수직으로 나누기"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t파일 마지막에서 시작"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t<lnum> 줄에서 시작"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <명령>\tvimrc 파일을 읽기 전에 <명령>을 실행"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <명령>\t\t첫째 파일을 읽은 뒤 <명령>을 실행"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <세션>\t\t첫째 파일을 읽은 뒤 <세션> 파일 불러 들이기"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t<scriptin> 파일에서 Normal 상태 명령 읽기"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t모든 입력된 명령을 <scriptout> 파일에 추가"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t모든 입력된 명령을 <scriptout> 파일에 저장"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t암호화된 파일 고치기"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t빔을 특정 X-서버와 연결"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tX 서버에 연결하지 않음"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t가능하면 빔 서버에서 <files> 편집"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  같음, 서버가 없다고 불평하지 않음"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  --remote와 같지만 다 고칠 때까지 기다립니다"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  같음, 서버가 없다고 불평하지 않음"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <files>  --remote와 같지만 파일별로 탭 페이지 사"
-"용"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t빔 서버로 <keys>를 보내고 끝내기"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t빔 서버에서 <expr> 실행하고 결과 출력"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t사용 가능한 빔 서버 이름을 표시하고 끝내기"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t빔 서버 <name>이 되거나 서버로 보내기"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <file>\tstartup timing 메시지를 <file>에 저장"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t.viminfo 대신 <viminfo>를 사용"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h 혹은 --help\t도움말(이 메시지)을 출력한 뒤 끝내기"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t판 정보를 출력한 뒤 끝내기"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim이 알고 있는 인자 (모티프 판):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim이 알고 있는 인자 (neXtaw 판):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim이 알고 있는 인자 (아테나 판):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t빔을 <display>에서 실행"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t아이콘 상태로 빔 시작"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t바탕 색으로 <color> 사용 (also: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t일반 색에 <color> 사용 (also: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\t일반 텍스트에 <font> 사용 (also: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t굵은 텍스트에 <font> 사용"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t기울임 텍스트에 <font> 사용"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t초기 지오미트리에 <geom> 사용 (also: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t가장자리 넓이에 <width> 사용 (also: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width>  스크롤바 넓이에 <width> 사용 (also: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t메뉴바 높이에 <height> 사용 (also: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t반전 비디오 사용 (also: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t반전 비디오 사용 안 함 (also: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t명시된 리소스 설정"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim이 알고있는 인자 (RISC OS 판):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <숫자>\t칸에서 창 초기 너비"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <숫자>\t줄에서 창 초기 높이"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim이 알고있는 인자 (GTK+ 판):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t빔을 <display>에서 실행 (also: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t메인 창 구분을 위해 유일한 역할 설정"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t빔을 다른 GTK 위젯 안에서 열음"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\tVim을 부모 응용 프로그램 내에서 열기"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\t다른 win32 위젯 안에서 Vim 열기"
-
-msgid "No display"
-msgstr "디스플레이가 없습니다"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 보내기가 실패하였습니다.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 보내기 실패. 로컬에서 실행됩니다\n"
-
-#, c-format
-#~ msgid "%d of %d edited"
-#~ msgstr ""
-
-msgid "No display: Send expression failed.\n"
-msgstr "디스플레이 없음: 표현식 보내기가 실패했습니다.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 표현식 보내기가 실패했습니다.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "설정된 마크가 없습니다"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: \"%s\"에 맞는 마크가 없습니다"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3221,6 +3571,7 @@ msgstr ""
 "마크 라인  col 파일/텍스트"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3229,11 +3580,13 @@ msgstr ""
 " 점프 라인  col 파일/텍스트"
 
 #. Highlight title
-#~ msgid ""
-#~ "\n"
-#~ "change line  col text"
-#~ msgstr ""
+#: ../mark.c:831
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3242,6 +3595,7 @@ msgstr ""
 "# 파일 마크:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3249,6 +3603,7 @@ msgstr ""
 "\n"
 "# 점프목록 (새것이 먼저):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3256,88 +3611,84 @@ msgstr ""
 "\n"
 "# 파일내의 마크 히스토리 (새것부터 오래된 순):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>'이 없습니다"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 정상적인 코드페이지가 아닙니다"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: IC 값을 설정할 수 없습니다"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: 입력 콘텍스트를 만들 수 없습니다"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: 입력 방식을 열다가 실패했습니다"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 경고: IM에 파괴 콜백을 설정할 수 없습니다"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 입력 방식이 어떤 형식도 지원하지 않습니다"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 입력 방식이 내 preedit 형식을 지원하지 않습니다"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: 구역이 잠궈지지 않았습니다"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: 스왑 파일을 읽기 위해 특정 위치로 갈 수 없습니다"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: 스왑 파일을 읽을 수 없습니다"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: 스왑 파일을 쓰기 위해 특정 위치로 갈 수 없습니다"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: 스왑 파일을 쓸 수 없습니다"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: 스왑 파일이 이미 존재합니다 (symlink 공격?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: 구역 번호 0을 얻지 못했나요?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: 구역 번호 1을 얻지 못했나요?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: 구역 번호 2를 얻지 못했나요?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: 스왑 파일을 암호화할 수 없습니다"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: 으윽, 스왑 파일을 잃어버렸습니다!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: 스왑 파일 이름을 바꿀 수 없습니다"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: \"%s\"의 스왑 파일을 열 수 없어서 복구는 불가능합니다"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): 구역 0을 얻지 못했나요??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: %s의 스왑 파일을 찾을 수 없습니다"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "사용할 스왑 파일 번호를 입력하십시오 (0은 끝내기): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s을(를) 열 수 없습니다"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Unable to read block 0 from "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3345,124 +3696,111 @@ msgstr ""
 "\n"
 "어떤 수정도 없었거나 빔이 스왑 파일을 갱신하지 않은 것 같습니다."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " cannot be used with this version of Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "빔 3.0 판을 사용하십시오.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s은(는) 빔 스왑 파일이 아닌 것 같습니다"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " 이 컴퓨터에서는 사용될 수 없습니다.\n"
 
-#~ msgid "The file was created on "
-#~ msgstr ""
-
-#~ msgid ""
-#~ ",\n"
-#~ "or the file has been damaged."
-#~ msgstr ""
-
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
+#: ../memline.c:924
+msgid "The file was created on "
 msgstr ""
-"E833: %s이(가) 암호화되어 있는 데, 이 Vim은 암호화를 지원하지 않습니다"
 
-#~ msgid " has been damaged (page size is smaller than minimum value).\n"
-#~ msgstr ""
+#: ../memline.c:928
+msgid ""
+",\n"
+"or the file has been damaged."
+msgstr ""
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "스왑 파일 \"%s\"을(를) 사용합니다"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "원래 파일 \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 경고: 원래 파일이 바뀌었습니다"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "스왑 파일이 암호화됨: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"새로운 암호 키를 입력했는 데, 파일을 저장하지 않았었다면,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"새로운 암호 키를 입력하세요."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"암호 키를 바꾼 후에 파일을 저장했었다면 같은 키로 텍스트 파일과"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"스왑파일을 저장하려면 엔터를 누르세요"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: %s의 구역 1을 읽을 수 없습니다"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???많은 줄을 잃어버림"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???줄 번호가 잘못되었습니다"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???빈 구역"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???줄을 잃어버림"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: 구역 1의 ID가 잘못되었습니다 (%s이(가) .swp 파일이 아닌가?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???구역 잃어버림"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? 여기부터 ???끝까지의 줄이 섞였습니다"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? 여기부터 ???끝까지의 줄이 끼워지거나 지워져 버린 것 같습니다"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???끝"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: 복구 중단되었습니다"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: 복구 도중 에러 생겼습니다; ???로 시작하는 줄을 찾아보십시오"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "더 많은 정보를 보려면 \":help E312\"를 입력하세요."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "복구가 끝났습니다. 모든 게 정상인 지 확인해 보셔야만 합니다."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3470,12 +3808,15 @@ msgstr ""
 "\n"
 "(어쩌면 다른 이름으로 저장하고 싶으실 지도 모르겠습니다\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "그리고 바뀐 내용을 확인하려면 원래 파일에 대해 diff를 실행하세요)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "복구가 끝났습니다. 버퍼의 내용이 파일 내용과 같습니다."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3485,43 +3826,52 @@ msgstr ""
 "이제 .swp 파일을 지우셔도 됩니다.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "텍스트 파일에 스왑파일에서 가져온 암호 키를 사용합니다.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "스왑 파일을 찾았음:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   현재 디렉토리에:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   명시된 이름을 사용:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   In directory "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- 없음 --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          소유자: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   날짜: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             날짜: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [빔 3.0 판의 것]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [빔 스왑 파일로 보이지 않습니다]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         파일 이름: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3529,12 +3879,15 @@ msgstr ""
 "\n"
 "          수정: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "예"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "아니오"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3542,9 +3895,11 @@ msgstr ""
 "\n"
 "         사용자 이름: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "  호스트 이름: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3552,6 +3907,7 @@ msgstr ""
 "\n"
 "         호스트 이름: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3559,16 +3915,11 @@ msgstr ""
 "\n"
 "        프로세스 ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (아직 실행중)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [빔 이번 판에서는 사용할 수 없음]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3576,75 +3927,97 @@ msgstr ""
 "\n"
 "         [이 컴퓨터에서는 사용할 수 없음]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [읽을 수 없음]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [열 수 없음]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: 보존할 수 없습니다, 스왑 파일이 없습니다"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "파일이 보존되었습니다"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 파일 보존을 실패했습니다"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 잘못된 lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: %<PRId64> 줄을 찾을 수 없습니다"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 잘못된 포인터 구역 id 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx는 0여야만 합니다"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 너무 많은 구역이 갱신되었나요?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: 잘못된 포인터 구역 id 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "구역 1이 지워졌나요?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: %<PRId64> 줄을 찾을 수 없습니다"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: 잘못된 포인터 구역 id"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count가 0입니다"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 줄 번호가 범위를 벗어났습니다: 마지막에서 %<PRId64> 만큼"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: 구역 %<PRId64>의 줄 갯수가 틀렸습니다"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "스택 크기 증가"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: 잘못된 포인터 구역 id 2"
 
+#: ../memline.c:3070
 #, c-format
-#~ msgid "E773: Symlink loop for \"%s\""
-#~ msgstr ""
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 주목"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3652,38 +4025,44 @@ msgstr ""
 "\n"
 "Found a swap file by the name \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "While opening file \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NEWER than swap file!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 다른 프로그램이 같은 파일을 고치고 있는중일 수 있습니다.\n"
 "    만약 그렇다면 같은 파일을 두 개의 프로그램에서 고치지\n"
 "    않도록 조심하시기 바랍니다.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    끝내거나 위험을 감수하시려면 계속하십시오.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 파일을 고치다가 죽었었습니다.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    만약 그렇다면 \":recover\" 혹은 \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3691,9 +4070,11 @@ msgstr ""
 "\"\n"
 "    을 사용하여 복구하십시오 (\":help recovery\" 참고).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    이미 복구하셨었다면 스왑파일 \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3701,18 +4082,23 @@ msgstr ""
 "\"\n"
 "    을(를) 지우셔야 이 메시지가 사라집니다.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "스왑 파일 \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\"이 이미 존재합니다!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "빔 - 주목"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "스왑 파일이 이미 존재합니다!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3726,6 +4112,7 @@ msgstr ""
 "끝내기(&Q)\n"
 "버리기(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3741,34 +4128,56 @@ msgstr ""
 "끝내기(&Q)\n"
 "버리기(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: 너무 많은 스왑 파일이 발견되었습니다"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 메모리 부족!  (%<PRIu64> 바이트를 할당)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: 메뉴 항목 경로의 부분이 하위 메뉴가 아닙니다"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: 메뉴가 다른 모드에서만 존재합니다"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: \"%s\" 메뉴 없음"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: 메뉴 이름 없음"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: 하위 메뉴 앞에는 메뉴 경로가 붙을 수 없습니다"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: 메뉴바에 곧바로 메뉴 항목을 더할 수는 없습니다"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 구분자는 메뉴 경로의 부분이 될 수 없습니다"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3776,60 +4185,73 @@ msgstr ""
 "\n"
 "--- 메뉴 ---"
 
-msgid "Tear off this menu"
-msgstr "이 메뉴를 떼어냄"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: 메뉴 항목 앞에는 메뉴 경로가 있어야 합니다"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: 메뉴를 찾을 수 없습니다: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s 모드에 대한 메뉴가 정의되어 있지 않습니다"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: 하위 메뉴 앞에 메뉴 경로가 있어야 합니다"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: 메뉴를 찾을 수 없음 - 메뉴 이름을 확인하십시오"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "%s 수행중 에러 발견:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "%4ld 줄:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 잘못된 레지스터 이름: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "메시지 관리자: Bram Moolenaar <Bram@vim.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "중단: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "계속하려면 엔터 혹은 명령을 입력하십시오"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 줄 %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 더 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: 화면/페이지/라인 아래로, b/u/k: 위로, q: 종료 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "질문"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3837,6 +4259,17 @@ msgstr ""
 "예(&Y)\n"
 "아니오(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"예(&Y)\n"
+"아니오(&N)\n"
+"취소(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3850,262 +4283,174 @@ msgstr ""
 "모두 버림(&D)\n"
 "취소(&C)"
 
-msgid "Select Directory dialog"
-msgstr "디렉토리 선택 대화상자"
-
-msgid "Save File dialog"
-msgstr "파일 저장 대화상자"
-
-msgid "Open File dialog"
-msgstr "파일 열기 대화상자"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: 미안합니다, 콘솔 상태에는 파일 브라우저가 없습니다"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf()에 넘어온 인자 갯수가 부족"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: printf()에 예상못한 Float 인자"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf()에 너무 많은 인자 넘어옴"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 경고: 읽기 전용 파일을 고치고 있습니다"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "숫자 입력후 <엔터>나 마우스 클릭 (숫자없으면 취소): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "숫자 입력후 <엔터> (숫자없으면 취소): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "한 줄 이상"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "한 줄 이하"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> 보다 많은 줄"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> 보다 적은 줄"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (중단되었습니다)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "삑!"
 
-msgid "Vim: preserving files...\n"
-msgstr "빔: 파일 보존중...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "빔: 끌났습니다.\n"
-
-msgid "ERROR: "
-msgstr "에러: "
-
-#, c-format
-#~ msgid ""
-#~ "\n"
-#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-#~ msgstr ""
-
-#, c-format
-#~ msgid ""
-#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-#~ "\n"
-#~ msgstr ""
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 줄이 너무 길어졌습니다"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 메모리 부족!  (%<PRIu64> 바이트를 할당)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "실행하려고 쉘 부름: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: 콜론이 없습니다"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 이상한 모드"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 이상한 마우스모양"
-
-msgid "E548: digit expected"
-msgstr "E548: 숫자가 필요합니다"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 이상한 백분율"
-
-msgid "Enter encryption key: "
-msgstr "암호 키 입력: "
-
-msgid "Enter same key again: "
-msgstr "같은 키를 다시 입력: "
-
-msgid "Keys don't match!"
-msgstr "키가 맞지 않습니다!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: 잘못된 경로: '**[번호]'는 경로의 마지막에 위치하거나 '%s' 뒤에 있어야 "
-"합니다."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath에서 \"%s\" 디렉토리를 찾을 수 없습니다"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: path에서 \"%s\" 파일을 찾을 수 없습니다"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: cdpath에서 더 이상의 \"%s\" 디렉토리를 찾을 수 없습니다"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: path에서 더 이상의 \"%s\" 파일을 찾을 수 없습니다"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Netbeans #2에 연결할 수 없습니다"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Netbeans에 연결할 수 없습니다"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans 연결 정보 파일이 접근 모드가 잘못됨: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "Netbeans 소켓에서 읽기"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: 버퍼 %<PRId64>에 대한 NetBeans 연결을 잃어버렸습니다"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: 이 GUI는 netbeans를 지원하지 않습니다"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans가 이미 연결되어 있습니다"
-
-msgid "E505: "
-msgstr "E505: "
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: 커서 밑에 식별자가 없습니다"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc'가 비어있습니다"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval 기능이 빠져있습니다"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "경고: 터미널이 비쥬얼 상태를 표시할 수 없습니다"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: 커서 밑에 문자열이 없습니다"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 현재의 'foldmethod'으로 접기를 지울 수 없습니다"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: changelist가 비었습니다"
 
-#~ msgid "E662: At start of changelist"
-#~ msgstr ""
+#: ../normal.c:5899
+msgid "E662: At start of changelist"
+msgstr ""
 
-#~ msgid "E663: At end of changelist"
-#~ msgstr ""
+#: ../normal.c:5901
+msgid "E663: At end of changelist"
+msgstr ""
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "VIM을 마치려면  :quit<Enter>  입력"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 line %sed 1 time"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 line %sed %d times"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> lines %sed 1 time"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> lines %sed %d times"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> lines to indent... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 line indented "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> lines indented "
 
-#~ msgid "E748: No previously used register"
-#~ msgstr ""
+#: ../ops.c:938
+msgid "E748: No previously used register"
+msgstr ""
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "cannot yank; delete anyway"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 line changed"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> lines changed"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "freeing %<PRId64> lines"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "block of 1 line yanked"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 line yanked"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "block of %<PRId64> lines yanked"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> lines yanked"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: %s 레지스터에 아무 것도 없습니다"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4113,9 +4458,11 @@ msgstr ""
 "\n"
 "--- 레지스터 ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "이상한 레지스터 이름"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4123,159 +4470,181 @@ msgstr ""
 "\n"
 "# 레지스터:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 모르는 레지스터 형식 %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 열; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 바이트"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 문자; %<PRId64> of %<PRId64> 바이"
-"트"
+"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; "
+"%<PRId64> of %<PRId64> 바이트"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 바이트 %<PRId64> of %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 문자 %<PRId64> of %<PRId64>; 바이트 %<PRId64> "
-"of %<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; "
+"%<PRId64> of %<PRId64> 문자; %<PRId64> of %<PRId64> 바이트"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 바이"
+"트 %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 문자 "
+"%<PRId64> of %<PRId64>; 바이트 %<PRId64> of %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=페이지 %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "빔을 날게 해 주셔서 고맙습니다"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 모르는 옵션"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: 지원되지 않는 옵션입니다"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: 모드라인에서 사용될 수 없습니다"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = 뒤에 숫자가 필요합니다"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: termcap에서 찾을 수 없습니다"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 이상한 글자 <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term'을 빈 문자열로 설정할 수 없습니다"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: GUI에서는 term을 바꿀 수 없습니다"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: GUI를 시작하려면 \":gui\"를 사용하십시오"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext'와 'patchmode'가 동일합니다"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: 'listchars' 값과 충돌이 발생합니다"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: 'fillchars' 값과 충돌이 발생합니다"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: GTK+ 2 GUI에서는 바뀔 수 없습니다"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: 콜론이 없습니다"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 빈 문자열입니다"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> 뒤에 숫자가 없습니다"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: 콤마가 없습니다"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: ' 값을 명시해 주셔야 합니다"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 출력할 수 없는, 혹은 와이드 문자를 포함하고 있습니다"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 잘못된 글꼴(들)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: 글꼴셋을 고를 수 없습니다"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 잘못된 글꼴셋"
-
-msgid "E533: can't select wide font"
-msgstr "E533: 와이드 글꼴을 고를 수 없습니다"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 잘못된 와이드 글꼴"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> 뒤에 이상한 글자"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: 콤마가 필요합니다"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring'은 비거나 %s을(를) 포함해야 합니다"
 
-msgid "E538: No mouse support"
-msgstr "E538: 마우스를 지원하지 않습니다"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 닫히지 않은 표현식 배열"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 너무 많은 항목"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: 균형이 안 잡힌 그룹"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: 미리 보기 창이 이미 존재합니다"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic은 UTF-8 인코딩 필요, ':set encoding=utf-8' 하세요"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 적어도 %d 줄이 필요합니다"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 적어도 %d 칸이 필요합니다"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 모르는 옵션: %s"
@@ -4283,10 +4652,12 @@ msgstr "E355: 모르는 옵션: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: 숫자가 필요: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4294,6 +4665,7 @@ msgstr ""
 "\n"
 "--- 터미널 코드 ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4301,6 +4673,7 @@ msgstr ""
 "\n"
 "--- 전역 옵션 값 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4308,6 +4681,7 @@ msgstr ""
 "\n"
 "--- 지역 옵션 값 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4315,140 +4689,21 @@ msgstr ""
 "\n"
 "--- 옵션 ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp 에러"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': %s에 대한 맞는 글자가 없습니다"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': 세미콜론 뒤에 글자가 더 있음: %s"
 
-msgid "cannot open "
-msgstr "cannot open "
-
-msgid "VIM: Can't open window!\n"
-msgstr "빔: 창을 열 수 없습니다!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "아미가도스 2.04나 더 높은 판이 필요합니다\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Need %s version %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "NIL을 열 수 없음:\n"
-
-msgid "Cannot create "
-msgstr "Cannot create "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "빔이 %d 값으로 끝냅니다\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "콘솔 상태를 바꿀 수 없습니다 ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: 콘솔이 아닌가??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: -f 옵션이 사용된 경우 쉘을 실행할 수 없습니다"
-
-msgid "Cannot execute "
-msgstr "Cannot execute "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " returned\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE가 너무 작습니다."
-
-msgid "I/O ERROR"
-msgstr "I/O 에러"
-
-msgid "Message"
-msgstr "메시지"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns'이 80이 아니어서, 외부 명령을 실행할 수 없습니다"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: 프린터를 고르지 못했습니다"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "to %s on %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 모르는 프린터 글꼴: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 인쇄 에러: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "'%s' 인쇄중"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 잘못된 글자셋 이름 \"%s\"이(가) 글꼴 이름 \"%s\"에 있습니다"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: 잘못된 글자 '%c'이(가) 글꼴 이름 \"%s\"에 있습니다"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "빔: 같은 시그널 두 번, 끝냅니다\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "빔: %s 시그널을 잡았습니다\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "빔: 죽을 시그널을 잡았습니다\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "X 디스플레이를 여는 데 %<PRId64> msec이 걸렸습니다"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"빔: X 에러가 생겼습니다\n"
-
-msgid "Testing the X display failed"
-msgstr "X 디스플레이 시험이 실패했습니다"
-
-msgid "Opening the X display timed out"
-msgstr "X 디스플레이를 열다가 시간이 초과되었습니다"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Could not get security context for "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Could not set security context for "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4456,13 +4711,7 @@ msgstr ""
 "\n"
 "Cannot execute shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"쉘 sh를 실행할 수 없습니다\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4470,367 +4719,471 @@ msgstr ""
 "\n"
 "shell returned "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"파이프를 만들 수 없습니다\n"
+"Could not get security context for "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"자식 프로세스를 만들 수 없습니다\n"
+"Could not set security context for "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"명령이 끝마쳐졌습니다\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP가 ICE 연결을 잃어버렸습니다"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "X 디스플레이 열기가 실패했습니다"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP가 save-yourself 요청을 실행하고 있습니다"
-
-msgid "XSMP opening connection"
-msgstr "XSMP가 연결을 여는 중입니다"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP가 ICE 연결 감시를 실패했습니다"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection 실패: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: path에서 \"%s\" 파일을 찾을 수 없습니다"
 
-msgid "At line"
-msgstr "At line"
-
-msgid "Could not load vim32.dll!"
-msgstr "vim32.dll을 불러 들일 수 없습니다!"
-
-msgid "VIM Error"
-msgstr "빔 에러"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "함수 포인터를 DLL로 바꿀 수 없습니다!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "쉘이 %d을(를) 돌려주었습니다"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "빔: %s 이벤트를 잡았습니다\n"
-
-msgid "close"
-msgstr "닫기"
-
-msgid "logoff"
-msgstr "로그아웃"
-
-msgid "shutdown"
-msgstr "셧다운"
-
-msgid "E371: Command not found"
-msgstr "E371: 명령을 찾을 수 없습니다"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE를 $PATH에서 찾을 수 없습니다.\n"
-"외부 명령이 끝난 뒤 멈출 수 없습니다.\n"
-"다 많은 정보를 보시려면 :help win32-vimrun을 보십시오."
-
-msgid "Vim Warning"
-msgstr "빔 경고"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: 형식 문자열에 %%%c이(가) 너무 많습니다"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: 형식 문자열에 %%%c이(가) 잘못되었습니다"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: 형식 문자열에 ]가 없습니다"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: 형식 문자열에 지원되지 않는 %%%c이(가) 있습니다"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: 형식 문자열 서두에 잘못된 %%%c이(가) 있습니다"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: 형식 문자열에 잘못된 %%%c이(가) 있습니다"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat'이 어떤 패턴도 포함하고 있지 않습니다"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: 빠졌거나 빈 디렉토리 이름"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 더 이상의 항목이 없습니다"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d of %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (줄을 지웠음)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: 퀵픽스 스택의 바닥입니다"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: 퀵픽스 스택의 꼭대기입니다"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "error list %d of %d; %d errors"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 쓸 수 없음, 'buftype' 옵션이 설정되어 있습니다"
 
-msgid "Error file"
-msgstr "에러 파일"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: 파일명 누락 혹은 잘못된 패턴"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "\"%s\" 파일을 열 수 없습니다"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: 버퍼가 로드되지 않았습니다"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: String이나 List가 있어야 함"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: %s%%[]에 잘못된 항목"
 
-msgid "E339: Pattern too long"
-msgstr "E339: 패턴이 너무 깁니다"
-
-msgid "E50: Too many \\z("
-msgstr "E50: \\z(가 너무 많습니다"
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: %s(가 너무 많습니다"
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: 맞지 않는 \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: 맞지 않는 %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: 맞지 않는 %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: 맞지 않는 %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: %s@ 뒤에 잘못된 문자"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: %s{...}s가 너무 많음"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Nested %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Nested %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: \\_를 잘 못 사용"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 뒤에 아무것도 없습니다"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: 이상한 후위 참조"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z(는 여기에서 허용되지 않습니다"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 등은 여기에서 허용되지 않습니다"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: \\z 뒤에 이상한 문자"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: %s%%[ 뒤에 ]가 없습니다"
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: 빈 %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: %s%%[dxouU] 뒤에 이상한 문자"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: %s%% 뒤에 이상한 문자"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ 뒤에 ]가 없습니다"
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: 맞지 않는 %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: 맞지 않는 %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: 맞지 않는 %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z(는 여기에서 허용되지 않습니다"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 등은 여기에서 허용되지 않습니다"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ 뒤에 ]가 없습니다"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: 빈 %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: 패턴이 너무 깁니다"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: \\z(가 너무 많습니다"
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: %s(가 너무 많습니다"
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: 맞지 않는 \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: %s@ 뒤에 잘못된 문자"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: %s{...}s가 너무 많음"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Nested %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Nested %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: \\_를 잘 못 사용"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 뒤에 아무것도 없습니다"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: 이상한 후위 참조"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: \\z 뒤에 이상한 문자"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: %s%%[dxouU] 뒤에 이상한 문자"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: %s%% 뒤에 이상한 문자"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...}에 구문 에러"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "외부 submatches:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: \\z(가 너무 많습니다"
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E828: 쓰기 위해 undo을 열 수 없습니다: %s"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " 선택치환"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 바꾸기"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 반대"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 끼워넣기"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (끼워넣기)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (바꾸기)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (선택치환)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " 헤브루"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " 아라비아"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (언어)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (붙이기)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " 비주얼"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " 비주얼 라인"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " 비주얼 블록"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " 고르기"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 라인 고르기"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 블록 고르기"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "기록중"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 잘못된 찾기 문자열: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 처음까지 맞는 문자열이 없습니다: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 끝까지 맞는 문자열이 없습니다: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ';' 뒤에는 '?'나 '/'가 와야 합니다"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (이전에 맞았던 목록 포함)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Included files "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "not found "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "in path ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Already listed)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  못 찾았음"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "포함된 파일 찾는 중: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "포함된 파일 %s 찾는 중"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 맞는 게 현재 줄에 있습니다"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "모든 포함된 파일을 찾았습니다"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "포함된 파일이 없습니다"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 정의를 찾을 수 없습니다"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: 패턴을 찾을 수 없습니다"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Substitute "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4841,84 +5194,97 @@ msgstr ""
 "# Last %sSearch Pattern:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: spell 파일 형식 에러"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: 잘린 spell 파일"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Trailing text in %s line %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affix name too long in %s line %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: affix 파일 FOL, LOW 혹은 UPP에 형식 에러"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL, LOW 혹은 UPP의 문자가 범위를 벗어남"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "단어 트리 압축중..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: 맞춤법 검사가 활성화되어 있지 않습니다"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr "경고: 단어 목록 \"%s_%s.spl\" 혹은 \"%s_ascii.spl\"을 찾을 수 없습니다"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "경고: 단어 목록 \"%s.%s.spl\" 혹은 \"%s.ascii.spl\"을 찾을 수 없습니다"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "spell 파일 \"%s\"을(를) 읽고 있습니다"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: spell 파일이 아닌 것 같습니다"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 오래된 spell 파일, 갱신이 필요합니다"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Spell 파일이 새 버젼의 Vim용입니다"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: spell 파일에 지원되지 않는 섹션"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "경고: %s 영역은 지원되지 않습니다"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "affix 파일 %s 읽는 중"
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "%s 라인 %d에 있는 단어 변환 실패: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "%s의 변환이 지원되지 않습니다: %s에서 %s로"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "%s의 변환이 지원되지 않습니다"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 라인 %d에 FLAG에 대한 잘못된 값: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 라인 %d에 플래그가 사용된 후 FLAG: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -4927,6 +5293,7 @@ msgstr ""
 "%s 라인 %d에 PFX 뒤에 COMPOUNDFORBIDFLAG을 정의한 것은 잘못된 결과를 초래할 "
 "수 있습니다"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -4935,34 +5302,42 @@ msgstr ""
 "%s 라인 %d에 PFX 뒤에 COMPOUNDPERMITFLAG을 정의한 것은 잘못된 결과를 초래할 "
 "수 있습니다"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDRULES 값: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDWORDMAX 값: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDMIN 값: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 COMPOUNDSYLMAX 값: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 CHECKCOMPOUNDPATTERN 값: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "%s 라인 %d에 연속된 affix 블록에 다른 결합 플래그: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s 라인 %d에 중복된 affix: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -4971,270 +5346,334 @@ msgstr ""
 "%s 라인 %d에 BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST에 대해서도 "
 "affix가 사용됨: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s 라인 %d에 Y나 N이 기대됨: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s 라인 %d가 망가진 상태: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s 라인 %d에 REP(SAL) 카운트가 기대됨"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s 라인 %d에 MAP 카운트가 기대됨"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s 라인 %d의 MAP에 중복된 문자"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s 라인 %d에 모르는 혹은 중복된 항목: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s에 FOL/LOW/UPP이 누락된 라인"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX이 SYLLABLE없이 사용됨"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "postponed 접두사가 너무 많습니다"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "compound 플래그가 너무 많습니다"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "postponed 접두사와(나) compound 플래그가 너무 많습니다"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "SOFO%s가 누락된 라인이 %s에 있습니다"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "%s에 SAL과 SOFO 라인이 둘 다 있습니다"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s 라인 %d에 숫자가 아닌 플래그: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 플래그: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s 값이 다른 .aff 파일에서 사용된 것과 다릅니다"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "사전 파일 %s 읽는 중 ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s에 단어 카운트가 없습니다"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "라인 %6d, 단어 %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s 라인 %d에 중복된 단어: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "%s 라인 %d에 처음 중복된 단어: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d개의 중복된 단어가 %s에 있습니다"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "무시된 %d개의 아스키문자열이 아닌 단어가 %s에 있습니다"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "단어 파일 %s 읽는 중 ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 중복된 /encoding= 라인 무시됨: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 단어 뒤의 /encoding= 라인 무시됨: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 중복된 /regions= 라인 무시됨: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s 라인 %d에 너무 많은 영역: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s 라인 %d의 / 라인 무시됨: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s 라인 %d에 잘못된 영역 번호: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s 라인 %d에 모르는 플래그: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "아스키 문자열이 아닌 %d개의 단어가 무시되었습니다"
 
-#~ msgid "E845: Insufficient memory, word list will be incomplete"
-#~ msgstr ""
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "%d/%d 노드가 압축됨; %d (%d%%)가 남음"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "맞춤법 파일을 읽는 중..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "soundfold 수행중..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "soundfold 수행 후의 단어 수: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "총 단어 수: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "%s 제안 파일을 쓰는 중 ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "추정된 런타임 메모리 사용량: %d 바이트"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 생성 파일명은 영역 이름과 달라야 합니다"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 최대 8개의 영역이 지원됩니다"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: %s에 잘못된 영역"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "경고: compound와 NOBREAK 둘 다 명시됨"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "spell 파일 %s 쓰는 중 ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "끝!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile'에 %<PRId64> 항목이 없습니다"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "%s에서 단어 삭제됨"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "%s에 단어 추가됨"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 단어가 spell 파일 간에 다릅니다"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "죄송, 제안할 게 없습니다"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "죄송, %<PRId64>개만 제안"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Change \"%.*s\" to:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: 철자가 바뀐적이 없습니다"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 찾을 수 없음: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: .sug 파일이 아닌 것 같음: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: 오래된 .sug 파일, 갱신 필요: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug 파일이 새 버젼의 Vim용임: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug 파일이 .spl 파일과 맞지 않음: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: .sug 파일 읽기 에러: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: MAP 항목에 중복된 문자"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "이 버퍼에 대해 정의된 구문 항목이 없습니다"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 잘못된 인자: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 이런 구문 클러스터는 없습니다: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "이 버퍼에 대해 정의된 구문 항목이 없습니다"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C-형식 주석문에 동기맞춤"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "동기맞춤 없음"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "syncing starts "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " lines before top line"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5242,6 +5681,7 @@ msgstr ""
 "\n"
 "--- Syntax sync 항목들 ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5249,6 +5689,7 @@ msgstr ""
 "\n"
 "syncing on items"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5256,198 +5697,273 @@ msgstr ""
 "\n"
 "--- Syntax 항목 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 이런 구문 클러스터는 없습니다: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; match "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " line breaks"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: contains 인자는 여기에 쓸 수 없습니다"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: 잘못된 cchar 값"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here는 여기에서 사용될 수 없습니다"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: %s에 대한 region 항목을 찾지 못했습니다"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: 파일이름이 필요합니다"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 파일 이름이 너무 많습니다"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' 누락: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' 누락: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: 충분치 않은 인자: 구문 영역 %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 이런 구문 클러스터는 없습니다: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: 클러스터가 명시되지 않았습니다"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: 패턴 구분자를 찾을 수 없습니다: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: 패턴 뒤에 쓰레기: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: 줄 연속 패턴이 두 번 사용되었습니다"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 비정상적인 인자: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 이퀄 기호가 빠졌음: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 빈 인자: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s은(는) 여기에서 허용되지 않습니다"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s은(는) contains 목록의 첫 번째여야 합니다"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 모르는 그룹 이름: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 잘못된 :syntax 하위 명령: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: syncolor.vim 반복 로딩"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: 하이라이트 그룹을 찾을 수 없습니다: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 충분치 않은 인자: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 너무 많은 인자: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: group이 설정값이 있습니다, highlight link 무시됨"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 뜻밖의 이퀄 기호: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 이퀄 기호가 빠졌음: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 인자가 빠졌음: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 비정상적인 값: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 모르는 FG 색상"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 모르는 BG 색상"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: 색 이름이나 숫자를 인식할 수 없음: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 터미널 코드가 너무 김: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 잘못된 인자: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 너무 많은 다른 하이라이트 속성이 사용되고 있습니다"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 그룹 이름에 출력할 수 없는 문자가 있습니다"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: 그룹 이름에 이상한 문자"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: 태그 스택의 끝입니다"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: 태그 스택의 처음입니다"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 첫 번째 맞는 태그 이전으로는 갈 수 없습니다"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: 태그를 찾을 수 없음: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "파일\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 맞는 태그가 하나 밖에 없습니다"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 마지막 맞는 태그 뒤로는 갈 수 없습니다"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "파일 \"%s\"이(가) 존재하지 않습니다"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d of %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " or more"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Using tag with different case!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: 파일 \"%s\"이(가) 존재하지 않습니다"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5455,66 +5971,79 @@ msgstr ""
 "\n"
 "  # TO tag         FROM line  in file/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "태그 파일 %s 찾는 중"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: %s에 대한 태그 파일 경로가 잘렸습니다\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr "태그 파일의 너무 긴 라인을 무시합니다"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: 태그 파일 \"%s\"에 형식 에러가 있습니다"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Before byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: 태그 파일이 정렬되어 있지 않음: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: 태그 파일이 없습니다"
 
-msgid "Ignoring long line in tags file"
-msgstr "태그 파일의 너무 긴 라인을 무시합니다"
-
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: 태그 패턴을 찾을 수 없습니다"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: 태그를 찾을 수 없지만 이거 같습니다!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "중복된 필드 명: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' not known. Available builtin terminals are:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "defaulting to '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: termcap 파일을 열 수 없습니다"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: 터미널 항목을 terminfo에서 찾을 수 없습니다"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: 터미널 항목을 termcap에서 찾을 수 없습니다"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap에 \"%s\" 항목이 없습니다"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 터미널이 \"cm\" 기능을 지원해야 합니다"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5522,251 +6051,169 @@ msgstr ""
 "\n"
 "--- 터미널 키 ---"
 
-msgid "new shell started\n"
-msgstr "새 쉘이 시작되었습니다\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "빔: 입력 읽는 중 에러, 끝내는중...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "빈 고르기 대신 CUT_BUFFER0을 사용했습니다"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: 줄 갯수가 모르는 사이에 바뀌었습니다"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "취소 불가능; 어쨌든 계속합니다"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: 쓰기 위해 undo을 열 수 없습니다: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: 깨진 undo 파일 (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "'undodir'에 있는 어떤 디렉토리에도 undo 파일을 쓸 수 없습니다"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "읽을 수가 없어서 undo 파일에 덮어쓸 수 없습니다: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "undo 파일이 아니어서 덮어쓸 수 없습니다: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "undo할 내용이 없어서 undo 파일 저장을 건너뜁니다"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "undo 파일 쓰는 중: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: undo 파일 쓰기 에러: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "소유자가 달라서 undo 파일을 읽지 않습니다: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "undo 파일 읽는 중: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: 읽기 위해 undo 파일을 열 수 없습니다: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: undo 파일이 아닙니다: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: 암호화되지 않은 파일이 암호화된 undo 파일을 가지고 있습니다: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Undo 파일을 해독할 수 없습니다: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Undo 파일이 암호화되었습니다: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: 호환되지 않는 undo 파일: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "파일 내용이 바뀌어서, undo 정보를 사용할 수 없습니다"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "undo 파일 %s을(를) 읽어들였습니다"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "더 이상의 수정이 없었습니다"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "더 이상의 수정은 없었습니다"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Undo 번호 %<PRId64>를 찾을 수 없습니다"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 잘못된 줄 번호"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "more line"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "more lines"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "line less"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "fewer lines"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "change"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "changes"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "before"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "after"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "취소할 게 없습니다"
 
-#~ msgid "number changes  when               saved"
-#~ msgstr ""
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> seconds ago"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo 뒤에 undojoin은 할 수 없습니다"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: undo 목록이 깨졌습니다"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: undo 줄이 없습니다"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 비트 GUI 판"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64비트 GUI 버젼"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32비트 GUI 버젼"
-
-msgid " in Win32s mode"
-msgstr " Win32s 상태"
-
-msgid " with OLE support"
-msgstr " OLE 지원"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 64비트 콘솔 버젼"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32비트 콘솔 버젼"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16비트 버젼"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32비트 MS-DOS 버젼"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16비트 MS-DOS 버젼"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (유닉스) 버젼"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 버젼"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 버젼"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS 버젼"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS 버젼"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5774,6 +6221,7 @@ msgstr ""
 "\n"
 "포함된 패치: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5781,9 +6229,11 @@ msgstr ""
 "\n"
 "별도의 패치: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modified by "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5791,9 +6241,11 @@ msgstr ""
 "\n"
 "Compiled "
 
+#: ../version.c:649
 msgid "by "
 msgstr "by "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5801,643 +6253,1604 @@ msgstr ""
 "\n"
 "Huge 버젼 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Big 버젼 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normal 버젼 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Small 버젼 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Tiny 버젼 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "GUI 없음."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "Photon GUI."
-
-msgid "with GUI."
-msgstr "GUI."
-
-msgid "with Carbon GUI."
-msgstr "Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "(클래식) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  기능 (+: 포함됨, -: 포함 안 됨):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "        시스템 vimrc 파일: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        사용자 vimrc 파일: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 사용자 두 번째 vimrc 파일: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 사용자 세 번째 vimrc 파일: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         사용자 exrc 파일: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  사용자 두 번째 exrc 파일: \""
 
-msgid "  system gvimrc file: \""
-msgstr "       시스템 gvimrc 파일: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       사용자 gvimrc 파일: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "사용자 두 번째 gvimrc 파일: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "사용자 세 번째 gvimrc 파일: \""
-
-msgid "    system menu file: \""
-msgstr "    시스템 메뉴 파일: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  fall-back for $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " f-b for $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "컴파일: "
 
-msgid "Compiler: "
-msgstr "컴파일러: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "링크: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  디버그 빌드"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "빔 - 향상된 Vi"
 
+#: ../version.c:769
 msgid "version "
 msgstr "판 "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "by Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "빔은 소스가 열려 있고 공짜로 배포됩니다"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "우간다에 사는 가난한 아이를 도와주세요!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "이에 대한 정보를 보려면    :help iccf<엔터>       입력"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "끝내려면                   :q<엔터>               입력"
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "온라인 도움말을 보려면     :help<엔터> 또는 <F1>  입력"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "판 정보를 보려면           :help version7<엔터>   입력"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi 호환 상태로 실행중입니다"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "빔 기본값을 사용하려면     :set nocp<엔터>        입력"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "이에 대한 정보를 보려면    :help cp-default<엔터> 입력"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "이에 대한 정보를 보려면    메뉴에서 도움말->고아  선택"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "모드없이 수행중이며, 입력된 문자는 삽입됩니다"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "메뉴에서 편집->전역 설정->삽입 모드 토글을 선택하시면 "
-
-msgid "                              for two modes      "
-msgstr "                         두 모드를 사용할 수 있습니다 "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "메뉴에서 편집->전역 설정->Vi 호환 토글을 선택하시면   "
-
-msgid "                              for Vim defaults   "
-msgstr "                          Vim이 기본값으로 동작합니다 "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "빔 개발을 후원해 주세요!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "빔 사용자로 등록하세요!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "이에 대한 정보를 보려면    :help sponsor<엔터>    입력"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "이에 대한 정보를 보려면    :help register<엔터>   입력"
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "이에 대한 정보를 보려면    메뉴 도움말->Sponsor/Register"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "경고: 윈도우즈 95/98/ME를 찾았음"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "이에 대한 정보를 보려면    :help windows95<엔터>  입력"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "이미 하나의 창만 있습니다"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: 미리 보기 창이 없습니다"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: 위 왼쪽과 아래 오른쪽을 동시에 나눌 수 없습니다"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: 다른 창이 나눠졌을 때에는 회전할 수 없습니다"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: 마지막 창을 닫을 수 없습니다"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: autocmd 창을 닫을 수 없습니다"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: 창을 닫을 수 없음, autocmd 창만 남음"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: 다른 창이 바뀌었습니다"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: 커서 밑에 파일 이름이 없습니다"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: path에서 \"%s\" 파일을 찾을 수 없습니다"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: 빈 비밀번호로 bf_key_init() 함수가 불려졌습니다"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: %s 라이브러리를 로드할 수 없습니다"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"미안합니다, 이 명령은 사용할 수 없습니다, Perl 라이브러리를 로딩할 수 없습니"
-"다."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish big/little endian use wrong"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Safe 모듈없이는 sandbox에서 Perl evaluation이 제한됩니다"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256 시험이 실패했습니다."
 
-msgid "Edit with &multiple Vims"
-msgstr "여러 빔으로 편집(&M)"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish 시험이 실패했습니다."
 
-msgid "Edit with single &Vim"
-msgstr "하나의 빔으로만 편집(&V)"
+#~ msgid "Patch file"
+#~ msgstr "패키 파일"
 
-msgid "Diff with Vim"
-msgstr "빔으로 Diff"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "확인(&O)\n"
+#~ "취소(&C)"
 
-msgid "Edit with &Vim"
-msgstr "빔으로 편집(&V)"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Vim 서버에 연결되어 있지 않습니다"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "하나의 빔으로만 편집 - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: %s(으)로 보낼 수 없습니다"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "선택된 파일(들)을 빔으로 편집"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 서버의 응답을 읽을 수 없습니다"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "프로세스 생성 에러: gvim이 path에 있는 지 확인하세요!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 클라이언트로 보낼 수 없습니다"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll 에러"
+#~ msgid "Save As"
+#~ msgstr "다른 이름으로 저장"
 
-msgid "Path length too long!"
-msgstr "경로가 너무 깁니다"
+#~ msgid "Edit File"
+#~ msgstr "파일 고치기"
 
-msgid "--No lines in buffer--"
-msgstr "--버퍼에 줄 없음--"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (못 찾았음)"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: 명령이 중지되었습니다"
+#~ msgid "Source Vim script"
+#~ msgstr "빔 스크립트 로드"
 
-msgid "E471: Argument required"
-msgstr "E471: 인자가 필요합니다"
+#~ msgid "unknown"
+#~ msgstr "모름"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: /, ? 혹은 &는 \\ 뒤에 와야 합니다"
+#~ msgid "Edit File in new window"
+#~ msgstr "새 창에서 파일 고치기"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 명령줄 창에 잘못됨; <CR> 실행, CTRL-C 끝내기"
+#~ msgid "Append File"
+#~ msgstr "파일 추가"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: 현재 디렉토리 또는 태그 찾기에서 exrc/vimrc에서의 명령은 허용 안 됩니다"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "창 위치: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif가 없습니다"
+#~ msgid "Save Redirection"
+#~ msgstr "리디렉션 저장"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry가 없습니다"
+#~ msgid "Save View"
+#~ msgstr "보기 저장"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile이 없습니다"
+#~ msgid "Save Session"
+#~ msgstr "세션 저장"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor 누락"
+#~ msgid "Save Setup"
+#~ msgstr "설정 저장"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :while없이 :endwhile이 있습니다"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #<는 +eval 기능이 포함되어야 사용할 수 있습니다"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :for 없는 :endfor"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 이 판에는 digraph가 없습니다"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 파일이 있습니다 (덮어쓰려면 ! 사용)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "은(는) 장치가 아닙니다 ('opendevice' 옵션으로 막힘)"
 
-msgid "E472: Command failed"
-msgstr "E472: 명령이 실패했습니다"
+#~ msgid "Reading from stdin..."
+#~ msgstr "표준입력에서 읽는 중..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 모르는 글꼴셋: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[암호화 되었습니다]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 모르는 글꼴: %s"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: 파일이 모르는 방법으로 암호화되어 있습니다"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: 글꼴 \"%s\"은(는) 고정넓이가 아닙니다"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans에서는 바뀌지 않은 버퍼를 쓸 수 없습니다"
 
-msgid "E473: Internal error"
-msgstr "E473: 내부 에러"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeans 버퍼에 대해서는 부분 저장을 할 수 없습니다"
 
-msgid "Interrupted"
-msgstr "중단되었습니다"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "장치 쓰기가 'opendevice' 옵션으로 막힘"
 
-msgid "E14: Invalid address"
-msgstr "E14: 잘못된 주소"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: The resource fork will be lost (덮어쓰려면 ! 더하기)"
 
-msgid "E474: Invalid argument"
-msgstr "E474: 잘못된 인자"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: GUI를 시작할 수 없습니다"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 잘못된 인자: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: \"%s\"에서 읽을 수 없습니다"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 잘못된 표현식: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 쓸만한 글꼴을 찾을 수 없어서 GUI를 실행할 수 없습니다"
 
-msgid "E16: Invalid range"
-msgstr "E16: 잘못된 범위"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide'가 이상합니다"
 
-msgid "E476: Invalid command"
-msgstr "E476: 잘못된 명령"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 값이 이상합니다"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\"은(는) 디렉토리입니다"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: 색 %s을(를) 할당할 수 없습니다"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 라이브러리 \"%s()\" 부르기 실패"
+#~ msgid "<cannot open> "
+#~ msgstr "<열 수 없음> "
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: %s 라이브러리 함수를 로드할 수 없습니다"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 글꼴 %s을(를) 얻을 수 없습니다"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 마크가 잘못된 줄 번호를 가지고 있습니다"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 현재 디렉토리로 돌아갈 수 없습니다"
 
-msgid "E20: Mark not set"
-msgstr "E20: 마크가 설정되어 있지 않습니다"
+#~ msgid "Pathname:"
+#~ msgstr "경로 이름:"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 바꿀 수 없음, 'modifiable'이 꺼져있습니다"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 현재 디렉토리를 얻을 수 없습니다"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 스크립트가 너무 깊게 중첩되었습니다"
+#~ msgid "OK"
+#~ msgstr "확인"
 
-msgid "E23: No alternate file"
-msgstr "E23: 다른 파일이 없습니다"
+#~ msgid "Cancel"
+#~ msgstr "취소"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: 그런 약어는 없습니다"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "스크롤바 위젯: 썸 픽스맵의 지오미트리를 얻을 수 없습니다."
 
-msgid "E477: No ! allowed"
-msgstr "E477: !은 허용되지 않습니다"
+#~ msgid "Vim dialog"
+#~ msgstr "빔 대화상자"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: 메시지와 콜백 모두를 사용해서는 BalloonEval을 만들 수 없습니다"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebrew는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+#~ msgid "Input _Methods"
+#~ msgstr "입력 방법(_M)"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "빔 - 찾아서 바꾸기..."
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabic은 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+#~ msgid "VIM - Search..."
+#~ msgstr "빔 - 찾기..."
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 이런 하이라이트 그룹 이름은 없습니다: %s"
+#~ msgid "Find what:"
+#~ msgstr "무얼 찾을까요:"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: 입력된 텍스트가 아직 없습니다"
+#~ msgid "Replace with:"
+#~ msgstr "바꿀 문자열:"
 
-msgid "E30: No previous command line"
-msgstr "E30: 이전 명령 줄이 없습니다"
+#~ msgid "Match whole word only"
+#~ msgstr "똑같은 낱말만"
 
-msgid "E31: No such mapping"
-msgstr "E31: 그런 맵핑이 없습니다"
+#~ msgid "Direction"
+#~ msgstr "방향"
 
-msgid "E479: No match"
-msgstr "E479: 맞지 않습니다"
+#~ msgid "Up"
+#~ msgstr "위로"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 맞지 않음: %s"
+#~ msgid "Down"
+#~ msgstr "아래로"
 
-msgid "E32: No file name"
-msgstr "E32: 파일 이름이 없습니다"
+#~ msgid "Find Next"
+#~ msgstr "다음 찾기"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 이전 바꾸기 정규 표현식이 없습니다"
+#~ msgid "Replace"
+#~ msgstr "바꾸기"
 
-msgid "E34: No previous command"
-msgstr "E34: 이전 명령이 없습니다"
+#~ msgid "Replace All"
+#~ msgstr "모두 바꾸기"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: 이전 정규표현식이 없습니다"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "빔: 세션 관리자로부터 \"die\" 요청을 받았습니다\n"
 
-msgid "E481: No range allowed"
-msgstr "E481: 범위는 허용되지 않습니다"
+#~ msgid "Close"
+#~ msgstr "닫기"
 
-msgid "E36: Not enough room"
-msgstr "E36: 빈 공간이 충분하지 않습니다"
+#~ msgid "New tab"
+#~ msgstr "새 탭"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: \"%s\"은(는) 등록된 서버명이 아닙니다"
+#~ msgid "Open Tab..."
+#~ msgstr "탭 열기..."
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: %s 파일을 만들 수 없습니다"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "빔: 메인 창이 죽게 될 것입니다\n"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: 임시 파일 이름을 얻을 수 없습니다"
+#~ msgid "&Filter"
+#~ msgstr "거르개(&F)"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: %s 파일을 열 수 없습니다"
+#~ msgid "&Cancel"
+#~ msgstr "취소(&C)"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: %s 파일을 읽을 수 없습니다"
+#~ msgid "Directories"
+#~ msgstr "디렉토리"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 마지막으로 고친 뒤 저장되지 않았습니다 (무시하려면 ! 더하기)"
+#~ msgid "Filter"
+#~ msgstr "거르개"
 
-msgid "E38: Null argument"
-msgstr "E38: 널 인자"
+#~ msgid "&Help"
+#~ msgstr "도움말(&H)"
 
-msgid "E39: Number expected"
-msgstr "E39: 숫자가 필요합니다"
+#~ msgid "Files"
+#~ msgstr "파일"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 에러파일 %s을(를) 열 수 없습니다"
+#~ msgid "&OK"
+#~ msgstr "확인(&O)"
 
-msgid "E233: cannot open display"
-msgstr "E233: 디스플레이를 열 수 없습니다"
+#~ msgid "Selection"
+#~ msgstr "고르기"
 
-msgid "E41: Out of memory!"
-msgstr "E41: 메모리가 바닥났습니다!"
+#~ msgid "Find &Next"
+#~ msgstr "다음 찾기(&N)"
 
-msgid "Pattern not found"
-msgstr "패턴을 찾을 수 없습니다"
+#~ msgid "&Replace"
+#~ msgstr "바꾸기(&R)"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 패턴을 찾을 수 없습니다: %s"
+#~ msgid "Replace &All"
+#~ msgstr "모두 바꾸기(&A)"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: 인자는 양수이어야 합니다"
+#~ msgid "&Undo"
+#~ msgstr "취소(&U)"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 이전 디렉토리로 갈 수 없습니다"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: 창 제목 \"%s\"을(를) 찾을 수 없습니다"
 
-msgid "E42: No Errors"
-msgstr "E42: 에러 없음"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 지원되지 않는 인자: \"-%s\": OLE 판을 사용하십시오."
 
-msgid "E776: No location list"
-msgstr "E776: 위치 목록 없음"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: MDI 응용프로그램 안에서 창을 열 수 없습니다"
 
-msgid "E43: Damaged match string"
-msgstr "E43: 깨진 맞는 문자열"
+#~ msgid "Close tab"
+#~ msgstr "탭 닫기"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 깨진 정규표현식 프로그램"
+#~ msgid "Open tab..."
+#~ msgstr "탭 열기..."
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' 옵션이 설정되어 있습니다 (덮어쓰려면 ! 더하기)"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "문자열 찾기 ('\\'를 찾으려면 '\\\\' 사용)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 읽기 전용 변수 \"%s\"을(를) 바꿀 수 없습니다"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "문자열 찾아 바꾸기 ('\\'를 찾으려면 '\\\\' 사용)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: sandbox 안에서는 변수를 설정할 수 없음: \"%s\""
+#~ msgid "Not Used"
+#~ msgstr "사용 않됨"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 에러파일 읽는 도중에 에러"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "디렉토리\t*.nothing\n"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: sandbox에서는 허용되지 않습니다"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "빔 E458: 색상맵 엔트리를 할당할 수 없습니다, 몇몇 색이 잘못될 수 있습니다"
 
-msgid "E523: Not allowed here"
-msgstr "E523: 여기에서 허용되지 않습니다"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: 다음 글자셋의 글꼴이 글꼴셋 %s에 없습니다:"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 스크린 상태 설정은 지원되지 않습니다"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: 글꼴셋 이름: %s"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: 스크롤 크기가 잘못되었습니다"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "글꼴 '%s'은(는) 고정넓이가 아닙니다"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' 옵션이 비었습니다"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: 글꼴셋 이름: %s\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: sign 자료를 읽을 수 없습니다"
+#~ msgid "Font0: %s\n"
+#~ msgstr "글꼴0: %s\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: 스왑 파일을 닫을 수 없습니다"
+#~ msgid "Font1: %s\n"
+#~ msgstr "글꼴1: %s\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: 태그 스택이 비었습니다"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "글꼴%<PRId64> 너비가 글꼴0의 두배가 아닙니다\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: 명령이 너무 복잡합니다"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "글꼴0 너비: %<PRId64>\n"
 
-msgid "E75: Name too long"
-msgstr "E75: 이름이 너무 깁니다"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "글꼴1 너비: %<PRId64>\n"
+#~ "\n"
 
-msgid "E76: Too many ["
-msgstr "E76: [가 너무 많습니다"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - 글꼴 선택기"
 
-msgid "E77: Too many file names"
-msgstr "E77: 파일 이름이 너무 많습니다"
+#~ msgid "Name:"
+#~ msgstr "이름:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: 끝에 문자가 더 있습니다"
+#~ msgid "Encoding:"
+#~ msgstr "인코딩:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 모르는 마크"
+#~ msgid "Font:"
+#~ msgstr "글꼴:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 만능 글자를 확장할 수 없습니다"
+#~ msgid "Style:"
+#~ msgstr "스타일:"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight'는 'winminheight'보다 커야 합니다"
+#~ msgid "Size:"
+#~ msgstr "크기:"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth'는 'winminwidth'보다 커야 합니다"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: 한글 오토마타 에러"
 
-msgid "E80: Error while writing"
-msgstr "E80: 쓰는 중에 에러"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 에러"
 
-msgid "Zero count"
-msgstr "Zero count"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: cscope 데이터베이스를 열 수 없음: %s"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: 스크립트 콘텍스트 밖에서 <SID> 사용"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: cscope 데이터베이스 정보를 얻을 수 없습니다"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: 잘못된 표현식이 받아졌습니다"
+#~ msgid "cannot save undo information"
+#~ msgstr "undo 정보를 저장할 수 없습니다"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: 영역이 보호되고 있어서 수정할 수 없습니다"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: 미안합니다, 이 명령은 사용할 수 없습니다, MzScheme 라이브러리를 로딩"
+#~ "할 수 없습니다."
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans는 읽기 전용 파일을 바꿀 수 없습니다"
+#~ msgid "invalid expression"
+#~ msgstr "잘못된 표현식"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 내부 에러: %s"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "표현식을 지원하지 않도록 컴파일 되었습니다"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: 패턴이 'maxmempattern'보다 많은 메모리를 사용합니다"
+#~ msgid "unknown option"
+#~ msgstr "모르는 옵션"
 
-msgid "E749: empty buffer"
-msgstr "E749: 빈 버퍼"
+#~ msgid "window index is out of range"
+#~ msgstr "창 번호가 범위를 벗어났습니다"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 잘못된 찾기 패턴 혹은 구분자"
+#~ msgid "couldn't open buffer"
+#~ msgstr "버퍼를 열 수 없었습니다"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 파일이 다른 버퍼에 로딩되어 있습니다"
+#~ msgid "cannot delete line"
+#~ msgstr "줄을 지울 수 없습니다"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: 옵션 '%s'이(가) 설정되어 있지 않습니다"
+#~ msgid "cannot replace line"
+#~ msgstr "줄을 바꿀 수 없습니다"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "처음까지 찾았음, 끝에서 계속"
+#~ msgid "cannot insert line"
+#~ msgstr "줄을 끼워넣을 수 없습니다"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "끝까지 찾았음, 처음부터 계속"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "문자열은 newline을 포함할 수 없습니다"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "\"%s\"에 대한 암호 키가 필요합니다"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim 에러: ~a"
 
-msgid "writelines() requires list of strings"
-msgstr "writelines()는 문자열 목록이 필요합니다"
+#~ msgid "Vim error"
+#~ msgstr "Vim 에러"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: 파이썬: I/O 객체 초기화중 에러가 생겼습니다"
+#~ msgid "buffer is invalid"
+#~ msgstr "버퍼가 이상합니다"
 
-msgid "no such buffer"
-msgstr "그런 버퍼는 없습니다"
+#~ msgid "window is invalid"
+#~ msgstr "창이 이상합니다"
 
-msgid "attempt to refer to deleted window"
-msgstr "지워진 창을 참조하려고 하였습니다"
+#~ msgid "linenr out of range"
+#~ msgstr "줄 번호가 범위를 벗어났습니다"
 
-msgid "readonly attribute"
-msgstr "읽기 전용 속성"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "Vim sandbox에서는 허용되지 않습니다"
 
-msgid "cursor position outside buffer"
-msgstr "퍼서 위치가 버퍼 밖에 있습니다"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: 이 Vim은 :py3을 사용한 후에 :python을 사용할 수 없습니다"
 
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<%p에 창 객체 (삭제됨)>"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: 미안합니다, 이 명령은 사용할 수 없습니다, 파이썬 라이브러리를 로딩"
+#~ "할 수 없습니다."
 
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<%p에 창 객체 (모름)>"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python을 재귀호출할 수 없습니다"
 
-#, c-format
-msgid "<window %d>"
-msgstr "<창 %d>"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "OutputObject 속성을 지울 수 없습니다"
 
-msgid "no such window"
-msgstr "그런 창은 없습니다"
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace는 정수여야만 합니다"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "지워진 버퍼를 참조하려고 하였습니다"
+#~ msgid "invalid attribute"
+#~ msgstr "잘못된 속성"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<%p에 버퍼 객체 (삭제됨)>"
+
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: 이 Vim은 :python을 사용한 후에 :py3을 사용할 수 없습니다"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: 미안합니다, 이 명령은 사용할 수 없습니다, 루비 라이브러리를 로딩할 "
+#~ "수 없습니다."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: 뜻밖의 return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: 뜻밖의 next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: 뜻밖의 break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: 뜻밖의 redo"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: 처리않된 예외"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 모르는 longjmp 상태 %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "토글 구현/정의"
+
+#~ msgid "Show base class of"
+#~ msgstr "...의 기본 클래스 보여주기"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "SNiFF+로 연결할 수 없습니다. 환경을 확인하십시오 (sniffemacs가 $PATH에서 "
+#~ "찾아져야 합니다).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 읽는 중 에러. 끊김"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ is currently "
+
+#~ msgid "not "
+#~ msgstr "not "
+
+#~ msgid "connected"
+#~ msgstr "connected"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 모르는 SNiFF+ 요청: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: SNiFF+에 연결 에러"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SniFF+가 연결되지 않았습니다"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: SniFF+ 버퍼가 아닙니다"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 쓰는 도중 에러. 끊겼습니다"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "잘못된 버퍼 번호"
+
+#~ msgid "not implemented yet"
+#~ msgstr "아직 구현되지 않았습니다"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "줄을 설정할 수 없습니다"
+
+#~ msgid "invalid mark name"
+#~ msgstr "잘못된 마크 이름"
+
+#~ msgid "mark not set"
+#~ msgstr "마크가 설정되지 않았습니다"
+
+#~ msgid "row %d column %d"
+#~ msgstr "행 %d 열 %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "줄을 끼워넣거나 더할 수 없습니다"
+
+#~ msgid "line number out of range"
+#~ msgstr "줄 번호가 범위를 벗어났습니다"
+
+#~ msgid "unknown flag: "
+#~ msgstr "모르는 플래그: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "모르는 빔 옵션"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "키보드 인터럽트"
+
+#~ msgid "vim error"
+#~ msgstr "빔 에러"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "버퍼/창 명령을 만들 수 없습니다: 객체가 지워집니다"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창이 이미 지워졌습니다"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL 심각한 에러: reflist가 깨졌나!? 이 문제를 vim-dev@vim.org로 알려"
+#~ "주십시오"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "콜백 명령을 등록할 수 없습니다: 버퍼/창 참조를 찾을 수 없습니다"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: 미안합니다, 이 명령은 사용할 수 없습니다, Tcl 라이브러리를 로딩할 "
+#~ "수 없습니다."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL 에러: 끝내기 코드가 정수가 아닌가!? 이 문제를 vim-dev@vim.org로 "
+#~ "알려주십시오"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 종료 코드 %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "줄을 얻을 수 없습니다"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "명령 서버 이름을 등록할 수 없습니다"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 대상프로그램으로 명령 보내기가 실패했습니다"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 잘못된 서버 id 사용됨: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: 빔 인스턴스 레지스트리 속성이 잘못되어 있습니다. 지웠습니다!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "이 GUI는 netbeans를 지원하지 않습니다\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "이 빔은 diff 기능 없이 컴파일 되었습니다."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb'는 사용할 수 없음: 컴파일할 때 포함되지 않음\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: 에러: NetBeans에서 gvim 시작 실패\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t이 gvim OLE에 등록"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tgvim을 OLE에서 등록취소"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tGUI로 실행 (\"gvim\"과 같음)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f 혹은 --nofork\t포그라운드: GUI로 시작할 때 fork하지 말 것"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t창을 열 때 newcli 사용하지 않음"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <장치>\t\tI/O에 <장치> 사용"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t.gvimrc 대신 <gvimrc>를 사용"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t암호화된 파일 고치기"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t빔을 특정 X-서버와 연결"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tX 서버에 연결하지 않음"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t가능하면 빔 서버에서 <files> 편집"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  같음, 서버가 없다고 불평하지 않음"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  --remote와 같지만 다 고칠 때까지 기다립니다"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  같음, 서버가 없다고 불평하지 않음"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <files>  --remote와 같지만 파일별로 탭 페이"
+#~ "지 사용"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t빔 서버로 <keys>를 보내고 끝내기"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t빔 서버에서 <expr> 실행하고 결과 출력"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t사용 가능한 빔 서버 이름을 표시하고 끝내기"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t빔 서버 <name>이 되거나 서버로 보내기"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고 있는 인자 (모티프 판):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고 있는 인자 (neXtaw 판):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고 있는 인자 (아테나 판):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t빔을 <display>에서 실행"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t아이콘 상태로 빔 시작"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t바탕 색으로 <color> 사용 (also: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t일반 색에 <color> 사용 (also: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\t일반 텍스트에 <font> 사용 (also: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t굵은 텍스트에 <font> 사용"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t기울임 텍스트에 <font> 사용"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t초기 지오미트리에 <geom> 사용 (also: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t가장자리 넓이에 <width> 사용 (also: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width>  스크롤바 넓이에 <width> 사용 (also: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t메뉴바 높이에 <height> 사용 (also: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t반전 비디오 사용 (also: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t반전 비디오 사용 안 함 (also: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t명시된 리소스 설정"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고있는 인자 (RISC OS 판):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <숫자>\t칸에서 창 초기 너비"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <숫자>\t줄에서 창 초기 높이"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim이 알고있는 인자 (GTK+ 판):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t빔을 <display>에서 실행 (also: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t메인 창 구분을 위해 유일한 역할 설정"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t빔을 다른 GTK 위젯 안에서 열음"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\tVim을 부모 응용 프로그램 내에서 열기"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\t다른 win32 위젯 안에서 Vim 열기"
+
+#~ msgid "No display"
+#~ msgstr "디스플레이가 없습니다"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 보내기가 실패하였습니다.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 보내기 실패. 로컬에서 실행됩니다\n"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "디스플레이 없음: 표현식 보내기가 실패했습니다.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 표현식 보내기가 실패했습니다.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 정상적인 코드페이지가 아닙니다"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: 입력 콘텍스트를 만들 수 없습니다"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: 입력 방식을 열다가 실패했습니다"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 경고: IM에 파괴 콜백을 설정할 수 없습니다"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 입력 방식이 어떤 형식도 지원하지 않습니다"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 입력 방식이 내 preedit 형식을 지원하지 않습니다"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: 스왑 파일을 암호화할 수 없습니다"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr ""
+#~ "E833: %s이(가) 암호화되어 있는 데, 이 Vim은 암호화를 지원하지 않습니다"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "스왑 파일이 암호화됨: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "새로운 암호 키를 입력했는 데, 파일을 저장하지 않았었다면,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "새로운 암호 키를 입력하세요."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "암호 키를 바꾼 후에 파일을 저장했었다면 같은 키로 텍스트 파일과"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "스왑파일을 저장하려면 엔터를 누르세요"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "텍스트 파일에 스왑파일에서 가져온 암호 키를 사용합니다.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [빔 이번 판에서는 사용할 수 없음]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "이 메뉴를 떼어냄"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "디렉토리 선택 대화상자"
+
+#~ msgid "Save File dialog"
+#~ msgstr "파일 저장 대화상자"
+
+#~ msgid "Open File dialog"
+#~ msgstr "파일 열기 대화상자"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: 미안합니다, 콘솔 상태에는 파일 브라우저가 없습니다"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "빔: 파일 보존중...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "빔: 끌났습니다.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "에러: "
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 줄이 너무 길어졌습니다"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 이상한 마우스모양"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "암호 키 입력: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "같은 키를 다시 입력: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "키가 맞지 않습니다!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Netbeans #2에 연결할 수 없습니다"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Netbeans에 연결할 수 없습니다"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 연결 정보 파일이 접근 모드가 잘못됨: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "Netbeans 소켓에서 읽기"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 버퍼 %<PRId64>에 대한 NetBeans 연결을 잃어버렸습니다"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: 이 GUI는 netbeans를 지원하지 않습니다"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans가 이미 연결되어 있습니다"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval 기능이 빠져있습니다"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "freeing %<PRId64> lines"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: GUI에서는 term을 바꿀 수 없습니다"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: GUI를 시작하려면 \":gui\"를 사용하십시오"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: GTK+ 2 GUI에서는 바뀔 수 없습니다"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 잘못된 글꼴(들)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 글꼴셋을 고를 수 없습니다"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 잘못된 글꼴셋"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: 와이드 글꼴을 고를 수 없습니다"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 잘못된 와이드 글꼴"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: 마우스를 지원하지 않습니다"
+
+#~ msgid "cannot open "
+#~ msgstr "cannot open "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "빔: 창을 열 수 없습니다!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "아미가도스 2.04나 더 높은 판이 필요합니다\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Need %s version %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "NIL을 열 수 없음:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Cannot create "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "빔이 %d 값으로 끝냅니다\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "콘솔 상태를 바꿀 수 없습니다 ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 콘솔이 아닌가??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: -f 옵션이 사용된 경우 쉘을 실행할 수 없습니다"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Cannot execute "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " returned\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE가 너무 작습니다."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 에러"
+
+#~ msgid "Message"
+#~ msgstr "메시지"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns'이 80이 아니어서, 외부 명령을 실행할 수 없습니다"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: 프린터를 고르지 못했습니다"
+
+#~ msgid "to %s on %s"
+#~ msgstr "to %s on %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 모르는 프린터 글꼴: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 인쇄 에러: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "'%s' 인쇄중"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 잘못된 글자셋 이름 \"%s\"이(가) 글꼴 이름 \"%s\"에 있습니다"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 잘못된 글자 '%c'이(가) 글꼴 이름 \"%s\"에 있습니다"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "빔: 같은 시그널 두 번, 끝냅니다\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "빔: %s 시그널을 잡았습니다\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "빔: 죽을 시그널을 잡았습니다\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "X 디스플레이를 여는 데 %<PRId64> msec이 걸렸습니다"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "빔: X 에러가 생겼습니다\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "X 디스플레이 시험이 실패했습니다"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "X 디스플레이를 열다가 시간이 초과되었습니다"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "쉘 sh를 실행할 수 없습니다\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "파이프를 만들 수 없습니다\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "자식 프로세스를 만들 수 없습니다\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "명령이 끝마쳐졌습니다\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP가 ICE 연결을 잃어버렸습니다"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "X 디스플레이 열기가 실패했습니다"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP가 save-yourself 요청을 실행하고 있습니다"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP가 연결을 여는 중입니다"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP가 ICE 연결 감시를 실패했습니다"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection 실패: %s"
+
+#~ msgid "At line"
+#~ msgstr "At line"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "vim32.dll을 불러 들일 수 없습니다!"
+
+#~ msgid "VIM Error"
+#~ msgstr "빔 에러"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "함수 포인터를 DLL로 바꿀 수 없습니다!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "쉘이 %d을(를) 돌려주었습니다"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "빔: %s 이벤트를 잡았습니다\n"
+
+#~ msgid "close"
+#~ msgstr "닫기"
+
+#~ msgid "logoff"
+#~ msgstr "로그아웃"
+
+#~ msgid "shutdown"
+#~ msgstr "셧다운"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 명령을 찾을 수 없습니다"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE를 $PATH에서 찾을 수 없습니다.\n"
+#~ "외부 명령이 끝난 뒤 멈출 수 없습니다.\n"
+#~ "다 많은 정보를 보시려면 :help win32-vimrun을 보십시오."
+
+#~ msgid "Vim Warning"
+#~ msgstr "빔 경고"
+
+#~ msgid "Error file"
+#~ msgstr "에러 파일"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "경고: 단어 목록 \"%s_%s.spl\" 혹은 \"%s_ascii.spl\"을 찾을 수 없습니다"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "%s의 변환이 지원되지 않습니다"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: %s에 대한 태그 파일 경로가 잘렸습니다\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "새 쉘이 시작되었습니다\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "빈 고르기 대신 CUT_BUFFER0을 사용했습니다"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "취소 불가능; 어쨌든 계속합니다"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr ""
+#~ "E832: 암호화되지 않은 파일이 암호화된 undo 파일을 가지고 있습니다: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Undo 파일을 해독할 수 없습니다: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Undo 파일이 암호화되었습니다: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 비트 GUI 판"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64비트 GUI 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32비트 GUI 버젼"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " Win32s 상태"
+
+#~ msgid " with OLE support"
+#~ msgstr " OLE 지원"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64비트 콘솔 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32비트 콘솔 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16비트 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32비트 MS-DOS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16비트 MS-DOS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (유닉스) 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "OpenVMS 버젼"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Big 버젼 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normal 버젼 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Small 버젼 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Tiny 버젼 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "(클래식) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "       시스템 gvimrc 파일: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       사용자 gvimrc 파일: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "사용자 두 번째 gvimrc 파일: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "사용자 세 번째 gvimrc 파일: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    시스템 메뉴 파일: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "컴파일러: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "이에 대한 정보를 보려면    메뉴에서 도움말->고아  선택"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "모드없이 수행중이며, 입력된 문자는 삽입됩니다"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "메뉴에서 편집->전역 설정->삽입 모드 토글을 선택하시면 "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                         두 모드를 사용할 수 있습니다 "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "메뉴에서 편집->전역 설정->Vi 호환 토글을 선택하시면   "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                          Vim이 기본값으로 동작합니다 "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "경고: 윈도우즈 95/98/ME를 찾았음"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "이에 대한 정보를 보려면    :help windows95<엔터>  입력"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: %s 라이브러리를 로드할 수 없습니다"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "미안합니다, 이 명령은 사용할 수 없습니다, Perl 라이브러리를 로딩할 수 없습"
+#~ "니다."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: Safe 모듈없이는 sandbox에서 Perl evaluation이 제한됩니다"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "여러 빔으로 편집(&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "하나의 빔으로만 편집(&V)"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "빔으로 Diff"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "빔으로 편집(&V)"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "하나의 빔으로만 편집 - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "선택된 파일(들)을 빔으로 편집"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "프로세스 생성 에러: gvim이 path에 있는 지 확인하세요!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 에러"
+
+#~ msgid "Path length too long!"
+#~ msgstr "경로가 너무 깁니다"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 모르는 글꼴셋: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 모르는 글꼴: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: 글꼴 \"%s\"은(는) 고정넓이가 아닙니다"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: %s 라이브러리 함수를 로드할 수 없습니다"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hebrew는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsi는 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabic은 사용할 수 없습니다: 컴파일 때 포함되지 않았습니다\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: \"%s\"은(는) 등록된 서버명이 아닙니다"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: 디스플레이를 열 수 없습니다"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 잘못된 표현식이 받아졌습니다"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 영역이 보호되고 있어서 수정할 수 없습니다"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans는 읽기 전용 파일을 바꿀 수 없습니다"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "\"%s\"에 대한 암호 키가 필요합니다"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines()는 문자열 목록이 필요합니다"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: 파이썬: I/O 객체 초기화중 에러가 생겼습니다"
+
+#~ msgid "no such buffer"
+#~ msgstr "그런 버퍼는 없습니다"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "지워진 창을 참조하려고 하였습니다"
+
+#~ msgid "readonly attribute"
+#~ msgstr "읽기 전용 속성"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "퍼서 위치가 버퍼 밖에 있습니다"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<%p에 창 객체 (삭제됨)>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<%p에 창 객체 (모름)>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<창 %d>"
+
+#~ msgid "no such window"
+#~ msgstr "그런 창은 없습니다"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "지워진 버퍼를 참조하려고 하였습니다"

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -26,148 +26,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 6.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-03-19 02:09+0100\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2007-03-21 11:51+0100\n"
 "Last-Translator: Øyvind A. Holm <sunny@sunbase.org>\n"
 "Language-Team: Norwegian <vim.in.norwegian@sunbase.org>\n"
+"Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Søppel etter valgparameter"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Plassliste]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Kan ikke reservere plass til noen buffere, avslutter ..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Kan ikke reservere plass til buffer, bruker en annen ..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Ingen buffere ble lastet ut"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Ingen buffere ble slettet"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Ingen buffere ble visket ut"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer ble lastet ut"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffere ble lastet ut"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer ble slettet"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffere ble slettet"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer ble visket ut"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffere ble visket ut"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Kan ikke laste ut siste buffer"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Fant ingen modifisert buffer"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Det finnes ingen listede buffere"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Bufferen %<PRId64> finnes ikke"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan ikke gå forbi siste buffer"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan ikke gå forbi første buffer"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Ikke lagret siden forrige forandring av bufferen %<PRId64> (legg til ! for å "
-"overstyre)"
+"E89: Ikke lagret siden forrige forandring av bufferen %<PRId64> (legg til ! "
+"for å overstyre)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Kan ikke laste ut siste buffer"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Advarsel: Listen med filnavn er overfylt"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Fant ikke bufferen %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Mer enn ett treff for %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Ingen samsvarende buffer for %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "linje %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: En buffer med dette navnet finnes allerede"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modifisert]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Uredigert]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Ny fil]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Lesefeil]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[SB]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[skrivebeskyttet]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 linje --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> linjer --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "linje %<PRId64> av %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Uten navn]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "hjelp"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Hjelp]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Forhåndsvisning]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Alt"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Bunn"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Topp"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -175,12 +242,11 @@ msgstr ""
 "\n"
 "# Bufferliste:\n"
 
-msgid "[Location List]"
-msgstr "[Plassliste]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-#~ msgid "[Quickfix List]"
-#~ msgstr ""
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -188,135 +254,204 @@ msgstr ""
 "\n"
 "--- Skilt ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Skilt for %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    linje=%<PRId64>  id=%d  navn=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Mangler kolon"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Ulovlig modus"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Siffer forventet"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Ulovlig prosent"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Kan ikke sammenligne flere enn %<PRId64> buffere"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Kan ikke åpne termcap-fil"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan ikke lage differansefiler"
 
-msgid "Patch file"
-msgstr "Patch fil"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Kan ikke lese differanse-utdata"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Kan ikke lese differanse-utdata"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Nåværende buffer er ikke i differansemodus"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Ingen annen buffer i differansemodus er redigerbar"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Ingen annen buffer i differansemodus"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Mer enn to buffere i differansemodus, vet ikke hvilken som skal brukes"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Kan ikke finne buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bufferen \"%s\" er ikke i differansemodus"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Uventet forandring i buffer"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape er ikke lovlig i spesialtegn"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Fant ikke keymap-fil"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Bruk av :loadkeymap utenfor en kjørt fil"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Tom tastaturoppsett-oppføring"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Nøkkelordfullføring (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 #, fuzzy
-#~ msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
-#~ msgstr " ^X-modus (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
+msgstr " ^X-modus (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Fullføring av hel linje (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Fullføring av filnavn (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Fullføring av tag (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Stimønster-fullføring (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Fullføring av defineringer (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Fullføring fra ordliste (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus-fullføring (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Kommandolinje-fullføring (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Brukerdefinert fullføring (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-fullføring (^O^N^P)"
 
+#: ../edit.c:96
 #, fuzzy
-#~ msgid " Spelling suggestion (s^N^P)"
-#~ msgstr " Staveforslag (^S^N^P)"
+msgid " Spelling suggestion (s^N^P)"
+msgstr " Staveforslag (^S^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokal nøkkelordfullføring (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Kom til slutten av avsnittet"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary'-valget er tomt"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus'-valget er tomt"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Leter gjennom ordliste: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (sett inn) Rulling (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (erstatt) Rulling (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Leter: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Leter gjennom tagger."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Legger til"
 
@@ -324,395 +459,585 @@ msgstr " Legger til"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Søker ..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Tilbake i originalen"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Ord fra annen linje"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Det eneste treffet"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "treff %d av %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "treff %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Uventede tegn i :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Listeindeks utenfor område: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Udefinert variabel: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Mangler ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Parameter til %s må være en liste"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Parameter til %s må være en liste eller ordliste"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Kan ikke bruke tom nøkkel med ordliste"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Liste påkrevet"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Ordliste påkrevet"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: For mange parametere til funksjonen: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Nøkkelen finnes ikke i ordliste: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funksjonen %s eksisterer allerede, legg til ! for å erstatte den"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Ordlisteoppføring finnes allerede"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funksjonsreferanse nødvendig"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Kan ikke bruke [:] sammen med en ordliste"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Feil variabeltype for %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Ukjent funksjon: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Ugyldig variabelnavn: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: Bruker en liste som en streng"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Færre mål enn listeelementer"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Flere mål enn listeelementer"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Dobbel ; i variabelliste"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Kan ikke liste variabler for %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Kan bare indeksere en liste eller ordliste"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] må komme sist"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] krever en listeverdi"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Listeverdien har flere elementer enn mål"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Listeverdien har ikke nok elementer"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Mangler \"in\" etter :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Mangler parenteser: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Variabelen finnes ikke: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Variabel nøstet for dypt for (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Mangler ':' etter '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Kan bare sammenligne liste med liste"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Ugyldig operasjon for lister"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Kan bare sammenligne ordliste med ordliste"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Ugyldig operasjon for ordliste"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Kan bare sammenligne funksjonsreferanse med funksjonsreferanse"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Ugyldig operasjon for funksjonsreferanser"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Kan ikke bruke [:] sammen med en ordliste"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Mangler ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Kan ikke indeksere en funksjonsreferanse"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Navn på valg mangler: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Ukjent valg: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Mangler anførselstegn (\"): %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Mangler apostrof ('): %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Mangler komma i liste: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Mangler slutt på liste ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Mangler kolon i ordliste: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Duplisert nøkkel i ordliste: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Mangler komma i ordliste: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Mangler slutt på ordliste '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Variabel nøstet for dypt for visning"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: For mange parametere til funksjonen: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: For mange parametere til funksjonen: %s"
+
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Ukjent funksjon: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Ikke nok parametere til funksjonen: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Bruk av \"<SID>\" utenfor skript-sammenheng: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Kaller ordlistefunksjon uten ordliste: %s"
 
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Nummer nødvendig etter ="
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: For mange parametere"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() kan bare brukes i innsettingsmodus"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Nøkkelen finnes allerede: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld linjer: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Ukjent funksjon: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Avbryt"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "kalte inputrestore() oftere enn inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Område ikke tillatt"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Ugyldig type for len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Økning er null"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Starten er bak slutten"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<tom>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Ingen forbindelse med Vim-tjeneren"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr " vim [parametere] "
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Klarer ikke sende til %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Klarer ikke lese svar fra tjeneren"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: For mange symbolske linker (runddans?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Klarer ikke sende til klienten"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr " vim [parametere] "
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funksjon for sorteringssammenligning feilet"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funksjon for sorteringssammenligning feilet"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Ugyldig)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Feil under skriving til midlertidig fil"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Bruker en liste som et nummer"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Bruker en funksjonsreferanse som et nummer"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Bruker en liste som et nummer"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Bruker en ordliste som et nummer"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Bruker en funksjonsreferanse som en streng"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Bruker en liste som en streng"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Bruker en ordliste som en streng"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Variabelnavn for funksjonsreferanse må ha stor forbokstav: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Variabelnavn er i konflikt med en eksisterende funksjon: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Variabeltype samsvarer ikke med: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Kan ikke slette variabel %s"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Variabelnavn for funksjonsreferanse må ha stor forbokstav: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Variabelnavn er i konflikt med en eksisterende funksjon: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Verdi er låst: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Ukjent"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Kan ikke forandre verdi for %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Variabel nøstet for dypt til å lage en kopi"
 
+#: ../eval.c:17249
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Ukjent funksjon: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Mangler '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Kan ikke sette IC-verdier (\"Input Context\")"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Ugyldig parameter: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Ugyldig parameter: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Mangler :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: Funksjonsnavn samsvarer ikke med skriptfilnavn: %s"
+
+#: ../eval.c:17549
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Kan ikke slette funksjonen %s: Den er i bruk"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Funksjonsnavn samsvarer ikke med skriptfilnavn: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Funksjonsnavn nødvendig"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: Funksjonsnavn må ha stor forbokstav eller inneholde et kolon: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Funksjonsnavn må ha stor forbokstav eller inneholde et kolon: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Kan ikke slette funksjonen %s: Den er i bruk"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Funksjonskalldybden er større enn 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "kaller %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s avbrutt"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s returnerer #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s returnerer %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "fortsetter i %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return er ikke innenfor en funksjon"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -720,6 +1045,7 @@ msgstr ""
 "\n"
 "# globale variabler:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -727,77 +1053,106 @@ msgstr ""
 "\n"
 "\tSist satt fra "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "Ingen inkluderte filer"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Oktal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Flytting av linjer inn i seg selv"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 linje flyttet"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> linjer flyttet"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> linjer filtrert"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autokommandoer må ikke forandre nåværende buffer"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Ikke lagret siden forrige forandring]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s i linje: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: For mange feil, hopper over resten av filen"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Leser viminfo-fil \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " merker"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "Ingen inkluderte filer"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FEILET"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo-fil er ikke skrivbar: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Kan ikke lagre viminfo-fil %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Lagrer viminfo-fil \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Denne viminfo-filen ble generert av Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -805,41 +1160,47 @@ msgstr ""
 "# Du kan redigere den hvis du er forsiktig!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Verdien av 'encoding' når denne filen ble skrevet\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Ulovlig starttegn"
 
-msgid "Save As"
-msgstr "Lagre som"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Skrive delvis fil?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Bruk ! for å skrive delvis buffer"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Overskrive eksisterende fil \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Swapfilen \"%s\" finnes, overskriv likevel?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Swapfilen finnes: %s (:silent! overstyrer)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Mangler filnavn for buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Filen ble ikke lagret: Lagring er deaktivert med 'write'-valget"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -848,61 +1209,91 @@ msgstr ""
 "'readonly'-valget er satt for \"%s\".\n"
 "Vil du lagre likevel?"
 
-msgid "Edit File"
-msgstr "Rediger fil"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "er skrivebeskyttet (legg til ! for å overstyre)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokommandoer slettet uventet den nye bufferen %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Ikke-numerisk parameter til :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Skallkommandoer er ikke tillatt i rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulære uttrykk kan ikke bli adskilt av bokstaver"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "Erstatt med %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Avbrutt) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 treff"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 erstatning"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> treff"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> erstatninger"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " i 1 linje"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " i %<PRId64> linjer"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan ikke gjøre :global rekursiv"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Regulært uttrykk mangler i global kommando"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Søkestreng funnet i alle linjene: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Fant ikke søketeksten"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -912,266 +1303,338 @@ msgstr ""
 "# Siste erstatningstekst:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Ingen panikk!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Dessverre ingen '%s' hjelp for %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Dessverre ingen hjelp for %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Fant ikke hjelpefilen \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Er ikke en katalog: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Kan ikke åpne %s for skriving"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Kan ikke åpne %s for lesing"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Tegnsettblanding i hjelpefilen innenfor samme språk: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplikat-tag \"%s\" i filen %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Ukjent skiltkommando: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Mangler skiltnavn"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: For mange skilt definert"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Ugyldig skilttekst: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Ukjent skilt: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Mangler skiltnummer"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ugyldig buffernavn: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Ulovlig skilt-ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (IKKE FUNNET)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (ikke støttet)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Slettet]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Går inn i debuggingsmodus. Skriv \"cont\" for å fortsette."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "linje %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "kommando: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Stoppunkt i \"%s%s\" linje %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Fant ikke stoppunkt: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Ingen stoppunkt definert"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  linje %<PRId64>"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Bruk først :profile start <filnavn>"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Lagre forandringer til \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Uten navn"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Ikke lagret siden siste forandringer i bufferen \"%s\""
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "Advarsel: Gikk uventet inn i en annen buffer (sjekk autokommandoer)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Det er bare en fil å redigere"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Kan ikke gå forbi første fil"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Kan ikke gå forbi siste fil"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Kompilatoren er ikke støttet: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Søker etter \"%s\" i \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Søker etter \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "ikke funnet i 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Kjør Vim-skript"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Kan ikke kjøre en katalog: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "kunne ikke kjøre \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "linje %<PRId64>: Kunne ikke kjøre \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "kjører \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "linje %<PRId64>: kjører \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "ferdig med kjøring av %s"
 
+#: ../ex_cmds2.c:2765
 #, fuzzy
-#~ msgid "modeline"
-#~ msgstr "1 linje lagt til"
+msgid "modeline"
+msgstr "1 linje lagt til"
 
+#: ../ex_cmds2.c:2767
 #, fuzzy
-#~ msgid "--cmd argument"
-#~ msgstr " vim [parametere] "
+msgid "--cmd argument"
+msgstr " vim [parametere] "
 
+#: ../ex_cmds2.c:2769
 #, fuzzy
-#~ msgid "-c argument"
-#~ msgstr " vim [parametere] "
+msgid "-c argument"
+msgstr " vim [parametere] "
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "miljøvariabel"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "feilbehandler"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Advarsel: Feil linjeseparator, det er mulig ^M mangler"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding brukt utenfor en kjørt fil"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish brukt utenfor en kjørt fil"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Nåværende %sspråk: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Kan ikke sette språk til \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Går inn i Ex-modus. Skriv \"visual\" for å gå til normalmodus."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Ved slutten av filen"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Kommando altfor rekursiv"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Unntak ikke fanget opp: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Slutt på kjørt fil"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Slutt på funksjon"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Flertydig bruk av brukerdefinert kommando"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Er ikke en editorkommando"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Område bakover er angitt"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Område bakover er angitt, OK å swappe"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Bruk w eller w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Kommandoen er ikke tilgjengelig i denne versjonen"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Bare ett filnavn tillatt"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 annen fil å redigere. Avslutt likevel?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d andre filer å redigere. Avslutt likevel?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 annen fil å redigere"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> andre filer å redigere"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Kommandoen finnes allerede: Legg til ! for å erstatte den"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1179,284 +1642,349 @@ msgstr ""
 "\n"
 "    Navn        Prm. Områd Fullfør   Definering"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Ingen brukerdefinerte kommandoer funnet"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Ingen attributt spesifisert"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Ugyldig antall parametere"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Antall repeteringer kan ikke bli spesifisert to ganger"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Ugyldig standardverdi for antall repeteringer"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: Trenger parameter til -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Ugyldig attributt: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Ugyldig kommandonavn"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Brukerdefinerte kommandoer må ha stor forbokstav"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Flertydig bruk av brukerdefinert kommando"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Brukerdefinert kommando finnes ikke: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Ugyldig \"complete\"-verdi: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Fullføringsparameter er bare tillatt for tilpasset fullføring"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Tilpassede fullføringer trenger et funksjonsparameter"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Kan ikke finne fargeoppsettet %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Vær hilset, Vim-bruker!"
 
+#: ../ex_docmd.c:5431
 #, fuzzy
-#~ msgid "E784: Cannot close last tab page"
-#~ msgstr "E444: Kan ikke lukke det siste vinduet"
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Kan ikke lukke det siste vinduet"
 
+#: ../ex_docmd.c:5462
 #, fuzzy
-#~ msgid "Already only one tab page"
-#~ msgstr "Allerede bare ett vindu"
+msgid "Already only one tab page"
+msgstr "Allerede bare ett vindu"
 
-msgid "Edit File in new window"
-msgstr "Rediger fil i nytt vindu"
-
+#: ../ex_docmd.c:6004
 #, fuzzy, c-format
-#~ msgid "Tab page %d"
-#~ msgstr "Side %d"
+msgid "Tab page %d"
+msgstr "Side %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Ingen swapfil"
 
-msgid "Append File"
-msgstr "Legg til fil"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Kan ikke skifte katalog, bufferen er forandret (legg til ! for å "
 "overstyre)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Ingen tidligere katalog"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Ukjent"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize trenger to numeriske parametere"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Vindusposisjon: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Lesing av vindusposisjon er ikke implementert på denne plattformen"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos trenger to numeriske parametere"
 
-msgid "Save Redirection"
-msgstr "Lagre omdirigering"
-
-msgid "Save View"
-msgstr "Lagre utseende"
-
-msgid "Save Session"
-msgstr "Lagre økt"
-
-msgid "Save Setup"
-msgstr "Lagre oppsett"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Kan ikke lage katalog: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" finnes (legg til ! for å overstyre)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Kan ikke åpne \"%s\" for skriving"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Parameter må være en bokstav eller vanlig/baklengs apostrof"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursiv bruk av :normal er for dyp"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Ingen alternative filnavn tilgjengelig som erstatning for '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr ""
 "E495: Ingen autokommandofilnavn tilgjengelig som erstatning for \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr ""
 "E496: Ingen buffernummer tilgjengelig som erstatning for \"<abuf>\" i "
 "autokommando"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: Ingen autokommandonavn tilgjengelig som erstatning for \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr ""
 "E498: Ingen ':source'-filnavn tilgjengelig som erstatning for \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr ""
+"E498: Ingen ':source'-filnavn tilgjengelig som erstatning for \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Tomt filnavn for '%' eller '#', virker bare med \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Resulterer i en tom streng"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Kan ikke åpne viminfo-fil for lesing"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Ingen spesialtegn i denne versjonen"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Kan ikke :throw unntak med 'Vim'-forstavelse"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
-#~ msgid "Exception thrown: %s"
-#~ msgstr ""
+msgid "Exception thrown: %s"
+msgstr ""
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Unntak fullført: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Unntak forkastet: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, linje %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Unntak fanget opp: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s satt på venting"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s gjenopptatt"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s forkastet"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Unntak"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Feil og avbrudd"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Feil"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Avbrudd"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Nøsting av :if for dyp"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif uten :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else uten :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif uten :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Flere forekomster av :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif etter :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Nøsting av :while/:for er for dyp"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue uten :while eller :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break uten :while eller :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Bruker :endfor sammen med :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Bruker :endwhile sammen med :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Nøsting av :try for dyp"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch uten :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch etter :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally uten :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Flere forekomster av :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry uten :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction er ikke innenfor en funksjon"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Ikke tillatt å redigere en annen buffer nå"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: Ikke tillatt å redigere en annen buffer nå"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "navn på tag"
 
-#~ msgid " kind file\n"
-#~ msgstr ""
+#: ../ex_getln.c:3181
+msgid " kind file\n"
+msgstr ""
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history'-valget er null"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1465,212 +1993,306 @@ msgstr ""
 "\n"
 "# %s-historie (nyeste til eldste):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Kommandolinje"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Søkestreng"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Uttrykk"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Inndatalinje"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar utenfor kommandolengden"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktivt vindu eller buffer slettet"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Ugyldig sti: '**[nummer]' må være på slutten av stien eller bli "
+"etterfulgt av '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Kan ikke finne katalogen \"%s\" i \"cdpath\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Kan ikke finne filen \"%s\" i stien"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Ingen flere katalog-\"%s\" funnet i \"cdpath\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Ingen flere fil-\"%s\" funnet i stien"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* Autokommandoer må ikke forandre nåværende buffer"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Ulovlig filnavn"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "er en katalog"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "er ikke en fil"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "er en enhet (frakoblet med 'opendevice'-valg)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Ny fil]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Ny KATALOG]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Filen er for stor]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Tilgang nektet]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: \"*ReadPre\"-autokommandoer gjorde filen uleselig"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: \"*ReadPre\"-autokommandoer må ikke forandre nåværende buffer"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Leser fra stdin ...\n"
 
-msgid "Reading from stdin..."
-msgstr "Leser fra stdin ..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Konverteringen gjorde filen uleselig!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[SB]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 tegn"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR mangler]"
 
-msgid "[NL found]"
-msgstr "[NL funnet]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[lange linjer splittes]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[IKKE konvertert]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[konvertert]"
 
-msgid "[crypted]"
-msgstr "[kryptert]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[KONVERTERINGSFEIL i linje %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[ULOVLIG BYTE i linje %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LESEFEIL]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Kan ikke finne midlertidig fil for konvertering"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konvertering med 'charconvert' feilet"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "Kan ikke lese utdata fra 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Ingen samsvarende autokommandoer for 'acwrite'-buffer"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Autokommandoer slettet eller lastet ut buffer som skulle lagres"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autokommando forandret linjeantall på en uventet måte"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans forbyr lagring av buffere som ikke er forandret"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Delvis lagring ikke tillatt for NetBeans-buffere"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "er ikke en fil eller skrivbar enhet"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "skriving til enhet er slått av med 'opendevice'-valg"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "er skrivebeskyttet (legg til ! for å overstyre)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Kan ikke skrive til backupfil (legg til ! for å overstyre)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Feil under lukking av backupfil (legg til ! for å overstyre)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Kan ikke lese fil for backup (legg til ! for å overstyre)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Kan ikke lese backupfil (legg til ! for å overstyre)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Kan ikke lage backupfil (legg til ! for å overstyre)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Ressursforgreningen ville gått tapt (legg til ! for å overstyre)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Kan ikke finne midlertidig fil for skriving"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Kan ikke konvertere (legg til ! for å lagre uten konvertering)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Kan ikke åpne lenket fil for skriving"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Kan ikke åpne fil for skriving"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync feilet"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Lukking feilet"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Feil under skriving, konvertering feilet (gjør 'fenc' tom for å "
 "overstyre)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: Feil under skriving, konvertering feilet (gjør 'fenc' tom for å "
+"overstyre)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Feil under lagring (full disk?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " KONVERTERINGSFEIL"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "linje %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Enhet]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Ny]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [l]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " lagt til"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [s]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " skrevet"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: Kan ikke lagre originalfil"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: Kan ikke oppdatere tom originalfil"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Kan ikke slette backupfil"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1678,75 +2300,96 @@ msgstr ""
 "\n"
 "ADVARSEL: Originalfilen kan bli tapt eller ødelagt\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ikke avslutt editoren før filen er skikkelig lagret!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos-format]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac-format]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix-format]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 linje, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> linjer, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 tegn"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> tegn"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[ingenlinjeslutt]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Ufullstendig sistelinje]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ADVARSEL: Filen er blitt forandret siden den ble lest!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Vil du virkelig skrive til den"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Feil under skriving til \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Feil under lukking av \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Feil under lesing av \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Autokommandoen \"FileChangedShell\" slettet buffer"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Filen \"%s\" er ikke lenger tilgjengelig"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1754,33 +2397,41 @@ msgid ""
 msgstr ""
 "W12: Advarsel: Filen \"%s\" er forandret og bufferen var også forandret i Vim"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Se \":help W12\" for mer informasjon."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Advarsel: Filen \"%s\" er forandret siden redigeringen startet"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Se \":help W11\" for mer informasjon."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Advarsel: Rettighetene til filen \"%s\" er forandret siden redigeringen "
 "startet"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Se \":help W16\" for mer informasjon."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Advarsel: Filen \"%s\" er blitt opprettet etter at redigeringen startet"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Advarsel"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1788,39 +2439,48 @@ msgstr ""
 "&OK\n"
 "&Åpne fil"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Kunne ikke forberede for relasting \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Kunne ikke laste \"%s\" på nytt"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Slettet--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "fjerner autokommando automatisk: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Gruppen finnes ikke: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Ulovlig tegn etter *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Handlingen finnes ikke: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Gruppen eller handlingen finnes ikke: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1828,566 +2488,799 @@ msgstr ""
 "\n"
 "--- Autokommandoer ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: Ugyldig buffernummer"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Kan ikke utføre autokommandoer for ALLE hendelser"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Ingen samsvarende autokommandoer"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Nøsting av autokommandoer for dyp"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokommandoer for \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Utfører %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autokommando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Mangler {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Mangler }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Ingen fold funnet"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Kan ikke lage fold med nåværende 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Kan ikke slette fold med nåværende 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld linjer foldet "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Legger til allerede lest buffer"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Rekursiv mapping"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Global forkortelse finnes allerede for %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Global mapping finnes allerede for %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Forkortelse finnes allerede for %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Mappingen finnes allerede for %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Ingen forkortelse funnet"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Ingen mapping funnet"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Ulovlig modus"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Kan ikke starte grafisk brukergrensesnitt (GUI)"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Ingen linjer i bufferen--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Kan ikke lese fra \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Kommandoen avbrutt"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Parameter nødvendig"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ skulle ha vært fulgt av /, ? eller &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Ugyldig i kommandolinjevindu; <ENTER> utfører, CTRL-C avslutter"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E665: Kan ikke starte grafisk brukergrensesnitt, fant ingen gyldig font"
+"E12: Kommandoen er ikke tillatt fra exrc/vimrc i nåværende katalog eller "
+"tagsøk"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' ugyldig"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Mangler :endif"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Verdien for 'imactivatekey' er ugyldig"
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Mangler :endtry"
 
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Mangler :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Mangler :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile uten :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor uten :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Filen finnes (legg til ! for å overstyre)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Kommandoen feilet"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Intern feil"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Avbrutt"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Ugyldig adresse"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Ugyldig parameter"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Kan ikke reservere farge %s"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Ugyldig paramter: %s"
 
-msgid "No match at cursor, finding next"
-msgstr "Ingen treff ved markøren, finner neste"
-
-msgid "<cannot open> "
-msgstr "<kan ikke åpne> "
-
+#: ../globals.h:1016
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: Kan ikke bruke skrifttypen %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Ugyldig uttrykk: %s"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: Kan ikke returnere til nåværende katalog"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Ugyldig område"
 
-msgid "Pathname:"
-msgstr "Sti:"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Ugyldig kommando"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: Kan ikke finne nåværende katalog"
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" er en katalog"
 
-msgid "OK"
-msgstr "OK"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Ugyldig \"scroll\"-verdi"
 
-msgid "Cancel"
-msgstr "Avbryt"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Rullefeltelement: Klarte ikke hente dimensjoner på \"thumb pixmap\"."
-
-msgid "Vim dialog"
-msgstr "Dialogvindu for Vim"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Kan ikke lage BalloonEval med både melding og tilbakekall"
-
-msgid "Vim dialog..."
-msgstr "Vim dialogvindu ..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Ja\n"
-"&Nei\n"
-"&Avbryt"
 
-msgid "Input _Methods"
-msgstr "Inndata-_metoder"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Søk og erstatt ..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Søk ..."
-
-msgid "Find what:"
-msgstr "Finn hva:"
-
-msgid "Replace with:"
-msgstr "Erstatt med:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Finn kun hele ord"
-
-#. match case button
-msgid "Match case"
-msgstr "Forskjell på store/små bokstaver"
-
-msgid "Direction"
-msgstr "Retning"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Opp"
-
-msgid "Down"
-msgstr "Ned"
-
-msgid "Find Next"
-msgstr "Finn neste"
-
-msgid "Replace"
-msgstr "Erstatt"
-
-msgid "Replace All"
-msgstr "Erstatt alle"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Mottok \"dø\"-forespørsel fra øktbehandleren\n"
-
-msgid "Close"
-msgstr "Lukk"
-
-#~ msgid "New tab"
-#~ msgstr ""
-
-#~ msgid "Open Tab..."
-#~ msgstr ""
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Uventet ødeleggelse av hovedvinduet\n"
-
-msgid "Font Selection"
-msgstr "Velge skrifttype"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Brukte CUT_BUFFER0 istedenfor tomt valg"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Avbryt"
-
-msgid "Directories"
-msgstr "Kataloger"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Hjelp"
-
-msgid "Files"
-msgstr "Filer"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Valg"
-
-msgid "Find &Next"
-msgstr "Finn &neste"
-
-msgid "&Replace"
-msgstr "E&rstatt"
-
-msgid "Replace &All"
-msgstr "Erstatt &alle"
-
-msgid "&Undo"
-msgstr "&Angre"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Fant ikke vindutittel \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Parameter ikke støttet: \"-%s\"; Bruk OLE-versjonen."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Klarer ikke åpne vindu inne i MDI-applikasjon"
-
-#~ msgid "Close tab"
-#~ msgstr ""
-
-#~ msgid "Open tab..."
-#~ msgstr ""
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Finn streng (bruk '\\\\' for å finne en '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Søk og erstatt (bruk '\\\\' for å finne en '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Ikke brukt"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Katalog\t*.ingenting\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: Kan ikke reservere fargekart, noen farger kan være feil"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Skrifttyper for de følgende tegnsett mangler i fontsett %s:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Navn på skrifttypesett: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Skrifttypen '%s' har ikke konstant bredde"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Navn på skrifttypesett: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Font%<PRId64>-bredde er ikke to ganger bredden av font0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Font0-bredde: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Font1-bredde: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Ugyldig skrifttypespesifisering"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Bibliotek-kall feilet for \"%s()\""
 
-msgid "&Dismiss"
-msgstr "&Forkast"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Merket har et ugyldig linjenummer"
 
-msgid "no specific match"
-msgstr "ingen spesifikke treff"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Merket ble ikke satt"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Skrifttypevelger"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Kan ikke gjøre forandringer, 'modifiable' er av"
 
-msgid "Name:"
-msgstr "Navn:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skripts nøstet for dypt"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Vis størrelse i punkter"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Ingen alternativ fil"
 
-msgid "Encoding:"
-msgstr "Koding:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Forkortelsen finnes ikke"
 
-msgid "Font:"
-msgstr "Skrifttype:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Ingen ! tillatt"
 
-msgid "Style:"
-msgstr "Stil:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI kan ikke brukes: Ikke slått på under kompilering"
 
-msgid "Size:"
-msgstr "Størrelse:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Uthevingsgruppe finnes ikke: %s"
 
-#~ msgid "E256: Hangul automata ERROR"
-#~ msgstr ""
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Ingen innlagt tekst enda"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Ingen tidligere kommandolinje"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Mappingen finnes ikke"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Ingen treff"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Ingen treff: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Mangler filnavn"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Ingen tidligere erstatninger med regulære uttrykk"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Ingen tidligere kommando"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Ingen tidligere regulære uttrykk"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Område er ikke tillatt"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Ikke nok plass"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Kan ikke opprette filen %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Kan ikke hente navn på midlertidig fil"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Kan ikke åpne filen %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Kan ikke lese filen %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Ikke lagret siden forrige forandring (legg til ! for å overstyre)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Ikke lagret siden forrige forandring]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nullparameter"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nummer forventet"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Kan ikke åpne feilfilen %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Ikke mer ledig hukommelse!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Fant ikke søketeksten"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Fant ikke søketeksten: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Parameteret må være positivt"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Kan ikke gå tilbake til tidligere katalog"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Ingen feil"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Ingen plassliste"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Ødelagt søkestreng"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Skadet program med regulært uttrykk"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly'-valget er satt (legg til ! for å overstyre)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Kan ikke forandre skrivebeskyttet variabel \"%s\""
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Kan ikke sette variabel i sandkassen: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Feil under lesing av feilfilen"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Ikke tillatt i sandkassen"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Ikke tillatt her"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Forandring av skjermmodus er ikke støttet"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Ugyldig \"scroll\"-verdi"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell'-valget er tomt"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Kunne ikke lese inn skiltdata!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Feil under lukking av swapfil"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: Tag-stack tom"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Kommandoen er for kompleks"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Navnet er for langt"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: For mange ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: For mange filnavn"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Etterfølgende tegn"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Ukjent merke"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Klarte ikke utvide jokertegn"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' kan ikke være mindre enn 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' kan ikke være mindre enn 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Feil under skriving"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Antall repeteringer er null"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Bruker <SID> utenom skript-kontekst"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Intern feil: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Søkestrengen bruker mer hukommelse enn 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Tom buffer"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Ugyldig søkestreng eller skilletegn"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Filen er lastet i en annen buffer"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Valget '%s' er ikke satt"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Ugyldig registernavn: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Søket traff TOPPEN, fortsetter fra BUNNEN"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Søket traff BUNNEN, fortsetter fra TOPPEN"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Mangler kolon"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Ulovlig komponent"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: Siffer forventet"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Side %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Ingen tekst for utskrift"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Skriver ut side %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopi %d av %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Skrevet ut: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Utskrift avbrutt"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Feil under skriving til Postscript-fil"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Kan ikke åpne filen \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Kan ikke lese Postscript-ressursfil \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Filen \"%s\" er ikke en Postscript-ressursfil"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Det er ikke støtte for Postscript-ressursfilen \"%s\""
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Ressursfilen \"%s\" er feil versjon"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Inkompatibel multibytekoding og tegnsett"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset kan ikke være tom med multibytekoding"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Ingen standardfont spesifisert for multibyteutskrift"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Kan ikke åpne Postscript-fil for skriving"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Kan ikke åpne filen \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Fant ikke Postscript-ressursfilen \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Fant ikke Postscript-ressursfilen \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Fant ikke Postscript-ressursfilen \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Klarte ikke å konvertere til utskriftskoding \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Sender til skriver ..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Feil under utskrift av Postscript-fil"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Skriverjobb sendt."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Legg til en ny database"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Forespørsel etter søkestreng"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Vis denne meldingen"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Drep en forbindelse"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Reinitialiser alle forbindelser"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Vis forbindelser"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Bruk: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Denne cscope-kommandoen støtter ikke splitting av vinduet.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Bruk: cstag <identifikator>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: Tag ikke funnet"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) feil: %d"
 
-msgid "E563: stat error"
-msgstr "E563: \"stat\"-feil"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s er ikke en katalog eller gyldig cscope-database"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "La til cscope-database %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Feil under lesing av cscope-forbindelse %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Ukjent cscope-søketype"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Kunne ikke lage cscope-rør (\"pipe\")"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Klarte ikke lage tvillingprosess for cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "Utføring av cs_create_connection feilet"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "Utføring av cs_create_connection feilet"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Klarte ikke starte cscope-prosess"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen for to_fp feilet"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen for fr_fp feilet"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Klarte ikke starte cscope-prosess"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: Ingen cscope-forbindelse"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: Ingen treff funnet for cscope-forespørsel %s av %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Ugyldig \"cscopequickfix\"-flagg %c for %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: Ingen treff funnet for cscope-forespørsel %s av %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope-kommandoer:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Bruk: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Kan ikke åpne cscope-database: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Kan ikke hente informasjon om cscope-database"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Duplisert cscope-database ikke lagt til"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: Maksimum antall cscope-forbindelser nådd"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope-forbindelse %s ikke funnet"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope-forbindelsen %s stengt"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Kritisk feil i cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope-tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2395,398 +3288,88 @@ msgstr ""
 "\n"
 "   #   linje"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "filnavn / kontekst / linje\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope-feil: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Alle cscope-databaser resatt"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "ingen cscope-forbindelser\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    databasenavn                        legg til sti\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr ""
-"???: Denne kommandoen er deaktivert, MzScheme-biblioteket kunne ikke lastes."
-
-msgid "invalid expression"
-msgstr "ugyldig uttrykk"
-
-msgid "expressions disabled at compile time"
-msgstr "uttrykk deaktivert på kompileringsstadiet"
-
-msgid "hidden option"
-msgstr "skjult valg"
-
-msgid "unknown option"
-msgstr "ukjent valg"
-
-msgid "window index is out of range"
-msgstr "indeks for vindu er utenfor område"
-
-msgid "couldn't open buffer"
-msgstr "klarte ikke å åpne buffer"
-
-msgid "cannot save undo information"
-msgstr "kan ikke lagre angre-informasjon"
-
-msgid "cannot delete line"
-msgstr "kan ikke slette linje"
-
-msgid "cannot replace line"
-msgstr "kan ikke erstatte linje"
-
-msgid "cannot insert line"
-msgstr "kan ikke sette inn linje"
-
-msgid "string cannot contain newlines"
-msgstr "streng kan ikke inneholde linjeskift"
-
-msgid "Vim error: ~a"
-msgstr "Vim-feil: ~a"
-
-msgid "Vim error"
-msgstr "Vim-feil"
-
-msgid "buffer is invalid"
-msgstr "buffer er ugyldig"
-
-msgid "window is invalid"
-msgstr "vindu er ugyldig"
-
-msgid "linenr out of range"
-msgstr "linjenummer utenfor område"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "ikke tillatt i Vim-sandkassen"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Denne kommandoen er deaktivert, Python-biblioteket kunne ikke lastes."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Kan ikke starte Python rekursivt"
-
-msgid "can't delete OutputObject attributes"
-msgstr "Kan ikke slette \"OutputObject\"-attributter"
-
-msgid "softspace must be an integer"
-msgstr "\"softspace\" må være et heltall"
-
-msgid "invalid attribute"
-msgstr "ugyldig attributt"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() krever en liste av strenger"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Feil under initialisering av I/U-objekter"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "forsøk på å referere til slettet buffer"
-
-msgid "line number out of range"
-msgstr "linjenummer utenfor område"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<bufferobjekt (slettet) ved %8lX>"
-
-msgid "invalid mark name"
-msgstr "ugyldig merkenavn"
-
-msgid "no such buffer"
-msgstr "bufferen finnes ikke"
-
-msgid "attempt to refer to deleted window"
-msgstr "forsøk på å referere til slettet vindu"
-
-msgid "readonly attribute"
-msgstr "skrivebeskyttet attributt"
-
-msgid "cursor position outside buffer"
-msgstr "markørposisjon utenfor buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<vindusobjekt (slettet) ved %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<vindusobjekt (ukjent) ved %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<vindu %d>"
-
-msgid "no such window"
-msgstr "vinduet finnes ikke"
-
-#~ msgid "E265: $_ must be an instance of String"
-#~ msgstr ""
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Denne kommandoen er deaktivert, Ruby-biblioteket kunne ikke lastes."
-
-msgid "E267: unexpected return"
-msgstr "E267: Uventet return"
-
-msgid "E268: unexpected next"
-msgstr "E268: Uvented next"
-
-msgid "E269: unexpected break"
-msgstr "E269: Uventet break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: Uventet redo"
-
-#~ msgid "E271: retry outside of rescue clause"
-#~ msgstr ""
-
-msgid "E272: unhandled exception"
-msgstr "E272: Ubehandlet unntak"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Ukjent longjmp-status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Bytt mellom implementasjon/definisjon"
-
-msgid "Show base class of"
-msgstr "Vis basisklasse av"
-
-msgid "Show overridden member function"
-msgstr "Vis overstyrt medlemsfunksjon"
-
-msgid "Retrieve from file"
-msgstr "Hent fra fil"
-
-msgid "Retrieve from project"
-msgstr "Hent fra prosjekt"
-
-msgid "Retrieve from all projects"
-msgstr "Hent fra alle prosjekter"
-
-msgid "Retrieve"
-msgstr "Hent"
-
-msgid "Show source of"
-msgstr "Vis kilde til"
-
-msgid "Find symbol"
-msgstr "Finn symbol"
-
-msgid "Browse class"
-msgstr "Bla gjennom klasse"
-
-msgid "Show class in hierarchy"
-msgstr "Vis klasse i hierarki"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Vis klasse i begrenset hierarki"
-
-msgid "Xref refers to"
-msgstr "Xref refererer til"
-
-msgid "Xref referred by"
-msgstr "Xref referert av"
-
-msgid "Xref has a"
-msgstr "Xref har en"
-
-msgid "Xref used by"
-msgstr "Xref brukt av"
-
-msgid "Show docu of"
-msgstr "Vis docu av"
-
-msgid "Generate docu for"
-msgstr "Generer docu for"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Kan ikke koble til SNiFF+. Sjekk miljøet (\"environment\") (sniffemacs må "
-"bli funnet i $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Feil under lesing. Frakoblet"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ er for øyeblikket "
-
-msgid "not "
-msgstr "ikke "
-
-msgid "connected"
-msgstr "oppkoblet"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Ukjent SNiFF+-forespørsel: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Feil ved oppkobling til SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ ikke tilkoblet"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ikke en SNiFF+-buffer"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Feil under skriving. Frakoblet"
-
-msgid "invalid buffer number"
-msgstr "ugyldig buffernummer"
-
-msgid "not implemented yet"
-msgstr "ikke implementert enda"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "kan ikke sette linje(r)"
-
-msgid "mark not set"
-msgstr "merke ikke satt"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "rad %d kolonne %d"
-
-msgid "cannot insert/append line"
-msgstr "kan ikke sette inn/legge til linje"
-
-msgid "unknown flag: "
-msgstr "ukjent flagg: "
-
-msgid "unknown vimOption"
-msgstr "ukjent vimOption"
-
-msgid "keyboard interrupt"
-msgstr "tastaturavbrudd"
-
-msgid "vim error"
-msgstr "vim-feil"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "kan ikke opprette buffer/vindukommando: Objektet slettes"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"kan ikke registrere callback-kommando: Buffer/vindu er allerede slettet"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL KRITISK FEIL: reflist skadet!? Vennligst rapporter dette til vim-"
-"dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"kan ikke registrere callback-kommando: Buffer/vindureferanse ikke funnet"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Denne kommandoen er deaktivert, Tcl-biblioteket kunne ikke lastes."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL-FEIL: Avslutningskode er ikke int!? Vennligst rapporter dette til "
-"vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Avslutningskode %d"
-
-msgid "cannot get line"
-msgstr "kan ikke hente linje"
-
-msgid "Unable to register a command server name"
-msgstr "Klarer ikke registrere kommandotjenernavn"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Klarte ikke sende kommando til destinasjonsprogrammet"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Ugyldig tjener-id brukt: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: Registry-egenskapen for VIM-oppføringen er ikke korrekt. Slettet!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Ukjent parameter til valg"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "For mange redigeringsparametere"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Parameter mangler etter"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Søppel etter valgparameter"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "For mange \"+command\"-, \"-c command\"- eller \"--cmd kommando\"-parametere"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Ugyldig parameter for"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d filer å redigere\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Denne Vim-versjonen er kompilert uten differansefunksjonen."
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Forsøk på å åpne skriptfilen igjen: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Kan ikke åpne for lesing: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Kan ikke åpne for skript-utdata: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Feil: Feil under start av gvim fra NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Advarsel: Utdata går ikke til en terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Advarsel: Inndata kommer ikke fra en terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc kommandolinje"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kan ikke lese fra \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2794,18 +3377,23 @@ msgstr ""
 "\n"
 "Mer info med: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[file ..]       rediger spesifisert(e) fil(er)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               les tekst fra stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          rediger fil hvor en tag er definert"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [feilfil]    rediger fil med første feil"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2815,9 +3403,11 @@ msgstr ""
 "\n"
 "bruk:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [parametere] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2825,11 +3415,7 @@ msgstr ""
 "\n"
 "   eller:"
 
-msgid "where case is ignored prepend / to make flag upper case"
-msgstr ""
-"der bokstavstørrelse ignoreres, legg til / i begynnelsen for\n"
-"å gjøre flagget om til stor bokstav"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2839,329 +3425,190 @@ msgstr ""
 "\n"
 "Parametere:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tBare filnavn etter dette"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tIkke utvid jokertegn"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistrer gvim for OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tFjern OLE-registrering for gvim"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tKjør med GUI (som \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  eller  --nofork\tForgrunn: Ikke fork når GUI-et startes"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi-modus (som \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx-modus (som \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tStille (batch) modus (bare for \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDifferanse-modus (som \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tLett modus (som \"evim\", uten modus)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivebeskyttet modus (som \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tBegrenset modus (som \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifisering (lagring av filer) ikke tillatt"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModifiseringer i teksten ikke tillatt"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinærmodus"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp-modus"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatibel med Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tIkke helt Vi-kompatibel: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tInformasjonsnivå (\"Verbose\")"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tDebuggingsmodus"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tIngen swapfil, bruk bare hukommelsen"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tList swapfiler og avslutt"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (med filnavn)\tGjenopprett kræsjet økt"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tSamme som -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tIkke bruk newcli for å åpne vindu"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <enhet>\t\tBruk <enhet> for I/U"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tStart i arabisk modus"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tStart i hebraisk modus"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tStart i persisk (Farsi) modus"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tSett terminaltypen til <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tBruk <vimrc> istedenfor eventuell .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tBruk <gvimrc> istedenfor eventuell .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tIkke last plugin-skripts"
 
+#: ../main.c:2227
 #, fuzzy
-#~ msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
-#~ msgstr "-o[N]\t\tÅpne N vinduer (standard: Ett for hver fil)"
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tÅpne N vinduer (standard: Ett for hver fil)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tÅpne N vinduer (standard: Ett for hver fil)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tSom -o men splitt loddrett"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tStart på slutten av filen"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnr>\t\tStart på linje <lnr>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <kommando>\tKjør <kommando> før lasting av vimrc-filer"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <kommando>\tKjør <kommando> etter lasting av første fil"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <økt>\t\tKjør filen <økt> etter lasting av første fil"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <innskript>\tLes normalmodus-kommandoer fra filen <innskript>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <utskript>\tLegg alle skrevne kommandoer til filen <utskript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <utskript>\tSkriv alle skrevne kommandoer til filen <utskript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tRediger krypterte filer"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tKoble vim til denne spesielle X-tjeneren"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tUnngå oppkobling til X-tjener"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <filer>\tRediger <filer> på en Vim-tjener hvis mulig"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <filer>  Samme, ikke klag hvis tjeneren mangler"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  Samme, ikke klag hvis tjeneren mangler"
-
-#, fuzzy
-#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
-#~ msgstr ""
-#~ "--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <nøkler>\tSend <nøkler> til en Vim-tjener og avslutt"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <uttrykk>\tEvaluer <uttrykk> på en Vim-tjener og skriv "
-"resultatet"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tList navn på tilgjengelige Vim-tjenere og avslutt"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <navn>\tSend til/bli Vim-tjeneren <navn>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tBruk <viminfo> istedenfor .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  eller  --help\tSkriv hjelpen (denne teksten) og avslutt"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tSkriv versjonsinformasjon og avslutt"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (Motif-versjon):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (neXtaw-versjon):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (Athena-versjon):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tKjør vim på <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tStart vim som ikon"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <navn>\t\tBruk ressurs som om Vim var <navn>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Ikke implementert)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <farge>\tBruk <farge> på bakgrunnen (også: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <farge>\tBruk <farge> på normal tekst (også: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <skrifttype>\t\tBruk <skrifttype> på normal tekst (også: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <skrifttype>\tBruk <skrifttype> på fet skrift"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <skrifttype>\tBruk <skrifttype> på skrå tekst"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tBruk <geom> for innledende vindusplassering (også: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr ""
-"-borderwidth <bredde>\tBruk en rammebredde tilsvarende <bredde> (også: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <bredde>  Bruk en rullefeltbredde tilsvarende <bredde> "
-"(også: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <høyde>\tBruk en menyblokkhøyde tilsvarende <høyde> (også: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tBruk invers video (også: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tIkke bruk invers video (også: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ressurs>\tSett den spesifiserte ressursen"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (RISC OS-versjon):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <antall>\tInnledende bredde på vindu i kolonner"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <antall>\tInnledende høyde på vindu i rader"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (GTK+-versjon):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tKjør vim på <display> (også: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tSett en unik \"role\" for å identifisere hovedvinduet"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tÅpne Vim innenfor et annet GTK-skjermelement"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <foreldretittel>\tStart Vim innenfor et foreldreprogram"
-
-msgid "No display"
-msgstr "Ingen display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Send feilet.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Send feilet. Prøver å utføre lokalt\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d av %d redigert"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Ingen display: Sending av uttrykk feilet.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Sending av uttrykk feilet.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Ingen merker satt"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Ingen merker samsvarer med \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3170,6 +3617,7 @@ msgstr ""
 "merk linje kol fil/tekst"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3178,6 +3626,7 @@ msgstr ""
 " hopp linje kol fil/tekst"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3185,7 +3634,7 @@ msgstr ""
 "\n"
 "forand linje kol tekst"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3194,7 +3643,7 @@ msgstr ""
 "# Filmerker:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3202,7 +3651,7 @@ msgstr ""
 "\n"
 "# Hoppliste (nyeste først):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3210,95 +3659,84 @@ msgstr ""
 "\n"
 "# Historie for merker inne i filer (yngst til eldst):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Mangler '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Er ikke en gyldig codepage"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Kan ikke sette IC-verdier (\"Input Context\")"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Klarte ikke opprette inndatakontekst"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Klarte ikke åpne inndatametode"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Advarsel: Klarte ikke sette \"destroy callback\" til inndatametode"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Inndatametode støtter ikke enhver stil"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: Inndatametode støtter ikke min \"preedit\" type"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: \"over-the-spot\"-stil trenger et skrifttypesett"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Din GTK+ er eldre enn 1.2.3. Statusområde deaktivert"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Inndatametodetjener kjører ikke"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Blokken var ikke låst"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Søkefeil i lesing av swapfil"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Lesefeil i swapfil"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Søkefeil i skriving til swapfil"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Skrivefeil i swapfil"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Swapfilen finnes allerede (symlenke-angrep?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Hentet ikke blokk nummer 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Hentet ikke blokk nummer 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Hentet ikke blokk nummer 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Opps, mistet swapfilen!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Klarte ikke skifte navn på swapfil"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Klarte ikke åpne swapfil for \"%s\", gjenoppretting umulig"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Hentet ikke blokk 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Ingen swapfil funnet for %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Skriv nummeret på swapfil som skal brukes (0 for å avslutte): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Kan ikke åpne %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Klarte ikke lese blokk 0 fra "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3307,22 +3745,28 @@ msgstr ""
 "Det er mulig ingen forandringer ble gjort, eller Vim oppdaterte ikke "
 "swapfilen."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " kan ikke brukes med denne Vim-versjonen.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Bruk Vim versjon 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ser ikke ut som en Vim-swapfil"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " kan ikke brukes på denne maskinen.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Filen ble laget på "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3330,63 +3774,85 @@ msgstr ""
 ",\n"
 "eller filen er blitt ødelagt."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Bruker swapfilen \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Originalfil \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Advarsel: Originalfilen kan ha blitt forandret"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Klarte ikke lese blokk 1 fra %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???MANGE LINJER MANGLER"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???FEIL LINJEANTALL"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???TOM BLOKK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LINJER MANGLER"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID til blokk 1 er feil (%s ikke en \".swp\"-fil?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOKK MANGLER"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? Herfra til ???SLUTT kan linjer være rotet til"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? Herfra til ???SLUTT kan linjer ha blitt lagt til eller slettet"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???SLUTT"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Gjenoppretting avbrutt"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Feil oppdaget under gjenoppretting; se etter linjer som starter med ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Se \":help E312\" for mer informasjon."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Gjenoppretting komplett. Du bør sjekke at alt er i orden."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3394,50 +3860,71 @@ msgstr ""
 "\n"
 "(Du vil kanskje lagre denne filen under et annet navn\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "og sammenligne den mot den originale filen for å finne forandringer)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Slett \".swp\"-filen etterpå.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Swapfiler funnet:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   I nåværende katalog:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Bruker spesifisert navn:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   I katalog "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- ingen --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          eies av: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   datert: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             datert: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [fra Vim versjon 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ser ikke ut som en Vim-swapfil]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         filnavn: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3445,12 +3932,15 @@ msgstr ""
 "\n"
 "          modifisert: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nei"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3458,9 +3948,11 @@ msgstr ""
 "\n"
 "         brukernavn: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   vertsnavn: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3468,6 +3960,7 @@ msgstr ""
 "\n"
 "         vertsnavn: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3475,16 +3968,11 @@ msgstr ""
 "\n"
 "        prosess-ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (kjører fortsatt)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [ikke brukbar med denne Vim-versjonen]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3492,75 +3980,97 @@ msgstr ""
 "\n"
 "         [ikke brukbar på denne maskinen]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [kan ikke leses]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [kan ikke åpnes]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Kan ikke bevare, swapfil mangler"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Fil bevart"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Bevaring feilet"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: Ugyldig lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: Kan ikke finne linje %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Pekerblokk-id feil 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx skulle være 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Oppdaterte for mange blokker?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Pekerblokk-id feil 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "slettet blokk 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Kan ikke finne linje %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Pekerblokk-id feil"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count er null"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Linjenummer utenfor område: %<PRId64> forbi slutten"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Linjeantall feil i blokk %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Stackstørrelse øker"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Pekerblokk-id feil 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Symlenkesløyfe for \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: VIKTIG"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3568,38 +4078,44 @@ msgstr ""
 "\n"
 "Fant en swapfil ved navn \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Under åpning av filen \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NYERE enn swapfil!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Det er mulig et annet program redigerer den samme filen.\n"
 "    Hvis det er tilfelle, vær forsiktig så du ikke ender opp med to\n"
 "    forskjellige utgaver av den samme filen når du gjør forandringer.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Avslutt, eller fortsett med varsomhet.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) En økt for denne filen kræsjet.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Hvis det er tilfelle, bruk \":recover\" eller \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3607,9 +4123,11 @@ msgstr ""
 "\"\n"
 "    for å gjenopprette forandringene (se \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Hvis du har gjort dette allerede, slett swapfilen \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3617,18 +4135,23 @@ msgstr ""
 "\"\n"
 "    for å unngå denne meldingen.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Swapfilen \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" finnes allerede!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - VIKTIG"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Swapfilen eksisterer allerede!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3642,6 +4165,7 @@ msgstr ""
 "&Avslutt\n"
 "Av&bryt"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3657,34 +4181,56 @@ msgstr ""
 "&Avslutt\n"
 "Av&bryt"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: For mange swapfiler funnet"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %<PRIu64> bytes)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Del av menyelement er ikke undermeny"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menyen eksisterer bare i en annen modus"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Ingen \"%s\"-meny"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Tomt menynavn"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Menysti kan ikke lede til en undermeny"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Kan ikke legge til menyelementer direkte på menylinjen"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Skilletegn kan ikke være del av en menysti"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3692,61 +4238,74 @@ msgstr ""
 "\n"
 "--- Menyer ---"
 
-msgid "Tear off this menu"
-msgstr "Riv av denne menyen"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Menystien må lede til et menyvalg"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Fant ikke menyen: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menyen er ikke definert for %s-modus"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Menystien må lede til en undermeny"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Fant ikke menyen - sjekk menynavnet"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Feil oppdaget under prosessering av %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "linje %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ugyldig registernavn: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "Vedlikeholder for norsk oversettelse: Øyvind A. Holm <sunny@sunbase.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Avbryt: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Trykk ENTER eller skriv kommando for å fortsette"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s linje %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Mer --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " MELLOMROM/d/j: Skjerm/side/linje ned, b/u/k: Opp, q: Avslutt "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Spørsmål"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3754,6 +4313,17 @@ msgstr ""
 "&Ja\n"
 "&Nei"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ja\n"
+"&Nei\n"
+"&Avbryt"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3767,260 +4337,177 @@ msgstr ""
 "&Forkast alle\n"
 "&Avbryt"
 
-msgid "Select Directory dialog"
-msgstr "\"Velge katalog\"-dialogvindu"
-
-msgid "Save File dialog"
-msgstr "\"Lagre fil\"-dialogvindu"
-
-msgid "Open File dialog"
-msgstr "\"Åpne fil\"-dialogvindu"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Dessverre ingen filbehandler i konsollmodus"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Ikke nok parametre for printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Ikke nok parametre for printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: For mange parametere for printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Advarsel: Forandrer en skrivebeskyttet fil"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Skriv nummer eller velg med musen (<Enter> avbryter)"
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Valgnummer (<Enter> avbryter)"
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 linje lagt til"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 linje fjernet"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> linjer lagt til"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> linjer fjernet"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Avbrutt)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Pip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: Bevarer filer ...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Ferdig.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "FEIL: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bytes] totalt alloc-frigjort %<PRIu64>-%<PRIu64>, i bruk %<PRIu64>, topp-bruk %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[kall] totale \"re/malloc()\"-er %<PRIu64>, totale \"free()\"-er %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Linjen blir for lang"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %<PRIu64> bytes)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Kaller skall for å utføre \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Mangler kolon"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Ulovlig modus"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Ulovlig utseende på musepekeren"
-
-msgid "E548: digit expected"
-msgstr "E548: Siffer forventet"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Ulovlig prosent"
-
-msgid "Enter encryption key: "
-msgstr "Skriv krypteringsnøkkel: "
-
-msgid "Enter same key again: "
-msgstr "Gjenta krypteringsnøkkelen: "
-
-msgid "Keys don't match!"
-msgstr "Krypteringsnøklene stemmer ikke overens!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Ugyldig sti: '**[nummer]' må være på slutten av stien eller bli "
-"etterfulgt av '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Kan ikke finne katalogen \"%s\" i \"cdpath\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Kan ikke finne filen \"%s\" i stien"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Ingen flere katalog-\"%s\" funnet i \"cdpath\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Ingen flere fil-\"%s\" funnet i stien"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Kan ikke koble til Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Kan ikke koble til Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Feil tilgangsmodus for infofilen til NetBeans-forbindelse: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "les fra Netbeans-socket"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Mistet NetBeans-forbindelse for buffer %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' er tomt"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval-funksjonaliteten er ikke tilgjengelig"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Advarsel: Terminalen kan ikke utheve"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Ingen streng under markør"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Ingen identifikator under markør"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' er tomt"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Advarsel: Terminalen kan ikke utheve"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Ingen streng under markør"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Kan ikke slette folder med nåværende 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Forandringslisten er tom"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Ved starten av forandringsliste"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 linje \"%s\"-et 1 gang"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 linje \"%s\"-et %d ganger"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> linjer \"%s\"-et 1 gang"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> linjer \"%s\"-et %d ganger"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> linjer å rykke inn ... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 linje rykket inn "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> linjer rykket inn "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Register ikke tidligere brukt"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "kan ikke kopiere til utklippstavle; slett likevel"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 linje forandret"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> linjer forandret"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "frigjør %<PRId64> linjer"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "blokk med 1 linje kopiert til utklippstavlen"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 linje kopiert til utklippstavlen"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "blokk med %<PRId64> linjer kopiert til utklippstavlen"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> linjer kopiert til utklippstavlen"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Ingenting i register %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4028,10 +4515,11 @@ msgstr ""
 "\n"
 "--- Registere ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Ulovlig registernavn"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4039,156 +4527,194 @@ msgstr ""
 "\n"
 "# Registere:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Ukjent registertype %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kol; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> bytes"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> tegn; %<PRId64> av %<PRId64> bytes"
+"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; "
+"%<PRId64> av %<PRId64> bytes"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s av %s; Linje %<PRId64> av %<PRId64>; Ord %<PRId64> av %<PRId64>; Byte %<PRId64> av %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s av %s; linje %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tegn %<PRId64> av %<PRId64>; byte %<PRId64> av "
-"%<PRId64>"
+"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; "
+"%<PRId64> av %<PRId64> tegn; %<PRId64> av %<PRId64> bytes"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s av %s; Linje %<PRId64> av %<PRId64>; Ord %<PRId64> av %<PRId64>; Byte "
+"%<PRId64> av %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s av %s; linje %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tegn "
+"%<PRId64> av %<PRId64>; byte %<PRId64> av %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Side %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Takk for at du fløy Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Ukjent valg"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Valget er ikke støttet"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Ikke tillatt i moduslinje"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Nummer nødvendig etter ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Ikke funnet i termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Ulovlig tegn <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Kan ikke sette 'term' til tom streng"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Kan ikke forandre \"term\" i grafisk brukergrensesnitt"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Bruk \":gui\" for å starte med grafisk brukergrensesnitt"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' og 'patchmode' er like"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Kan ikke forandres i GTK+ 2 GUI"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Mangler kolon"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Tom streng"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Mangler nummer etter <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Mangler komma"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Må spesifisere en \"'\"-verdi"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Inneholder uskrivelige eller brede tegn"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Ugyldig(e) skrifttype(r)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Kan ikke velge skrifttypesett"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Ugyldig skrifttypesett"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Kan ikke velge bred skrifttype"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Ugyldig bred skrifttype"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ulovlig tegn etter <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Komma nødvendig"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' må være tom eller inneholde %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Ingen støtte for mus"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Uttrykkssekvens som ikke er lukket"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: For mange elementer"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Ubalanserte grupper"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Det finnes allerede et forhåndsvisningsvindu"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabisk trenger UTF-8, utfør ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Trenger minst %d linjer"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Trenger minst %d kolonner"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Ukjent valg: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Nummer nødvendig etter ="
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4196,6 +4722,7 @@ msgstr ""
 "\n"
 "--- Terminalkoder ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4203,6 +4730,7 @@ msgstr ""
 "\n"
 "--- Globale valgverdier ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4210,6 +4738,7 @@ msgstr ""
 "\n"
 "--- Lokale valgverdier ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4217,126 +4746,21 @@ msgstr ""
 "\n"
 "--- Valg ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: \"get_varp\"-FEIL"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Samsvarende tegn mangler for %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Ekstra tegn etter semikolon: %s"
 
-msgid "cannot open "
-msgstr "kan ikke åpne "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Kan ikke åpne vindu!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Trenger Amigados versjon 2.04 eller nyere\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Trenger %s versjon %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Kan ikke åpne NIL:\n"
-
-msgid "Cannot create "
-msgstr "Kan ikke opprette "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim avslutter med %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "kan ikke forandre konsollmodus ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: Ikke et konsoll??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Kan ikke kjøre skall med \"-f\"-valg"
-
-msgid "Cannot execute "
-msgstr "Kan ikke utføre "
-
-msgid "shell "
-msgstr "skall "
-
-msgid " returned\n"
-msgstr " returnerte\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE for liten."
-
-msgid "I/O ERROR"
-msgstr "I/U-FEIL"
-
-msgid "Message"
-msgstr "Melding"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' er ikke 80, kan ikke utføre eksterne kommandoer"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Valg av skriver feilet"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "til %s på %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Ukjent skrifttype for skriver: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Feil under utskrift: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Skriver ut '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Ulovlig navn på tegnsett \"%s\" i skrifttypenavn \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Ulovlig tegn '%c' i skrifttypenavn \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Dobbelt signal, avslutter\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Mottok dødelig signal %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Mottok dødelig signal\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Åpning av X-display tok %<PRId64> millisekunder"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Mottok X-feil\n"
-
-msgid "Testing the X display failed"
-msgstr "Test av X-display feilet"
-
-msgid "Opening the X display timed out"
-msgstr "Tidsavbrudd for åpning av X-display"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4344,13 +4768,7 @@ msgstr ""
 "\n"
 "Kan ikke kjøre skall "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Kan ikke kjøre skallet sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4358,749 +4776,953 @@ msgstr ""
 "\n"
 "skallet returnerte "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Kan ikke opprette rør (\"pipe\")\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Kan ikke opprette tvillingprosess (\"fork\")\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Kommando avsluttet\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP mistet ICE-forbindelsen"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Åpning av X-display feilet"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP håndterer \"redd-deg-selv\"-forespørsel"
-
-msgid "XSMP opening connection"
-msgstr "XSMP åpner forbindelse"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Overvåkning av XSMP ICE-forbindelse feilet"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection feilet: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Kan ikke finne filen \"%s\" i stien"
 
-msgid "At line"
-msgstr "På linje"
-
-msgid "Could not load vim32.dll!"
-msgstr "Klarte ikke laste vim32.dll!"
-
-msgid "VIM Error"
-msgstr "VIM-feil"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Klarte ikke ordne opp i funksjonspekere til DLL-en!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "skallet returnerte %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Mottok \"%s\"-hendelse\n"
-
-msgid "close"
-msgstr "lukk"
-
-msgid "logoff"
-msgstr "logg av"
-
-msgid "shutdown"
-msgstr "kjør ned"
-
-msgid "E371: Command not found"
-msgstr "E371: Kommando ikke funnet"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE ikke funnet i $PATH.\n"
-"Eksterne kommandoer kommer ikke til å vente etter fullføring.\n"
-"Se \":help win32-vimrun\" for mer informasjon."
-
-msgid "Vim Warning"
-msgstr "Vim-advarsel"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: For mange %%%c i formatstreng"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Uventet %%%c i formatstreng"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Mangler ] i formatstreng"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c ikke støttet i formatstreng"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Ugyldig %%%c i formatstreng-prefiks"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Ugyldig %%%c i formatstreng"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' inneholder ikke søkestreng"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Manglende eller tomt katalognavn"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Ingen flere elementer"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d av %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (linjen slettet)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: På bunnen av quickfix-stack"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: På toppen av quickfix-stack"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "feilliste %d av %d; %d feil"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Kan ikke lagre, 'buftype'-valget er satt"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Filnavn mangler eller ugyldig søkestreng"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Kan ikke åpne filen \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Bufferen er ikke lastet"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Streng eller liste forventet"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Ugyldig element i %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Søkestrengen er for lang"
-
-msgid "E50: Too many \\z("
-msgstr "E50: For mange \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: For mange %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Usamsvarende \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Usamsvarende %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Usamsvarende %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Usamsvarende %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Ugyldig tegn etter %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: For mange komplekse %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Nøstede %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Nøstede %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: Ugyldig bruk av \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c etterfølger ingenting"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Ulovlig tilbakereferanse"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( ikke tillatt her"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 med venner er ikke tillatt her"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Ugyldig tegn etter \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Mangler ] etter %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Tom %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Ugyldig tegn etter %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Ugyldig tegn etter %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Mangler ] etter %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Usamsvarende %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Usamsvarende %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Usamsvarende %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( ikke tillatt her"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 med venner er ikke tillatt her"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Mangler ] etter %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Tom %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Søkestrengen er for lang"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: For mange \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: For mange %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Usamsvarende \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: Ugyldig tegn etter %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: For mange komplekse %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Nøstede %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Nøstede %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Ugyldig bruk av \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c etterfølger ingenting"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Ulovlig tilbakereferanse"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Ugyldig tegn etter \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Ugyldig tegn etter %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Ugyldig tegn etter %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaksfeil i %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Eksterne deltreff:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: For mange \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Kan ikke finne midlertidig fil for skriving"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-ERSTATT"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ERSTATT"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " OMVENDT"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " SETT INN"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (sett inn)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (erstatt)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-erstatt)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hebraisk"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " arabisk"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lang)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (lim inn)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUELL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUELL LINJE"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUELL BLOKK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " VELG"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " VELG LINJE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " VELG BLOKK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "spiller inn"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Ugyldig søkestreng: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Søket kom til TOPPEN uten treff på: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Søket kom til BUNNEN uten treff på: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Forventet '?' eller '/' etter ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (inkluderer tidligere utlistede treff)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Inkluderte filer "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "ikke funnet "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "i sti ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Allerede listet)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  IKKE FUNNET"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Leter gjennom inkludert fil: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Leter gjennom inkludert fil %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Treffet er på nåværende linje"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Alle inkluderte filer ble funnet"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Ingen inkluderte filer"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Fant ikke definisjonen"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Fant ikke søketeksten"
 
-#, c-format
-#~ msgid ""
-#~ "\n"
-#~ "# Last %sSearch Pattern:\n"
-#~ "~"
-#~ msgstr ""
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 erstatning"
 
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Formateringsfeil i stavefil"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Valg av skriver feilet"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Etterfølgende tekst i %s linje %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affiksnavn for langt i %s linje %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Formatfeil i affiksfil FOL, LOW eller UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Tegn i FOL, LOW eller UPP er utenfor område"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Pakker ordtre ..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Stavekontroll er ikke aktivisert"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Advarsel: Kan ikke finne ordliste \"%s.%s.spl\" eller \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Leser stavefil \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Dette ser ikke ut som en stavefil"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Gammel stavefil, trenger oppdatering"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Stavefilen er for en nyere versjon av Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Ustøttet seksjon i stavefil"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Advarsel: Region %s ikke støttet"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Leser affiksfil %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konverteringsfeil for ord i %s linje %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konvertering i %s ikke støttet: Fra %s til %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konvertering i %s ikke støttet"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Ugyldig verdi for FLAG i %s linje %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG etter bruk av flagg i %s linje %d: %s"
 
+#: ../spell.c:4723
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "Feil COMPOUNDMIN-verdi i %s linje %d: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Feil COMPOUNDWORDMAX-verdi i %s linje %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Feil COMPOUNDMIN-verdi i %s linje %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Feil COMPOUNDSYLMAX-verdi i %s linje %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Feil CHECKCOMPOUNDPATTERN-verdi i %s linje %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Forskjellig kombinasjonsflagg i affiksblokk som fortsetter i %s linje %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Duplisert affiks i %s linje %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
 "line %d: %s"
 msgstr ""
-"Affiks også brukt for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST i %"
-"s linje %d: %s"
+"Affiks også brukt for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST i "
+"%s linje %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Forventet Y eller N i %s linje %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Brutt betingelse i %s linje %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Forventet REP(SAL)-antall i %s linje %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Forventet MAP-antall i %s linje %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Duplisert tegn i MAP i %s linje %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Ukjent eller duplisert element i %s linje %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Mangler FOL/LOW/UPP-linje i %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX brukt uten SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "For mange utsatte forstavelser"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "For mange sammensatte flagg"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "For mange utsatte forstavelser og/eller sammensatte flagg"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Mangler SOFO%s-linje i %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Både SAL- og SOFO-linjer i %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flagg er ikke et tall i %s linje %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Ulovlig flagg i %s linje %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s-verdi er forskjellig fra det som er bruk i en annen .aff-fil"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Leser ordlistefil %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Ingen ord-antall i %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "linje %6d, ord %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Duplisert ord i %s linje %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Første dupliserte ord i %s linje %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d duplisert(e) ord i %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ignorerte %d ord med ikke-ASCII-tegn i %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Leser ordfil %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Duplisert '/encoding='-linje ignorert i %s linje %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "'/encoding='-linje etter ord ignorert i %s linje %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Duplisert '/regions='-linje ignorert i %s linje %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "For mange regioner i %s linje %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "'/'-linje ignorert i %s linje %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Ugyldig regionnummer i %s linje %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Ukjent flagg i %s linje %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignorerte %d ord med ikke-ASCII-tegn"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Pakket %d av %d noder; %d (%d%%) igjen"
 
+#: ../spell.c:7340
 #, fuzzy
-#~ msgid "Reading back spell file..."
-#~ msgstr "Leser stavefil \"%s\""
+msgid "Reading back spell file..."
+msgstr "Leser stavefil \"%s\""
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
-#~ msgid "Performing soundfolding..."
-#~ msgstr ""
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
 
+#: ../spell.c:7368
 #, c-format
-#~ msgid "Number of words after soundfolding: %<PRId64>"
-#~ msgstr ""
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Totalt antall ord: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Skriver forslagsfil %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Anslått hukommelsesbruk under kjøring: %d bytes"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Utdatafilnavn må ikke ha regionnavn"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Kun opp til 8 regioner er støttet"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Ugyldig region i %s"
 
-#~ msgid "Warning: both compounding and NOBREAK specified"
-#~ msgstr ""
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Lagrer stavefil %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Ferdig!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' har ikke %<PRId64> poster"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Ord fjernet fra %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Ord lagt til %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Tegn i ord varierer mellom stavefiler"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Dessverre, ingen forslag"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Dessverre bare %<PRId64> forslag"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Forandre \"%.*s\" til:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Ingen tidligere staveerstatninger"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Ikke funnet: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Dette ser ikke ut som en .sug-fil: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Gammel .sug-fil, trenger oppdatering: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug-fila er for en nyere versjon av Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug-fil samsvarer ikke med .spl-fil: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Feil under lesing av .sug-fil: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Duplisert tegn i MAP-oppføring"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Ingen syntakselementer er definert for denne bufferen"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Ulovlig parameter: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaksklyngen finnes ikke: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Ingen syntakselementer er definert for denne bufferen"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synkroniserer C-lignende kommentarer"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "ingen synkronisering"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synkronisering starter "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " linjer før topplinje"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5108,6 +5730,7 @@ msgstr ""
 "\n"
 "--- \"Syntax sync\"-elementer ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5115,6 +5738,7 @@ msgstr ""
 "\n"
 "synkroniserer på elementer"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5122,199 +5746,275 @@ msgstr ""
 "\n"
 "--- Syntakselementer ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Syntaksklyngen finnes ikke: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksimal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; samsvarer med "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " linjeskift"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: \"contains\"-parameter aksepteres ikke her"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: \"containedin\"-parameter aksepteres ikke her"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Ugyldig parameter"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: \"group[t]here\" aksepteres ikke her"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Fant ikke regionelement for %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Trenger filnavn"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: For mange filnavn"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Mangler ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Mangler '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Ikke nok parametere: syntax region %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaksklyngen finnes ikke: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Ingen klynge er spesifisert"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Skilletegn for søketekst ble ikke funnet: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Søppel etter søketekst: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: syntax sync: Søkestreng for linjefortsettelser er spesifisert to ganger"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Ulovlige parametere: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Mangler \"er lik\"-tegn: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Tomt parameter: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s er ikke tillatt her"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s må være først i \"contains\"-liste"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Ukjent gruppenavn: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Ugyldig \":syntax\"-delkommando: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Rekursiv løkke laster syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Fant ikke uthevingsgruppe: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Ikke nok parametere: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: For mange parametere: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Syntaxgruppen har oppsett, uthevingslenke ignoreres"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Uventet \"er lik\"-tegn: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Mangler \"er lik\"-tegn: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Mangler parameter: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Ulovlig verdi: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Ukjent forgrunnsfarge"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Ukjent bakgrunnsfarge"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Kjenner ikke til fargenavnet eller -nummeret: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Terminalkoden er for lang: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Ulovlig parameter: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: For mange forskjellige uthevingsattributter i bruk"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ikke-skrivbart tegn i gruppenavn"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Ugyldig tegn i gruppenavn"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: På bunnen av tag-stack"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: På toppen av tag-stack"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Kan ikke gå før første samsvarende tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Fant ikke tag: %s"
 
-#~ msgid "  # pri kind tag"
-#~ msgstr ""
+#: ../tag.c:528
+msgid "  # pri kind tag"
+msgstr ""
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "fil\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Det finnes bare en samsvarende tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Kan ikke gå forbi siste samsvarende tag"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Filen \"%s\" finnes ikke"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d av %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " eller mer"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Bruker tag med forskjellig bokstavstørrelse!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Filen \"%s\" finnes ikke"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5322,59 +6022,79 @@ msgstr ""
 "\n"
 "  # TIL tag        FRA  linje i fil/tekst"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Leter i tagfil %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Sti til tagfil kuttet for %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formatfeil i tagfil \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Før byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tagfil ikke sortert: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Ingen tagfil"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Kan ikke finne tagsøkestreng"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Kunne ikke finne tag, bare gjetter!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Duplisert affiks i %s linje %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' ikke kjent. Tilgjengelige innebygde terminaler er:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "faller tilbake på '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Kan ikke åpne termcap-fil"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Fant ikke terminaloppføring i terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Fant ikke terminaloppføring i termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Ingen \"%s\"-oppføring i termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminalfunksjonen \"cm\" nødvendig"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5382,160 +6102,169 @@ msgstr ""
 "\n"
 "--- Terminaltaster ---"
 
-msgid "new shell started\n"
-msgstr "nytt skall startet\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Feil under lesing av inndata, avslutter ...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Ingen angremuligheter; fortsett likevel"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: Uventet forandring i buffer"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Kan ikke åpne fil for skriving"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Lagrer viminfo-fil \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Skrivefeil i swapfil"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Leser ordfil %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Kan ikke åpne viminfo-fil for lesing"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Ikke funnet: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Kan ikke åpne filen %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "ferdig med kjøring av %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Allerede ved eldste forandring"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Allerede ved nyeste forandring"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "Angrenummer %<PRId64> ikke funnet"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: Gale linjenummer"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "linje lagt til"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "linjer lagt til"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "linje fjernet"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "linjer fjernet"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "forandring"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "forandringer"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "før"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "etter"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Ingenting å angre"
 
-msgid "number changes  time"
-msgstr "nummer forandringer tidspunkt"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekunder siden"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin er ikke tillatt etter undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: Angrelisten er skadet"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Angrelisten mangler"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS Windows 16/32-bits grafisk versjon"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS Windows 64-bits grafisk versjon"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32-bits GUI-versjon"
-
-msgid " in Win32s mode"
-msgstr " i Win32s-modus"
-
-msgid " with OLE support"
-msgstr " med OLE-støtte"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bits konsollversjon"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16-bits versjon"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32-bits MS-DOS-versjon"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16-bits MS-DOS-versjon"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix)-versjon"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X-versjon"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS-versjon"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS-versjon"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5543,9 +6272,18 @@ msgstr ""
 "\n"
 "Inkluderte patcher: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Eksterne deltreff:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modifisert av "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5553,9 +6291,11 @@ msgstr ""
 "\n"
 "Kompilert "
 
+#: ../version.c:649
 msgid "by "
 msgstr "av "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5563,604 +6303,1622 @@ msgstr ""
 "\n"
 "Diger (\"huge\") versjon "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Stor (\"big\") versjon "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normal versjon "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Liten (\"small\") versjon "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Spinkel (\"tiny\") versjon "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "uten GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "med GTK2-GNOME GUI."
-
-msgid "with GTK-GNOME GUI."
-msgstr "med GTK-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "med GTK2 GUI."
-
-msgid "with GTK GUI."
-msgstr "med GTK GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "med X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "med X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "med X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "med Photon GUI."
-
-msgid "with GUI."
-msgstr "med GUI."
-
-msgid "with Carbon GUI."
-msgstr "med Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "med Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "med (klassisk) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Funksjoner inkludert (+) eller ikke (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "        vimrc-fil på systemet: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        vimrc-fil for brukere: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  vimrc-fil nr. 2 for brukere: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  vimrc-fil nr. 3 for brukere: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         exrc-fil for brukere: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   exrc-fil nr. 2 for brukere: \""
 
-msgid "  system gvimrc file: \""
-msgstr "       gvimrc-fil på systemet: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       gvimrc-fil for brukere: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr " gvimrc-fil nr. 2 for brukere: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr " gvimrc-fil nr. 3 for brukere: \""
-
-msgid "    system menu file: \""
-msgstr "          menyfil på systemet: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       $VIM faller tilbake på: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "$VIMRUNTIME faller tilbake på: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilering: "
 
-msgid "Compiler: "
-msgstr "Kompilator: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Linking: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  DEBUGGINGSVERSJON"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved - Forbedret Vi"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versjon "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "av Bram Moolenaar med flere"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim er åpen kildekode og kan fritt distribueres"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Hjelp fattige barn i Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "skriv  :help iccf<Enter>          for informasjon  "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "skriv  :q<Enter>                  for å avslutte   "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "skriv  :help<Enter>  eller  <F1>  for on-line hjelp"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "skriv  :help version7<Enter>      for versjonsinfo "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Kjører i Vi-kompatibel modus"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "skriv  :set nocp<Enter>           for standard Vim "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "skriv  :help cp-default<Enter>    for informasjon  "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "meny:  Hjelp->Foreldreløse        for informasjon  "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Kjører uten modus, tastetrykk blir lagt inn i teksten"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "meny:  Rediger->Globale innstillinger->Innsettingsmodus av/på"
-
-msgid "                              for two modes      "
-msgstr "                                  for to moduser   "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "meny:  Rediger->Globale innstillinger->Vi-kompatibilitet av/på"
-
-msgid "                              for Vim defaults   "
-msgstr "                                  for standard Vim "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Støtt utviklingen av Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Bli registrert bruker av Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "skriv  :help sponsor<Enter>       for informasjon  "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "skriv  :help register<Enter>      for informasjon  "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "meny:  Hjelp->Støtte/Registrering  for informasjon "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ADVARSEL: Windows 95/98/ME oppdaget"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "skriv  :help windows95<Enter>     for informasjon  "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Allerede bare ett vindu"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Vindu for forhåndsvisning finnes ikke"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Kan ikke splitte \"topleft\" og \"botright\" på en gang"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Kan ikke rotere når et annet vindu er splittet"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Kan ikke lukke det siste vinduet"
 
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Kan ikke lukke det siste vinduet"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Kan ikke lukke det siste vinduet"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Annet vindu inneholder forandringer"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Ingen filnavn under markøren"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Kan ikke finne filen \"%s\" i stien"
+#~ msgid "Patch file"
+#~ msgstr "Patch fil"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Klarte ikke laste bibliotek %s"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Avbryt"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Denne kommandoen er deaktivert, Perl-biblioteket kunne ikke lastes."
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Ingen forbindelse med Vim-tjeneren"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Evaluering av Perl er ikke tillatt i sandkassen uten \"Safe\"-modulen"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Klarer ikke sende til %s"
 
-msgid "Edit with &multiple Vims"
-msgstr "Rediger med &flere Vim-er"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Klarer ikke lese svar fra tjeneren"
 
-msgid "Edit with single &Vim"
-msgstr "Rediger med enkel &Vim"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Klarer ikke sende til klienten"
 
-msgid "Diff with Vim"
-msgstr "Differanse med Vim"
+#~ msgid "Save As"
+#~ msgstr "Lagre som"
 
-msgid "Edit with &Vim"
-msgstr "Rediger med &Vim"
+#~ msgid "Edit File"
+#~ msgstr "Rediger fil"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Rediger med eksisterende Vim - "
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (IKKE FUNNET)"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Redigerer de(n) valgte filen(e) med Vim"
+#~ msgid "Source Vim script"
+#~ msgstr "Kjør Vim-skript"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Klarte ikke lage prosess: Sjekk at gvim er i stien!"
+#~ msgid "Edit File in new window"
+#~ msgstr "Rediger fil i nytt vindu"
 
-msgid "gvimext.dll error"
-msgstr "Feil i gvimext.dll"
+#~ msgid "Append File"
+#~ msgstr "Legg til fil"
 
-msgid "Path length too long!"
-msgstr "Lengden på stien er for lang!"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Vindusposisjon: X %d, Y %d"
 
-msgid "--No lines in buffer--"
-msgstr "--Ingen linjer i bufferen--"
+#~ msgid "Save Redirection"
+#~ msgstr "Lagre omdirigering"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Kommandoen avbrutt"
+#~ msgid "Save View"
+#~ msgstr "Lagre utseende"
 
-msgid "E471: Argument required"
-msgstr "E471: Parameter nødvendig"
+#~ msgid "Save Session"
+#~ msgstr "Lagre økt"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ skulle ha vært fulgt av /, ? eller &"
+#~ msgid "Save Setup"
+#~ msgstr "Lagre oppsett"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ugyldig i kommandolinjevindu; <ENTER> utfører, CTRL-C avslutter"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Ingen spesialtegn i denne versjonen"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Kommandoen er ikke tillatt fra exrc/vimrc i nåværende katalog eller "
-"tagsøk"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "er en enhet (frakoblet med 'opendevice'-valg)"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Mangler :endif"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Leser fra stdin ..."
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Mangler :endtry"
+#~ msgid "[NL found]"
+#~ msgstr "[NL funnet]"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Mangler :endwhile"
+#~ msgid "[crypted]"
+#~ msgstr "[kryptert]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Mangler :endfor"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans forbyr lagring av buffere som ikke er forandret"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile uten :while"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Delvis lagring ikke tillatt for NetBeans-buffere"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor uten :for"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "skriving til enhet er slått av med 'opendevice'-valg"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Filen finnes (legg til ! for å overstyre)"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Ressursforgreningen ville gått tapt (legg til ! for å overstyre)"
 
-msgid "E472: Command failed"
-msgstr "E472: Kommandoen feilet"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Kan ikke starte grafisk brukergrensesnitt (GUI)"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Ukjent skrifttypesett: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Kan ikke lese fra \"%s\""
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Ukjent skrifttype: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Kan ikke starte grafisk brukergrensesnitt, fant ingen gyldig font"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Skrifttypen \"%s\" har ikke fast bredde"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' ugyldig"
 
-msgid "E473: Internal error"
-msgstr "E473: Intern feil"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Verdien for 'imactivatekey' er ugyldig"
 
-msgid "Interrupted"
-msgstr "Avbrutt"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Kan ikke reservere farge %s"
 
-msgid "E14: Invalid address"
-msgstr "E14: Ugyldig adresse"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Ingen treff ved markøren, finner neste"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Ugyldig parameter"
+#~ msgid "<cannot open> "
+#~ msgstr "<kan ikke åpne> "
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Ugyldig paramter: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: Kan ikke bruke skrifttypen %s"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Ugyldig uttrykk: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: Kan ikke returnere til nåværende katalog"
 
-msgid "E16: Invalid range"
-msgstr "E16: Ugyldig område"
+#~ msgid "Pathname:"
+#~ msgstr "Sti:"
 
-msgid "E476: Invalid command"
-msgstr "E476: Ugyldig kommando"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: Kan ikke finne nåværende katalog"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" er en katalog"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Bibliotek-kall feilet for \"%s()\""
+#~ msgid "Cancel"
+#~ msgstr "Avbryt"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Klarte ikke laste biblioteksfunksjon %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Rullefeltelement: Klarte ikke hente dimensjoner på \"thumb pixmap\"."
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Merket har et ugyldig linjenummer"
+#~ msgid "Vim dialog"
+#~ msgstr "Dialogvindu for Vim"
 
-msgid "E20: Mark not set"
-msgstr "E20: Merket ble ikke satt"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Kan ikke lage BalloonEval med både melding og tilbakekall"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Kan ikke gjøre forandringer, 'modifiable' er av"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialogvindu ..."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skripts nøstet for dypt"
+#~ msgid "Input _Methods"
+#~ msgstr "Inndata-_metoder"
 
-msgid "E23: No alternate file"
-msgstr "E23: Ingen alternativ fil"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Søk og erstatt ..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Forkortelsen finnes ikke"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Søk ..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: Ingen ! tillatt"
+#~ msgid "Find what:"
+#~ msgstr "Finn hva:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI kan ikke brukes: Ikke slått på under kompilering"
+#~ msgid "Replace with:"
+#~ msgstr "Erstatt med:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebraisk kan ikke brukes: Ikke slått på under kompilering\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Finn kun hele ord"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E27: Persisk (Farsi) kan ikke brukes: Ikke slått på under kompilering\n"
+#~ msgid "Match case"
+#~ msgstr "Forskjell på store/små bokstaver"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabisk kan ikke brukes: Ikke slått på under kompilering\n"
+#~ msgid "Direction"
+#~ msgstr "Retning"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Uthevingsgruppe finnes ikke: %s"
+#~ msgid "Up"
+#~ msgstr "Opp"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Ingen innlagt tekst enda"
+#~ msgid "Down"
+#~ msgstr "Ned"
 
-msgid "E30: No previous command line"
-msgstr "E30: Ingen tidligere kommandolinje"
+#~ msgid "Find Next"
+#~ msgstr "Finn neste"
 
-msgid "E31: No such mapping"
-msgstr "E31: Mappingen finnes ikke"
+#~ msgid "Replace"
+#~ msgstr "Erstatt"
 
-msgid "E479: No match"
-msgstr "E479: Ingen treff"
+#~ msgid "Replace All"
+#~ msgstr "Erstatt alle"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Ingen treff: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Mottok \"dø\"-forespørsel fra øktbehandleren\n"
 
-msgid "E32: No file name"
-msgstr "E32: Mangler filnavn"
+#~ msgid "Close"
+#~ msgstr "Lukk"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Ingen tidligere erstatninger med regulære uttrykk"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Uventet ødeleggelse av hovedvinduet\n"
 
-msgid "E34: No previous command"
-msgstr "E34: Ingen tidligere kommando"
+#~ msgid "Font Selection"
+#~ msgstr "Velge skrifttype"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Ingen tidligere regulære uttrykk"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Brukte CUT_BUFFER0 istedenfor tomt valg"
 
-msgid "E481: No range allowed"
-msgstr "E481: Område er ikke tillatt"
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
 
-msgid "E36: Not enough room"
-msgstr "E36: Ikke nok plass"
+#~ msgid "&Cancel"
+#~ msgstr "&Avbryt"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Ingen registrert tjener kalt \"%s\""
+#~ msgid "Directories"
+#~ msgstr "Kataloger"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Kan ikke opprette filen %s"
+#~ msgid "Filter"
+#~ msgstr "Filter"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Kan ikke hente navn på midlertidig fil"
+#~ msgid "&Help"
+#~ msgstr "&Hjelp"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Kan ikke åpne filen %s"
+#~ msgid "Files"
+#~ msgstr "Filer"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Kan ikke lese filen %s"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Ikke lagret siden forrige forandring (legg til ! for å overstyre)"
+#~ msgid "Selection"
+#~ msgstr "Valg"
 
-msgid "E38: Null argument"
-msgstr "E38: Nullparameter"
+#~ msgid "Find &Next"
+#~ msgstr "Finn &neste"
 
-msgid "E39: Number expected"
-msgstr "E39: Nummer forventet"
+#~ msgid "&Replace"
+#~ msgstr "E&rstatt"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Kan ikke åpne feilfilen %s"
+#~ msgid "Replace &All"
+#~ msgstr "Erstatt &alle"
 
-msgid "E233: cannot open display"
-msgstr "E233: Kan ikke åpne display"
+#~ msgid "&Undo"
+#~ msgstr "&Angre"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Ikke mer ledig hukommelse!"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Fant ikke vindutittel \"%s\""
 
-msgid "Pattern not found"
-msgstr "Fant ikke søketeksten"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Parameter ikke støttet: \"-%s\"; Bruk OLE-versjonen."
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Fant ikke søketeksten: %s"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Klarer ikke åpne vindu inne i MDI-applikasjon"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Parameteret må være positivt"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Finn streng (bruk '\\\\' for å finne en '\\')"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Kan ikke gå tilbake til tidligere katalog"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Søk og erstatt (bruk '\\\\' for å finne en '\\')"
 
-msgid "E42: No Errors"
-msgstr "E42: Ingen feil"
+#~ msgid "Not Used"
+#~ msgstr "Ikke brukt"
 
-msgid "E776: No location list"
-msgstr "E776: Ingen plassliste"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Katalog\t*.ingenting\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Ødelagt søkestreng"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: Kan ikke reservere fargekart, noen farger kan være feil"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Skadet program med regulært uttrykk"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Skrifttyper for de følgende tegnsett mangler i fontsett %s:"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly'-valget er satt (legg til ! for å overstyre)"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Navn på skrifttypesett: %s"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Kan ikke forandre skrivebeskyttet variabel \"%s\""
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Skrifttypen '%s' har ikke konstant bredde"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Kan ikke sette variabel i sandkassen: \"%s\""
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Navn på skrifttypesett: %s\n"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Feil under lesing av feilfilen"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Ikke tillatt i sandkassen"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Ikke tillatt her"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Font%<PRId64>-bredde er ikke to ganger bredden av font0\n"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Forandring av skjermmodus er ikke støttet"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Font0-bredde: %<PRId64>\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Ugyldig \"scroll\"-verdi"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Font1-bredde: %<PRId64>\n"
+#~ "\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell'-valget er tomt"
+#~ msgid "Invalid font specification"
+#~ msgstr "Ugyldig skrifttypespesifisering"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Kunne ikke lese inn skiltdata!"
+#~ msgid "&Dismiss"
+#~ msgstr "&Forkast"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Feil under lukking av swapfil"
+#~ msgid "no specific match"
+#~ msgstr "ingen spesifikke treff"
 
-msgid "E73: tag stack empty"
-msgstr "E73: Tag-stack tom"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Skrifttypevelger"
 
-msgid "E74: Command too complex"
-msgstr "E74: Kommandoen er for kompleks"
+#~ msgid "Name:"
+#~ msgstr "Navn:"
 
-msgid "E75: Name too long"
-msgstr "E75: Navnet er for langt"
+#~ msgid "Show size in Points"
+#~ msgstr "Vis størrelse i punkter"
 
-msgid "E76: Too many ["
-msgstr "E76: For mange ["
+#~ msgid "Encoding:"
+#~ msgstr "Koding:"
 
-msgid "E77: Too many file names"
-msgstr "E77: For mange filnavn"
+#~ msgid "Font:"
+#~ msgstr "Skrifttype:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Etterfølgende tegn"
+#~ msgid "Style:"
+#~ msgstr "Stil:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Ukjent merke"
+#~ msgid "Size:"
+#~ msgstr "Størrelse:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Klarte ikke utvide jokertegn"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: \"stat\"-feil"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' kan ikke være mindre enn 'winminheight'"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Kan ikke åpne cscope-database: %s"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' kan ikke være mindre enn 'winminwidth'"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Kan ikke hente informasjon om cscope-database"
 
-msgid "E80: Error while writing"
-msgstr "E80: Feil under skriving"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: Maksimum antall cscope-forbindelser nådd"
 
-msgid "Zero count"
-msgstr "Antall repeteringer er null"
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Denne kommandoen er deaktivert, MzScheme-biblioteket kunne ikke "
+#~ "lastes."
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Bruker <SID> utenom skript-kontekst"
+#~ msgid "invalid expression"
+#~ msgstr "ugyldig uttrykk"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Ugyldig uttrykk mottatt"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "uttrykk deaktivert på kompileringsstadiet"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Regionen er beskyttet og kan ikke modifiseres"
+#~ msgid "hidden option"
+#~ msgstr "skjult valg"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans tillater ikke forandringer i skrivebeskyttede filer"
+#~ msgid "unknown option"
+#~ msgstr "ukjent valg"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Intern feil: %s"
+#~ msgid "window index is out of range"
+#~ msgstr "indeks for vindu er utenfor område"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Søkestrengen bruker mer hukommelse enn 'maxmempattern'"
+#~ msgid "couldn't open buffer"
+#~ msgstr "klarte ikke å åpne buffer"
 
-msgid "E749: empty buffer"
-msgstr "E749: Tom buffer"
+#~ msgid "cannot save undo information"
+#~ msgstr "kan ikke lagre angre-informasjon"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Ugyldig søkestreng eller skilletegn"
+#~ msgid "cannot delete line"
+#~ msgstr "kan ikke slette linje"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Filen er lastet i en annen buffer"
+#~ msgid "cannot replace line"
+#~ msgstr "kan ikke erstatte linje"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Valget '%s' er ikke satt"
+#~ msgid "cannot insert line"
+#~ msgstr "kan ikke sette inn linje"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Søket traff TOPPEN, fortsetter fra BUNNEN"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "streng kan ikke inneholde linjeskift"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Søket traff BUNNEN, fortsetter fra TOPPEN"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim-feil: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim-feil"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer er ugyldig"
+
+#~ msgid "window is invalid"
+#~ msgstr "vindu er ugyldig"
+
+#~ msgid "linenr out of range"
+#~ msgstr "linjenummer utenfor område"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "ikke tillatt i Vim-sandkassen"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Denne kommandoen er deaktivert, Python-biblioteket kunne ikke "
+#~ "lastes."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Kan ikke starte Python rekursivt"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "Kan ikke slette \"OutputObject\"-attributter"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "\"softspace\" må være et heltall"
+
+#~ msgid "invalid attribute"
+#~ msgstr "ugyldig attributt"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() krever en liste av strenger"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Feil under initialisering av I/U-objekter"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "forsøk på å referere til slettet buffer"
+
+#~ msgid "line number out of range"
+#~ msgstr "linjenummer utenfor område"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<bufferobjekt (slettet) ved %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "ugyldig merkenavn"
+
+#~ msgid "no such buffer"
+#~ msgstr "bufferen finnes ikke"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "forsøk på å referere til slettet vindu"
+
+#~ msgid "readonly attribute"
+#~ msgstr "skrivebeskyttet attributt"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "markørposisjon utenfor buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<vindusobjekt (slettet) ved %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<vindusobjekt (ukjent) ved %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<vindu %d>"
+
+#~ msgid "no such window"
+#~ msgstr "vinduet finnes ikke"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Denne kommandoen er deaktivert, Ruby-biblioteket kunne ikke lastes."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: Uventet return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: Uvented next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: Uventet break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: Uventet redo"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Ubehandlet unntak"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Ukjent longjmp-status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Bytt mellom implementasjon/definisjon"
+
+#~ msgid "Show base class of"
+#~ msgstr "Vis basisklasse av"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Vis overstyrt medlemsfunksjon"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Hent fra fil"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Hent fra prosjekt"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Hent fra alle prosjekter"
+
+#~ msgid "Retrieve"
+#~ msgstr "Hent"
+
+#~ msgid "Show source of"
+#~ msgstr "Vis kilde til"
+
+#~ msgid "Find symbol"
+#~ msgstr "Finn symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Bla gjennom klasse"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Vis klasse i hierarki"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Vis klasse i begrenset hierarki"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref refererer til"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref referert av"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref har en"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref brukt av"
+
+#~ msgid "Show docu of"
+#~ msgstr "Vis docu av"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generer docu for"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Kan ikke koble til SNiFF+. Sjekk miljøet (\"environment\") (sniffemacs må "
+#~ "bli funnet i $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Feil under lesing. Frakoblet"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ er for øyeblikket "
+
+#~ msgid "not "
+#~ msgstr "ikke "
+
+#~ msgid "connected"
+#~ msgstr "oppkoblet"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Ukjent SNiFF+-forespørsel: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Feil ved oppkobling til SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ ikke tilkoblet"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ikke en SNiFF+-buffer"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Feil under skriving. Frakoblet"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "ugyldig buffernummer"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ikke implementert enda"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "kan ikke sette linje(r)"
+
+#~ msgid "mark not set"
+#~ msgstr "merke ikke satt"
+
+#~ msgid "row %d column %d"
+#~ msgstr "rad %d kolonne %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "kan ikke sette inn/legge til linje"
+
+#~ msgid "unknown flag: "
+#~ msgstr "ukjent flagg: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "ukjent vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "tastaturavbrudd"
+
+#~ msgid "vim error"
+#~ msgstr "vim-feil"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "kan ikke opprette buffer/vindukommando: Objektet slettes"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "kan ikke registrere callback-kommando: Buffer/vindu er allerede slettet"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL KRITISK FEIL: reflist skadet!? Vennligst rapporter dette til "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "kan ikke registrere callback-kommando: Buffer/vindureferanse ikke funnet"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Denne kommandoen er deaktivert, Tcl-biblioteket kunne ikke lastes."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL-FEIL: Avslutningskode er ikke int!? Vennligst rapporter dette "
+#~ "til vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Avslutningskode %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "kan ikke hente linje"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Klarer ikke registrere kommandotjenernavn"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Klarte ikke sende kommando til destinasjonsprogrammet"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Ugyldig tjener-id brukt: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Registry-egenskapen for VIM-oppføringen er ikke korrekt. Slettet!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Denne Vim-versjonen er kompilert uten differansefunksjonen."
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Feil: Feil under start av gvim fra NetBeans\n"
+
+#~ msgid "where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "der bokstavstørrelse ignoreres, legg til / i begynnelsen for\n"
+#~ "å gjøre flagget om til stor bokstav"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistrer gvim for OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tFjern OLE-registrering for gvim"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tKjør med GUI (som \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  eller  --nofork\tForgrunn: Ikke fork når GUI-et startes"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tInformasjonsnivå (\"Verbose\")"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tIkke bruk newcli for å åpne vindu"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <enhet>\t\tBruk <enhet> for I/U"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tBruk <gvimrc> istedenfor eventuell .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tRediger krypterte filer"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tKoble vim til denne spesielle X-tjeneren"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tUnngå oppkobling til X-tjener"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <filer>\tRediger <filer> på en Vim-tjener hvis mulig"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <filer>  Samme, ikke klag hvis tjeneren mangler"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  Samme, ikke klag hvis tjeneren mangler"
+
+#, fuzzy
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr ""
+#~ "--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <nøkler>\tSend <nøkler> til en Vim-tjener og avslutt"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <uttrykk>\tEvaluer <uttrykk> på en Vim-tjener og skriv "
+#~ "resultatet"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tList navn på tilgjengelige Vim-tjenere og avslutt"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <navn>\tSend til/bli Vim-tjeneren <navn>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (Motif-versjon):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (neXtaw-versjon):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (Athena-versjon):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tKjør vim på <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tStart vim som ikon"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <navn>\t\tBruk ressurs som om Vim var <navn>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Ikke implementert)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <farge>\tBruk <farge> på bakgrunnen (også: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <farge>\tBruk <farge> på normal tekst (også: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <skrifttype>\t\tBruk <skrifttype> på normal tekst (også: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <skrifttype>\tBruk <skrifttype> på fet skrift"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <skrifttype>\tBruk <skrifttype> på skrå tekst"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tBruk <geom> for innledende vindusplassering (også: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <bredde>\tBruk en rammebredde tilsvarende <bredde> (også: -"
+#~ "bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <bredde>  Bruk en rullefeltbredde tilsvarende <bredde> "
+#~ "(også: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <høyde>\tBruk en menyblokkhøyde tilsvarende <høyde> (også: -"
+#~ "mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tBruk invers video (også: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tIkke bruk invers video (også: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ressurs>\tSett den spesifiserte ressursen"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (RISC OS-versjon):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <antall>\tInnledende bredde på vindu i kolonner"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <antall>\tInnledende høyde på vindu i rader"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (GTK+-versjon):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tKjør vim på <display> (også: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <role>\tSett en unik \"role\" for å identifisere hovedvinduet"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tÅpne Vim innenfor et annet GTK-skjermelement"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <foreldretittel>\tStart Vim innenfor et foreldreprogram"
+
+#~ msgid "No display"
+#~ msgstr "Ingen display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Send feilet.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Send feilet. Prøver å utføre lokalt\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d av %d redigert"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Ingen display: Sending av uttrykk feilet.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Sending av uttrykk feilet.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Er ikke en gyldig codepage"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Klarte ikke opprette inndatakontekst"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Klarte ikke åpne inndatametode"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Advarsel: Klarte ikke sette \"destroy callback\" til inndatametode"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Inndatametode støtter ikke enhver stil"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: Inndatametode støtter ikke min \"preedit\" type"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: \"over-the-spot\"-stil trenger et skrifttypesett"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Din GTK+ er eldre enn 1.2.3. Statusområde deaktivert"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Inndatametodetjener kjører ikke"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [ikke brukbar med denne Vim-versjonen]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Riv av denne menyen"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "\"Velge katalog\"-dialogvindu"
+
+#~ msgid "Save File dialog"
+#~ msgstr "\"Lagre fil\"-dialogvindu"
+
+#~ msgid "Open File dialog"
+#~ msgstr "\"Åpne fil\"-dialogvindu"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Dessverre ingen filbehandler i konsollmodus"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: Bevarer filer ...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Ferdig.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "FEIL: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] totalt alloc-frigjort %<PRIu64>-%<PRIu64>, i bruk %<PRIu64>, topp-"
+#~ "bruk %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[kall] totale \"re/malloc()\"-er %<PRIu64>, totale \"free()\"-er "
+#~ "%<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Linjen blir for lang"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Ulovlig utseende på musepekeren"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Skriv krypteringsnøkkel: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Gjenta krypteringsnøkkelen: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Krypteringsnøklene stemmer ikke overens!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Kan ikke koble til Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Kan ikke koble til Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Feil tilgangsmodus for infofilen til NetBeans-forbindelse: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "les fra Netbeans-socket"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Mistet NetBeans-forbindelse for buffer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval-funksjonaliteten er ikke tilgjengelig"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "frigjør %<PRId64> linjer"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Kan ikke forandre \"term\" i grafisk brukergrensesnitt"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Bruk \":gui\" for å starte med grafisk brukergrensesnitt"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Kan ikke forandres i GTK+ 2 GUI"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Ugyldig(e) skrifttype(r)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Kan ikke velge skrifttypesett"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Ugyldig skrifttypesett"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Kan ikke velge bred skrifttype"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Ugyldig bred skrifttype"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Ingen støtte for mus"
+
+#~ msgid "cannot open "
+#~ msgstr "kan ikke åpne "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Kan ikke åpne vindu!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Trenger Amigados versjon 2.04 eller nyere\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Trenger %s versjon %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Kan ikke åpne NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Kan ikke opprette "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim avslutter med %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "kan ikke forandre konsollmodus ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: Ikke et konsoll??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Kan ikke kjøre skall med \"-f\"-valg"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Kan ikke utføre "
+
+#~ msgid "shell "
+#~ msgstr "skall "
+
+#~ msgid " returned\n"
+#~ msgstr " returnerte\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE for liten."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/U-FEIL"
+
+#~ msgid "Message"
+#~ msgstr "Melding"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' er ikke 80, kan ikke utføre eksterne kommandoer"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Valg av skriver feilet"
+
+#~ msgid "to %s on %s"
+#~ msgstr "til %s på %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Ukjent skrifttype for skriver: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Feil under utskrift: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Skriver ut '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Ulovlig navn på tegnsett \"%s\" i skrifttypenavn \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Ulovlig tegn '%c' i skrifttypenavn \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Dobbelt signal, avslutter\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Mottok dødelig signal %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Mottok dødelig signal\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Åpning av X-display tok %<PRId64> millisekunder"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Mottok X-feil\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test av X-display feilet"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Tidsavbrudd for åpning av X-display"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan ikke kjøre skallet sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan ikke opprette rør (\"pipe\")\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan ikke opprette tvillingprosess (\"fork\")\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kommando avsluttet\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP mistet ICE-forbindelsen"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Åpning av X-display feilet"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP håndterer \"redd-deg-selv\"-forespørsel"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP åpner forbindelse"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Overvåkning av XSMP ICE-forbindelse feilet"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection feilet: %s"
+
+#~ msgid "At line"
+#~ msgstr "På linje"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Klarte ikke laste vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM-feil"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Klarte ikke ordne opp i funksjonspekere til DLL-en!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "skallet returnerte %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Mottok \"%s\"-hendelse\n"
+
+#~ msgid "close"
+#~ msgstr "lukk"
+
+#~ msgid "logoff"
+#~ msgstr "logg av"
+
+#~ msgid "shutdown"
+#~ msgstr "kjør ned"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Kommando ikke funnet"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE ikke funnet i $PATH.\n"
+#~ "Eksterne kommandoer kommer ikke til å vente etter fullføring.\n"
+#~ "Se \":help win32-vimrun\" for mer informasjon."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim-advarsel"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konvertering i %s ikke støttet"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: \"containedin\"-parameter aksepteres ikke her"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Sti til tagfil kuttet for %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "nytt skall startet\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Ingen angremuligheter; fortsett likevel"
+
+#~ msgid "number changes  time"
+#~ msgstr "nummer forandringer tidspunkt"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS Windows 16/32-bits grafisk versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS Windows 64-bits grafisk versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bits GUI-versjon"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " i Win32s-modus"
+
+#~ msgid " with OLE support"
+#~ msgstr " med OLE-støtte"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bits konsollversjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16-bits versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32-bits MS-DOS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16-bits MS-DOS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix)-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Stor (\"big\") versjon "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normal versjon "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Liten (\"small\") versjon "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Spinkel (\"tiny\") versjon "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "med GTK2-GNOME GUI."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "med GTK-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "med GTK2 GUI."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "med GTK GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "med X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "med X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "med X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "med Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "med GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "med Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "med Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "med (klassisk) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "       gvimrc-fil på systemet: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       gvimrc-fil for brukere: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr " gvimrc-fil nr. 2 for brukere: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr " gvimrc-fil nr. 3 for brukere: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "          menyfil på systemet: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompilator: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "meny:  Hjelp->Foreldreløse        for informasjon  "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Kjører uten modus, tastetrykk blir lagt inn i teksten"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "meny:  Rediger->Globale innstillinger->Innsettingsmodus av/på"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                                  for to moduser   "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "meny:  Rediger->Globale innstillinger->Vi-kompatibilitet av/på"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                  for standard Vim "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ADVARSEL: Windows 95/98/ME oppdaget"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "skriv  :help windows95<Enter>     for informasjon  "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Klarte ikke laste bibliotek %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "Denne kommandoen er deaktivert, Perl-biblioteket kunne ikke lastes."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Evaluering av Perl er ikke tillatt i sandkassen uten \"Safe\"-"
+#~ "modulen"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Rediger med &flere Vim-er"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Rediger med enkel &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Differanse med Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Rediger med &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Rediger med eksisterende Vim - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Redigerer de(n) valgte filen(e) med Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Klarte ikke lage prosess: Sjekk at gvim er i stien!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "Feil i gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Lengden på stien er for lang!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Ukjent skrifttypesett: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Ukjent skrifttype: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Skrifttypen \"%s\" har ikke fast bredde"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Klarte ikke laste biblioteksfunksjon %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hebraisk kan ikke brukes: Ikke slått på under kompilering\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Persisk (Farsi) kan ikke brukes: Ikke slått på under kompilering\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabisk kan ikke brukes: Ikke slått på under kompilering\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Ingen registrert tjener kalt \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Kan ikke åpne display"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Ugyldig uttrykk mottatt"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Regionen er beskyttet og kan ikke modifiseres"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans tillater ikke forandringer i skrivebeskyttede filer"

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-05-29 07:43+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2012-03-28 08:07+0200\n"
 "Last-Translator: YOUR NAME <E-MAIL@ADDRESS>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.nl>\n"
@@ -18,153 +18,208 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() uitgevoerd met leeg wachtwoord"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Rommel na optieargument"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: gebruik Blowfish big/little endian is onjuist"
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Locatielijst]"
 
-msgid "E818: sha256 test failed"
-msgstr "E818: sha256 test mislukt"
+#: ../buffer.c:93
+#, fuzzy
+msgid "[Quickfix List]"
+msgstr "[Quickfix-lijst]"
 
-msgid "E819: Blowfish test failed"
-msgstr "E819: Blowfish test mislukt"
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: buffer of buffernaam gewijzigd door autocommands"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: kan geen buffer aanmaken, beëindigen..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: kan geen buffer aanmaken, een andere wordt gebruikt..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: geen van de buffers is gelost"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: geen van de buffers is verwijderd"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: geen van de buffers is gewist"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer gelost"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffers gelost"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer verwijderd"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffers verwijderd"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer gewist"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffers gewist"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: kan laatste buffer niet legen"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: geen aangepast buffer gevonden"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: er is geen vermelde buffer"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Buffer %<PRId64> bestaat niet"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: kan niet voorbij het laatste buffer komen"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: kan niet vóór het eerste buffer komen"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
-msgstr "E89: niets opgeslagen sinds laatste wijziging van buffer %<PRId64> (voeg ! toe om te forceren)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr ""
+"E89: niets opgeslagen sinds laatste wijziging van buffer %<PRId64> (voeg ! "
+"toe om te forceren)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: kan laatste buffer niet legen"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: waarschuwing: lijst met bestandsnamen is vol"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: buffer %<PRId64> niet gevonden"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: %s meermaals gevonden"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: geen overeenkomstig buffer voor %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "regel %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: buffer met deze naam bestaat al"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Gewijzigd]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Niet bewerkt]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nieuw bestand]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Leesfouten]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[alleen-lezen]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 regel --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> regels --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "regel %<PRId64> van %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Geen naam]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "hulp"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Hulp]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Voorvertoning]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Alles"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Bodem"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Top"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -172,15 +227,11 @@ msgstr ""
 "\n"
 "# Bufferlijst:\n"
 
-msgid "[Location List]"
-msgstr "[Locatielijst]"
-
-msgid "[Quickfix list]"
-msgstr "[Quickfix-lijst]"
-
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Klad]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -188,137 +239,202 @@ msgstr ""
 "\n"
 "--- Tekens ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Tekens voor %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    regel=%<PRId64>  id=%d  naam=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr ""
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr ""
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr ""
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr ""
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: kan niet meer dan %<PRId64> buffers vergelijken"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: kan tijdelijke bestand niet lezen of opslaan"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: kan geen verschillen genereren"
 
-msgid "Patch file"
-msgstr "Patch-bestand"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: kan patch-uitvoer niet lezen"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: kan diff-uitvoer niet lezen"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: huidige buffer is niet in diff-modus"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: geen ander buffer in diff-modus is bewerkbaar"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: geen ander buffer in diff-modus"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
-msgstr "E101: meer dan twee buffers in diff-modus, weet niet welke gebruikt moet worden"
+msgstr ""
+"E101: meer dan twee buffers in diff-modus, weet niet welke gebruikt moet "
+"worden"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: kan buffer \"%s\" niet vinden"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: buffer \"%s\" is niet in diff-modus"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: buffer is onverwacht gewijzigd"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape in digraph niet toegestaan"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: bestand met toetsbindingen niet gevonden"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Gebruik van :loadkeymap niet in een 'sourced' bestand"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: toetsbinding leeg"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " trefwoordvoltooiing (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X-modus (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " gehele-regelvoltooiing (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " bestandsnaamvoltooiing (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " tag-voltooiing (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Padpatroonvoltooiing (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " definitievoltooiiing (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dictionaryvoltooiing (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurusvoltooiing (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " opdrachtregelvoltooiing (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " gebruikergedefinieerde voltooiing (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " omni-voltooiing (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " spellingsuggestie (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " lokaal-trefwoordvoltooiing (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Einde van paragraaf"
 
+#: ../edit.c:101
+#, fuzzy
+msgid "E839: Completion function changed window"
+msgstr "E813: sluiten autocmd-venster is mislukt"
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'Dictionary'-optie is leeg"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus'-optie is leeg"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Doorzoeken Dictionary: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (invoegen) scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (vervangen) scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "doorzoeken: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Doorzoeken tags."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " toevoegen"
 
@@ -326,426 +442,586 @@ msgstr " toevoegen"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- doorzoeken..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Terug naar origineel"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Woord uit andere regel"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Het enige resultaat"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "resultaat %d van %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "resultaat %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: onverwachte tekens in :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: lijstindex buiten bereik: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: ongedefinieerde variabele: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ontbrekende ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: argument van %s moet een List zijn"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: argument van %s moet een List of Dictionary zijn"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: kan geen leeg trefwoord als Dictionary gebruiken"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: List is vereist"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Dictionary is vereist"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: te veel argumenten voor functie: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: trefwoord niet aangetroffen in Dictionary: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: function %s bestaat reeds, voeg ! toe om te vervangen"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: woord bestaat al in Dictionary"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref is vereist"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: kan [:] niet met een Dictionary gebruiken"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: onjuist type variabele voor %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: onbekende functie: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: ongeldige variabelenaam: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Float gebruiken als een String"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: minder doelen dan Listitems"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: meer doelen dan Listitems"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Dubbele ; in variabelenlijst"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: kan variabelen voor %s niet tonen"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: alleen een List of Dictionary kan geÃ¯ndexeerd worden"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] moet als laatste staan"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] vereist een Listwaarde"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Listwaarde heeft meer  value has more items than target"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Listwaarde heeft onvoldoende items"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: \"in\" ontbreekt na :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: ontbrekende haakjes: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: onbekende variabele: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variabele is te diep genest om te beveiligen"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: ':' ontbreekt na '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: List kan alleen met een Lijst worden vergeleken"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: ongeldige bewerking voor Listen"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Dictionary kan alleen met Woordenboek worden vergeleken"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: ongeldige bewerking voor Dictionary"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref kan alleen met Funcref worden vergeleken"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: ongeldige bewerking voor Funcrefs"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: '%' kan niet met Float worden gebruikt"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' ontbreekt"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: een Funcref kan niet geÃ¯ndexeerd worden"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: optienaam ontbreekt: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: onbekende optie: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: ontbrekend aanhaalteken: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: ontbrekend aanhaalteken: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: komma ontbreekt in List: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: einde van List ']' ontbreekt: %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: dubbelepunt in Dictionary ontbreekt: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: dubbele sleutel in Dictionary: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: komma ontbreekt in Dictionary: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: einde van Dictionary '}' ontbreekt: %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variabele is te diep genest om te tonen"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: teveel argumenten voor functie %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: ongeldige argumenten voor functie %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: onbekende functie: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: onvoldoende argumenten voor functie: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: gebruik van <SID> buiten een scriptcontext: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: dict-functie aanroep zonder Dictionary: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Number of Float vereist"
 
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "argument van -c"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699:teveel argumenten"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() kan alleen in Invoegmodus worden gebruikt"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: sleutel bestaat al: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "argument van --cmd"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "argument van -c"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "argument van -c"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld regels: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: onbekende functie: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Annuleren"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() vaker aangeroepen dan inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "argument van -c"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: bereik niet toegestaan"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: ongeldig type voor len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: stap is nul"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: start na einde"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<leeg>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: geen verbinding met Vim-server"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "argument van --cmd"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: verzenden naar %s onmogelijk"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: lezen van serverantwoord onmogelijk"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: teveel symbolische koppelingen (oneindige lus?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: verzenden nar client onmogelijk"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "argument van -c"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "argument van -c"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argument van -c"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: sorteer-vergelijkfunctie mislukt"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: sorteer-vergelijkfunctie mislukt"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(ongeldig)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: opslaan van temp-bestand is mislukt"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: een Float wordt als Number gebruikt"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: een Funcref wordt als Number gebruikt"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: List wordt als een Number gebruikt"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Dictionary gebruiken als een Number"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref gebruiken als een String"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: List gebruiken als een String"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Dictionary gebruiken als een String"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Float gebruiken als een String"
-
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: variabelenaam van Funcref moet beginnen met een hoofdletter: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: variablenaam botst met bestaande functie: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: variabelesoort past niet bij: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: kan variabele %s niet verwijderen"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: variabelenaam van Funcref moet beginnen met een hoofdletter: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: variablenaam botst met bestaande functie: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: waarde is geblokkeerd: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Onbekend"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: kan waarde van %s niet veranderen"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: variabele te diep genest om een kopie te maken"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: ongedefinieerde functie: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: ontbrekende '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E804: '%' kan niet met Float worden gebruikt"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: ongeldig argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: ongeldig argument: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: ontbrekende :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: functienaam botst met variabele: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: kan functie %s niet opnieuw definiÃ«ren, het is in gebruik"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
-msgstr "E746: functienaam komt niet overeen met bestandsnaam van het script: %s"
+msgstr ""
+"E746: functienaam komt niet overeen met bestandsnaam van het script: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: functienaam is vereist"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
-msgstr "E128: functionnaam moet met een hoofdletter beginnen of een dubbelepunt bevatten: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: functionnaam moet met een hoofdletter beginnen of een dubbelepunt "
+"bevatten: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: functionnaam moet met een hoofdletter beginnen of een dubbelepunt "
+"bevatten: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: functie %s wordt gebruikt en kan niet worden verwijderd"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: diepte functieaanroep overstijgt 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "%s aanroepen"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s afgebroken"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s komt terug met de waarde #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s komt terug met de waarde %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "voortzetten in %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return niet binnen een functie"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -753,6 +1029,7 @@ msgstr ""
 "\n"
 "# globale variabelen:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -760,83 +1037,104 @@ msgstr ""
 "\n"
 "\tLaatst ingesteld door "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Geen oudere bestanden"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: verplaats regels in zichzelf"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 regel verplaatst"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> regels verplaatst"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> regels gefilterd"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autocommands mogen huidige buffer niet wijzigen"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Niets opgeslagen sinds laatste wijziging]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s in regel: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: teveel fouten, restand van bestand overgeslagen"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Inlezen viminfo-bestand \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " markering"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " oud-bestanden"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " MISLUKT"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: viminfo-bestand is niet schrijfbaar: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: kan niet naar viminfo-bestand %s schrijven!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "viminfo-bestand \"%s\" opslaan"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Dit viminfo-bestand is aangemaakt door Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -844,41 +1142,48 @@ msgstr ""
 "# Bewerken is toegestaan, maar doe het met aandacht!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Waarde van 'encoding' bij het opslaan van dit bestand\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Ongeldig startteken"
 
-msgid "Save As"
-msgstr "Opslaan als"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Gedeeltelijk bestand opslaan?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: gebruik ! om gedeeltelijk buffer op te slaan"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Bestaand bestand \"%s\" overschrijven?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Wisselbestand \"%s\" bestaat, toch overschrijven?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: wisselbestand bestaat: %s (:silent! overschrijft)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: buffer %<PRId64> heeft geen bestandsnaam"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
-msgstr "E142: bestand is niet opgeslagen: opslaan is uitgeschakeld door 'write'-optie"
+msgstr ""
+"E142: bestand is niet opgeslagen: opslaan is uitgeschakeld door 'write'-optie"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -887,6 +1192,7 @@ msgstr ""
 "'alleen-lezen'-optie is inschakeld voor \"%s\".\n"
 "Toch opslaan?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -897,65 +1203,83 @@ msgstr ""
 "Mogelijk kan er toch naar weggeschreven worden.\n"
 "Proberen op te slaan?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" is alleen-lezen (voeg ! toe om te overschrijven)"
 
-msgid "Edit File"
-msgstr "Bestand bewerken"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: 'Autocommands' hebben het nieuwe buffer %s onverwacht verwijderd"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: niet-numeriek argument voor :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: in rvim zijn shell-opdrachten zijn niet toegestaan"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: reguliere expressies kunnen niet begrensd worden door letters"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "vervang door %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Onderbroken) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 overeenkomst"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 vervanging"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> overeenkomsten"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> vervangingen"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " op 1 regel"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " op %<PRId64> regels"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: kan :global niet recursief uitvoeren"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: reguliere expressies ontbreken bij global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Patroon aangetroffen in iedere regel: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "patroon niet gevonden"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -965,263 +1289,336 @@ msgstr ""
 "# Laatst vervangingsstring:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: geen paniek!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: helaas, geen '%s'-hulp voor %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: helaas, geen hulp voor %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "helaas, hulpbestand \"%s\" is niet gevonden"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: geen map: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: kan %s niet openen om naar te schrijven"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: kan %s niet openen om uit te lezen"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: mengelmoes van hulpbestandcoderingen binnen een taal: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: dubbele tag \"%s\" in bestand %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: onbekende opdracht voor margetekens: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: ontbrekende naam margeteken"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: teveel margetekens gedefinieerd"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: ongeldige tekst margeteken: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: onbekend margeteken: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: ontbrekend nummer margeteken"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: ongeldige buffernaam: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: ongeldige id margeteken: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NIET GEVONDEN)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr "(niet ondersteund)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Verwijderd]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Debug-modus gestart.  Typ \"cont\" om verder te gaan."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "regel %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "'Breakpoint' in \"%s%s\" regel %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 'Breakpoint' niet gevonden: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Geen 'breakpoints' opgegeven"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  regel %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: gebruik eerst \":profile start {fname}\""
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "veranderingen opslaan in \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "naamloos"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: niets opgeslagen sinds laatste wijziging van buffer \"%s\""
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Waarschuwing: onverwacht ander buffer binnengegaan (controleer 'autocommands')"
+msgstr ""
+"Waarschuwing: onverwacht ander buffer binnengegaan (controleer "
+"'autocommands')"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: slechts een bestand beschikbaar voor bewerking"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: kan niet verder terug dan eerste bestand"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: kan niet verder dan laatste bestand"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: compiler niet ondersteund: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Naar \"%s\" in \"%s\" zoeken"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Naar \"%s\" zoeken"
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "niet gevonden in 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Vim-script laden"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "kan geen map laden: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "kan \"%s\" niet laden"
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "regel %<PRId64>: kan \"%s\" niet laden"
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" laden"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "regel %<PRId64>: \"%s\" laden"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "laden van %s afgerond"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modusregel"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "argument van --cmd"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "argument van -c"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "omgevingsvariabele"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "foutafhandeling"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: waarschuwing: ongeldige regelscheiding, ^M kan ontbreken"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding buiten een geladen bestand gebruikt"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish buiten een geladen bestand gebruikt"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Huidige %s-taal: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: taal kan niet ingesteld worden op \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Ex-modus betreden.  Typ \"visual\" om naar de Normaal-modus te gaan."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: bij bestandseinde"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: opdracht te recursief"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: uitzondering niet afgevangen: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Einde van geladen bestand"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Einde van functie"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: dubbelzinnig gebruik van gebruikergedefinieerde opdracht"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: geen editor-opdracht"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Teruggaand bereik opgegeven"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Teruggaand bereik opgegeven, wisselen is toegestaan"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: w of w>> gebruiken"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Helaas, in deze versie is de opdracht niet beschikbaar"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: slechts een bestandsnaam toegestaan"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 bestand wacht nog op bewerking.  Toch stoppen?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d bestanden wachten nog op bewerking.  Toch stoppen?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 bestand wacht op bewerking"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> bestanden wachten op bewerking"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: opdracht bestaat al: voeg ! toe om het te vervangen"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1229,283 +1626,348 @@ msgstr ""
 "\n"
 "    Naam        Args Berk.  Compleet  Definitie"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Geen gebruikergedefinieerde opdrachten gevonden"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: geen attribute opgegeven"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: ongeldig aantal argumenten"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: aantal kan niet tweemaal worden opgegeven"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: ongeldige standaardwaarde voor aantal"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: argument vereist voor -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: ongeldig attribute: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: ongeldige opdrachtnaam"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
-msgstr "E183: door gebruiker gedefinieerde opdrachten moet een een hoofdletter beginnen"
+msgstr ""
+"E183: door gebruiker gedefinieerde opdrachten moet een een hoofdletter "
+"beginnen"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: dubbelzinnig gebruik van gebruikergedefinieerde opdracht"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: deze door gebruiker gedefinieerde opdracht bestaat niet: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: ongeldige voltooiingswaarde: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: argument voor voltooiing alleen toegestaan bij aangepaste voltooiing"
+msgstr ""
+"E468: argument voor voltooiing alleen toegestaan bij aangepaste voltooiing"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: aangepaste voltooiing vereist een functieargument"
 
-msgid "unknown"
-msgstr "onbekend"
-
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: kan kleurenschema %s niet vinden"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Gegroet, Vim-gebruiker!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: laatste tabpagina kan niet afgesloten worden"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Reeds beperkt tot één tabpagina"
 
-msgid "Edit File in new window"
-msgstr "Bestand in nieuw venster bewerken"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Tabpagina %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Geen wisselbestand"
 
-msgid "Append File"
-msgstr "Bestand toevoegen"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
-msgstr "E747: kan niet van map veranderen, buffer is gewijzigd (voeg ! toe om te forceren)"
+msgstr ""
+"E747: kan niet van map veranderen, buffer is gewijzigd (voeg ! toe om te "
+"forceren)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: geen voorgaande map"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: onbekend"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize vereist twee getallen als argument"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Vensterpositie: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
-msgstr "E188: verkrijgen van vensterpositie is voor dit platform niet geïmplementeerd"
+msgstr ""
+"E188: verkrijgen van vensterpositie is voor dit platform niet geïmplementeerd"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos vereist twee getallen als argument"
 
-msgid "Save Redirection"
-msgstr "'Redirection' opslaan"
-
-msgid "Save View"
-msgstr "Beeld opslaan"
-
-msgid "Save Session"
-msgstr "Sessie opslaan"
-
-msgid "Save Setup"
-msgstr "Instellingen opslaan"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: kan map %s niet aanmaken"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" bestaat al (voeg ! toe om te forceren)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" kan niet worden beschreven"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
-msgstr "E191: argument moet een letter zijn of een aanhaalteken, voor of achterwaarts"
+msgstr ""
+"E191: argument moet een letter zijn of een aanhaalteken, voor of achterwaarts"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: recursief gebruik van :normal gaat te diep"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< is zonder de +eval-functionaliteit niet beschikbaar"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
-msgstr "E194: er is geen wisselende bestandsnaam beschikbaar om '#' te vervangen"
+msgstr ""
+"E194: er is geen wisselende bestandsnaam beschikbaar om '#' te vervangen"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
-msgstr "E495: er is geen 'autocommand'-bestandsnaam om \"<afile>\" te vervangen"
+msgstr ""
+"E495: er is geen 'autocommand'-bestandsnaam om \"<afile>\" te vervangen"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: er is geen 'autocommand'-buffernummer om \"<abuf>\" te vervangen"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
-msgstr "E497: er is geen 'autocommand'-naamovereenkomst om \"<amatch>\" te vervangen"
+msgstr ""
+"E497: er is geen 'autocommand'-naamovereenkomst om \"<amatch>\" te vervangen"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: er is geen :source-bestandsnaam om \"<sfile>\" te vervangen"
 
-#, no-c-format
-msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
-msgstr "E499: lege bestandsnaam voor '%' of '#', werkt alleen samen met \":p:h\""
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: er is geen :source-bestandsnaam om \"<sfile>\" te vervangen"
 
+#: ../ex_docmd.c:7903
+#, c-format
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
+msgstr ""
+"E499: lege bestandsnaam voor '%' of '#', werkt alleen samen met \":p:h\""
+
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: resulteert in een lege string"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: het 'viminfo'-bestand kan niet worden gelezen"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: deze versie bevat geen 'digraphs'"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: :throw exceptions met 'Vim' als voorvoegsel zijn niet mogelijk"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Geworpen uitzondering: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Afgeronde uitzondering: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Afgedankte uitzondering: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, regel %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Gevangen uitzondering: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s aanhanging gemaakt"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s voortgezet"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s afgedankt"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Uitzondering"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Fout en onderbreken"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Fout"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Onderbreken"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: te diepe :if-nesting"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif zonder :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else zonder :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif zonder :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: meerdere :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif na :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: te diepe :while/:for-nesting"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue zonder :while of :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break zonder :while of :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: gebruik van :endfor met :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: gebruik van :endwhile met :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: te diepe :try-nesting"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch zonder :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch na :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally zonder :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: meerdere :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry zonder :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction niet binnen een functie"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: nu een andere buffer bewerken is niet toegestaan"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: nu bufferinformatie wijzigen is niet toegestaan"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "tagnaam"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr "soor bestand\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history'-optie is nul"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1514,224 +1976,309 @@ msgstr ""
 "\n"
 "# %s Historie (jongste naar oudste):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Opdrachtregel"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Zoekstring"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Expressie"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Invoerregel"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar is langer dan toegestaan voor een opdracht"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: actieve venster of buffer verwijderd"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr ""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr ""
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr ""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr ""
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: buffer of buffernaam gewijzigd door autocommands"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Ongeldige bestandsnaam"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "is een map"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "is geen bestand"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "is een apparaat (uitgeschakeld door optie 'opendevice'"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nieuw bestand]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nieuwe MAP]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "Bestand te groot"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Geen rechten]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre autocommands hebben het bestand niet-leesbaar gemaakt"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre autocommands mogen huidige buffer niet wijzigen"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: lezen van standaardinvoer...\n"
 
-msgid "Reading from stdin..."
-msgstr "Lezen van standaardinvoer..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: bestand niet-leesbaar gemaakt door conversatie"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[karakter speciaal]"
 
-msgid "[RO]"
-msgstr "[RO]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR ontbreekt]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[lange regels gesplitst]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NIET omgezet]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[omgezet]"
 
-msgid "[crypted]"
-msgstr "[versleuteld]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[OMZETFOUT in regel %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[ONGELDIGE BYTE in regel %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LEESFOUTEN]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Tijdelijk bestand voor conversie ontbreekt"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Conversatie met 'charconvert' is mislukt"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "uitvoer van 'charconvert' kan niet worden gelezen"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: bestand is met onbekende methode versleuteld"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: geen overeenkomende autocommands voor 'acwrite'-buffer"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
-msgstr "E203: autocommands hebben buffer verwijderd of gelost die moest worden opgeslagen"
+msgstr ""
+"E203: autocommands hebben buffer verwijderd of gelost die moest worden "
+"opgeslagen"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
-msgstr "E204: autocommand heeft op onverwachte wijze het aantal regels gewijzigd"
+msgstr ""
+"E204: autocommand heeft op onverwachte wijze het aantal regels gewijzigd"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "Netbeans staat het opslaan van onveranderde buffers niet toe"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Deelopslag voor buffers van Netbeans niet toegestaan"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "is geen bestand of schrijfbaar apparaat"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "het schrijven naar apparaat is uitgeschakeld met optie 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "is alleen-lezen (voeg ! toe om te schrijven)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: kan niet naar back-upbestand schrijven (voeg hiervoor ! toe)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
-msgstr "E507: fout tijdens afsluiten van back-upbestand (voeg ! om toch af te sluiten)"
+msgstr ""
+"E507: fout tijdens afsluiten van back-upbestand (voeg ! om toch af te "
+"sluiten)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
-msgstr "E508: kan bestand voor back-up niet lezen (voeg ! toe om toch te lezen)"
+msgstr ""
+"E508: kan bestand voor back-up niet lezen (voeg ! toe om toch te lezen)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
-msgstr "E509: kan back-upbestand niet aanmaken (voeg ! toe om dit toch aan te maken)"
+msgstr ""
+"E509: kan back-upbestand niet aanmaken (voeg ! toe om dit toch aan te maken)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: kan back-upbestand niet maken (voeg ! toe om dit toch te maken)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: de afsplitsing van middelen zou verloren gaan (voeg ! toe om dit toch te doen)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: kan tijdelijk bestand voor wegschrijven niet vinden"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: kan niet omzetten (voeg ! toe om zonder omzetting op te slaan)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: kan niet schrijven naar gekoppeld bestand"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: kan niet schrijven naar bestand"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: fsync is mislukt"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Afsluiten is mislukt"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: schrijffout waarbij omzetting is mislukt (leeg 'fenc' om te overschrijven)"
+msgstr ""
+"E513: schrijffout waarbij omzetting is mislukt (leeg 'fenc' om te "
+"overschrijven)"
 
+#: ../fileio.c:3441
 #, c-format
-msgid "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to override)"
-msgstr "E513: schrijffout waarbij omzetting in regel %<PRId64> is mislukt (leeg 'fenc' om te overschrijven)"
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: schrijffout waarbij omzetting in regel %<PRId64> is mislukt (leeg "
+"'fenc' om te overschrijven)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: schrijffout (is bestandssysteem vol?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " OMZETTINGFOUT"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " in regel %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Apparaat]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nieuw]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " toegevoegd"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " opgeslagen"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patch-modus: kan oorspronkelijke bestand niet opslaan"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patch-modus: kan oorspronkelijk leeg bestand niet aanraken"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: back-upbestand kan niet worden verwijderd"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1739,103 +2286,140 @@ msgstr ""
 "\n"
 "WAARSCHUWING: oorspronkelijk bestand kan verloren gaan of beschadigen\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "verlaat vim niet voordat het bestand volledig opgeslagen is!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos-format]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac-format]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix-format]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 regel, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> regels, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 teken"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> tekens"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Laatste regel onvolledig]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "WAARSCHUWING: het bestand is na het laden gewijzigd!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Wilt u er zeker naar schrijven"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: schrijven naar \"%s\" is mislukt"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: afsluiten van \"%s\" is mislukt"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: lezen van \"%s\" is mislukt"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: buffer verwijderd door 'autocommand' FileChangedShell"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: bestand \"%s\" is niet meer beschikbaar"
 
+#: ../fileio.c:4906
 #, c-format
-msgid "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as well"
+msgid ""
+"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
+"well"
 msgstr "W12: waarschuwing: bestand \"%s\" en de buffer zijn gewijzigd in Vim "
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Lees \":help W12\" voor meer informatie."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
-msgstr "W11: waarschuwing: bestand \"%s\" is gewijzigd sinds het begin van het bewerken"
+msgstr ""
+"W11: waarschuwing: bestand \"%s\" is gewijzigd sinds het begin van het "
+"bewerken"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Lees \":help W11\" voor meer informatie."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
-msgstr "W16: waarschuwing: rechten van bestand \"%s\" zijn gewijzigd sinds het begin van het bewerken"
+msgstr ""
+"W16: waarschuwing: rechten van bestand \"%s\" zijn gewijzigd sinds het begin "
+"van het bewerken"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Lees \":help W16\" voor meer informatie"
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
-msgstr "W13: waarschuwing: na het begin van het bewerken van bestand \"%s\" is deze ook elders aangemaakt"
+msgstr ""
+"W13: waarschuwing: na het begin van het bewerken van bestand \"%s\" is deze "
+"ook elders aangemaakt"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Waarschuwing"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1843,39 +2427,48 @@ msgstr ""
 "&OK\n"
 "Bestand &Laden"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: het voorbereiden van \"%s\" voor het opnieuw laden is mislukt"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: kan \"%s\" niet opnieuw laden"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Verwijderd--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "automatisch verwijderen 'autocommand': %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: groep \"%s\" bestaat niet"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: ongeldig teken na *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: onbekend 'event': %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: onbekende groep of 'event': %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1883,548 +2476,763 @@ msgstr ""
 "\n"
 "--- Auto-Commands ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: ongeldig buffernummer "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: autocommands kunnen niet voor alle 'events' worden uitgevoerd"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Geen overeenkomstige autocommands"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: hierarchie van aanroepen autocommands te diep"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s 'Auto commands' voor \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "%s uitvoeren"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: ontbrekende {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: ontbrekende }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: geen vouw gevonden"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: kan geen vouw aanmaken met huidige 'vouwmethode'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: kan geen vouw verwijderen met huidige 'vouwmethode'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld regels gevouwen "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: aan leesbuffer toevoegen"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: recursieve toewijzing"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: algemene afkorting bestaat al voor %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: er bestaat al een algemene toewijzing voor %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: er bestaat al een afkorting voor %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: toewijzing bestaat al voor %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Geen afkorting gevonden"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Geen toewijzing gevonden"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: ongeldige modus"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: de GUI kan niet worden gestart"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "-- geen regels in buffer --"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: kan niet gelezen worden uit \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: opdracht afgebroken"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: de GUI kan niet gestart worden, er is geen geldig lettertype gevonden"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argument vereist"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' ongeldig"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ moet worden gevolgd door /, ? of &"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: waarde van 'imactivatekey' is ongeldig"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: ongeldig in opdrachtregelvenster; <CR> voert uit, CTRL-C stopt"
 
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: kan de kleur %s niet reserveren"
-
-msgid "No match at cursor, finding next"
-msgstr "Op cursorpositie is geen overeenkomst: de volgende zoeken"
-
-msgid "<cannot open> "
-msgstr "<kan niet openen> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: lettertype %s niet gevonden"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: teruggaan naar huidige map is niet mogelijk"
-
-msgid "Pathname:"
-msgstr "Padnaam:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: vaststellen huidige map is niet mogelijk"
-
-msgid "OK"
-msgstr "Ok"
-
-msgid "Cancel"
-msgstr "Annuleren"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar-widget: vaststellen afmetingen van miniaturenkaart niet mogelijk."
-
-msgid "Vim dialog"
-msgstr "Vim-dialoog"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: aanmaken 'BalloonEval' met zowel een bericht als een 'callback' is niet mogelijk"
-
-msgid "Vim dialog..."
-msgstr "Vim-dialoog..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Ja\n"
-"&Nee\n"
-"&Annuleren"
 
-msgid "Input _Methods"
-msgstr "Invoer_wijzen"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - zoeken en vervangen..."
-
-msgid "VIM - Search..."
-msgstr "VIM - zoeken..."
-
-msgid "Find what:"
-msgstr "Zoek naar:"
-
-msgid "Replace with:"
-msgstr "Vervang door:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Alleen volledig woord"
-
-#. match case button
-msgid "Match case"
-msgstr "Hoofdlettergevoelig"
-
-msgid "Direction"
-msgstr "Richting"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Opwaarts"
-
-msgid "Down"
-msgstr "Neerwaarts"
-
-msgid "Find Next"
-msgstr "Volgende zoeken"
-
-msgid "Replace"
-msgstr "Vervangen"
-
-msgid "Replace All"
-msgstr "Alles vervangen"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: \"die\"-verzoek van sessiebeheerder ontvangen\n"
-
-msgid "Close"
-msgstr "Sluiten"
-
-msgid "New tab"
-msgstr "Nieuw tabblad"
-
-msgid "Open Tab..."
-msgstr "Tabblad openen..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: hoofdvenster onverwacht gesloten\n"
-
-msgid "Font Selection"
-msgstr "Lettertypeselectie"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Annuleren"
-
-msgid "Directories"
-msgstr "Mappen"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Hulp"
-
-msgid "Files"
-msgstr "Bestanden"
-
-msgid "&OK"
-msgstr "&Ok"
-
-msgid "Selection"
-msgstr "Selectie"
-
-msgid "Find &Next"
-msgstr "&Volgende zoeken"
-
-msgid "&Replace"
-msgstr "Ve&rvangen"
-
-msgid "Replace &All"
-msgstr "&Alles vervangen"
-
-msgid "&Undo"
-msgstr "&Herstellen"
-
-#, c-format
-msgid "E610: Can't load Zap font '%s'"
-msgstr "E610: Zap-lettertype '%s' kan niet worden geladen"
-
-#, c-format
-msgid "E611: Can't use font %s"
-msgstr "E611: lettertype %s kan niet worden gebruikt"
-
-msgid ""
-"\n"
-"Sending message to terminate child process.\n"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
 msgstr ""
-"\n"
-"Bericht versturen om kindproces te beëindigen.\n"
 
-#, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: kan venstertitel \"%s\" niet vinden"
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: argument niet ondersteund: \"-%s\"; gebruik de OLE-versie."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: kan geen venster binnen MDI-applicatie openen"
-
-msgid "Close tab"
-msgstr "Tabblad sluiten"
-
-msgid "Open tab..."
-msgstr "Tabblad openen..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Tekenreeks zoeken (gebruik '\\\\' om een '\\' te vinden)"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Zoeken & vervangen (gebruik '\\\\' om een '\\' te vinden')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Niet gebruikt"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Map\t*.niets\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "E458: kan geen kleur toewijzen, sommige kleuren kunnen onjuist zijn"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: lettertypen voor de volgende tekenverzamelingen ontbreken in verzameling %s:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: naam lettertypeverzameling: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Lettertype '%s' heeft geen vaste breedte"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: naam lettertypeverzameling: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Breedte font%<PRId64> is niet het dubbele van font0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Font0-breedte: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
 msgstr ""
-"Font1-breedte: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Onjuiste specificatie van lettertype"
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr ""
 
-msgid "&Dismiss"
-msgstr "&Afwijzen"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr ""
 
-msgid "no specific match"
-msgstr "geen specifieke overeenkomst"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr ""
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Lettertypekiezer"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr ""
 
-msgid "Name:"
-msgstr "Naam:"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr ""
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Grootte in punten tonen"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr ""
 
-msgid "Encoding:"
-msgstr "Codering:"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: interne fout"
 
-msgid "Font:"
-msgstr "Lettertype:"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "onderbroken"
 
-msgid "Style:"
-msgstr "Stijl:"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: ongeldig adres"
 
-msgid "Size:"
-msgstr "Grootte:"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: ongeldig argument"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: 'Hangul automata'-fout"
+#: ../globals.h:1015
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: ongeldig argument: %s"
 
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: ongeldige expressie: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: ongeldig bereik"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: ongeldige opdracht"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr ""
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: ongeldige scroll-grootte"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
+msgstr ""
+
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
+
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr ""
+
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: markering heeft een ongeldig regelnummer"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Markering is niet ingesteld"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: kan geen veranderingen maken, 'modifiable' is uitgeschakeld"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: scripts "
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr ""
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr ""
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr ""
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr ""
+
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: naam van deze oplichtgroep is onbekend: %s"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr ""
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr ""
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr ""
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: geen overeenkomst"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: geen overeenkomst: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: geen bestandsnaam"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: geen eerdere reguliere expressie substitutie"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: geen eerdere opdracht"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: geen eerdere reguliere expressie"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: een bereik is niet toegestaan"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: onvoldoende ruimte"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: aanmaken bestand %s is mislukt"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: bepalen naam tijdelijk bestand is mislukt"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: openen bestand %s is mislukt"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: lezen bestand %s is mislukt"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr ""
+"E37: niets opgeslagen sinds laatste wijziging (voeg ! toe om te forceren)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Niets opgeslagen sinds laatste wijziging]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: leeg argument (null)"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: getal verwacht"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: openen foutenbestand %s is mislukt"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: te weinig geheugen!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "patroon niet gevonden"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: patroon niet gevonden: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: argument moet positief zijn"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: kan niet terug naar vorig Dictionary"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: geen fouten"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr ""
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: beschadigde zoekstring"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: regexp-programma is misvormd"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr ""
+"E45: 'alleen-lezen'-optie is ingeschakeld (voeg ! toe om te overschrijven)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: kan alleen-lezenvariabele \"%s\" niet veranderen"
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: kan variabele niet instellen in de zandbak: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: fout tijdens lezen foutenbestand"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: niet toegestaan in zandbak"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: hier niet toegestaan"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: instelling schermmodus niet ondersteund"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: ongeldige scroll-grootte"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell'-optie is leeg"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr ""
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr ""
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr ""
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: opdracht te ingewikkeld"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: te lange naam"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: teveel ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: teveel bestandsnamen"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: nakomende tekens"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: onbekende markering"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: vervangen jokertekens is mislukt"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' kan niet kleiner zijn dan 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' kan niet kleiner zijn dan 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: opslaan is mislukt"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Aantal is nul"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> wordt buiten de scriptcontext gebruikt"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: interne fout: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: patroon gebruikt meer geheugen dan 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: leeg buffer"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: zoekpatroon of scheidingsteken is ongeldig"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: bestand is in een ander buffer geladen"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Optie '%s' is niet ingesteld"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "ongeldige registernaam"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "zoeken bereikte TOP, verder vanaf BODEM"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "zoeken bereikte BODEM, verder vanaf TOP"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: dubbelepunt ontbreekt"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: ongeldige component"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: cijfer verwacht"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Pagina %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Geen tekst om af te drukken"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Afdrukken van pagina %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr "Kopie %d van %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Afgedrukt: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Afdrukken afgebroken"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: wegschrijven Postscript-uitvoerbestand is mislukt"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: openen bestand \"%s\" is mislukt"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: kan 'Postscript resource'-bestand \"%s\" niet lezen"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: bestand \"%s\" is geen 'Postscript resource'-bestand"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: bestand \"%s\" is geen ondersteund 'Postscript resource'-bestand"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: 'resource'-bestand \"%s\" heeft verkeerde versie"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Multi-byte-codering en de tekenverzameling zijn onverenigbaar."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset mag bij multi-byte-codering niet leeg zijn."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: geen standaard lettertype opgegeven voor multi-byte-afdrukken."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: openen van PostScript-uitoverbestand is mislukt"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Bestand \"%s\" kan niet worden geopend"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: 'PostScript resource'-bestand \"prolog.ps\" is niet gevonden"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: 'PostScript resource'-bestand \"cidfont.ps\" is niet gevonden"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: 'PostScript resource'-bestand \"%s.ps\" is niet gevonden"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: omzetten naar afdrukcodering \"%s\" is mislukt"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Naar printer versturen..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Afdrukken van PostScript-bestand is mislukt"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Afdrukopdracht verzonden"
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Nieuwe databank toevoegen"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Naar een patroon zoeken"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Dit bericht tonen"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Een verbinding verbreken"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Alle verbindingen opnieuw initialiseren"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Verbindingen tonen"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Gebruik: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Deze cscope-opdracht ondersteunt niet het splitsen van het venster.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Gebruik: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tag is gevonden"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: bevraag((%s) fout: %d"
 
-msgid "E563: stat error"
-msgstr "E563: bevragingsfout"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s is geen map of een geldige cscope-databank"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "cscope-databank %s toegevoegd"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: lezen van cscope-verbinding %<PRId64> is mislukt"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: soort cscope-zoekopdracht is onbekend"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: aanmaken cscopei-pijp is mislukt"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: nieuw cscope-proces beginnen is mislukt"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "uitvoering cs_create_connection is mislukt"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "uitvoering cs_create_connection is mislukt"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen voor to_fp is mislukt"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen voor fr_fp is mislukt"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: voortbrengen cscope-proces is mislukt"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: geen cscope-verbindingen"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cscopequickfix-vlag %c voor %c is ongeldig"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: cscope-zoekopdracht %s van %s leverde geen resultaten"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope-opdrachten:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Gebruik: %s)"
 
+#: ../if_cscope.c:1155
+#, fuzzy
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2434,7 +3242,7 @@ msgid ""
 "       g: Find this definition\n"
 "       i: Find files #including this file\n"
 "       s: Find this C symbol\n"
-"       t: Find assignments to\n"
+"       t: Find this text string\n"
 msgstr ""
 "\n"
 "       c: zoek functies die deze functie aanroepen\n"
@@ -2446,32 +3254,31 @@ msgstr ""
 "       s: zoek dit C-symbool\n"
 "       t: zoek toekenningen aan\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: openen is mislukt van cscope-databank: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: opvragen cscope-databankinformatie is mislukt"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: dubbele cscope-databank is niet toegevoegd"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope-verbinding %s is niet gevonden"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope-verbinding %s is verbroken"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: fatale fout in cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope-tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2479,378 +3286,87 @@ msgstr ""
 "\n"
 "   #   regel"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "bestandsnaam / context / regel\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope-fout: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Alle cscope-databanken opnieuw ingesteld"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "geen cscope-verbindingen\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    databanknaam                        padvoorvoegsel\n"
 
-msgid "E815: Sorry, this command is disabled, the MzScheme libraries could not be loaded."
-msgstr "E815: helaas, deze opdracht is uitgeschakeld. De MzScheme-bibliotheken kunnen niet geladen worden."
-
-msgid "invalid expression"
-msgstr "ongeldige uitdrukking"
-
-msgid "expressions disabled at compile time"
-msgstr "tijdens compileren zijn de expressies uitgeschakeld"
-
-msgid "hidden option"
-msgstr "verborgen optie"
-
-msgid "unknown option"
-msgstr "onbekende optie"
-
-msgid "window index is out of range"
-msgstr "vensterindex valt buiten het bereik"
-
-msgid "couldn't open buffer"
-msgstr "buffer openen is mislukt"
-
-msgid "cannot save undo information"
-msgstr "herstelinformatie kan niet worden opgeslagen"
-
-msgid "cannot delete line"
-msgstr "regel kan niet worden verwijderd"
-
-msgid "cannot replace line"
-msgstr "regel kan niet worden vervangen"
-
-msgid "cannot insert line"
-msgstr "regel kan niet worden ingevoegd"
-
-msgid "string cannot contain newlines"
-msgstr "tekenreeks kan geen regeleinden bevatten"
-
-msgid "Vim error: ~a"
-msgstr "Vim-fout: ~a"
-
-msgid "Vim error"
-msgstr "Vim-fout"
-
-msgid "buffer is invalid"
-msgstr "buffer is ongeldig"
-
-msgid "window is invalid"
-msgstr "venster is ongeldig"
-
-msgid "linenr out of range"
-msgstr "regelnummer buiten het bereik"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "niet toegestaan in de Vim-zandbak"
-
-msgid "E263: Sorry, this command is disabled, the Python library could not be loaded."
-msgstr "E263: helaas, deze opdracht is uitgeschakeld. De Python-bibliotheek kan niet worden geladen."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python kan niet recursief worden aangeroepen"
-
-msgid "can't delete OutputObject attributes"
-msgstr "attributen van OutputObject kunnen niet worden verwijderd"
-
-msgid "softspace must be an integer"
-msgstr "zachte spatie moet een geheel getal zijn"
-
-msgid "invalid attribute"
-msgstr "ongeldig attribuut"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() vereist een lijst met tekenreeksen"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: initialiseren I/O-objecten is mislukt"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "poging om naar een verwijderd buffer te verwijzen"
-
-msgid "line number out of range"
-msgstr "regelnummer valt buiten het bereik"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<buffer-object (verwijderd) bij %p>"
-
-msgid "invalid mark name"
-msgstr "naam markering ongeldig"
-
-msgid "no such buffer"
-msgstr "onbekende buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "poging om naar een verwijderd venster te verwijzen"
-
-msgid "readonly attribute"
-msgstr "alleen-lezen attribuut"
-
-msgid "cursor position outside buffer"
-msgstr "cursorpositie valt buiten buffer"
-
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<venster-object (verwijderd) bij %p>"
-
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<venster-object (onbekend) bij %p>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<venster %d>"
-
-msgid "no such window"
-msgstr "onbekend venster"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ moet een instantie van String zijn"
-
-msgid "E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: helaas, deze opdracht is uitgeschakeld. De Ruby-bibliotheek kan niet worden geladen."
-
-msgid "E267: unexpected return"
-msgstr "E267: onverwacht resultaat"
-
-msgid "E268: unexpected next"
-msgstr "E268: onverwachte volgende"
-
-msgid "E269: unexpected break"
-msgstr "E269: onverwachte onderbreking"
-
-msgid "E270: unexpected redo"
-msgstr "E270: onverwachte herstelopdracht"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: hernieuwde poging buiten de reddingsclausule"
-
-msgid "E272: unhandled exception"
-msgstr "E272: niet-afgehandelde uitzondering"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: onbekende longjmp-status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Implementatie/definitie wisselen"
-
-msgid "Show base class of"
-msgstr "Toon basisklasse van"
-
-msgid "Show overridden member function"
-msgstr "Toon overschreven member-functie"
-
-msgid "Retrieve from file"
-msgstr "Uit bestand halen"
-
-msgid "Retrieve from project"
-msgstr "Uit project halen"
-
-msgid "Retrieve from all projects"
-msgstr "Uit alle projecten halen"
-
-msgid "Retrieve"
-msgstr "Ophalen"
-
-msgid "Show source of"
-msgstr "Toon broncode van"
-
-msgid "Find symbol"
-msgstr "Zoek symbool"
-
-msgid "Browse class"
-msgstr "Bekijk klasse"
-
-msgid "Show class in hierarchy"
-msgstr "Toon klasse in hierarchie"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Toon klasse in beperkte hierarchie"
-
-msgid "Xref refers to"
-msgstr "Xref verwijst naar"
-
-msgid "Xref referred by"
-msgstr "Xref wordt naar verwezen door"
-
-msgid "Xref has a"
-msgstr "Xref heeft een"
-
-msgid "Xref used by"
-msgstr "Xref gebruikt door"
-
-msgid "Show docu of"
-msgstr "Toon documentatie van"
-
-msgid "Generate docu for"
-msgstr "Genereer documentatie voor"
-
-msgid "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in $PATH).\n"
-msgstr "Verbinden met SNiFF+ is mislukt. Controleer omgevingsvariabelen (sniffemacs moet in $PATH staan).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: leesfout. Verbroken"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ is momenteel "
-
-msgid "not "
-msgstr "niet "
-
-msgid "connected"
-msgstr "verbonden"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: onbekend SNiFF+-verzoek: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: verbinden met SNiFF+ is mislukt"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ niet verbonden"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: geen SNiFF+-buffer"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: schrijven is mislukt. Verbroken"
-
-msgid "invalid buffer number"
-msgstr "buffernummer is ongeldig"
-
-msgid "not implemented yet"
-msgstr "nog niet geïmplementeerd"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "kan regel(s) niet instellen"
-
-msgid "mark not set"
-msgstr "markering niet ingesteld"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "rij %d kolom %d"
-
-msgid "cannot insert/append line"
-msgstr "invoegen/toevoegen regel is mislukt"
-
-msgid "unknown flag: "
-msgstr "unbekende instelling: "
-
-msgid "unknown vimOption"
-msgstr "onbekende vim-optie"
-
-msgid "keyboard interrupt"
-msgstr "toetsenbord-interrupt"
-
-msgid "vim error"
-msgstr "vim-fout"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "aanmaken buffer-/vensteropdracht is mislukt: object wordt verwijderd"
-
-msgid "cannot register callback command: buffer/window is already being deleted"
-msgstr " kan 'callback'-opdracht niet registreren: buffer/venster is reeds verwijderd"
-
-#. This should never happen.  Famous last word?
-msgid "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"
-msgstr "E280: TCL FATALE FOUT: reflist misschien corrupt!? Meld dit a.u.b. aan vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "'callback'-opdracht kan niet worden geregistreerd: buffer-/vensterreferentie ontbreekt"
-
-msgid "E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: Helaas, deze opdracht is uitgeschakeld: het laden van de Tcl-bibliotheek is mislukt."
-
-msgid "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: Tcl-fout: afsluitcode is geen geheel getal!? Meld dit a.u.b. aan vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: afsluitcode %d"
-
-msgid "cannot get line"
-msgstr "kan regel niet verkrijgen"
-
-msgid "Unable to register a command server name"
-msgstr "Het registreren van een opdrachtservernaam is mislukt"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: versturen van opdracht naar het doelprogramma is mislukt"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: ongeldige server-id gebruikt: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: registereigenschap van VIM-instantie is misvormd.  Verwijderd!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Onbekend optieargument"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Teveel bewerkargumenten"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argument ontbreekt na"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Rommel na optieargument"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Teveel \"+opdracht\", \"-c opdracht\" of \"--cmd opdracht\"-argumenten"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Ongeldig argument voor"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d bestanden om te bewerken\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "Netbeans wordt door deze GUI niet ondersteund\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Deze Vim is niet met de diff-functionaliteit gecompileerd"
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' kan niet worden gebruikt: was tijdens compilatie niet ingeschakeld\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Poging scriptbestand wederom te openen: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Openen om te lezen is mislukt: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Openen voor script-uitvoer is mislukt: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Fout: gvim starten vanuit Netbeans is mislukt\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Waarschuwing: Uitvoer gaan niet naar een terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Waarschuwing: Invoer komt niet van een terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc-opdracjtregel"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kan niet lezen vanuit \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2858,18 +3374,23 @@ msgstr ""
 "\n"
 "Meer informatie via: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[bestand ..]       bewerk opgegeven bestand(en)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               lees tekst vanuit stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          bewerk bestand waar tag is gedefinieerd"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [foutbestand]  bewerk bestand dat eerste fout bevat"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2879,9 +3400,11 @@ msgstr ""
 "\n"
 "Gebruik:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumenten] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2889,13 +3412,7 @@ msgstr ""
 "\n"
 "   of:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Daar waar hoofdletters genegeerd worden kan met / vlag in hoofdletters gezet worden"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2905,162 +3422,441 @@ msgstr ""
 "\n"
 "Argumenten:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tHierna alleen bestandsnamen"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tJokertekens niet vervangen"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tDeze gvim voor OLE registreren"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tgvim afmelden voor OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tMet GUI opstarten (zoals \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  of  --nofork\tVoorgrond: niet afsplitsen tijdens opstarten GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi-modus (zoals \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx-modus (zoals \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tStille (bulk)modus (alleen bij \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff-modus (zoals \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tEenvoudige modus (zoals \"evim\", zonder modus)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tAlleen-lezen modus (zoals \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tBeperkte modus (zoals \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tAanpassingen (bestanden opslaan) niet toegestaan"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tTekstuele aanpassingen niet toegestaan"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinaire modus"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp-modus"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tUitwisselbaar met Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNiet volledig met Vi uitwisselbaar: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
-msgstr "-V[N][fname]\t\tWees uitbundig [niveau N] [schrijf berichten naar fname]"
+msgstr ""
+"-V[N][fname]\t\tWees uitbundig [niveau N] [schrijf berichten naar fname]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tFoutopspoormodus"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tGeen wisselbestand, alleen geheugen gebruiken"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tWisselbestanden tonen en stoppen"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (bestandsnaam)\tHerstel ontspoorde sessie"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tGelijk aan -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tGebruik geen newcli om venster te openen"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tGebruik <device> voor in- en uitvoer"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tIn Arabische modus starten"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tIn Hebrewsche modus starten"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tIn Perzische modus starten"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tTerminalsoort op <terminal> instellen"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tGebruik <vimrc> in plaats van enige .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tGebruik <gvimrc> in plaats van enige .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tGeen plugin-scripts laden"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tN tabpagina's openen (standaard: 1 per bestand)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tN vensters openen (standaard: 1 per bestand)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tGelijk aan -o maar vertikaal gesplitst"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tAan einde van bestand beginnen"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tOp regel <lnum> beginnen"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
-msgstr "--cmd <opdracht>\tOpdracht <opdracht> uitvoeren voor enige vimrc-bestand"
+msgstr ""
+"--cmd <opdracht>\tOpdracht <opdracht> uitvoeren voor enige vimrc-bestand"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <opdracht>\t\tOpdracht <opdracht> uitvoeren na eerste bestand"
 
+#: ../main.c:2235
+#, fuzzy
+msgid "-S <session>\t\tSource file <session> after loading the first file"
+msgstr "-c <opdracht>\t\tOpdracht <opdracht> uitvoeren na eerste bestand"
+
+#: ../main.c:2236
+msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
+msgstr ""
+
+#: ../main.c:2237
+msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
+msgstr ""
+
+#: ../main.c:2238
+msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
+msgstr ""
+
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
+
+#: ../main.c:2242
+#, fuzzy
+msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
+msgstr "-u <vimrc>\t\tGebruik <vimrc> in plaats van enige .vimrc"
+
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  of  --help\tDit bericht tonen en stoppen"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tVersieinformatie tonen en stoppen"
 
+#: ../mark.c:676
+#, fuzzy
+msgid "No marks set"
+msgstr " markering"
+
+#: ../mark.c:678
+#, fuzzy, c-format
+msgid "E283: No marks matching \"%s\""
+msgstr "E480: geen overeenkomst: %s"
+
+#. Highlight title
+#: ../mark.c:687
+msgid ""
+"\n"
+"mark line  col file/text"
+msgstr ""
+
+#. Highlight title
+#: ../mark.c:789
+msgid ""
+"\n"
+" jump line  col file/text"
+msgstr ""
+
+#. Highlight title
+#: ../mark.c:831
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
+
+#: ../mark.c:1238
+msgid ""
+"\n"
+"# File marks:\n"
+msgstr ""
+
+#. Write the jumplist with -'
+#: ../mark.c:1271
+#, fuzzy
+msgid ""
+"\n"
+"# Jumplist (newest first):\n"
+msgstr ""
+"\n"
+"# %s Historie (jongste naar oudste):\n"
+
+#: ../mark.c:1352
+#, fuzzy
+msgid ""
+"\n"
+"# History of marks within files (newest to oldest):\n"
+msgstr ""
+"\n"
+"# %s Historie (jongste naar oudste):\n"
+
+#: ../mark.c:1431
+#, fuzzy
+msgid "Missing '>'"
+msgstr "E111: ontbrekende ']'"
+
+#: ../memfile.c:426
+msgid "E293: block was not locked"
+msgstr ""
+
+#: ../memfile.c:799
+msgid "E294: Seek error in swap file read"
+msgstr ""
+
+#: ../memfile.c:803
+msgid "E295: Read error in swap file"
+msgstr ""
+
+#: ../memfile.c:849
+msgid "E296: Seek error in swap file write"
+msgstr ""
+
+#: ../memfile.c:865
+#, fuzzy
+msgid "E297: Write error in swap file"
+msgstr "E677: opslaan van temp-bestand is mislukt"
+
+#: ../memfile.c:1036
+#, fuzzy
+msgid "E300: Swap file already exists (symlink attack?)"
+msgstr "Wisselbestand bestaat reeds."
+
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Ophalen blok nummer 0 mislukt?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Ophalen blok nummer 1 mislukt?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Ophalen blok nummer 2 mislukt?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Helaas, wisselbestand is verdwenen!!!"
 
-msgid "Enter number of swap file to use (0 to quit): "
-msgstr "Typ het nummer van het wisselbestand om te gebruiken (0 om te stoppen): "
+#: ../memline.c:477
+#, fuzzy
+msgid "E302: Could not rename swap file"
+msgstr "E566: aanmaken cscopei-pijp is mislukt"
 
+#: ../memline.c:554
+#, c-format
+msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
+msgstr ""
+
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
+msgstr "E298: Ophalen blok nummer 0 mislukt?"
+
+#. no swap files found
+#: ../memline.c:830
+#, fuzzy, c-format
+msgid "E305: No swap file found for %s"
+msgstr "E326: teveel wisselbestanden aangetroffen"
+
+#: ../memline.c:839
+msgid "Enter number of swap file to use (0 to quit): "
+msgstr ""
+"Typ het nummer van het wisselbestand om te gebruiken (0 om te stoppen): "
+
+#: ../memline.c:879
+#, fuzzy, c-format
+msgid "E306: Cannot open %s"
+msgstr "E233: openen scherm is mislukt"
+
+#: ../memline.c:897
+msgid "Unable to read block 0 from "
+msgstr ""
+
+#: ../memline.c:900
+msgid ""
+"\n"
+"Maybe no changes were made or Vim did not update the swap file."
+msgstr ""
+
+#: ../memline.c:909
+#, fuzzy
+msgid " cannot be used with this version of Vim.\n"
+msgstr ""
+"\n"
+"         [onbruikbaar met deze versie van Vim]"
+
+#: ../memline.c:911
+#, fuzzy
+msgid "Use Vim version 3.0.\n"
+msgstr "         [van Vim-versie 3.0]"
+
+#: ../memline.c:916
+#, fuzzy, c-format
+msgid "E307: %s does not look like a Vim swap file"
+msgstr "         [lijkt geen Vvim-wisselbestand te zijn]"
+
+#: ../memline.c:922
+#, fuzzy
+msgid " cannot be used on this computer.\n"
+msgstr ""
+"\n"
+"         [onbruikbaar op deze computer]"
+
+#: ../memline.c:924
+msgid "The file was created on "
+msgstr ""
+
+#: ../memline.c:928
+msgid ""
+",\n"
+"or the file has been damaged."
+msgstr ""
+
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Toepassen van wisselbestand \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Oorspronkelijke bestand \"%s\""
 
+#: ../memline.c:995
+msgid "E308: Warning: Original file may have been changed"
+msgstr ""
+
+#: ../memline.c:1061
+#, fuzzy, c-format
+msgid "E309: Unable to read block 1 from %s"
+msgstr "E241: verzenden naar %s onmogelijk"
+
+#: ../memline.c:1065
+msgid "???MANY LINES MISSING"
+msgstr ""
+
+#: ../memline.c:1076
+msgid "???LINE COUNT WRONG"
+msgstr ""
+
+#: ../memline.c:1082
+msgid "???EMPTY BLOCK"
+msgstr ""
+
+#: ../memline.c:1103
+msgid "???LINES MISSING"
+msgstr ""
+
+#: ../memline.c:1128
+#, c-format
+msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
+msgstr ""
+
+#: ../memline.c:1133
+msgid "???BLOCK MISSING"
+msgstr ""
+
+#: ../memline.c:1147
+msgid "??? from here until ???END lines may be messed up"
+msgstr ""
+
+#: ../memline.c:1164
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr ""
+
+#: ../memline.c:1181
+msgid "???END"
+msgstr ""
+
+#: ../memline.c:1238
+#, fuzzy
+msgid "E311: Recovery Interrupted"
+msgstr " (onderbroken)"
+
+#: ../memline.c:1243
+msgid ""
+"E312: Errors detected while recovering; look for lines starting with ???"
+msgstr ""
+
+#: ../memline.c:1245
+#, fuzzy
+msgid "See \":help E312\" for more information."
+msgstr "Lees \":help W12\" voor meer informatie."
+
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Herstel is afgerond. Controleer of het resultaat juist is."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3068,12 +3864,17 @@ msgstr ""
 "\n"
 "(Een advies is dit bestand onder een andere naam op te slaan\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "en met 'diff' te controleren op wijzigingen)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
-msgstr "Herstel is afgerond. Inhoud van het buffer komt overeen met de bestandsinhoud."
+msgstr ""
+"Herstel is afgerond. Inhoud van het buffer komt overeen met de "
+"bestandsinhoud."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3084,39 +3885,51 @@ msgstr ""
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Gevonden wisselbestanden:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   In huidige map:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Gebruikt opgegeven naam:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   In map "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- geen --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          eigenaar: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   datum: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             datum: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [van Vim-versie 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [lijkt geen Vvim-wisselbestand te zijn]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "      bestandsnaam: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3124,12 +3937,15 @@ msgstr ""
 "\n"
 "           bewerkt: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nee"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3137,9 +3953,11 @@ msgstr ""
 "\n"
 "    gebruikersnaam: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "  host-naam:"
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3147,6 +3965,7 @@ msgstr ""
 "\n"
 "         host-naam: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3154,16 +3973,11 @@ msgstr ""
 "\n"
 "         proces-id: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr "    (nog actief)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [onbruikbaar met deze versie van Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3171,28 +3985,97 @@ msgstr ""
 "\n"
 "         [onbruikbaar op deze computer]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [lezen is onmogelijk]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [openen is onmogelijk]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: kan niet worden behouden, want er is geen wisselbestand"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Bestand behouden"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: behouden is mislukt"
 
+#: ../memline.c:1819
+#, fuzzy, c-format
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E157: ongeldige id margeteken: %<PRId64>"
+
+#: ../memline.c:1851
+#, fuzzy, c-format
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E684: lijstindex buiten bereik: %<PRId64>"
+
+#: ../memline.c:2236
+msgid "E317: pointer block id wrong 3"
+msgstr ""
+
+#: ../memline.c:2311
+msgid "stack_idx should be 0"
+msgstr ""
+
+#: ../memline.c:2369
+msgid "E318: Updated too many blocks?"
+msgstr ""
+
+#: ../memline.c:2511
+msgid "E317: pointer block id wrong 4"
+msgstr ""
+
+#: ../memline.c:2536
+msgid "deleted block 1?"
+msgstr ""
+
+#: ../memline.c:2707
+#, fuzzy, c-format
+msgid "E320: Cannot find line %<PRId64>"
+msgstr " in regel %<PRId64>;"
+
+#: ../memline.c:2916
+msgid "E317: pointer block id wrong"
+msgstr ""
+
+#: ../memline.c:2930
+msgid "pe_line_count is zero"
+msgstr ""
+
+#: ../memline.c:2955
+#, fuzzy, c-format
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E684: lijstindex buiten bereik: %<PRId64>"
+
+#: ../memline.c:2959
+#, fuzzy, c-format
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E684: lijstindex buiten bereik: %<PRId64>"
+
+#: ../memline.c:2999
+msgid "Stack size increases"
+msgstr ""
+
+#: ../memline.c:3038
+msgid "E317: pointer block id wrong 2"
+msgstr ""
+
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Symbolische koppelingslus voor \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: OPGELET"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3200,38 +4083,44 @@ msgstr ""
 "\n"
 "Er is een wisselbestand aangetroffen met de naam \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "bij het openen van bestand \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "    NIEUWER dan het wisselbestand!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Mogelijk wordt dit bestand met een ander programma bewerkt.\n"
 "    Als dit het geval is, pas dan op niet met twee verschillende\n"
 "    versies van hetzelfde bestand te eindigen bij het bewerken.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Stop of ga aandachtig verder.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Een sessie waarin dit bestand werd bewerkt is onverhoeds gestopt.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Als dit het geval is, gebruikt dan \":recover\" of \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3239,9 +4128,11 @@ msgstr ""
 "\"\n"
 "    om de aanpassingen te herstellen (zie \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Als dit al gedaan is, verwijder dan het wisselbestand \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3249,18 +4140,23 @@ msgstr ""
 "\"\n"
 "    om dit bericht te voorkomen.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Wisselbestand \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" bestaat al!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - OPGELET"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Wisselbestand bestaat reeds."
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3274,6 +4170,7 @@ msgstr ""
 "&Stoppen\n"
 "&Afbreken"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3289,330 +4186,324 @@ msgstr ""
 "&Stoppen\n"
 "&Afbreken"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: teveel wisselbestanden aangetroffen"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr ""
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: deel van menu-itempad is geen submenu"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: menu bestaat alleen in andere modus"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: geen menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: menunaam is leeg"
 
+#: ../menu.c:340
+#, fuzzy
+msgid "E330: Menu path must not lead to a sub-menu"
+msgstr "E327: deel van menu-itempad is geen submenu"
+
+#: ../menu.c:365
+msgid "E331: Must not add menu items directly to menu bar"
+msgstr ""
+
+#: ../menu.c:370
+msgid "E332: Separator cannot be part of a menu path"
+msgstr ""
+
+#. Now we have found the matching menu, and we list the mappings
+#. Highlight title
+#: ../menu.c:762
+#, fuzzy
+msgid ""
+"\n"
+"--- Menus ---"
+msgstr ""
+"\n"
+"--- Tekens ---"
+
+#: ../menu.c:1313
+msgid "E333: Menu path must lead to a menu item"
+msgstr ""
+
+#: ../menu.c:1330
+#, fuzzy, c-format
+msgid "E334: Menu not found: %s"
+msgstr "E486: patroon niet gevonden: %s"
+
+#: ../menu.c:1396
 #, c-format
-#~ msgid "E335: Menu not defined for %s mode"
-#~ msgstr ""
+msgid "E335: Menu not defined for %s mode"
+msgstr ""
 
-#~ msgid "E336: Menu path must lead to a sub-menu"
-#~ msgstr ""
+#: ../menu.c:1426
+msgid "E336: Menu path must lead to a sub-menu"
+msgstr ""
 
-#~ msgid "E337: Menu not found - check menu names"
-#~ msgstr ""
+#: ../menu.c:1447
+msgid "E337: Menu not found - check menu names"
+msgstr ""
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Fout opgetreden tijdens verwerken van %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "regel %4ld:"
 
+#: ../message.c:617
 #, c-format
-#~ msgid "E354: Invalid register name: '%s'"
-#~ msgstr ""
+msgid "E354: Invalid register name: '%s'"
+msgstr ""
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Vertaald door: Erwin Poeze <erwin.poeze@gmail.com>"
 
-#~ msgid "Interrupt: "
-#~ msgstr ""
+#: ../message.c:986
+msgid "Interrupt: "
+msgstr ""
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Toets ENTER of typ een opdracht om verder te gaan"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s regel %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- meer --"
 
-#~ msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
-#~ msgstr ""
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Vraag"
 
-#~ msgid ""
-#~ "&Yes\n"
-#~ "&No"
-#~ msgstr ""
+#: ../message.c:3023
+msgid ""
+"&Yes\n"
+"&No"
+msgstr ""
 
-#~ msgid ""
-#~ "&Yes\n"
-#~ "&No\n"
-#~ "Save &All\n"
-#~ "&Discard All\n"
-#~ "&Cancel"
-#~ msgstr ""
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ja\n"
+"&Nee\n"
+"&Annuleren"
 
-#~ msgid "Select Directory dialog"
-#~ msgstr ""
+#: ../message.c:3045
+msgid ""
+"&Yes\n"
+"&No\n"
+"Save &All\n"
+"&Discard All\n"
+"&Cancel"
+msgstr ""
 
-#~ msgid "Save File dialog"
-#~ msgstr ""
+#: ../message.c:3058
+msgid "E766: Insufficient arguments for printf()"
+msgstr ""
 
-#~ msgid "Open File dialog"
-#~ msgstr ""
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
 
-#. TODO: non-GUI file selector here
-#~ msgid "E338: Sorry, no file browser in console mode"
-#~ msgstr ""
+#: ../message.c:3873
+msgid "E767: Too many arguments to printf()"
+msgstr ""
 
-#~ msgid "E766: Insufficient arguments for printf()"
-#~ msgstr ""
+#: ../misc1.c:2256
+msgid "W10: Warning: Changing a readonly file"
+msgstr ""
 
-#~ msgid "E807: Expected Float argument for printf()"
-#~ msgstr ""
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
 
-#~ msgid "E767: Too many arguments to printf()"
-#~ msgstr ""
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
 
-#~ msgid "W10: Warning: Changing a readonly file"
-#~ msgstr ""
-
-#~ msgid "Type number and <Enter> or click with mouse (empty cancels): "
-#~ msgstr ""
-
-#~ msgid "Type number and <Enter> (empty cancels): "
-#~ msgstr ""
-
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 regel meer"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 regel minder"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> regels meer"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> regels minder"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (onderbroken)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "biep!"
 
-#~ msgid "Vim: preserving files...\n"
-#~ msgstr ""
-
-#. close all memfiles, without deleting
-#~ msgid "Vim: Finished.\n"
-#~ msgstr ""
-
+#: ../misc2.c:738
 #, c-format
-#~ msgid "ERROR: "
-#~ msgstr ""
+msgid "Calling shell to execute: \"%s\""
+msgstr ""
 
-#, c-format
-#~ msgid ""
-#~ "\n"
-#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-#~ msgstr ""
+#: ../normal.c:183
+msgid "E349: No identifier under cursor"
+msgstr ""
 
-#, c-format
-#~ msgid ""
-#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-#~ "\n"
-#~ msgstr ""
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr ""
 
-#~ msgid "E340: Line is becoming too long"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "Calling shell to execute: \"%s\""
-#~ msgstr ""
-
-#~ msgid "E545: Missing colon"
-#~ msgstr ""
-
-#~ msgid "E546: Illegal mode"
-#~ msgstr ""
-
-#~ msgid "E547: Illegal mouseshape"
-#~ msgstr ""
-
-#~ msgid "E548: digit expected"
-#~ msgstr ""
-
-#~ msgid "E549: Illegal percentage"
-#~ msgstr ""
-
-#~ msgid "Enter encryption key: "
-#~ msgstr ""
-
-#~ msgid "Enter same key again: "
-#~ msgstr ""
-
-#~ msgid "Keys don't match!"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E343: Invalid path: '**[number]' must be at the end of the path or be followed by '%s'."
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E344: Can't find directory \"%s\" in cdpath"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E345: Can't find file \"%s\" in path"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E346: No more directory \"%s\" found in cdpath"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E347: No more file \"%s\" found in path"
-#~ msgstr ""
-
-#~ msgid "Cannot connect to Netbeans #2"
-#~ msgstr ""
-
-#~ msgid "Cannot connect to Netbeans"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-#~ msgstr ""
-
-#~ msgid "read from Netbeans socket"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-#~ msgstr ""
-
-#~ msgid "E511: netbeans already connected"
-#~ msgstr ""
-
-#~ msgid "E505: "
-#~ msgstr ""
-
-#~ msgid "E349: No identifier under cursor"
-#~ msgstr ""
-
-#~ msgid "E774: 'operatorfunc' is empty"
-#~ msgstr ""
-
-#~ msgid "E775: Eval feature not available"
-#~ msgstr ""
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "waarschuwing: terminal kan niet oplichten"
 
-#~ msgid "E348: No string under cursor"
-#~ msgstr ""
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr ""
 
-#~ msgid "E352: Cannot erase folds with current 'foldmethod'"
-#~ msgstr ""
+#: ../normal.c:3937
+msgid "E352: Cannot erase folds with current 'foldmethod'"
+msgstr ""
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: wijzigingslijst is leeg"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: begin van wijzigingslijst"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: einde van wijzigingslijst"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Typ :quit<Enter> om Vim te verlaten"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 regel %sed 1 maal"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 regel %sed %d maal"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> regels %sed 1 maal"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> regels %sed %d maal"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> in te springen regels... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 regel ingesprongen "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> regels ingesprongen "
 
-#~ msgid "E748: No previously used register"
-#~ msgstr ""
+#: ../ops.c:938
+msgid "E748: No previously used register"
+msgstr ""
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "kopiÃ«ren niet mogelijk; toch verwijderd"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 regel gewijzigd"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> regels gewijzigd"
 
-#, c-format
-#~ msgid "freeing %<PRId64> lines"
-#~ msgstr ""
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "blok van 1 regel gekopieerd"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 regel gekopieerd"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "blok van %<PRId64> regels gekopieerd"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> regels gekopieerd"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: niets in register %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3620,10 +4511,11 @@ msgstr ""
 "\n"
 "--- Registers ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "ongeldige registernaam"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3631,145 +4523,181 @@ msgstr ""
 "\n"
 "# Registers:\n"
 
+#: ../ops.c:4575
 #, c-format
-#~ msgid "E574: Unknown register type %d"
-#~ msgstr ""
+msgid "E574: Unknown register type %d"
+msgstr ""
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> koln; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "geselecteerd %s%<PRId64> van %<PRId64> regels; %<PRId64> van %<PRId64> woorden; %<PRId64> van %<PRId64> bytes"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"geselecteerd %s%<PRId64> van %<PRId64> regels; %<PRId64> van %<PRId64> "
+"woorden; %<PRId64> van %<PRId64> bytes"
 
+#: ../ops.c:5105
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
-msgstr "geselecteerd %s%<PRId64> van %<PRId64> regels; %<PRId64> van %<PRId64> woorden; %<PRId64> van %<PRId64> rekens; %<PRId64> van %<PRId64> bytes"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"geselecteerd %s%<PRId64> van %<PRId64> regels; %<PRId64> van %<PRId64> "
+"woorden; %<PRId64> van %<PRId64> rekens; %<PRId64> van %<PRId64> bytes"
 
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "kol %s van %s; regel %<PRId64> van %<PRId64>; woord %<PRId64> van %<PRId64>; byte %<PRId64> van %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"kol %s van %s; regel %<PRId64> van %<PRId64>; woord %<PRId64> van %<PRId64>; "
+"byte %<PRId64> van %<PRId64>"
 
+#: ../ops.c:5133
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "kol %s van %s; regel %<PRId64> van %<PRId64>; woord %<PRId64> van %<PRId64>; teken %<PRId64> van %<PRId64>; byte %<PRId64> van %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"kol %s van %s; regel %<PRId64> van %<PRId64>; woord %<PRId64> van %<PRId64>; "
+"teken %<PRId64> van %<PRId64>; byte %<PRId64> van %<PRId64>"
 
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> voor BOD)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=pagina %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dank voor het gebruik van Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: onbekende optie"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: optie niet ondersteund"
 
-#~ msgid "E520: Not allowed in a modeline"
-#~ msgstr ""
+#: ../option.c:2740
+msgid "E520: Not allowed in a modeline"
+msgstr ""
 
-#~ msgid "E521: Number required after ="
-#~ msgstr ""
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
 
-#~ msgid "E522: Not found in termcap"
-#~ msgstr ""
+#: ../option.c:2924
+msgid "E521: Number required after ="
+msgstr ""
 
+#: ../option.c:3226 ../option.c:3864
+msgid "E522: Not found in termcap"
+msgstr ""
+
+#: ../option.c:3335
 #, c-format
-#~ msgid "E539: Illegal character <%s>"
-#~ msgstr ""
+msgid "E539: Illegal character <%s>"
+msgstr ""
 
-#~ msgid "E529: Cannot set 'term' to empty string"
-#~ msgstr ""
+#: ../option.c:3862
+msgid "E529: Cannot set 'term' to empty string"
+msgstr ""
 
-#~ msgid "E530: Cannot change term in GUI"
-#~ msgstr ""
+#: ../option.c:3885
+msgid "E589: 'backupext' and 'patchmode' are equal"
+msgstr ""
 
-#~ msgid "E531: Use \":gui\" to start the GUI"
-#~ msgstr ""
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
-#~ msgid "E589: 'backupext' and 'patchmode' are equal"
-#~ msgstr ""
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
 
-#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-#~ msgstr ""
+#: ../option.c:4163
+msgid "E524: Missing colon"
+msgstr ""
 
-#~ msgid "E524: Missing colon"
-#~ msgstr ""
+#: ../option.c:4165
+msgid "E525: Zero length string"
+msgstr ""
 
-#~ msgid "E525: Zero length string"
-#~ msgstr ""
-
+#: ../option.c:4220
 #, c-format
-#~ msgid "E526: Missing number after <%s>"
-#~ msgstr ""
+msgid "E526: Missing number after <%s>"
+msgstr ""
 
-#~ msgid "E527: Missing comma"
-#~ msgstr ""
+#: ../option.c:4232
+msgid "E527: Missing comma"
+msgstr ""
 
-#~ msgid "E528: Must specify a ' value"
-#~ msgstr ""
+#: ../option.c:4239
+msgid "E528: Must specify a ' value"
+msgstr ""
 
-#~ msgid "E595: contains unprintable or wide character"
-#~ msgstr ""
+#: ../option.c:4271
+msgid "E595: contains unprintable or wide character"
+msgstr ""
 
-#~ msgid "E596: Invalid font(s)"
-#~ msgstr ""
-
-#~ msgid "E597: can't select fontset"
-#~ msgstr ""
-
-#~ msgid "E598: Invalid fontset"
-#~ msgstr ""
-
-#~ msgid "E533: can't select wide font"
-#~ msgstr ""
-
-#~ msgid "E534: Invalid wide font"
-#~ msgstr ""
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: ongeldig teken na <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: komma is vereist"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' moet leeg zijn of het volgende bevatten: %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: geen muisondersteuning"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: ongepaarde expressie-volgorde"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: teveel items"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: ongepaarde groepen"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: een voorvertoningsvenster bestaat al"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabisch vereist UTF-8, typ ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: vereist minstens %d regels"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: vereist minstens %d kolommen"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: onbekende optie: %s"
@@ -3777,10 +4705,12 @@ msgstr "E355: onbekende optie: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: 'Number' vereist: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3788,6 +4718,7 @@ msgstr ""
 "\n"
 "--- Terminal-codes ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3795,6 +4726,7 @@ msgstr ""
 "\n"
 "--- Globale optiewaarden ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3802,6 +4734,7 @@ msgstr ""
 "\n"
 "--- Lokale optiewaarden ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3809,501 +4742,492 @@ msgstr ""
 "\n"
 "--- Opties ---"
 
-#~ msgid "E356: get_varp ERROR"
-#~ msgstr ""
+#: ../option.c:6816
+msgid "E356: get_varp ERROR"
+msgstr ""
 
+#: ../option.c:7696
 #, c-format
-#~ msgid "E357: 'langmap': Matching character missing for %s"
-#~ msgstr ""
+msgid "E357: 'langmap': Matching character missing for %s"
+msgstr ""
 
+#: ../option.c:7715
 #, c-format
-#~ msgid "E358: 'langmap': Extra characters after semicolon: %s"
-#~ msgstr ""
+msgid "E358: 'langmap': Extra characters after semicolon: %s"
+msgstr ""
 
-msgid "cannot open "
-msgstr "gefaald tijden openen van "
+#: ../os/shell.c:194
+msgid ""
+"\n"
+"Cannot execute shell "
+msgstr ""
 
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: kan venster niet openen!\n"
+#: ../os/shell.c:439
+msgid ""
+"\n"
+"shell returned "
+msgstr ""
 
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Vereist Amigados versie 2.04 of nieuwer\n"
+#: ../os_unix.c:465 ../os_unix.c:471
+msgid ""
+"\n"
+"Could not get security context for "
+msgstr ""
 
+#: ../os_unix.c:479
+msgid ""
+"\n"
+"Could not set security context for "
+msgstr ""
+
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Vereist %s versie %<PRId64>\n"
+msgid "dlerror = \"%s\""
+msgstr ""
 
-#~ msgid "Cannot open NIL:\n"
-#~ msgstr ""
-
-msgid "Cannot create "
-msgstr "Gefaald tijdens aanmaken van "
-
+#: ../path.c:1449
 #, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim stoppen met %d\n"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: bestand \"%s\" niet in pad gevonden"
 
-#~ msgid "cannot change console mode ?!\n"
-#~ msgstr ""
-
-#~ msgid "mch_get_shellsize: not a console??\n"
-#~ msgstr ""
-
-#. if Vim opened a window: Executing a shell may cause crashes
-#~ msgid "E360: Cannot execute shell with -f option"
-#~ msgstr ""
-
-#~ msgid "Cannot execute "
-#~ msgstr ""
-
-#~ msgid "shell "
-#~ msgstr ""
-
-#~ msgid " returned\n"
-#~ msgstr ""
-
-#~ msgid "ANCHOR_BUF_SIZE too small."
-#~ msgstr ""
-
-#~ msgid "I/O ERROR"
-#~ msgstr ""
-
-#~ msgid "Message"
-#~ msgstr ""
-
-#~ msgid "'columns' is not 80, cannot execute external commands"
-#~ msgstr ""
-
-#~ msgid "E237: Printer selection failed"
-#~ msgstr ""
-
+#: ../quickfix.c:359
 #, c-format
-#~ msgid "to %s on %s"
-#~ msgstr ""
+msgid "E372: Too many %%%c in format string"
+msgstr ""
 
+#: ../quickfix.c:371
 #, c-format
-#~ msgid "E613: Unknown printer font: %s"
-#~ msgstr ""
+msgid "E373: Unexpected %%%c in format string"
+msgstr ""
 
+#: ../quickfix.c:420
+msgid "E374: Missing ] in format string"
+msgstr ""
+
+#: ../quickfix.c:431
 #, c-format
-#~ msgid "E238: Print error: %s"
-#~ msgstr ""
+msgid "E375: Unsupported %%%c in format string"
+msgstr ""
 
+#: ../quickfix.c:448
 #, c-format
-#~ msgid "Printing '%s'"
-#~ msgstr ""
+msgid "E376: Invalid %%%c in format string prefix"
+msgstr ""
 
+#: ../quickfix.c:454
 #, c-format
-#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-#~ msgstr ""
+msgid "E377: Invalid %%%c in format string"
+msgstr ""
 
+#. nothing found
+#: ../quickfix.c:477
+msgid "E378: 'errorformat' contains no pattern"
+msgstr ""
+
+#: ../quickfix.c:695
+msgid "E379: Missing or empty directory name"
+msgstr ""
+
+#: ../quickfix.c:1305
+msgid "E553: No more items"
+msgstr ""
+
+#: ../quickfix.c:1674
 #, c-format
-#~ msgid "E245: Illegal char '%c' in font name \"%s\""
-#~ msgstr ""
+msgid "(%d of %d)%s%s: "
+msgstr ""
 
-#~ msgid "E366: Invalid 'osfiletype' option - using Text"
-#~ msgstr ""
+#: ../quickfix.c:1676
+msgid " (line deleted)"
+msgstr ""
 
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: dubbel signaal, stoppen\n"
+#: ../quickfix.c:1863
+msgid "E380: At bottom of quickfix stack"
+msgstr ""
 
+#: ../quickfix.c:1869
+msgid "E381: At top of quickfix stack"
+msgstr ""
+
+#: ../quickfix.c:1880
 #, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: fataal signaal gevangen %s\n"
+msgid "error list %d of %d; %d errors"
+msgstr ""
 
+#: ../quickfix.c:2427
+msgid "E382: Cannot write, 'buftype' option is set"
+msgstr ""
+
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
 #, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: fataal signaal gevangen\n"
+msgid "Cannot open file \"%s\""
+msgstr ""
 
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Openen van X-display vereiste %<PRId64> ms"
-
-#~ msgid ""
-#~ "\n"
-#~ "Vim: Got X error\n"
-#~ msgstr ""
-
-#~ msgid "Testing the X display failed"
-#~ msgstr ""
-
-#~ msgid "Opening the X display timed out"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Could not get security context for "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Could not set security context for "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot execute shell "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot execute shell sh\n"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "shell returned "
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot create pipes\n"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot fork\n"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "\n"
-#~ "Command terminated\n"
-#~ msgstr ""
-
-#~ msgid "XSMP lost ICE connection"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "dlerror = \"%s\""
-#~ msgstr ""
-
-#~ msgid "Opening the X display failed"
-#~ msgstr ""
-
-#~ msgid "XSMP handling save-yourself request"
-#~ msgstr ""
-
-#~ msgid "XSMP opening connection"
-#~ msgstr ""
-
-#~ msgid "XSMP ICE connection watch failed"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "XSMP SmcOpenConnection failed: %s"
-#~ msgstr ""
-
-msgid "At line"
-msgstr "Bij regel"
-
-#~ msgid "Could not load vim32.dll!"
-#~ msgstr ""
-
-msgid "VIM Error"
-msgstr "Vim-fout"
-
-#~ msgid "Could not fix up function pointers to the DLL!"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "shell returned %d"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "Vim: Caught %s event\n"
-#~ msgstr ""
-
-msgid "close"
-msgstr "sluiten"
-
-msgid "logoff"
-msgstr "uitloggen"
-
-msgid "shutdown"
-msgstr "afsluiten"
-
-msgid "E371: Command not found"
-msgstr "E371: opdracht niet gevonden"
-
-#~ msgid ""
-#~ "VIMRUN.EXE not found in your $PATH.\n"
-#~ "External commands will not pause after completion.\n"
-#~ "See  :help win32-vimrun  for more information."
-#~ msgstr ""
-
-msgid "Vim Warning"
-msgstr "Vim-waarschuwing"
-
-#, c-format
-#~ msgid "E372: Too many %%%c in format string"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E373: Unexpected %%%c in format string"
-#~ msgstr ""
-
-#~ msgid "E374: Missing ] in format string"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E375: Unsupported %%%c in format string"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E376: Invalid %%%c in format string prefix"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E377: Invalid %%%c in format string"
-#~ msgstr ""
-
-#~ msgid "E378: 'errorformat' contains no pattern"
-#~ msgstr ""
-
-#~ msgid "E379: Missing or empty directory name"
-#~ msgstr ""
-
-#~ msgid "E553: No more items"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "(%d of %d)%s%s: "
-#~ msgstr ""
-
-#~ msgid " (line deleted)"
-#~ msgstr ""
-
-#~ msgid "E380: At bottom of quickfix stack"
-#~ msgstr ""
-
-#~ msgid "E381: At top of quickfix stack"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "error list %d of %d; %d errors"
-#~ msgstr ""
-
-#~ msgid "E382: Cannot write, 'buftype' option is set"
-#~ msgstr ""
-
-#~ msgid "E683: File name missing or invalid pattern"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "Cannot open file \"%s\""
-#~ msgstr ""
-
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: buffer is niet geladen"
 
-#~ msgid "E777: String or List expected"
-#~ msgstr ""
+#: ../quickfix.c:3487
+msgid "E777: String or List expected"
+msgstr ""
 
+#: ../regexp.c:359
 #, c-format
-#~ msgid "E369: invalid item in %s%%[]"
-#~ msgstr ""
+msgid "E369: invalid item in %s%%[]"
+msgstr ""
 
-#~ msgid "E339: Pattern too long"
-#~ msgstr ""
-
-#~ msgid "E50: Too many \\z("
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E51: Too many %s("
-#~ msgstr ""
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: \\z( is niet gepaard"
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: %s%%( is niet gepaard"
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: %s( is niet gepaard"
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: %s) is ongepaard"
-
-#, c-format
-#~ msgid "E59: invalid character after %s@"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E60: Too many complex %s{...}s"
-#~ msgstr ""
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: geneste %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: geneste %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: onjuist gebruikt van \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c volgt op niets"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: ongeldige terugverwijzing"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( hier niet toegestaan"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 en andere hier niet toegestaan"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: ongeldig teken na \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: ontbrekende ] na %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: leeg %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: onjuist teken na %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: onjuist teken na %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: ontbrekende ] na %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: %s%%( is niet gepaard"
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: %s( is niet gepaard"
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: %s) is ongepaard"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( hier niet toegestaan"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 en andere hier niet toegestaan"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: ontbrekende ] na %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: leeg %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr ""
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr ""
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr ""
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: \\z( is niet gepaard"
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr ""
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr ""
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: geneste %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: geneste %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: onjuist gebruikt van \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c volgt op niets"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: ongeldige terugverwijzing"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: ongeldig teken na \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: onjuist teken na %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: onjuist teken na %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaxfout in %s{...}"
 
-#~ msgid "External submatches:\n"
-#~ msgstr ""
+#: ../regexp.c:3805
+msgid "External submatches:\n"
+msgstr ""
 
-#~ msgid " VREPLACE"
-#~ msgstr ""
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr ""
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: kan tijdelijk bestand voor wegschrijven niet vinden"
+
+#: ../screen.c:7435
+msgid " VREPLACE"
+msgstr ""
+
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " VERVANGEN"
 
-#~ msgid " REVERSE"
-#~ msgstr ""
+#: ../screen.c:7440
+msgid " REVERSE"
+msgstr ""
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INVOEGEN"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (invoegen)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (vervangen)"
 
-#~ msgid " (vreplace)"
-#~ msgstr ""
+#: ../screen.c:7447
+msgid " (vreplace)"
+msgstr ""
 
-#~ msgid " Hebrew"
-#~ msgstr ""
+#: ../screen.c:7449
+msgid " Hebrew"
+msgstr ""
 
-#~ msgid " Arabic"
-#~ msgstr ""
+#: ../screen.c:7454
+msgid " Arabic"
+msgstr ""
 
-#~ msgid " (lang)"
-#~ msgstr ""
+#: ../screen.c:7456
+msgid " (lang)"
+msgstr ""
 
-#~ msgid " (paste)"
-#~ msgstr ""
+#: ../screen.c:7459
+msgid " (paste)"
+msgstr ""
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUEEL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUELE REGEL"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUEEL BLOK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " SELECTEREN"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " REGELSELECTIE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " BLOKSELECTIE"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "opnemen"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: ongeldige zoekstring: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: TOP bereikt zonder overeenkomst voor: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: BODEM bereikt zonder overeenkomst voor: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: verwachte '?' of '/' na ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (bevat eerder getoonde overeenkomst)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- bevatte bestanden "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "niet gevonden "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "in pad ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Reeds getoond)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NIET GEVONDEN"
 
+#: ../search.c:4211
 #, c-format
-#~ msgid "Scanning included file: %s"
-#~ msgstr ""
+msgid "Scanning included file: %s"
+msgstr ""
 
+#: ../search.c:4216
 #, c-format
-#~ msgid "Searching included file %s"
-#~ msgstr ""
+msgid "Searching included file %s"
+msgstr ""
 
-#~ msgid "E387: Match is on current line"
-#~ msgstr ""
+#: ../search.c:4405
+msgid "E387: Match is on current line"
+msgstr ""
 
-#~ msgid "All included files were found"
-#~ msgstr ""
+#: ../search.c:4517
+msgid "All included files were found"
+msgstr ""
 
-#~ msgid "No included files"
-#~ msgstr ""
+#: ../search.c:4519
+msgid "No included files"
+msgstr ""
 
-#~ msgid "E388: Couldn't find definition"
-#~ msgstr ""
+#: ../search.c:4527
+msgid "E388: Couldn't find definition"
+msgstr ""
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: kan zoekpatroon niet vinden"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Vervangen "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4314,900 +5238,1011 @@ msgstr ""
 "# Laatste %szoekpatroon:\n"
 "~"
 
-#~ msgid "E759: Format error in spell file"
-#~ msgstr ""
+#: ../spell.c:951
+msgid "E759: Format error in spell file"
+msgstr ""
 
-#~ msgid "E758: Truncated spell file"
-#~ msgstr ""
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
 
+#: ../spell.c:953
 #, c-format
-#~ msgid "Trailing text in %s line %d: %s"
-#~ msgstr ""
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:954
 #, c-format
-#~ msgid "Affix name too long in %s line %d: %s"
-#~ msgstr ""
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
 
-#~ msgid "E761: Format error in affix file FOL, LOW or UPP"
-#~ msgstr ""
+#: ../spell.c:955
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr ""
 
-#~ msgid "E762: Character in FOL, LOW or UPP is out of range"
-#~ msgstr ""
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
 
-#~ msgid "Compressing word tree..."
-#~ msgstr ""
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
 
-#~ msgid "E756: Spell checking is not enabled"
-#~ msgstr ""
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
 
+#: ../spell.c:2249
 #, c-format
-#~ msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-#~ msgstr ""
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
 
+#: ../spell.c:2473
 #, c-format
-#~ msgid "Reading spell file \"%s\""
-#~ msgstr ""
+msgid "Reading spell file \"%s\""
+msgstr ""
 
-#~ msgid "E757: This does not look like a spell file"
-#~ msgstr ""
+#: ../spell.c:2496
+msgid "E757: This does not look like a spell file"
+msgstr ""
 
-#~ msgid "E771: Old spell file, needs to be updated"
-#~ msgstr ""
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
 
-#~ msgid "E772: Spell file is for newer version of Vim"
-#~ msgstr ""
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
 
-#~ msgid "E770: Unsupported section in spell file"
-#~ msgstr ""
+#: ../spell.c:2602
+msgid "E770: Unsupported section in spell file"
+msgstr ""
 
+#: ../spell.c:3762
 #, c-format
-#~ msgid "Warning: region %s not supported"
-#~ msgstr ""
+msgid "Warning: region %s not supported"
+msgstr ""
 
+#: ../spell.c:4550
 #, c-format
-#~ msgid "Reading affix file %s ..."
-#~ msgstr ""
+msgid "Reading affix file %s ..."
+msgstr ""
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
-#~ msgid "Conversion failure for word in %s line %d: %s"
-#~ msgstr ""
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
-#~ msgid "Conversion in %s not supported: from %s to %s"
-#~ msgstr ""
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
 
+#: ../spell.c:4642
 #, c-format
-#~ msgid "Conversion in %s not supported"
-#~ msgstr ""
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4655
 #, c-format
-#~ msgid "Invalid value for FLAG in %s line %d: %s"
-#~ msgstr ""
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4723
 #, c-format
-#~ msgid "FLAG after using flags in %s line %d: %s"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-#~ msgid "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line %d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4747
 #, c-format
-#~ msgid "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line %d"
-#~ msgstr ""
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4771
 #, c-format
-#~ msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
-#~ msgstr ""
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4777
 #, c-format
-#~ msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
-#~ msgstr ""
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4783
 #, c-format
-#~ msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
-#~ msgstr ""
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4795
 #, c-format
-#~ msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
-#~ msgstr ""
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4847
 #, c-format
-#~ msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
-#~ msgstr ""
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4850
 #, c-format
-#~ msgid "Different combining flag in continued affix block in %s line %d: %s"
-#~ msgstr ""
+msgid "Duplicate affix in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4871
 #, c-format
-#~ msgid "Duplicate affix in %s line %d: %s"
-#~ msgstr ""
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
 
+#: ../spell.c:4893
 #, c-format
-#~ msgid "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s line %d: %s"
-#~ msgstr ""
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:4968
 #, c-format
-#~ msgid "Expected Y or N in %s line %d: %s"
-#~ msgstr ""
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:5091
 #, c-format
-#~ msgid "Broken condition in %s line %d: %s"
-#~ msgstr ""
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
 
+#: ../spell.c:5120
 #, c-format
-#~ msgid "Expected REP(SAL) count in %s line %d"
-#~ msgstr ""
+msgid "Expected MAP count in %s line %d"
+msgstr ""
 
+#: ../spell.c:5132
 #, c-format
-#~ msgid "Expected MAP count in %s line %d"
-#~ msgstr ""
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
 
+#: ../spell.c:5176
 #, c-format
-#~ msgid "Duplicate character in MAP in %s line %d"
-#~ msgstr ""
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:5197
 #, c-format
-#~ msgid "Unrecognized or duplicate item in %s line %d: %s"
-#~ msgstr ""
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
 
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+msgid "Too many postponed prefixes"
+msgstr ""
+
+#: ../spell.c:5238
+msgid "Too many compound flags"
+msgstr ""
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
 #, c-format
-#~ msgid "Missing FOL/LOW/UPP line in %s"
-#~ msgstr ""
+msgid "Missing SOFO%s line in %s"
+msgstr ""
 
-#~ msgid "COMPOUNDSYLMAX used without SYLLABLE"
-#~ msgstr ""
-
-#~ msgid "Too many postponed prefixes"
-#~ msgstr ""
-
-#~ msgid "Too many compound flags"
-#~ msgstr ""
-
-#~ msgid "Too many postponed prefixes and/or compound flags"
-#~ msgstr ""
-
+#: ../spell.c:5253
 #, c-format
-#~ msgid "Missing SOFO%s line in %s"
-#~ msgstr ""
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
 
+#: ../spell.c:5331
 #, c-format
-#~ msgid "Both SAL and SOFO lines in %s"
-#~ msgstr ""
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:5334
 #, c-format
-#~ msgid "Flag is not a number in %s line %d: %s"
-#~ msgstr ""
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
-#~ msgid "Illegal flag in %s line %d: %s"
-#~ msgstr ""
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
 
+#: ../spell.c:5602
 #, c-format
-#~ msgid "%s value differs from what is used in another .aff file"
-#~ msgstr ""
+msgid "Reading dictionary file %s ..."
+msgstr ""
 
+#: ../spell.c:5611
 #, c-format
-#~ msgid "Reading dictionary file %s ..."
-#~ msgstr ""
+msgid "E760: No word count in %s"
+msgstr ""
 
+#: ../spell.c:5669
 #, c-format
-#~ msgid "E760: No word count in %s"
-#~ msgstr ""
+msgid "line %6d, word %6d - %s"
+msgstr ""
 
+#: ../spell.c:5691
 #, c-format
-#~ msgid "line %6d, word %6d - %s"
-#~ msgstr ""
+msgid "Duplicate word in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:5694
 #, c-format
-#~ msgid "Duplicate word in %s line %d: %s"
-#~ msgstr ""
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:5746
 #, c-format
-#~ msgid "First duplicate word in %s line %d: %s"
-#~ msgstr ""
+msgid "%d duplicate word(s) in %s"
+msgstr ""
 
+#: ../spell.c:5748
 #, c-format
-#~ msgid "%d duplicate word(s) in %s"
-#~ msgstr ""
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
 
+#: ../spell.c:6115
 #, c-format
-#~ msgid "Ignored %d word(s) with non-ASCII characters in %s"
-#~ msgstr ""
+msgid "Reading word file %s ..."
+msgstr ""
 
+#: ../spell.c:6155
 #, c-format
-#~ msgid "Reading word file %s ..."
-#~ msgstr ""
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6159
 #, c-format
-#~ msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6180
 #, c-format
-#~ msgid "/encoding= line after word ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6185
 #, c-format
-#~ msgid "Duplicate /regions= line ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6198
 #, c-format
-#~ msgid "Too many regions in %s line %d: %s"
-#~ msgstr ""
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6224
 #, c-format
-#~ msgid "/ line ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "Invalid region nr in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6230
 #, c-format
-#~ msgid "Invalid region nr in %s line %d: %s"
-#~ msgstr ""
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6257
 #, c-format
-#~ msgid "Unrecognized flags in %s line %d: %s"
-#~ msgstr ""
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
 
+#: ../spell.c:6656
 #, c-format
-#~ msgid "Ignored %d words with non-ASCII characters"
-#~ msgstr ""
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
 
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
 #, c-format
-#~ msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
-#~ msgstr ""
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
 
-#~ msgid "Reading back spell file..."
-#~ msgstr ""
-
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
-#~ msgid "Performing soundfolding..."
-#~ msgstr ""
-
+#: ../spell.c:7476
 #, c-format
-#~ msgid "Number of words after soundfolding: %<PRId64>"
-#~ msgstr ""
+msgid "Total number of words: %d"
+msgstr ""
 
+#: ../spell.c:7655
 #, c-format
-#~ msgid "Total number of words: %d"
-#~ msgstr ""
+msgid "Writing suggestion file %s ..."
+msgstr ""
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
-#~ msgid "Writing suggestion file %s ..."
-#~ msgstr ""
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
 
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr ""
+
+#: ../spell.c:7846
 #, c-format
-#~ msgid "Estimated runtime memory use: %d bytes"
-#~ msgstr ""
+msgid "E755: Invalid region in %s"
+msgstr ""
 
-#~ msgid "E751: Output file name must not have region name"
-#~ msgstr ""
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
 
-#~ msgid "E754: Only up to 8 regions supported"
-#~ msgstr ""
-
+#: ../spell.c:7920
 #, c-format
-#~ msgid "E755: Invalid region in %s"
-#~ msgstr ""
+msgid "Writing spell file %s ..."
+msgstr ""
 
-#~ msgid "Warning: both compounding and NOBREAK specified"
-#~ msgstr ""
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
 
+#: ../spell.c:8034
 #, c-format
-#~ msgid "Writing spell file %s ..."
-#~ msgstr ""
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
 
-#~ msgid "Done!"
-#~ msgstr ""
-
+#: ../spell.c:8074
 #, c-format
-#~ msgid "E765: 'spellfile' does not have %<PRId64> entries"
-#~ msgstr ""
+msgid "Word '%.*s' removed from %s"
+msgstr ""
 
+#: ../spell.c:8117
 #, c-format
-#~ msgid "Word removed from %s"
-#~ msgstr ""
+msgid "Word '%.*s' added to %s"
+msgstr ""
 
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
 #, c-format
-#~ msgid "Word added to %s"
-#~ msgstr ""
-
-#~ msgid "E763: Word characters differ between spell files"
-#~ msgstr ""
-
-#~ msgid "Sorry, no suggestions"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "Sorry, only %<PRId64> suggestions"
-#~ msgstr ""
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr ""
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
-#~ msgid "Change \"%.*s\" to:"
-#~ msgstr ""
+msgid "Change \"%.*s\" to:"
+msgstr ""
 
+#: ../spell.c:8737
 #, c-format
-#~ msgid " < \"%.*s\""
-#~ msgstr ""
+msgid " < \"%.*s\""
+msgstr ""
 
-#~ msgid "E752: No previous spell replacement"
-#~ msgstr ""
+#: ../spell.c:8882
+msgid "E752: No previous spell replacement"
+msgstr ""
 
+#: ../spell.c:8925
 #, c-format
-#~ msgid "E753: Not found: %s"
-#~ msgstr ""
+msgid "E753: Not found: %s"
+msgstr ""
 
+#: ../spell.c:9276
 #, c-format
-#~ msgid "E778: This does not look like a .sug file: %s"
-#~ msgstr ""
+msgid "E778: This does not look like a .sug file: %s"
+msgstr ""
 
+#: ../spell.c:9282
 #, c-format
-#~ msgid "E779: Old .sug file, needs to be updated: %s"
-#~ msgstr ""
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
 
+#: ../spell.c:9286
 #, c-format
-#~ msgid "E780: .sug file is for newer version of Vim: %s"
-#~ msgstr ""
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
 
+#: ../spell.c:9295
 #, c-format
-#~ msgid "E781: .sug file doesn't match .spl file: %s"
-#~ msgstr ""
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
 
+#: ../spell.c:9305
 #, c-format
-#~ msgid "E782: error while reading .sug file: %s"
-#~ msgstr ""
+msgid "E782: error while reading .sug file: %s"
+msgstr ""
 
 #. This should have been checked when generating the .spl
-#. * file.
-#~ msgid "E783: duplicate char in MAP entry"
-#~ msgstr ""
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr ""
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
-#~ msgid "E390: Illegal argument: %s"
-#~ msgstr ""
+msgid "E390: Illegal argument: %s"
+msgstr ""
 
+#: ../syntax.c:3299
 #, c-format
-#~ msgid "E391: No such syntax cluster: %s"
-#~ msgstr ""
+msgid "E391: No such syntax cluster: %s"
+msgstr ""
 
-#~ msgid "No Syntax items defined for this buffer"
-#~ msgstr ""
+#: ../syntax.c:3433
+msgid "syncing on C-style comments"
+msgstr ""
 
-#~ msgid "syncing on C-style comments"
-#~ msgstr ""
+#: ../syntax.c:3439
+msgid "no syncing"
+msgstr ""
 
-#~ msgid "no syncing"
-#~ msgstr ""
+#: ../syntax.c:3441
+msgid "syncing starts "
+msgstr ""
 
-#~ msgid "syncing starts "
-#~ msgstr ""
+#: ../syntax.c:3443 ../syntax.c:3506
+msgid " lines before top line"
+msgstr ""
 
-#~ msgid " lines before top line"
-#~ msgstr ""
+#: ../syntax.c:3448
+msgid ""
+"\n"
+"--- Syntax sync items ---"
+msgstr ""
 
-#~ msgid ""
-#~ "\n"
-#~ "--- Syntax sync items ---"
-#~ msgstr ""
+#: ../syntax.c:3452
+msgid ""
+"\n"
+"syncing on items"
+msgstr ""
 
-#~ msgid ""
-#~ "\n"
-#~ "syncing on items"
-#~ msgstr ""
+#: ../syntax.c:3457
+msgid ""
+"\n"
+"--- Syntax items ---"
+msgstr ""
 
-#~ msgid ""
-#~ "\n"
-#~ "--- Syntax items ---"
-#~ msgstr ""
-
+#: ../syntax.c:3475
 #, c-format
-#~ msgid "E392: No such syntax cluster: %s"
-#~ msgstr ""
+msgid "E392: No such syntax cluster: %s"
+msgstr ""
 
-#~ msgid "minimal "
-#~ msgstr ""
+#: ../syntax.c:3497
+msgid "minimal "
+msgstr ""
 
-#~ msgid "maximal "
-#~ msgstr ""
+#: ../syntax.c:3503
+msgid "maximal "
+msgstr ""
 
-#~ msgid "; match "
-#~ msgstr ""
+#: ../syntax.c:3513
+msgid "; match "
+msgstr ""
 
-#~ msgid " line breaks"
-#~ msgstr ""
+#: ../syntax.c:3515
+msgid " line breaks"
+msgstr ""
 
-#~ msgid "E395: contains argument not accepted here"
-#~ msgstr ""
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr ""
 
-#~ msgid "E396: containedin argument not accepted here"
-#~ msgstr ""
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: ongeldig argument"
 
-#~ msgid "E393: group[t]here not accepted here"
-#~ msgstr ""
+#: ../syntax.c:4107
+msgid "E393: group[t]here not accepted here"
+msgstr ""
 
+#: ../syntax.c:4126
 #, c-format
-#~ msgid "E394: Didn't find region item for %s"
-#~ msgstr ""
+msgid "E394: Didn't find region item for %s"
+msgstr ""
 
-#~ msgid "E397: Filename required"
-#~ msgstr ""
+#: ../syntax.c:4188
+msgid "E397: Filename required"
+msgstr ""
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: teveel bestandsnamen"
+
+#: ../syntax.c:4303
 #, c-format
-#~ msgid "E789: Missing ']': %s"
-#~ msgstr ""
+msgid "E789: Missing ']': %s"
+msgstr ""
 
+#: ../syntax.c:4531
 #, c-format
-#~ msgid "E398: Missing '=': %s"
-#~ msgstr ""
+msgid "E398: Missing '=': %s"
+msgstr ""
 
+#: ../syntax.c:4666
 #, c-format
-#~ msgid "E399: Not enough arguments: syntax region %s"
-#~ msgstr ""
+msgid "E399: Not enough arguments: syntax region %s"
+msgstr ""
 
-#~ msgid "E400: No cluster specified"
-#~ msgstr ""
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E541: teveel items"
 
+#: ../syntax.c:4954
+msgid "E400: No cluster specified"
+msgstr ""
+
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
-#~ msgid "E401: Pattern delimiter not found: %s"
-#~ msgstr ""
+msgid "E401: Pattern delimiter not found: %s"
+msgstr ""
 
+#: ../syntax.c:5049
 #, c-format
-#~ msgid "E402: Garbage after pattern: %s"
-#~ msgstr ""
+msgid "E402: Garbage after pattern: %s"
+msgstr ""
 
-#~ msgid "E403: syntax sync: line continuations pattern specified twice"
-#~ msgstr ""
+#: ../syntax.c:5120
+msgid "E403: syntax sync: line continuations pattern specified twice"
+msgstr ""
 
+#: ../syntax.c:5169
 #, c-format
-#~ msgid "E404: Illegal arguments: %s"
-#~ msgstr ""
+msgid "E404: Illegal arguments: %s"
+msgstr ""
 
+#: ../syntax.c:5217
 #, c-format
-#~ msgid "E405: Missing equal sign: %s"
-#~ msgstr ""
+msgid "E405: Missing equal sign: %s"
+msgstr ""
 
+#: ../syntax.c:5222
 #, c-format
-#~ msgid "E406: Empty argument: %s"
-#~ msgstr ""
+msgid "E406: Empty argument: %s"
+msgstr ""
 
+#: ../syntax.c:5240
 #, c-format
-#~ msgid "E407: %s not allowed here"
-#~ msgstr ""
+msgid "E407: %s not allowed here"
+msgstr ""
 
+#: ../syntax.c:5246
 #, c-format
-#~ msgid "E408: %s must be first in contains list"
-#~ msgstr ""
+msgid "E408: %s must be first in contains list"
+msgstr ""
 
+#: ../syntax.c:5304
 #, c-format
-#~ msgid "E409: Unknown group name: %s"
-#~ msgstr ""
+msgid "E409: Unknown group name: %s"
+msgstr ""
 
+#: ../syntax.c:5512
 #, c-format
-#~ msgid "E410: Invalid :syntax subcommand: %s"
-#~ msgstr ""
+msgid "E410: Invalid :syntax subcommand: %s"
+msgstr ""
 
-#~ msgid "E679: recursive loop loading syncolor.vim"
-#~ msgstr ""
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
 
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
 #, c-format
-#~ msgid "E411: highlight group not found: %s"
-#~ msgstr ""
+msgid "E411: highlight group not found: %s"
+msgstr ""
 
+#: ../syntax.c:6278
 #, c-format
-#~ msgid "E412: Not enough arguments: \":highlight link %s\""
-#~ msgstr ""
+msgid "E412: Not enough arguments: \":highlight link %s\""
+msgstr ""
 
+#: ../syntax.c:6284
 #, c-format
-#~ msgid "E413: Too many arguments: \":highlight link %s\""
-#~ msgstr ""
+msgid "E413: Too many arguments: \":highlight link %s\""
+msgstr ""
 
-#~ msgid "E414: group has settings, highlight link ignored"
-#~ msgstr ""
+#: ../syntax.c:6302
+msgid "E414: group has settings, highlight link ignored"
+msgstr ""
 
+#: ../syntax.c:6367
 #, c-format
-#~ msgid "E415: unexpected equal sign: %s"
-#~ msgstr ""
+msgid "E415: unexpected equal sign: %s"
+msgstr ""
 
+#: ../syntax.c:6395
 #, c-format
-#~ msgid "E416: missing equal sign: %s"
-#~ msgstr ""
+msgid "E416: missing equal sign: %s"
+msgstr ""
 
+#: ../syntax.c:6418
 #, c-format
-#~ msgid "E417: missing argument: %s"
-#~ msgstr ""
+msgid "E417: missing argument: %s"
+msgstr ""
 
+#: ../syntax.c:6446
 #, c-format
-#~ msgid "E418: Illegal value: %s"
-#~ msgstr ""
+msgid "E418: Illegal value: %s"
+msgstr ""
 
-#~ msgid "E419: FG color unknown"
-#~ msgstr ""
+#: ../syntax.c:6496
+msgid "E419: FG color unknown"
+msgstr ""
 
-#~ msgid "E420: BG color unknown"
-#~ msgstr ""
+#: ../syntax.c:6504
+msgid "E420: BG color unknown"
+msgstr ""
 
+#: ../syntax.c:6564
 #, c-format
-#~ msgid "E421: Color name or number not recognized: %s"
-#~ msgstr ""
+msgid "E421: Color name or number not recognized: %s"
+msgstr ""
 
+#: ../syntax.c:6714
 #, c-format
-#~ msgid "E422: terminal code too long: %s"
-#~ msgstr ""
+msgid "E422: terminal code too long: %s"
+msgstr ""
 
+#: ../syntax.c:6753
 #, c-format
-#~ msgid "E423: Illegal argument: %s"
-#~ msgstr ""
+msgid "E423: Illegal argument: %s"
+msgstr ""
 
-#~ msgid "E424: Too many different highlighting attributes in use"
-#~ msgstr ""
+#: ../syntax.c:6925
+msgid "E424: Too many different highlighting attributes in use"
+msgstr ""
 
-#~ msgid "E669: Unprintable character in group name"
-#~ msgstr ""
+#: ../syntax.c:7427
+msgid "E669: Unprintable character in group name"
+msgstr ""
 
-#~ msgid "W18: Invalid character in group name"
-#~ msgstr ""
+#: ../syntax.c:7434
+msgid "W18: Invalid character in group name"
+msgstr ""
 
-#~ msgid "E555: at bottom of tag stack"
-#~ msgstr ""
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
 
-#~ msgid "E556: at top of tag stack"
-#~ msgstr ""
+#: ../tag.c:104
+msgid "E555: at bottom of tag stack"
+msgstr ""
 
-#~ msgid "E425: Cannot go before first matching tag"
-#~ msgstr ""
+#: ../tag.c:105
+msgid "E556: at top of tag stack"
+msgstr ""
 
+#: ../tag.c:380
+msgid "E425: Cannot go before first matching tag"
+msgstr ""
+
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tag niet gevonden: %s"
 
-#~ msgid "  # pri kind tag"
-#~ msgstr ""
+#: ../tag.c:528
+msgid "  # pri kind tag"
+msgstr ""
 
-#~ msgid "file\n"
-#~ msgstr ""
+#: ../tag.c:531
+msgid "file\n"
+msgstr ""
 
-#~ msgid "E427: There is only one matching tag"
-#~ msgstr ""
+#: ../tag.c:829
+msgid "E427: There is only one matching tag"
+msgstr ""
 
-#~ msgid "E428: Cannot go beyond last matching tag"
-#~ msgstr ""
+#: ../tag.c:831
+msgid "E428: Cannot go beyond last matching tag"
+msgstr ""
 
+#: ../tag.c:850
 #, c-format
-#~ msgid "File \"%s\" does not exist"
-#~ msgstr ""
+msgid "File \"%s\" does not exist"
+msgstr ""
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
-#~ msgid "tag %d of %d%s"
-#~ msgstr ""
+msgid "tag %d of %d%s"
+msgstr ""
 
-#~ msgid " or more"
-#~ msgstr ""
+#: ../tag.c:862
+msgid " or more"
+msgstr ""
 
-#~ msgid "  Using tag with different case!"
-#~ msgstr ""
+#: ../tag.c:864
+msgid "  Using tag with different case!"
+msgstr ""
 
+#: ../tag.c:909
 #, c-format
-#~ msgid "E429: File \"%s\" does not exist"
-#~ msgstr ""
+msgid "E429: File \"%s\" does not exist"
+msgstr ""
 
 #. Highlight title
-#~ msgid ""
-#~ "\n"
-#~ "  # TO tag         FROM line  in file/text"
-#~ msgstr ""
+#: ../tag.c:960
+msgid ""
+"\n"
+"  # TO tag         FROM line  in file/text"
+msgstr ""
 
+#: ../tag.c:1303
 #, c-format
-#~ msgid "Searching tags file %s"
-#~ msgstr ""
+msgid "Searching tags file %s"
+msgstr ""
 
-#, c-format
-#~ msgid "E430: Tag file path truncated for %s\n"
-#~ msgstr ""
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
-#~ msgid "E431: Format error in tags file \"%s\""
-#~ msgstr ""
+msgid "E431: Format error in tags file \"%s\""
+msgstr ""
 
+#: ../tag.c:1917
 #, c-format
-#~ msgid "Before byte %<PRId64>"
-#~ msgstr ""
+msgid "Before byte %<PRId64>"
+msgstr ""
 
+#: ../tag.c:1929
 #, c-format
-#~ msgid "E432: Tags file not sorted: %s"
-#~ msgstr ""
+msgid "E432: Tags file not sorted: %s"
+msgstr ""
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: geen tags-bestand"
 
-#~ msgid "Ignoring long line in tags file"
-#~ msgstr ""
+#: ../tag.c:2536
+msgid "E434: Can't find tag pattern"
+msgstr ""
 
-#~ msgid "E434: Can't find tag pattern"
-#~ msgstr ""
+#: ../tag.c:2544
+msgid "E435: Couldn't find tag, just guessing!"
+msgstr ""
 
-#~ msgid "E435: Couldn't find tag, just guessing!"
-#~ msgstr ""
-
-#~ msgid "' not known. Available builtin terminals are:"
-#~ msgstr ""
-
-#~ msgid "defaulting to '"
-#~ msgstr ""
-
-#~ msgid "E557: Cannot open termcap file"
-#~ msgstr ""
-
-#~ msgid "E558: Terminal entry not found in terminfo"
-#~ msgstr ""
-
-#~ msgid "E559: Terminal entry not found in termcap"
-#~ msgstr ""
-
+#: ../tag.c:2797
 #, c-format
-#~ msgid "E436: No \"%s\" entry in termcap"
-#~ msgstr ""
+msgid "Duplicate field name: %s"
+msgstr ""
 
-#~ msgid "E437: terminal capability \"cm\" required"
-#~ msgstr ""
+#: ../term.c:1442
+msgid "' not known. Available builtin terminals are:"
+msgstr ""
+
+#: ../term.c:1463
+msgid "defaulting to '"
+msgstr ""
+
+#: ../term.c:1731
+msgid "E557: Cannot open termcap file"
+msgstr ""
+
+#: ../term.c:1735
+msgid "E558: Terminal entry not found in terminfo"
+msgstr ""
+
+#: ../term.c:1737
+msgid "E559: Terminal entry not found in termcap"
+msgstr ""
+
+#: ../term.c:1878
+#, c-format
+msgid "E436: No \"%s\" entry in termcap"
+msgstr ""
+
+#: ../term.c:2249
+msgid "E437: terminal capability \"cm\" required"
+msgstr ""
 
 #. Highlight title
-#~ msgid ""
-#~ "\n"
-#~ "--- Terminal keys ---"
-#~ msgstr ""
+#: ../term.c:4376
+msgid ""
+"\n"
+"--- Terminal keys ---"
+msgstr ""
 
-#~ msgid "new shell started\n"
-#~ msgstr ""
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: lezen van de invoer is mislukt. Stoppen...\n"
 
-#~ msgid "Used CUT_BUFFER0 instead of empty selection"
-#~ msgstr ""
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: buffer is onverwacht gewijzigd"
 
-#. must display the prompt
-#~ msgid "No undo possible; continue anyway"
-#~ msgstr ""
-
-#. magic at start of header
-#. magic after last header
-#. magic at start of entry
-#. magic after last entry
-#. 2-byte undofile version number
-#. idem, encrypted
+#: ../undo.c:627
 #, c-format
-#~ msgid "E828: Cannot open undo file for writing: %s"
-#~ msgstr ""
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr ""
 
+#: ../undo.c:717
 #, c-format
-#~ msgid "E825: Corrupted undo file (%s): %s"
-#~ msgstr ""
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
 
-#~ msgid "Cannot write undo file in any directory in 'undodir'"
-#~ msgstr ""
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
 
+#: ../undo.c:1074
 #, c-format
-#~ msgid "Will not overwrite with undo file, cannot read: %s"
-#~ msgstr ""
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
 
+#: ../undo.c:1092
 #, c-format
-#~ msgid "Will not overwrite, this is not an undo file: %s"
-#~ msgstr ""
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
 
-#~ msgid "Skipping undo file write, noting to undo"
-#~ msgstr ""
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
 
+#: ../undo.c:1121
 #, c-format
-#~ msgid "Writing undo file: %s"
-#~ msgstr ""
+msgid "Writing undo file: %s"
+msgstr ""
 
+#: ../undo.c:1213
 #, c-format
-#~ msgid "E829: write error in undo file: %s"
-#~ msgstr ""
+msgid "E829: write error in undo file: %s"
+msgstr ""
 
+#: ../undo.c:1280
 #, c-format
-#~ msgid "Not reading undo file, owner differs: %s"
-#~ msgstr ""
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
 
+#: ../undo.c:1292
 #, c-format
-#~ msgid "Reading undo file: %s"
-#~ msgstr ""
+msgid "Reading undo file: %s"
+msgstr ""
 
+#: ../undo.c:1299
 #, c-format
-#~ msgid "E822: Cannot open undo file for reading: %s"
-#~ msgstr ""
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr ""
 
+#: ../undo.c:1308
 #, c-format
-#~ msgid "E823: Not an undo file: %s"
-#~ msgstr ""
+msgid "E823: Not an undo file: %s"
+msgstr ""
 
+#: ../undo.c:1313
 #, c-format
-#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
-#~ msgstr ""
+msgid "E824: Incompatible undo file: %s"
+msgstr ""
 
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
 #, c-format
-#~ msgid "E826: Undo file decryption failed: %s"
-#~ msgstr ""
+msgid "Finished reading undo file %s"
+msgstr ""
 
-#, c-format
-#~ msgid "E827: Undo file is encrypted: %s"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "E824: Incompatible undo file: %s"
-#~ msgstr ""
-
-#~ msgid "File contents changed, cannot use undo info"
-#~ msgstr ""
-
-#, c-format
-#~ msgid "Finished reading undo file %s"
-#~ msgstr ""
-
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Reeds de laatste wijziging"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Reeds de nieuwste wijziging"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Ongedaan-nummer %<PRId64> niet gevonden"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: regelnummers onjuist"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "extra regel"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "extra regel"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "regel minder"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "regels minder"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "wijziging"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "wijzigingen"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "voor"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "na"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Niets om ongedaan te maken"
 
-msgid "number changes  time"
-msgstr "aantal wijzign  tijd"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> seconden geleden"
 
-#~ msgid "E790: undojoin is not allowed after undo"
-#~ msgstr ""
-
-#~ msgid "E439: undo list corrupt"
-#~ msgstr ""
-
-#~ msgid "E440: undo line missing"
-#~ msgstr ""
-
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
+#: ../undo.c:2372
+msgid "E790: undojoin is not allowed after undo"
 msgstr ""
-"\n"
-"MS-Windows 16/32-bit GUI-versie"
 
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
+#: ../undo.c:2466
+msgid "E439: undo list corrupt"
 msgstr ""
-"\n"
-"MS-Windows 64-bit GUI-versie"
 
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
+#: ../undo.c:2495
+msgid "E440: undo line missing"
 msgstr ""
-"\n"
-"MS-Windows 32-bit GUIversie"
 
-msgid " in Win32s mode"
-msgstr " in Win32s-modus"
-
-msgid " with OLE support"
-msgstr "met OLE-ondersteuning"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 64-bit console-versie"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bit console-versie"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16-bit-versie"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32-bit MS-DOS-versie"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16-bit MS-DOS-versie"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix)-versie"
-
-msgid ""
-"\n"
-"MacOS X-versie"
-msgstr ""
-"\n"
-"MacOS X version"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS-versie"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS-versie"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"OpenVMS-versie"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5215,6 +6250,7 @@ msgstr ""
 "\n"
 "Inclusief 'patches': "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5222,9 +6258,11 @@ msgstr ""
 "\n"
 "Extra 'patches': "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Aangepast door "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5232,9 +6270,11 @@ msgstr ""
 "\n"
 "Gecompileerd "
 
+#: ../version.c:649
 msgid "by "
 msgstr "door "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5242,607 +6282,1111 @@ msgstr ""
 "\n"
 "Enorme versie "
 
-msgid ""
-"\n"
-"Big version "
+#: ../version.c:661
+msgid "without GUI."
 msgstr ""
-"\n"
-"Grote versie "
 
-msgid ""
-"\n"
-"Normal version "
+#: ../version.c:662
+msgid "  Features included (+) or not (-):\n"
 msgstr ""
-"\n"
-"Normale versie "
 
-msgid ""
-"\n"
-"Small version "
+#: ../version.c:667
+msgid "   system vimrc file: \""
 msgstr ""
-"\n"
-"Kleine versie "
 
-msgid ""
-"\n"
-"Tiny version "
+#: ../version.c:672
+msgid "     user vimrc file: \""
 msgstr ""
-"\n"
-"Mini versie "
 
-#~ msgid "without GUI."
-#~ msgstr ""
+#: ../version.c:677
+msgid " 2nd user vimrc file: \""
+msgstr ""
 
-#~ msgid "with GTK2-GNOME GUI."
-#~ msgstr ""
+#: ../version.c:682
+msgid " 3rd user vimrc file: \""
+msgstr ""
 
-#~ msgid "with GTK-GNOME GUI."
-#~ msgstr ""
+#: ../version.c:687
+msgid "      user exrc file: \""
+msgstr ""
 
-#~ msgid "with GTK2 GUI."
-#~ msgstr ""
+#: ../version.c:692
+msgid "  2nd user exrc file: \""
+msgstr ""
 
-#~ msgid "with GTK GUI."
-#~ msgstr ""
+#: ../version.c:699
+msgid "  fall-back for $VIM: \""
+msgstr ""
 
-#~ msgid "with X11-Motif GUI."
-#~ msgstr ""
+#: ../version.c:705
+msgid " f-b for $VIMRUNTIME: \""
+msgstr ""
 
-#~ msgid "with X11-neXtaw GUI."
-#~ msgstr ""
-
-#~ msgid "with X11-Athena GUI."
-#~ msgstr ""
-
-#~ msgid "with Photon GUI."
-#~ msgstr ""
-
-#~ msgid "with GUI."
-#~ msgstr ""
-
-#~ msgid "with Carbon GUI."
-#~ msgstr ""
-
-#~ msgid "with Cocoa GUI."
-#~ msgstr ""
-
-#~ msgid "with (classic) GUI."
-#~ msgstr ""
-
-#~ msgid "  Features included (+) or not (-):\n"
-#~ msgstr ""
-
-#~ msgid "   system vimrc file: \""
-#~ msgstr ""
-
-#~ msgid "     user vimrc file: \""
-#~ msgstr ""
-
-#~ msgid " 2nd user vimrc file: \""
-#~ msgstr ""
-
-#~ msgid " 3rd user vimrc file: \""
-#~ msgstr ""
-
-#~ msgid "      user exrc file: \""
-#~ msgstr ""
-
-#~ msgid "  2nd user exrc file: \""
-#~ msgstr ""
-
-#~ msgid "  system gvimrc file: \""
-#~ msgstr ""
-
-#~ msgid "    user gvimrc file: \""
-#~ msgstr ""
-
-#~ msgid "2nd user gvimrc file: \""
-#~ msgstr ""
-
-#~ msgid "3rd user gvimrc file: \""
-#~ msgstr ""
-
-#~ msgid "    system menu file: \""
-#~ msgstr ""
-
-#~ msgid "  fall-back for $VIM: \""
-#~ msgstr ""
-
-#~ msgid " f-b for $VIMRUNTIME: \""
-#~ msgstr ""
-
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Compilatie: "
 
-msgid "Compiler: "
-msgstr "Compiler: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Linking: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  DEBUG BUILD"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versie "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "door Bram Moolenaar en anderen"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim is open-source en vrij verspreidbaar"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Help arme kinderen in Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "typ :help iccf<Enter> voor informatie"
 
-msgid "type   :q<Enter>               to exit"
+#: ../version.c:779
+#, fuzzy
+msgid "type  :q<Enter>               to exit         "
 msgstr "typ :q<Enter> om te stoppen"
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "typ :help<Enter> of <F1> voor on-line hulp"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "typ :help version7<Enter> voor versieinformatie"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "wordt uitgevoerd in Vi compatible-modus"
 
-msgid "type :set nocp<Enter> for Vim defaults"
+#: ../version.c:785
+#, fuzzy
+msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "typ :set nocp<Enter>  voor standaardinstellingen van Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "typ :help cp-default<Enter> voor informatie hierover"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu Help->Orphans voor informatie"
-
-#~ msgid "Running modeless, typed text is inserted"
-#~ msgstr ""
-
-#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-#~ msgstr ""
-
-#~ msgid "                              for two modes      "
-#~ msgstr ""
-
-#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-#~ msgstr ""
-
-#~ msgid "                              for Vim defaults   "
-#~ msgstr ""
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Ondersteun de ontwikkeling van Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Word een geregistreerde Vim-gebruiker!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "typ   :help sponsor<Enter>    voor informatie "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "typ   :help register<Enter>   voor informatie "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu  Help->Sponsor/Register  voor informatie    "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "Waarschuwing: Windows 95/98/ME gedetecteerd"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "typ   :help windows95<Enter>  voor informatie hierover"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Reeds beperkt tot een venster"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: er is geen voorvertoningsvenster"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: kan linkerbovenzijde en rechteronderzijde niet gelijktijdig splitsen"
+msgstr ""
+"E442: kan linkerbovenzijde en rechteronderzijde niet gelijktijdig splitsen"
 
-#~ msgid "E443: Cannot rotate when another window is split"
-#~ msgstr ""
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr ""
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: sluiten laatste venster is mislukt"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: sluiten autocmd-venster is mislukt"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
-msgstr "E814: venster kan niet sluiten want autocmd-venster blijft als enige achter"
+msgstr ""
+"E814: venster kan niet sluiten want autocmd-venster blijft als enige achter"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: ander venster blijft achter"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: cursor staat niet op een bestandsnaam"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: bestand \"%s\" niet in pad gevonden"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() uitgevoerd met leeg wachtwoord"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: laden van bibliotheek %s is mislukt"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-#~ msgid "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: gebruik Blowfish big/little endian is onjuist"
+
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: sha256 test mislukt"
+
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Blowfish test mislukt"
+
+#~ msgid "Patch file"
+#~ msgstr "Patch-bestand"
+
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
 #~ msgstr ""
+#~ "&OK\n"
+#~ "&Annuleren"
 
-#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: geen verbinding met Vim-server"
+
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: lezen van serverantwoord onmogelijk"
+
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: verzenden nar client onmogelijk"
+
+#~ msgid "Save As"
+#~ msgstr "Opslaan als"
+
+#~ msgid "Edit File"
+#~ msgstr "Bestand bewerken"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NIET GEVONDEN)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "Vim-script laden"
+
+#~ msgid "unknown"
+#~ msgstr "onbekend"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "Bestand in nieuw venster bewerken"
+
+#~ msgid "Append File"
+#~ msgstr "Bestand toevoegen"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Vensterpositie: X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "'Redirection' opslaan"
+
+#~ msgid "Save View"
+#~ msgstr "Beeld opslaan"
+
+#~ msgid "Save Session"
+#~ msgstr "Sessie opslaan"
+
+#~ msgid "Save Setup"
+#~ msgstr "Instellingen opslaan"
+
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< is zonder de +eval-functionaliteit niet beschikbaar"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: deze versie bevat geen 'digraphs'"
+
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "is een apparaat (uitgeschakeld door optie 'opendevice'"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "Lezen van standaardinvoer..."
+
+#~ msgid "[crypted]"
+#~ msgstr "[versleuteld]"
+
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: bestand is met onbekende methode versleuteld"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "Netbeans staat het opslaan van onveranderde buffers niet toe"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Deelopslag voor buffers van Netbeans niet toegestaan"
+
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "het schrijven naar apparaat is uitgeschakeld met optie 'opendevice'"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
 #~ msgstr ""
+#~ "E460: de afsplitsing van middelen zou verloren gaan (voeg ! toe om dit "
+#~ "toch te doen)"
 
-#~ msgid "Edit with &multiple Vims"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: de GUI kan niet worden gestart"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: kan niet gelezen worden uit \"%s\""
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
 #~ msgstr ""
+#~ "E665: de GUI kan niet gestart worden, er is geen geldig lettertype "
+#~ "gevonden"
 
-#~ msgid "Edit with single &Vim"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' ongeldig"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: waarde van 'imactivatekey' is ongeldig"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: kan de kleur %s niet reserveren"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Op cursorpositie is geen overeenkomst: de volgende zoeken"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<kan niet openen> "
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: lettertype %s niet gevonden"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: teruggaan naar huidige map is niet mogelijk"
+
+#~ msgid "Pathname:"
+#~ msgstr "Padnaam:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: vaststellen huidige map is niet mogelijk"
+
+#~ msgid "OK"
+#~ msgstr "Ok"
+
+#~ msgid "Cancel"
+#~ msgstr "Annuleren"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
 #~ msgstr ""
+#~ "Scrollbar-widget: vaststellen afmetingen van miniaturenkaart niet "
+#~ "mogelijk."
 
-#~ msgid "Diff with Vim"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim-dialoog"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
 #~ msgstr ""
+#~ "E232: aanmaken 'BalloonEval' met zowel een bericht als een 'callback' is "
+#~ "niet mogelijk"
 
-#~ msgid "Edit with &Vim"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim-dialoog..."
+
+#~ msgid "Input _Methods"
+#~ msgstr "Invoer_wijzen"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - zoeken en vervangen..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - zoeken..."
+
+#~ msgid "Find what:"
+#~ msgstr "Zoek naar:"
+
+#~ msgid "Replace with:"
+#~ msgstr "Vervang door:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "Alleen volledig woord"
+
+#~ msgid "Match case"
+#~ msgstr "Hoofdlettergevoelig"
+
+#~ msgid "Direction"
+#~ msgstr "Richting"
+
+#~ msgid "Up"
+#~ msgstr "Opwaarts"
+
+#~ msgid "Down"
+#~ msgstr "Neerwaarts"
+
+#~ msgid "Find Next"
+#~ msgstr "Volgende zoeken"
+
+#~ msgid "Replace"
+#~ msgstr "Vervangen"
+
+#~ msgid "Replace All"
+#~ msgstr "Alles vervangen"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: \"die\"-verzoek van sessiebeheerder ontvangen\n"
+
+#~ msgid "Close"
+#~ msgstr "Sluiten"
+
+#~ msgid "New tab"
+#~ msgstr "Nieuw tabblad"
+
+#~ msgid "Open Tab..."
+#~ msgstr "Tabblad openen..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: hoofdvenster onverwacht gesloten\n"
+
+#~ msgid "Font Selection"
+#~ msgstr "Lettertypeselectie"
+
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
+
+#~ msgid "&Cancel"
+#~ msgstr "&Annuleren"
+
+#~ msgid "Directories"
+#~ msgstr "Mappen"
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "&Help"
+#~ msgstr "&Hulp"
+
+#~ msgid "Files"
+#~ msgstr "Bestanden"
+
+#~ msgid "&OK"
+#~ msgstr "&Ok"
+
+#~ msgid "Selection"
+#~ msgstr "Selectie"
+
+#~ msgid "Find &Next"
+#~ msgstr "&Volgende zoeken"
+
+#~ msgid "&Replace"
+#~ msgstr "Ve&rvangen"
+
+#~ msgid "Replace &All"
+#~ msgstr "&Alles vervangen"
+
+#~ msgid "&Undo"
+#~ msgstr "&Herstellen"
+
+#~ msgid "E610: Can't load Zap font '%s'"
+#~ msgstr "E610: Zap-lettertype '%s' kan niet worden geladen"
+
+#~ msgid "E611: Can't use font %s"
+#~ msgstr "E611: lettertype %s kan niet worden gebruikt"
+
+#~ msgid ""
+#~ "\n"
+#~ "Sending message to terminate child process.\n"
 #~ msgstr ""
+#~ "\n"
+#~ "Bericht versturen om kindproces te beëindigen.\n"
 
-#. Now concatenate
-#~ msgid "Edit with existing Vim - "
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: kan venstertitel \"%s\" niet vinden"
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: argument niet ondersteund: \"-%s\"; gebruik de OLE-versie."
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: kan geen venster binnen MDI-applicatie openen"
+
+#~ msgid "Close tab"
+#~ msgstr "Tabblad sluiten"
+
+#~ msgid "Open tab..."
+#~ msgstr "Tabblad openen..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Tekenreeks zoeken (gebruik '\\\\' om een '\\' te vinden)"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Zoeken & vervangen (gebruik '\\\\' om een '\\' te vinden')"
+
+#~ msgid "Not Used"
+#~ msgstr "Niet gebruikt"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Map\t*.niets\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "E458: kan geen kleur toewijzen, sommige kleuren kunnen onjuist zijn"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
 #~ msgstr ""
+#~ "E250: lettertypen voor de volgende tekenverzamelingen ontbreken in "
+#~ "verzameling %s:"
 
-#~ msgid "Edits the selected file(s) with Vim"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: naam lettertypeverzameling: %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Lettertype '%s' heeft geen vaste breedte"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: naam lettertypeverzameling: %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Breedte font%<PRId64> is niet het dubbele van font0\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Font0-breedte: %<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
 #~ msgstr ""
+#~ "Font1-breedte: %<PRId64>\n"
+#~ "\n"
 
-#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgid "Invalid font specification"
+#~ msgstr "Onjuiste specificatie van lettertype"
+
+#~ msgid "&Dismiss"
+#~ msgstr "&Afwijzen"
+
+#~ msgid "no specific match"
+#~ msgstr "geen specifieke overeenkomst"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Lettertypekiezer"
+
+#~ msgid "Name:"
+#~ msgstr "Naam:"
+
+#~ msgid "Show size in Points"
+#~ msgstr "Grootte in punten tonen"
+
+#~ msgid "Encoding:"
+#~ msgstr "Codering:"
+
+#~ msgid "Font:"
+#~ msgstr "Lettertype:"
+
+#~ msgid "Style:"
+#~ msgstr "Stijl:"
+
+#~ msgid "Size:"
+#~ msgstr "Grootte:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: 'Hangul automata'-fout"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: bevragingsfout"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: openen is mislukt van cscope-databank: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: opvragen cscope-databankinformatie is mislukt"
+
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
 #~ msgstr ""
+#~ "E815: helaas, deze opdracht is uitgeschakeld. De MzScheme-bibliotheken "
+#~ "kunnen niet geladen worden."
 
-#~ msgid "gvimext.dll error"
+#~ msgid "invalid expression"
+#~ msgstr "ongeldige uitdrukking"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "tijdens compileren zijn de expressies uitgeschakeld"
+
+#~ msgid "hidden option"
+#~ msgstr "verborgen optie"
+
+#~ msgid "unknown option"
+#~ msgstr "onbekende optie"
+
+#~ msgid "window index is out of range"
+#~ msgstr "vensterindex valt buiten het bereik"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "buffer openen is mislukt"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "herstelinformatie kan niet worden opgeslagen"
+
+#~ msgid "cannot delete line"
+#~ msgstr "regel kan niet worden verwijderd"
+
+#~ msgid "cannot replace line"
+#~ msgstr "regel kan niet worden vervangen"
+
+#~ msgid "cannot insert line"
+#~ msgstr "regel kan niet worden ingevoegd"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "tekenreeks kan geen regeleinden bevatten"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim-fout: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim-fout"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer is ongeldig"
+
+#~ msgid "window is invalid"
+#~ msgstr "venster is ongeldig"
+
+#~ msgid "linenr out of range"
+#~ msgstr "regelnummer buiten het bereik"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "niet toegestaan in de Vim-zandbak"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
 #~ msgstr ""
+#~ "E263: helaas, deze opdracht is uitgeschakeld. De Python-bibliotheek kan "
+#~ "niet worden geladen."
 
-#~ msgid "Path length too long!"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python kan niet recursief worden aangeroepen"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "attributen van OutputObject kunnen niet worden verwijderd"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "zachte spatie moet een geheel getal zijn"
+
+#~ msgid "invalid attribute"
+#~ msgstr "ongeldig attribuut"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() vereist een lijst met tekenreeksen"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: initialiseren I/O-objecten is mislukt"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "poging om naar een verwijderd buffer te verwijzen"
+
+#~ msgid "line number out of range"
+#~ msgstr "regelnummer valt buiten het bereik"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<buffer-object (verwijderd) bij %p>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "naam markering ongeldig"
+
+#~ msgid "no such buffer"
+#~ msgstr "onbekende buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "poging om naar een verwijderd venster te verwijzen"
+
+#~ msgid "readonly attribute"
+#~ msgstr "alleen-lezen attribuut"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "cursorpositie valt buiten buffer"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<venster-object (verwijderd) bij %p>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<venster-object (onbekend) bij %p>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<venster %d>"
+
+#~ msgid "no such window"
+#~ msgstr "onbekend venster"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ moet een instantie van String zijn"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
 #~ msgstr ""
+#~ "E266: helaas, deze opdracht is uitgeschakeld. De Ruby-bibliotheek kan "
+#~ "niet worden geladen."
 
-msgid "--No lines in buffer--"
-msgstr "-- geen regels in buffer --"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: onverwacht resultaat"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: opdracht afgebroken"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: onverwachte volgende"
 
-msgid "E471: Argument required"
-msgstr "E471: Argument vereist"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: onverwachte onderbreking"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ moet worden gevolgd door /, ? of &"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: onverwachte herstelopdracht"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: ongeldig in opdrachtregelvenster; <CR> voert uit, CTRL-C stopt"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: hernieuwde poging buiten de reddingsclausule"
 
-#~ msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: niet-afgehandelde uitzondering"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: onbekende longjmp-status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Implementatie/definitie wisselen"
+
+#~ msgid "Show base class of"
+#~ msgstr "Toon basisklasse van"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Toon overschreven member-functie"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Uit bestand halen"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Uit project halen"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Uit alle projecten halen"
+
+#~ msgid "Retrieve"
+#~ msgstr "Ophalen"
+
+#~ msgid "Show source of"
+#~ msgstr "Toon broncode van"
+
+#~ msgid "Find symbol"
+#~ msgstr "Zoek symbool"
+
+#~ msgid "Browse class"
+#~ msgstr "Bekijk klasse"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Toon klasse in hierarchie"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Toon klasse in beperkte hierarchie"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref verwijst naar"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref wordt naar verwezen door"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref heeft een"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref gebruikt door"
+
+#~ msgid "Show docu of"
+#~ msgstr "Toon documentatie van"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Genereer documentatie voor"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
 #~ msgstr ""
+#~ "Verbinden met SNiFF+ is mislukt. Controleer omgevingsvariabelen "
+#~ "(sniffemacs moet in $PATH staan).\n"
 
-#~ msgid "E171: Missing :endif"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: leesfout. Verbroken"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ is momenteel "
+
+#~ msgid "not "
+#~ msgstr "niet "
+
+#~ msgid "connected"
+#~ msgstr "verbonden"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: onbekend SNiFF+-verzoek: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: verbinden met SNiFF+ is mislukt"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ niet verbonden"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: geen SNiFF+-buffer"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: schrijven is mislukt. Verbroken"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "buffernummer is ongeldig"
+
+#~ msgid "not implemented yet"
+#~ msgstr "nog niet geïmplementeerd"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "kan regel(s) niet instellen"
+
+#~ msgid "mark not set"
+#~ msgstr "markering niet ingesteld"
+
+#~ msgid "row %d column %d"
+#~ msgstr "rij %d kolom %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "invoegen/toevoegen regel is mislukt"
+
+#~ msgid "unknown flag: "
+#~ msgstr "unbekende instelling: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "onbekende vim-optie"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "toetsenbord-interrupt"
+
+#~ msgid "vim error"
+#~ msgstr "vim-fout"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
 #~ msgstr ""
+#~ "aanmaken buffer-/vensteropdracht is mislukt: object wordt verwijderd"
 
-#~ msgid "E600: Missing :endtry"
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
 #~ msgstr ""
+#~ " kan 'callback'-opdracht niet registreren: buffer/venster is reeds "
+#~ "verwijderd"
 
-#~ msgid "E170: Missing :endwhile"
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
 #~ msgstr ""
+#~ "E280: TCL FATALE FOUT: reflist misschien corrupt!? Meld dit a.u.b. aan "
+#~ "vim-dev@vim.org"
 
-#~ msgid "E170: Missing :endfor"
+#~ msgid "cannot register callback command: buffer/window reference not found"
 #~ msgstr ""
+#~ "'callback'-opdracht kan niet worden geregistreerd: buffer-/"
+#~ "vensterreferentie ontbreekt"
 
-#~ msgid "E588: :endwhile without :while"
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
 #~ msgstr ""
+#~ "E571: Helaas, deze opdracht is uitgeschakeld: het laden van de Tcl-"
+#~ "bibliotheek is mislukt."
 
-#~ msgid "E588: :endfor without :for"
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
 #~ msgstr ""
+#~ "E281: Tcl-fout: afsluitcode is geen geheel getal!? Meld dit a.u.b. aan "
+#~ "vim-dev@vim.org"
 
-#~ msgid "E13: File exists (add ! to override)"
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: afsluitcode %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "kan regel niet verkrijgen"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Het registreren van een opdrachtservernaam is mislukt"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: versturen van opdracht naar het doelprogramma is mislukt"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: ongeldige server-id gebruikt: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
 #~ msgstr ""
+#~ "E251: registereigenschap van VIM-instantie is misvormd.  Verwijderd!"
 
-#~ msgid "E472: Command failed"
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "Netbeans wordt door deze GUI niet ondersteund\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Deze Vim is niet met de diff-functionaliteit gecompileerd"
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
 #~ msgstr ""
+#~ "'-nb' kan niet worden gebruikt: was tijdens compilatie niet ingeschakeld\n"
 
-#, c-format
-#~ msgid "E234: Unknown fontset: %s"
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Fout: gvim starten vanuit Netbeans is mislukt\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
 #~ msgstr ""
+#~ "\n"
+#~ "Daar waar hoofdletters genegeerd worden kan met / vlag in hoofdletters "
+#~ "gezet worden"
 
-#, c-format
-#~ msgid "E235: Unknown font: %s"
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tDeze gvim voor OLE registreren"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tgvim afmelden voor OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tMet GUI opstarten (zoals \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  of  --nofork\tVoorgrond: niet afsplitsen tijdens opstarten GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tGebruik geen newcli om venster te openen"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tGebruik <device> voor in- en uitvoer"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tGebruik <gvimrc> in plaats van enige .gvimrc"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: geen muisondersteuning"
+
+#~ msgid "cannot open "
+#~ msgstr "gefaald tijden openen van "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: kan venster niet openen!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Vereist Amigados versie 2.04 of nieuwer\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Vereist %s versie %<PRId64>\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Gefaald tijdens aanmaken van "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim stoppen met %d\n"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: dubbel signaal, stoppen\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: fataal signaal gevangen %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: fataal signaal gevangen\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Openen van X-display vereiste %<PRId64> ms"
+
+#~ msgid "At line"
+#~ msgstr "Bij regel"
+
+#~ msgid "VIM Error"
+#~ msgstr "Vim-fout"
+
+#~ msgid "close"
+#~ msgstr "sluiten"
+
+#~ msgid "logoff"
+#~ msgstr "uitloggen"
+
+#~ msgid "shutdown"
+#~ msgstr "afsluiten"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: opdracht niet gevonden"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim-waarschuwing"
+
+#~ msgid "number changes  time"
+#~ msgstr "aantal wijzign  tijd"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
 #~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI-versie"
 
-#, c-format
-#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
 #~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI-versie"
 
-msgid "E473: Internal error"
-msgstr "E473: interne fout"
-
-msgid "Interrupted"
-msgstr "onderbroken"
-
-msgid "E14: Invalid address"
-msgstr "E14: ongeldig adres"
-
-msgid "E474: Invalid argument"
-msgstr "E474: ongeldig argument"
-
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: ongeldig argument: %s"
-
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: ongeldige expressie: %s"
-
-msgid "E16: Invalid range"
-msgstr "E16: ongeldig bereik"
-
-msgid "E476: Invalid command"
-msgstr "E476: ongeldige opdracht"
-
-#, c-format
-#~ msgid "E17: \"%s\" is a directory"
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
 #~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUIversie"
 
-#, c-format
-#~ msgid "E364: Library call failed for \"%s()\""
+#~ msgid " in Win32s mode"
+#~ msgstr " in Win32s-modus"
+
+#~ msgid " with OLE support"
+#~ msgstr "met OLE-ondersteuning"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
 #~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64-bit console-versie"
 
-#, c-format
-#~ msgid "E448: Could not load library function %s"
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
 #~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bit console-versie"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: markering heeft een ongeldig regelnummer"
-
-msgid "E20: Mark not set"
-msgstr "E20: Markering is niet ingesteld"
-
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: kan geen veranderingen maken, 'modifiable' is uitgeschakeld"
-
-msgid "E22: Scripts nested too deep"
-msgstr "E22: scripts "
-
-#~ msgid "E23: No alternate file"
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
 #~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16-bit-versie"
 
-#~ msgid "E24: No such abbreviation"
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
 #~ msgstr ""
+#~ "\n"
+#~ "32-bit MS-DOS-versie"
 
-#~ msgid "E477: No ! allowed"
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
 #~ msgstr ""
+#~ "\n"
+#~ "16-bit MS-DOS-versie"
 
-#~ msgid "E25: GUI cannot be used: Not enabled at compile time"
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
 #~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix)-versie"
 
-#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X-versie"
 #~ msgstr ""
+#~ "\n"
+#~ "MacOS X version"
 
-#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
 #~ msgstr ""
+#~ "\n"
+#~ "MacOS-versie"
 
-#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
 #~ msgstr ""
+#~ "\n"
+#~ "RISC OS-versie"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: naam van deze oplichtgroep is onbekend: %s"
-
-#~ msgid "E29: No inserted text yet"
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
 #~ msgstr ""
+#~ "\n"
+#~ "OpenVMS-versie"
 
-#~ msgid "E30: No previous command line"
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
 #~ msgstr ""
+#~ "\n"
+#~ "Grote versie "
 
-#~ msgid "E31: No such mapping"
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
 #~ msgstr ""
+#~ "\n"
+#~ "Normale versie "
 
-msgid "E479: No match"
-msgstr "E479: geen overeenkomst"
-
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: geen overeenkomst: %s"
-
-msgid "E32: No file name"
-msgstr "E32: geen bestandsnaam"
-
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: geen eerdere reguliere expressie substitutie"
-
-msgid "E34: No previous command"
-msgstr "E34: geen eerdere opdracht"
-
-msgid "E35: No previous regular expression"
-msgstr "E35: geen eerdere reguliere expressie"
-
-msgid "E481: No range allowed"
-msgstr "E481: een bereik is niet toegestaan"
-
-msgid "E36: Not enough room"
-msgstr "E36: onvoldoende ruimte"
-
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: \"%s\" niet gevonden als geregistreerde server"
-
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: aanmaken bestand %s is mislukt"
-
-msgid "E483: Can't get temp file name"
-msgstr "E483: bepalen naam tijdelijk bestand is mislukt"
-
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: openen bestand %s is mislukt"
-
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: lezen bestand %s is mislukt"
-
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: niets opgeslagen sinds laatste wijziging (voeg ! toe om te forceren)"
-
-msgid "E38: Null argument"
-msgstr "E38: leeg argument (null)"
-
-msgid "E39: Number expected"
-msgstr "E39: getal verwacht"
-
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: openen foutenbestand %s is mislukt"
-
-msgid "E233: cannot open display"
-msgstr "E233: openen scherm is mislukt"
-
-msgid "E41: Out of memory!"
-msgstr "E41: te weinig geheugen!"
-
-msgid "Pattern not found"
-msgstr "patroon niet gevonden"
-
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: patroon niet gevonden: %s"
-
-msgid "E487: Argument must be positive"
-msgstr "E487: argument moet positief zijn"
-
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: kan niet terug naar vorig Dictionary"
-
-msgid "E42: No Errors"
-msgstr "E42: geen fouten"
-
-#~ msgid "E776: No location list"
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
 #~ msgstr ""
+#~ "\n"
+#~ "Kleine versie "
 
-msgid "E43: Damaged match string"
-msgstr "E43: beschadigde zoekstring"
-
-msgid "E44: Corrupted regexp program"
-msgstr "E44: regexp-programma is misvormd"
-
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'alleen-lezen'-optie is ingeschakeld (voeg ! toe om te overschrijven)"
-
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: kan alleen-lezenvariabele \"%s\" niet veranderen"
-
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: kan variabele niet instellen in de zandbak: \"%s\""
-
-msgid "E47: Error while reading errorfile"
-msgstr "E47: fout tijdens lezen foutenbestand"
-
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: niet toegestaan in zandbak"
-
-msgid "E523: Not allowed here"
-msgstr "E523: hier niet toegestaan"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: instelling schermmodus niet ondersteund"
-
-msgid "E49: Invalid scroll size"
-msgstr "E49: ongeldige scroll-grootte"
-
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell'-optie is leeg"
-
-#~ msgid "E255: Couldn't read in sign data!"
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
 #~ msgstr ""
+#~ "\n"
+#~ "Mini versie "
 
-#~ msgid "E72: Close error on swap file"
+#~ msgid "Compiler: "
+#~ msgstr "Compiler: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu Help->Orphans voor informatie"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "Waarschuwing: Windows 95/98/ME gedetecteerd"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "typ   :help windows95<Enter>  voor informatie hierover"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: laden van bibliotheek %s is mislukt"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: \"%s\" niet gevonden als geregistreerde server"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: ontvangen expressie is ongeldig"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Regio is bescherm en kan niet worden veranderd"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
 #~ msgstr ""
-
-#~ msgid "E73: tag stack empty"
-#~ msgstr ""
-
-msgid "E74: Command too complex"
-msgstr "E74: opdracht te ingewikkeld"
-
-msgid "E75: Name too long"
-msgstr "E75: te lange naam"
-
-msgid "E76: Too many ["
-msgstr "E76: teveel ["
-
-msgid "E77: Too many file names"
-msgstr "E77: teveel bestandsnamen"
-
-msgid "E488: Trailing characters"
-msgstr "E488: nakomende tekens"
-
-msgid "E78: Unknown mark"
-msgstr "E78: onbekende markering"
-
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: vervangen jokertekens is mislukt"
-
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' kan niet kleiner zijn dan 'winminheight'"
-
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' kan niet kleiner zijn dan 'winminwidth'"
-
-msgid "E80: Error while writing"
-msgstr "E80: opslaan is mislukt"
-
-msgid "Zero count"
-msgstr "Aantal is nul"
-
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> wordt buiten de scriptcontext gebruikt"
-
-msgid "E449: Invalid expression received"
-msgstr "E449: ontvangen expressie is ongeldig"
-
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Regio is bescherm en kan niet worden veranderd"
-
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans staat geen veranderingen in alleen-lezenbestanden toe"
-
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: interne fout: %s"
-
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: patroon gebruikt meer geheugen dan 'maxmempattern'"
-
-msgid "E749: empty buffer"
-msgstr "E749: leeg buffer"
-
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: zoekpatroon of scheidingsteken is ongeldig"
-
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: bestand is in een ander buffer geladen"
-
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Optie '%s' is niet ingesteld"
-
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "zoeken bereikte TOP, verder vanaf BODEM"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "zoeken bereikte BODEM, verder vanaf TOP"
-
+#~ "E744: NetBeans staat geen veranderingen in alleen-lezenbestanden toe"

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -1774,10 +1774,6 @@ msgstr "1 teken"
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> tekens"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> tekens"
-
 msgid "[noeol]"
 msgstr "[noeol]"
 

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -26,148 +26,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 6.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-03-19 02:09+0100\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2007-03-21 11:51+0100\n"
 "Last-Translator: Øyvind A. Holm <sunny@sunbase.org>\n"
 "Language-Team: Norwegian <vim.in.norwegian@sunbase.org>\n"
+"Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Søppel etter valgparameter"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Plassliste]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Kan ikke reservere plass til noen buffere, avslutter ..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Kan ikke reservere plass til buffer, bruker en annen ..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Ingen buffere ble lastet ut"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Ingen buffere ble slettet"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Ingen buffere ble visket ut"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer ble lastet ut"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffere ble lastet ut"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer ble slettet"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffere ble slettet"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer ble visket ut"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffere ble visket ut"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Kan ikke laste ut siste buffer"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Fant ingen modifisert buffer"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Det finnes ingen listede buffere"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Bufferen %<PRId64> finnes ikke"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan ikke gå forbi siste buffer"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan ikke gå forbi første buffer"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Ikke lagret siden forrige forandring av bufferen %<PRId64> (legg til ! for å "
-"overstyre)"
+"E89: Ikke lagret siden forrige forandring av bufferen %<PRId64> (legg til ! "
+"for å overstyre)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Kan ikke laste ut siste buffer"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Advarsel: Listen med filnavn er overfylt"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Fant ikke bufferen %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Mer enn ett treff for %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Ingen samsvarende buffer for %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "linje %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: En buffer med dette navnet finnes allerede"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modifisert]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Uredigert]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Ny fil]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Lesefeil]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[SB]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[skrivebeskyttet]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 linje --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> linjer --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "linje %<PRId64> av %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Uten navn]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "hjelp"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Hjelp]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Forhåndsvisning]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Alt"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Bunn"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Topp"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -175,12 +242,11 @@ msgstr ""
 "\n"
 "# Bufferliste:\n"
 
-msgid "[Location List]"
-msgstr "[Plassliste]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-#~ msgid "[Quickfix List]"
-#~ msgstr ""
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -188,135 +254,204 @@ msgstr ""
 "\n"
 "--- Skilt ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Skilt for %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    linje=%<PRId64>  id=%d  navn=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Mangler kolon"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Ulovlig modus"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Siffer forventet"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Ulovlig prosent"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Kan ikke sammenligne flere enn %<PRId64> buffere"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Kan ikke åpne termcap-fil"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan ikke lage differansefiler"
 
-msgid "Patch file"
-msgstr "Patch fil"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Kan ikke lese differanse-utdata"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Kan ikke lese differanse-utdata"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Nåværende buffer er ikke i differansemodus"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Ingen annen buffer i differansemodus er redigerbar"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Ingen annen buffer i differansemodus"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Mer enn to buffere i differansemodus, vet ikke hvilken som skal brukes"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Kan ikke finne buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bufferen \"%s\" er ikke i differansemodus"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Uventet forandring i buffer"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape er ikke lovlig i spesialtegn"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Fant ikke keymap-fil"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Bruk av :loadkeymap utenfor en kjørt fil"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Tom tastaturoppsett-oppføring"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Nøkkelordfullføring (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 #, fuzzy
-#~ msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
-#~ msgstr " ^X-modus (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
+msgstr " ^X-modus (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Fullføring av hel linje (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Fullføring av filnavn (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Fullføring av tag (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Stimønster-fullføring (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Fullføring av defineringer (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Fullføring fra ordliste (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus-fullføring (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Kommandolinje-fullføring (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Brukerdefinert fullføring (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-fullføring (^O^N^P)"
 
+#: ../edit.c:96
 #, fuzzy
-#~ msgid " Spelling suggestion (s^N^P)"
-#~ msgstr " Staveforslag (^S^N^P)"
+msgid " Spelling suggestion (s^N^P)"
+msgstr " Staveforslag (^S^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokal nøkkelordfullføring (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Kom til slutten av avsnittet"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary'-valget er tomt"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus'-valget er tomt"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Leter gjennom ordliste: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (sett inn) Rulling (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (erstatt) Rulling (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Leter: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Leter gjennom tagger."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Legger til"
 
@@ -324,395 +459,585 @@ msgstr " Legger til"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Søker ..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Tilbake i originalen"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Ord fra annen linje"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Det eneste treffet"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "treff %d av %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "treff %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Uventede tegn i :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Listeindeks utenfor område: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Udefinert variabel: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Mangler ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Parameter til %s må være en liste"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Parameter til %s må være en liste eller ordliste"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Kan ikke bruke tom nøkkel med ordliste"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Liste påkrevet"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Ordliste påkrevet"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: For mange parametere til funksjonen: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Nøkkelen finnes ikke i ordliste: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funksjonen %s eksisterer allerede, legg til ! for å erstatte den"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Ordlisteoppføring finnes allerede"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funksjonsreferanse nødvendig"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Kan ikke bruke [:] sammen med en ordliste"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Feil variabeltype for %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Ukjent funksjon: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Ugyldig variabelnavn: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: Bruker en liste som en streng"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Færre mål enn listeelementer"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Flere mål enn listeelementer"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Dobbel ; i variabelliste"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Kan ikke liste variabler for %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Kan bare indeksere en liste eller ordliste"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] må komme sist"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] krever en listeverdi"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Listeverdien har flere elementer enn mål"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Listeverdien har ikke nok elementer"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Mangler \"in\" etter :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Mangler parenteser: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Variabelen finnes ikke: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Variabel nøstet for dypt for (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Mangler ':' etter '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Kan bare sammenligne liste med liste"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Ugyldig operasjon for lister"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Kan bare sammenligne ordliste med ordliste"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Ugyldig operasjon for ordliste"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Kan bare sammenligne funksjonsreferanse med funksjonsreferanse"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Ugyldig operasjon for funksjonsreferanser"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Kan ikke bruke [:] sammen med en ordliste"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Mangler ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Kan ikke indeksere en funksjonsreferanse"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Navn på valg mangler: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Ukjent valg: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Mangler anførselstegn (\"): %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Mangler apostrof ('): %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Mangler komma i liste: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Mangler slutt på liste ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Mangler kolon i ordliste: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Duplisert nøkkel i ordliste: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Mangler komma i ordliste: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Mangler slutt på ordliste '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Variabel nøstet for dypt for visning"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: For mange parametere til funksjonen: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: For mange parametere til funksjonen: %s"
+
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Ukjent funksjon: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Ikke nok parametere til funksjonen: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Bruk av \"<SID>\" utenfor skript-sammenheng: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Kaller ordlistefunksjon uten ordliste: %s"
 
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Nummer nødvendig etter ="
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: For mange parametere"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() kan bare brukes i innsettingsmodus"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Nøkkelen finnes allerede: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld linjer: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Ukjent funksjon: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Avbryt"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "kalte inputrestore() oftere enn inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Område ikke tillatt"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Ugyldig type for len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Økning er null"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Starten er bak slutten"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<tom>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Ingen forbindelse med Vim-tjeneren"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr " vim [parametere] "
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Klarer ikke sende til %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Klarer ikke lese svar fra tjeneren"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: For mange symbolske linker (runddans?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Klarer ikke sende til klienten"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr " vim [parametere] "
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr " vim [parametere] "
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funksjon for sorteringssammenligning feilet"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funksjon for sorteringssammenligning feilet"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Ugyldig)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Feil under skriving til midlertidig fil"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Bruker en liste som et nummer"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Bruker en funksjonsreferanse som et nummer"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Bruker en liste som et nummer"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Bruker en ordliste som et nummer"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Bruker en funksjonsreferanse som en streng"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Bruker en liste som en streng"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Bruker en ordliste som en streng"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Variabelnavn for funksjonsreferanse må ha stor forbokstav: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Variabelnavn er i konflikt med en eksisterende funksjon: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Variabeltype samsvarer ikke med: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Kan ikke slette variabel %s"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Variabelnavn for funksjonsreferanse må ha stor forbokstav: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Variabelnavn er i konflikt med en eksisterende funksjon: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Verdi er låst: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Ukjent"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Kan ikke forandre verdi for %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Variabel nøstet for dypt til å lage en kopi"
 
+#: ../eval.c:17249
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Ukjent funksjon: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Mangler '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Kan ikke sette IC-verdier (\"Input Context\")"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Ugyldig parameter: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Ugyldig parameter: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Mangler :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: Funksjonsnavn samsvarer ikke med skriptfilnavn: %s"
+
+#: ../eval.c:17549
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Kan ikke slette funksjonen %s: Den er i bruk"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Funksjonsnavn samsvarer ikke med skriptfilnavn: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Funksjonsnavn nødvendig"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: Funksjonsnavn må ha stor forbokstav eller inneholde et kolon: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Funksjonsnavn må ha stor forbokstav eller inneholde et kolon: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Kan ikke slette funksjonen %s: Den er i bruk"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Funksjonskalldybden er større enn 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "kaller %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s avbrutt"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s returnerer #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s returnerer %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "fortsetter i %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return er ikke innenfor en funksjon"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -720,6 +1045,7 @@ msgstr ""
 "\n"
 "# globale variabler:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -727,77 +1053,106 @@ msgstr ""
 "\n"
 "\tSist satt fra "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "Ingen inkluderte filer"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Oktal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Flytting av linjer inn i seg selv"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 linje flyttet"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> linjer flyttet"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> linjer filtrert"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autokommandoer må ikke forandre nåværende buffer"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Ikke lagret siden forrige forandring]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s i linje: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: For mange feil, hopper over resten av filen"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Leser viminfo-fil \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " merker"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "Ingen inkluderte filer"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FEILET"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo-fil er ikke skrivbar: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Kan ikke lagre viminfo-fil %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Lagrer viminfo-fil \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Denne viminfo-filen ble generert av Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -805,41 +1160,47 @@ msgstr ""
 "# Du kan redigere den hvis du er forsiktig!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Verdien av 'encoding' når denne filen ble skrevet\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Ulovlig starttegn"
 
-msgid "Save As"
-msgstr "Lagre som"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Skrive delvis fil?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Bruk ! for å skrive delvis buffer"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Overskrive eksisterende fil \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Swapfilen \"%s\" finnes, overskriv likevel?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Swapfilen finnes: %s (:silent! overstyrer)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Mangler filnavn for buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Filen ble ikke lagret: Lagring er deaktivert med 'write'-valget"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -848,61 +1209,91 @@ msgstr ""
 "'readonly'-valget er satt for \"%s\".\n"
 "Vil du lagre likevel?"
 
-msgid "Edit File"
-msgstr "Rediger fil"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "er skrivebeskyttet (legg til ! for å overstyre)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokommandoer slettet uventet den nye bufferen %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Ikke-numerisk parameter til :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Skallkommandoer er ikke tillatt i rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulære uttrykk kan ikke bli adskilt av bokstaver"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "Erstatt med %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Avbrutt) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 treff"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 erstatning"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> treff"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> erstatninger"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " i 1 linje"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " i %<PRId64> linjer"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan ikke gjøre :global rekursiv"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Regulært uttrykk mangler i global kommando"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Søkestreng funnet i alle linjene: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Fant ikke søketeksten"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -912,266 +1303,338 @@ msgstr ""
 "# Siste erstatningstekst:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Ingen panikk!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Dessverre ingen '%s' hjelp for %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Dessverre ingen hjelp for %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Fant ikke hjelpefilen \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Er ikke en katalog: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Kan ikke åpne %s for skriving"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Kan ikke åpne %s for lesing"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Tegnsettblanding i hjelpefilen innenfor samme språk: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplikat-tag \"%s\" i filen %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Ukjent skiltkommando: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Mangler skiltnavn"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: For mange skilt definert"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Ugyldig skilttekst: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Ukjent skilt: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Mangler skiltnummer"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ugyldig buffernavn: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Ulovlig skilt-ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (IKKE FUNNET)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (ikke støttet)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Slettet]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Går inn i debuggingsmodus. Skriv \"cont\" for å fortsette."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "linje %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "kommando: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Stoppunkt i \"%s%s\" linje %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Fant ikke stoppunkt: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Ingen stoppunkt definert"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  linje %<PRId64>"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Bruk først :profile start <filnavn>"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Lagre forandringer til \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Uten navn"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Ikke lagret siden siste forandringer i bufferen \"%s\""
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "Advarsel: Gikk uventet inn i en annen buffer (sjekk autokommandoer)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Det er bare en fil å redigere"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Kan ikke gå forbi første fil"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Kan ikke gå forbi siste fil"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Kompilatoren er ikke støttet: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Søker etter \"%s\" i \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Søker etter \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "ikke funnet i 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Kjør Vim-skript"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Kan ikke kjøre en katalog: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "kunne ikke kjøre \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "linje %<PRId64>: Kunne ikke kjøre \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "kjører \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "linje %<PRId64>: kjører \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "ferdig med kjøring av %s"
 
+#: ../ex_cmds2.c:2765
 #, fuzzy
-#~ msgid "modeline"
-#~ msgstr "1 linje lagt til"
+msgid "modeline"
+msgstr "1 linje lagt til"
 
+#: ../ex_cmds2.c:2767
 #, fuzzy
-#~ msgid "--cmd argument"
-#~ msgstr " vim [parametere] "
+msgid "--cmd argument"
+msgstr " vim [parametere] "
 
+#: ../ex_cmds2.c:2769
 #, fuzzy
-#~ msgid "-c argument"
-#~ msgstr " vim [parametere] "
+msgid "-c argument"
+msgstr " vim [parametere] "
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "miljøvariabel"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "feilbehandler"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Advarsel: Feil linjeseparator, det er mulig ^M mangler"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding brukt utenfor en kjørt fil"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish brukt utenfor en kjørt fil"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Nåværende %sspråk: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Kan ikke sette språk til \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Går inn i Ex-modus. Skriv \"visual\" for å gå til normalmodus."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Ved slutten av filen"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Kommando altfor rekursiv"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Unntak ikke fanget opp: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Slutt på kjørt fil"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Slutt på funksjon"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Flertydig bruk av brukerdefinert kommando"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Er ikke en editorkommando"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Område bakover er angitt"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Område bakover er angitt, OK å swappe"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Bruk w eller w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Kommandoen er ikke tilgjengelig i denne versjonen"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Bare ett filnavn tillatt"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 annen fil å redigere. Avslutt likevel?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d andre filer å redigere. Avslutt likevel?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 annen fil å redigere"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> andre filer å redigere"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Kommandoen finnes allerede: Legg til ! for å erstatte den"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1179,284 +1642,349 @@ msgstr ""
 "\n"
 "    Navn        Prm. Områd Fullfør   Definering"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Ingen brukerdefinerte kommandoer funnet"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Ingen attributt spesifisert"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Ugyldig antall parametere"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Antall repeteringer kan ikke bli spesifisert to ganger"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Ugyldig standardverdi for antall repeteringer"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: Trenger parameter til -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Ugyldig attributt: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Ugyldig kommandonavn"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Brukerdefinerte kommandoer må ha stor forbokstav"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Flertydig bruk av brukerdefinert kommando"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Brukerdefinert kommando finnes ikke: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Ugyldig \"complete\"-verdi: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Fullføringsparameter er bare tillatt for tilpasset fullføring"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Tilpassede fullføringer trenger et funksjonsparameter"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Kan ikke finne fargeoppsettet %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Vær hilset, Vim-bruker!"
 
+#: ../ex_docmd.c:5431
 #, fuzzy
-#~ msgid "E784: Cannot close last tab page"
-#~ msgstr "E444: Kan ikke lukke det siste vinduet"
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Kan ikke lukke det siste vinduet"
 
+#: ../ex_docmd.c:5462
 #, fuzzy
-#~ msgid "Already only one tab page"
-#~ msgstr "Allerede bare ett vindu"
+msgid "Already only one tab page"
+msgstr "Allerede bare ett vindu"
 
-msgid "Edit File in new window"
-msgstr "Rediger fil i nytt vindu"
-
+#: ../ex_docmd.c:6004
 #, fuzzy, c-format
-#~ msgid "Tab page %d"
-#~ msgstr "Side %d"
+msgid "Tab page %d"
+msgstr "Side %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Ingen swapfil"
 
-msgid "Append File"
-msgstr "Legg til fil"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Kan ikke skifte katalog, bufferen er forandret (legg til ! for å "
 "overstyre)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Ingen tidligere katalog"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Ukjent"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize trenger to numeriske parametere"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Vindusposisjon: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Lesing av vindusposisjon er ikke implementert på denne plattformen"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos trenger to numeriske parametere"
 
-msgid "Save Redirection"
-msgstr "Lagre omdirigering"
-
-msgid "Save View"
-msgstr "Lagre utseende"
-
-msgid "Save Session"
-msgstr "Lagre økt"
-
-msgid "Save Setup"
-msgstr "Lagre oppsett"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Kan ikke lage katalog: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" finnes (legg til ! for å overstyre)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Kan ikke åpne \"%s\" for skriving"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Parameter må være en bokstav eller vanlig/baklengs apostrof"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursiv bruk av :normal er for dyp"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Ingen alternative filnavn tilgjengelig som erstatning for '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr ""
 "E495: Ingen autokommandofilnavn tilgjengelig som erstatning for \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr ""
 "E496: Ingen buffernummer tilgjengelig som erstatning for \"<abuf>\" i "
 "autokommando"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: Ingen autokommandonavn tilgjengelig som erstatning for \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr ""
 "E498: Ingen ':source'-filnavn tilgjengelig som erstatning for \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr ""
+"E498: Ingen ':source'-filnavn tilgjengelig som erstatning for \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Tomt filnavn for '%' eller '#', virker bare med \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Resulterer i en tom streng"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Kan ikke åpne viminfo-fil for lesing"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Ingen spesialtegn i denne versjonen"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Kan ikke :throw unntak med 'Vim'-forstavelse"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
-#~ msgid "Exception thrown: %s"
-#~ msgstr ""
+msgid "Exception thrown: %s"
+msgstr ""
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Unntak fullført: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Unntak forkastet: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, linje %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Unntak fanget opp: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s satt på venting"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s gjenopptatt"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s forkastet"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Unntak"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Feil og avbrudd"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Feil"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Avbrudd"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Nøsting av :if for dyp"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif uten :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else uten :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif uten :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Flere forekomster av :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif etter :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Nøsting av :while/:for er for dyp"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue uten :while eller :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break uten :while eller :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Bruker :endfor sammen med :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Bruker :endwhile sammen med :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Nøsting av :try for dyp"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch uten :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch etter :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally uten :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Flere forekomster av :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry uten :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction er ikke innenfor en funksjon"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Ikke tillatt å redigere en annen buffer nå"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: Ikke tillatt å redigere en annen buffer nå"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "navn på tag"
 
-#~ msgid " kind file\n"
-#~ msgstr ""
+#: ../ex_getln.c:3181
+msgid " kind file\n"
+msgstr ""
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history'-valget er null"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1465,212 +1993,306 @@ msgstr ""
 "\n"
 "# %s-historie (nyeste til eldste):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Kommandolinje"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Søkestreng"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Uttrykk"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Inndatalinje"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar utenfor kommandolengden"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktivt vindu eller buffer slettet"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Ugyldig sti: '**[nummer]' må være på slutten av stien eller bli "
+"etterfulgt av '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Kan ikke finne katalogen \"%s\" i \"cdpath\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Kan ikke finne filen \"%s\" i stien"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Ingen flere katalog-\"%s\" funnet i \"cdpath\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Ingen flere fil-\"%s\" funnet i stien"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* Autokommandoer må ikke forandre nåværende buffer"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Ulovlig filnavn"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "er en katalog"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "er ikke en fil"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "er en enhet (frakoblet med 'opendevice'-valg)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Ny fil]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Ny KATALOG]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Filen er for stor]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Tilgang nektet]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: \"*ReadPre\"-autokommandoer gjorde filen uleselig"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: \"*ReadPre\"-autokommandoer må ikke forandre nåværende buffer"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Leser fra stdin ...\n"
 
-msgid "Reading from stdin..."
-msgstr "Leser fra stdin ..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Konverteringen gjorde filen uleselig!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[SB]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 tegn"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR mangler]"
 
-msgid "[NL found]"
-msgstr "[NL funnet]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[lange linjer splittes]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[IKKE konvertert]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[konvertert]"
 
-msgid "[crypted]"
-msgstr "[kryptert]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[KONVERTERINGSFEIL i linje %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[ULOVLIG BYTE i linje %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LESEFEIL]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Kan ikke finne midlertidig fil for konvertering"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konvertering med 'charconvert' feilet"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "Kan ikke lese utdata fra 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Ingen samsvarende autokommandoer for 'acwrite'-buffer"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Autokommandoer slettet eller lastet ut buffer som skulle lagres"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autokommando forandret linjeantall på en uventet måte"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans forbyr lagring av buffere som ikke er forandret"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Delvis lagring ikke tillatt for NetBeans-buffere"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "er ikke en fil eller skrivbar enhet"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "skriving til enhet er slått av med 'opendevice'-valg"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "er skrivebeskyttet (legg til ! for å overstyre)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Kan ikke skrive til backupfil (legg til ! for å overstyre)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Feil under lukking av backupfil (legg til ! for å overstyre)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Kan ikke lese fil for backup (legg til ! for å overstyre)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Kan ikke lese backupfil (legg til ! for å overstyre)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Kan ikke lage backupfil (legg til ! for å overstyre)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Ressursforgreningen ville gått tapt (legg til ! for å overstyre)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Kan ikke finne midlertidig fil for skriving"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Kan ikke konvertere (legg til ! for å lagre uten konvertering)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Kan ikke åpne lenket fil for skriving"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Kan ikke åpne fil for skriving"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync feilet"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Lukking feilet"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Feil under skriving, konvertering feilet (gjør 'fenc' tom for å "
 "overstyre)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: Feil under skriving, konvertering feilet (gjør 'fenc' tom for å "
+"overstyre)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Feil under lagring (full disk?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " KONVERTERINGSFEIL"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "linje %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Enhet]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Ny]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [l]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " lagt til"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [s]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " skrevet"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: Kan ikke lagre originalfil"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: Kan ikke oppdatere tom originalfil"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Kan ikke slette backupfil"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1678,75 +2300,96 @@ msgstr ""
 "\n"
 "ADVARSEL: Originalfilen kan bli tapt eller ødelagt\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "ikke avslutt editoren før filen er skikkelig lagret!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos-format]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac-format]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix-format]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 linje, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> linjer, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 tegn"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> tegn"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[ingenlinjeslutt]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Ufullstendig sistelinje]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ADVARSEL: Filen er blitt forandret siden den ble lest!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Vil du virkelig skrive til den"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Feil under skriving til \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Feil under lukking av \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Feil under lesing av \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Autokommandoen \"FileChangedShell\" slettet buffer"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Filen \"%s\" er ikke lenger tilgjengelig"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1754,33 +2397,41 @@ msgid ""
 msgstr ""
 "W12: Advarsel: Filen \"%s\" er forandret og bufferen var også forandret i Vim"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Se \":help W12\" for mer informasjon."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Advarsel: Filen \"%s\" er forandret siden redigeringen startet"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Se \":help W11\" for mer informasjon."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Advarsel: Rettighetene til filen \"%s\" er forandret siden redigeringen "
 "startet"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Se \":help W16\" for mer informasjon."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Advarsel: Filen \"%s\" er blitt opprettet etter at redigeringen startet"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Advarsel"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1788,39 +2439,48 @@ msgstr ""
 "&OK\n"
 "&Åpne fil"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Kunne ikke forberede for relasting \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Kunne ikke laste \"%s\" på nytt"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Slettet--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "fjerner autokommando automatisk: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Gruppen finnes ikke: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Ulovlig tegn etter *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Handlingen finnes ikke: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Gruppen eller handlingen finnes ikke: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1828,566 +2488,799 @@ msgstr ""
 "\n"
 "--- Autokommandoer ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: Ugyldig buffernummer"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Kan ikke utføre autokommandoer for ALLE hendelser"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Ingen samsvarende autokommandoer"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Nøsting av autokommandoer for dyp"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokommandoer for \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Utfører %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autokommando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Mangler {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Mangler }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Ingen fold funnet"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Kan ikke lage fold med nåværende 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Kan ikke slette fold med nåværende 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld linjer foldet "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Legger til allerede lest buffer"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Rekursiv mapping"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Global forkortelse finnes allerede for %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Global mapping finnes allerede for %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Forkortelse finnes allerede for %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Mappingen finnes allerede for %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Ingen forkortelse funnet"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Ingen mapping funnet"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Ulovlig modus"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Kan ikke starte grafisk brukergrensesnitt (GUI)"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Ingen linjer i bufferen--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Kan ikke lese fra \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Kommandoen avbrutt"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Parameter nødvendig"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ skulle ha vært fulgt av /, ? eller &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Ugyldig i kommandolinjevindu; <ENTER> utfører, CTRL-C avslutter"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E665: Kan ikke starte grafisk brukergrensesnitt, fant ingen gyldig font"
+"E12: Kommandoen er ikke tillatt fra exrc/vimrc i nåværende katalog eller "
+"tagsøk"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' ugyldig"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Mangler :endif"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Verdien for 'imactivatekey' er ugyldig"
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Mangler :endtry"
 
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Mangler :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Mangler :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile uten :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor uten :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Filen finnes (legg til ! for å overstyre)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Kommandoen feilet"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Intern feil"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Avbrutt"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Ugyldig adresse"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Ugyldig parameter"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Kan ikke reservere farge %s"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Ugyldig paramter: %s"
 
-msgid "No match at cursor, finding next"
-msgstr "Ingen treff ved markøren, finner neste"
-
-msgid "<cannot open> "
-msgstr "<kan ikke åpne> "
-
+#: ../globals.h:1016
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: Kan ikke bruke skrifttypen %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Ugyldig uttrykk: %s"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: Kan ikke returnere til nåværende katalog"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Ugyldig område"
 
-msgid "Pathname:"
-msgstr "Sti:"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Ugyldig kommando"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: Kan ikke finne nåværende katalog"
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" er en katalog"
 
-msgid "OK"
-msgstr "OK"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Ugyldig \"scroll\"-verdi"
 
-msgid "Cancel"
-msgstr "Avbryt"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Rullefeltelement: Klarte ikke hente dimensjoner på \"thumb pixmap\"."
-
-msgid "Vim dialog"
-msgstr "Dialogvindu for Vim"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Kan ikke lage BalloonEval med både melding og tilbakekall"
-
-msgid "Vim dialog..."
-msgstr "Vim dialogvindu ..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Ja\n"
-"&Nei\n"
-"&Avbryt"
 
-msgid "Input _Methods"
-msgstr "Inndata-_metoder"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Søk og erstatt ..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Søk ..."
-
-msgid "Find what:"
-msgstr "Finn hva:"
-
-msgid "Replace with:"
-msgstr "Erstatt med:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Finn kun hele ord"
-
-#. match case button
-msgid "Match case"
-msgstr "Forskjell på store/små bokstaver"
-
-msgid "Direction"
-msgstr "Retning"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Opp"
-
-msgid "Down"
-msgstr "Ned"
-
-msgid "Find Next"
-msgstr "Finn neste"
-
-msgid "Replace"
-msgstr "Erstatt"
-
-msgid "Replace All"
-msgstr "Erstatt alle"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Mottok \"dø\"-forespørsel fra øktbehandleren\n"
-
-msgid "Close"
-msgstr "Lukk"
-
-#~ msgid "New tab"
-#~ msgstr ""
-
-#~ msgid "Open Tab..."
-#~ msgstr ""
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Uventet ødeleggelse av hovedvinduet\n"
-
-msgid "Font Selection"
-msgstr "Velge skrifttype"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Brukte CUT_BUFFER0 istedenfor tomt valg"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Avbryt"
-
-msgid "Directories"
-msgstr "Kataloger"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Hjelp"
-
-msgid "Files"
-msgstr "Filer"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Valg"
-
-msgid "Find &Next"
-msgstr "Finn &neste"
-
-msgid "&Replace"
-msgstr "E&rstatt"
-
-msgid "Replace &All"
-msgstr "Erstatt &alle"
-
-msgid "&Undo"
-msgstr "&Angre"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Fant ikke vindutittel \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Parameter ikke støttet: \"-%s\"; Bruk OLE-versjonen."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Klarer ikke åpne vindu inne i MDI-applikasjon"
-
-#~ msgid "Close tab"
-#~ msgstr ""
-
-#~ msgid "Open tab..."
-#~ msgstr ""
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Finn streng (bruk '\\\\' for å finne en '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Søk og erstatt (bruk '\\\\' for å finne en '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Ikke brukt"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Katalog\t*.ingenting\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: Kan ikke reservere fargekart, noen farger kan være feil"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Skrifttyper for de følgende tegnsett mangler i fontsett %s:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Navn på skrifttypesett: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Skrifttypen '%s' har ikke konstant bredde"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Navn på skrifttypesett: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Font%<PRId64>-bredde er ikke to ganger bredden av font0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Font0-bredde: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Font1-bredde: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Ugyldig skrifttypespesifisering"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Bibliotek-kall feilet for \"%s()\""
 
-msgid "&Dismiss"
-msgstr "&Forkast"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Merket har et ugyldig linjenummer"
 
-msgid "no specific match"
-msgstr "ingen spesifikke treff"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Merket ble ikke satt"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Skrifttypevelger"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Kan ikke gjøre forandringer, 'modifiable' er av"
 
-msgid "Name:"
-msgstr "Navn:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skripts nøstet for dypt"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Vis størrelse i punkter"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Ingen alternativ fil"
 
-msgid "Encoding:"
-msgstr "Koding:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Forkortelsen finnes ikke"
 
-msgid "Font:"
-msgstr "Skrifttype:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Ingen ! tillatt"
 
-msgid "Style:"
-msgstr "Stil:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI kan ikke brukes: Ikke slått på under kompilering"
 
-msgid "Size:"
-msgstr "Størrelse:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Uthevingsgruppe finnes ikke: %s"
 
-#~ msgid "E256: Hangul automata ERROR"
-#~ msgstr ""
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Ingen innlagt tekst enda"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Ingen tidligere kommandolinje"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Mappingen finnes ikke"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Ingen treff"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Ingen treff: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Mangler filnavn"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Ingen tidligere erstatninger med regulære uttrykk"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Ingen tidligere kommando"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Ingen tidligere regulære uttrykk"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Område er ikke tillatt"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Ikke nok plass"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Kan ikke opprette filen %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Kan ikke hente navn på midlertidig fil"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Kan ikke åpne filen %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Kan ikke lese filen %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Ikke lagret siden forrige forandring (legg til ! for å overstyre)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Ikke lagret siden forrige forandring]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nullparameter"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nummer forventet"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Kan ikke åpne feilfilen %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Ikke mer ledig hukommelse!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Fant ikke søketeksten"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Fant ikke søketeksten: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Parameteret må være positivt"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Kan ikke gå tilbake til tidligere katalog"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Ingen feil"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Ingen plassliste"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Ødelagt søkestreng"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Skadet program med regulært uttrykk"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly'-valget er satt (legg til ! for å overstyre)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Kan ikke forandre skrivebeskyttet variabel \"%s\""
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Kan ikke sette variabel i sandkassen: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Feil under lesing av feilfilen"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Ikke tillatt i sandkassen"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Ikke tillatt her"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Forandring av skjermmodus er ikke støttet"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Ugyldig \"scroll\"-verdi"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell'-valget er tomt"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Kunne ikke lese inn skiltdata!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Feil under lukking av swapfil"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: Tag-stack tom"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Kommandoen er for kompleks"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Navnet er for langt"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: For mange ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: For mange filnavn"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Etterfølgende tegn"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Ukjent merke"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Klarte ikke utvide jokertegn"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' kan ikke være mindre enn 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' kan ikke være mindre enn 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Feil under skriving"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Antall repeteringer er null"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Bruker <SID> utenom skript-kontekst"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Intern feil: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Søkestrengen bruker mer hukommelse enn 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Tom buffer"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Ugyldig søkestreng eller skilletegn"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Filen er lastet i en annen buffer"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Valget '%s' er ikke satt"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Ugyldig registernavn: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Søket traff TOPPEN, fortsetter fra BUNNEN"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Søket traff BUNNEN, fortsetter fra TOPPEN"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Mangler kolon"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Ulovlig komponent"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: Siffer forventet"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Side %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Ingen tekst for utskrift"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Skriver ut side %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopi %d av %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Skrevet ut: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Utskrift avbrutt"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Feil under skriving til Postscript-fil"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Kan ikke åpne filen \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Kan ikke lese Postscript-ressursfil \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Filen \"%s\" er ikke en Postscript-ressursfil"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Det er ikke støtte for Postscript-ressursfilen \"%s\""
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Ressursfilen \"%s\" er feil versjon"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Inkompatibel multibytekoding og tegnsett"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset kan ikke være tom med multibytekoding"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Ingen standardfont spesifisert for multibyteutskrift"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Kan ikke åpne Postscript-fil for skriving"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Kan ikke åpne filen \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Fant ikke Postscript-ressursfilen \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Fant ikke Postscript-ressursfilen \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Fant ikke Postscript-ressursfilen \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Klarte ikke å konvertere til utskriftskoding \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Sender til skriver ..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Feil under utskrift av Postscript-fil"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Skriverjobb sendt."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Legg til en ny database"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Forespørsel etter søkestreng"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Vis denne meldingen"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Drep en forbindelse"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Reinitialiser alle forbindelser"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Vis forbindelser"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Bruk: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Denne cscope-kommandoen støtter ikke splitting av vinduet.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Bruk: cstag <identifikator>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: Tag ikke funnet"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) feil: %d"
 
-msgid "E563: stat error"
-msgstr "E563: \"stat\"-feil"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s er ikke en katalog eller gyldig cscope-database"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "La til cscope-database %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Feil under lesing av cscope-forbindelse %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Ukjent cscope-søketype"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Kunne ikke lage cscope-rør (\"pipe\")"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Klarte ikke lage tvillingprosess for cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "Utføring av cs_create_connection feilet"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "Utføring av cs_create_connection feilet"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Klarte ikke starte cscope-prosess"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen for to_fp feilet"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen for fr_fp feilet"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Klarte ikke starte cscope-prosess"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: Ingen cscope-forbindelse"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: Ingen treff funnet for cscope-forespørsel %s av %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Ugyldig \"cscopequickfix\"-flagg %c for %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: Ingen treff funnet for cscope-forespørsel %s av %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope-kommandoer:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Bruk: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Kan ikke åpne cscope-database: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Kan ikke hente informasjon om cscope-database"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Duplisert cscope-database ikke lagt til"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: Maksimum antall cscope-forbindelser nådd"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope-forbindelse %s ikke funnet"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope-forbindelsen %s stengt"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Kritisk feil i cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope-tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2395,398 +3288,88 @@ msgstr ""
 "\n"
 "   #   linje"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "filnavn / kontekst / linje\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope-feil: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Alle cscope-databaser resatt"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "ingen cscope-forbindelser\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    databasenavn                        legg til sti\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr ""
-"???: Denne kommandoen er deaktivert, MzScheme-biblioteket kunne ikke lastes."
-
-msgid "invalid expression"
-msgstr "ugyldig uttrykk"
-
-msgid "expressions disabled at compile time"
-msgstr "uttrykk deaktivert på kompileringsstadiet"
-
-msgid "hidden option"
-msgstr "skjult valg"
-
-msgid "unknown option"
-msgstr "ukjent valg"
-
-msgid "window index is out of range"
-msgstr "indeks for vindu er utenfor område"
-
-msgid "couldn't open buffer"
-msgstr "klarte ikke å åpne buffer"
-
-msgid "cannot save undo information"
-msgstr "kan ikke lagre angre-informasjon"
-
-msgid "cannot delete line"
-msgstr "kan ikke slette linje"
-
-msgid "cannot replace line"
-msgstr "kan ikke erstatte linje"
-
-msgid "cannot insert line"
-msgstr "kan ikke sette inn linje"
-
-msgid "string cannot contain newlines"
-msgstr "streng kan ikke inneholde linjeskift"
-
-msgid "Vim error: ~a"
-msgstr "Vim-feil: ~a"
-
-msgid "Vim error"
-msgstr "Vim-feil"
-
-msgid "buffer is invalid"
-msgstr "buffer er ugyldig"
-
-msgid "window is invalid"
-msgstr "vindu er ugyldig"
-
-msgid "linenr out of range"
-msgstr "linjenummer utenfor område"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "ikke tillatt i Vim-sandkassen"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Denne kommandoen er deaktivert, Python-biblioteket kunne ikke lastes."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Kan ikke starte Python rekursivt"
-
-msgid "can't delete OutputObject attributes"
-msgstr "Kan ikke slette \"OutputObject\"-attributter"
-
-msgid "softspace must be an integer"
-msgstr "\"softspace\" må være et heltall"
-
-msgid "invalid attribute"
-msgstr "ugyldig attributt"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() krever en liste av strenger"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Feil under initialisering av I/U-objekter"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "forsøk på å referere til slettet buffer"
-
-msgid "line number out of range"
-msgstr "linjenummer utenfor område"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<bufferobjekt (slettet) ved %8lX>"
-
-msgid "invalid mark name"
-msgstr "ugyldig merkenavn"
-
-msgid "no such buffer"
-msgstr "bufferen finnes ikke"
-
-msgid "attempt to refer to deleted window"
-msgstr "forsøk på å referere til slettet vindu"
-
-msgid "readonly attribute"
-msgstr "skrivebeskyttet attributt"
-
-msgid "cursor position outside buffer"
-msgstr "markørposisjon utenfor buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<vindusobjekt (slettet) ved %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<vindusobjekt (ukjent) ved %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<vindu %d>"
-
-msgid "no such window"
-msgstr "vinduet finnes ikke"
-
-#~ msgid "E265: $_ must be an instance of String"
-#~ msgstr ""
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Denne kommandoen er deaktivert, Ruby-biblioteket kunne ikke lastes."
-
-msgid "E267: unexpected return"
-msgstr "E267: Uventet return"
-
-msgid "E268: unexpected next"
-msgstr "E268: Uvented next"
-
-msgid "E269: unexpected break"
-msgstr "E269: Uventet break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: Uventet redo"
-
-#~ msgid "E271: retry outside of rescue clause"
-#~ msgstr ""
-
-msgid "E272: unhandled exception"
-msgstr "E272: Ubehandlet unntak"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Ukjent longjmp-status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Bytt mellom implementasjon/definisjon"
-
-msgid "Show base class of"
-msgstr "Vis basisklasse av"
-
-msgid "Show overridden member function"
-msgstr "Vis overstyrt medlemsfunksjon"
-
-msgid "Retrieve from file"
-msgstr "Hent fra fil"
-
-msgid "Retrieve from project"
-msgstr "Hent fra prosjekt"
-
-msgid "Retrieve from all projects"
-msgstr "Hent fra alle prosjekter"
-
-msgid "Retrieve"
-msgstr "Hent"
-
-msgid "Show source of"
-msgstr "Vis kilde til"
-
-msgid "Find symbol"
-msgstr "Finn symbol"
-
-msgid "Browse class"
-msgstr "Bla gjennom klasse"
-
-msgid "Show class in hierarchy"
-msgstr "Vis klasse i hierarki"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Vis klasse i begrenset hierarki"
-
-msgid "Xref refers to"
-msgstr "Xref refererer til"
-
-msgid "Xref referred by"
-msgstr "Xref referert av"
-
-msgid "Xref has a"
-msgstr "Xref har en"
-
-msgid "Xref used by"
-msgstr "Xref brukt av"
-
-msgid "Show docu of"
-msgstr "Vis docu av"
-
-msgid "Generate docu for"
-msgstr "Generer docu for"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Kan ikke koble til SNiFF+. Sjekk miljøet (\"environment\") (sniffemacs må "
-"bli funnet i $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Feil under lesing. Frakoblet"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ er for øyeblikket "
-
-msgid "not "
-msgstr "ikke "
-
-msgid "connected"
-msgstr "oppkoblet"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Ukjent SNiFF+-forespørsel: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Feil ved oppkobling til SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ ikke tilkoblet"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Ikke en SNiFF+-buffer"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Feil under skriving. Frakoblet"
-
-msgid "invalid buffer number"
-msgstr "ugyldig buffernummer"
-
-msgid "not implemented yet"
-msgstr "ikke implementert enda"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "kan ikke sette linje(r)"
-
-msgid "mark not set"
-msgstr "merke ikke satt"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "rad %d kolonne %d"
-
-msgid "cannot insert/append line"
-msgstr "kan ikke sette inn/legge til linje"
-
-msgid "unknown flag: "
-msgstr "ukjent flagg: "
-
-msgid "unknown vimOption"
-msgstr "ukjent vimOption"
-
-msgid "keyboard interrupt"
-msgstr "tastaturavbrudd"
-
-msgid "vim error"
-msgstr "vim-feil"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "kan ikke opprette buffer/vindukommando: Objektet slettes"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"kan ikke registrere callback-kommando: Buffer/vindu er allerede slettet"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL KRITISK FEIL: reflist skadet!? Vennligst rapporter dette til vim-"
-"dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"kan ikke registrere callback-kommando: Buffer/vindureferanse ikke funnet"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Denne kommandoen er deaktivert, Tcl-biblioteket kunne ikke lastes."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL-FEIL: Avslutningskode er ikke int!? Vennligst rapporter dette til "
-"vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Avslutningskode %d"
-
-msgid "cannot get line"
-msgstr "kan ikke hente linje"
-
-msgid "Unable to register a command server name"
-msgstr "Klarer ikke registrere kommandotjenernavn"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Klarte ikke sende kommando til destinasjonsprogrammet"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Ugyldig tjener-id brukt: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: Registry-egenskapen for VIM-oppføringen er ikke korrekt. Slettet!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Ukjent parameter til valg"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "For mange redigeringsparametere"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Parameter mangler etter"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Søppel etter valgparameter"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "For mange \"+command\"-, \"-c command\"- eller \"--cmd kommando\"-parametere"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Ugyldig parameter for"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d filer å redigere\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Denne Vim-versjonen er kompilert uten differansefunksjonen."
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Forsøk på å åpne skriptfilen igjen: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Kan ikke åpne for lesing: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Kan ikke åpne for skript-utdata: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Feil: Feil under start av gvim fra NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Advarsel: Utdata går ikke til en terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Advarsel: Inndata kommer ikke fra en terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc kommandolinje"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kan ikke lese fra \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2794,18 +3377,23 @@ msgstr ""
 "\n"
 "Mer info med: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[file ..]       rediger spesifisert(e) fil(er)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               les tekst fra stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          rediger fil hvor en tag er definert"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [feilfil]    rediger fil med første feil"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2815,9 +3403,11 @@ msgstr ""
 "\n"
 "bruk:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [parametere] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2825,11 +3415,7 @@ msgstr ""
 "\n"
 "   eller:"
 
-msgid "where case is ignored prepend / to make flag upper case"
-msgstr ""
-"der bokstavstørrelse ignoreres, legg til / i begynnelsen for\n"
-"å gjøre flagget om til stor bokstav"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2839,329 +3425,190 @@ msgstr ""
 "\n"
 "Parametere:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tBare filnavn etter dette"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tIkke utvid jokertegn"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistrer gvim for OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tFjern OLE-registrering for gvim"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tKjør med GUI (som \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  eller  --nofork\tForgrunn: Ikke fork når GUI-et startes"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi-modus (som \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx-modus (som \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tStille (batch) modus (bare for \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDifferanse-modus (som \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tLett modus (som \"evim\", uten modus)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivebeskyttet modus (som \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tBegrenset modus (som \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifisering (lagring av filer) ikke tillatt"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModifiseringer i teksten ikke tillatt"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinærmodus"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp-modus"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatibel med Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tIkke helt Vi-kompatibel: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tInformasjonsnivå (\"Verbose\")"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tDebuggingsmodus"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tIngen swapfil, bruk bare hukommelsen"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tList swapfiler og avslutt"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (med filnavn)\tGjenopprett kræsjet økt"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tSamme som -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tIkke bruk newcli for å åpne vindu"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <enhet>\t\tBruk <enhet> for I/U"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tStart i arabisk modus"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tStart i hebraisk modus"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tStart i persisk (Farsi) modus"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tSett terminaltypen til <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tBruk <vimrc> istedenfor eventuell .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tBruk <gvimrc> istedenfor eventuell .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tIkke last plugin-skripts"
 
+#: ../main.c:2227
 #, fuzzy
-#~ msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
-#~ msgstr "-o[N]\t\tÅpne N vinduer (standard: Ett for hver fil)"
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tÅpne N vinduer (standard: Ett for hver fil)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tÅpne N vinduer (standard: Ett for hver fil)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tSom -o men splitt loddrett"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tStart på slutten av filen"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnr>\t\tStart på linje <lnr>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <kommando>\tKjør <kommando> før lasting av vimrc-filer"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <kommando>\tKjør <kommando> etter lasting av første fil"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <økt>\t\tKjør filen <økt> etter lasting av første fil"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <innskript>\tLes normalmodus-kommandoer fra filen <innskript>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <utskript>\tLegg alle skrevne kommandoer til filen <utskript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <utskript>\tSkriv alle skrevne kommandoer til filen <utskript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tRediger krypterte filer"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tKoble vim til denne spesielle X-tjeneren"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tUnngå oppkobling til X-tjener"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <filer>\tRediger <filer> på en Vim-tjener hvis mulig"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <filer>  Samme, ikke klag hvis tjeneren mangler"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  Samme, ikke klag hvis tjeneren mangler"
-
-#, fuzzy
-#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
-#~ msgstr ""
-#~ "--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <nøkler>\tSend <nøkler> til en Vim-tjener og avslutt"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <uttrykk>\tEvaluer <uttrykk> på en Vim-tjener og skriv "
-"resultatet"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tList navn på tilgjengelige Vim-tjenere og avslutt"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <navn>\tSend til/bli Vim-tjeneren <navn>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tBruk <viminfo> istedenfor .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  eller  --help\tSkriv hjelpen (denne teksten) og avslutt"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tSkriv versjonsinformasjon og avslutt"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (Motif-versjon):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (neXtaw-versjon):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (Athena-versjon):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tKjør vim på <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tStart vim som ikon"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <navn>\t\tBruk ressurs som om Vim var <navn>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Ikke implementert)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <farge>\tBruk <farge> på bakgrunnen (også: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <farge>\tBruk <farge> på normal tekst (også: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <skrifttype>\t\tBruk <skrifttype> på normal tekst (også: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <skrifttype>\tBruk <skrifttype> på fet skrift"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <skrifttype>\tBruk <skrifttype> på skrå tekst"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tBruk <geom> for innledende vindusplassering (også: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr ""
-"-borderwidth <bredde>\tBruk en rammebredde tilsvarende <bredde> (også: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <bredde>  Bruk en rullefeltbredde tilsvarende <bredde> "
-"(også: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <høyde>\tBruk en menyblokkhøyde tilsvarende <høyde> (også: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tBruk invers video (også: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tIkke bruk invers video (også: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ressurs>\tSett den spesifiserte ressursen"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (RISC OS-versjon):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <antall>\tInnledende bredde på vindu i kolonner"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <antall>\tInnledende høyde på vindu i rader"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Parametere gjenkjent av gvim (GTK+-versjon):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tKjør vim på <display> (også: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tSett en unik \"role\" for å identifisere hovedvinduet"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tÅpne Vim innenfor et annet GTK-skjermelement"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <foreldretittel>\tStart Vim innenfor et foreldreprogram"
-
-msgid "No display"
-msgstr "Ingen display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Send feilet.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Send feilet. Prøver å utføre lokalt\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d av %d redigert"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Ingen display: Sending av uttrykk feilet.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Sending av uttrykk feilet.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Ingen merker satt"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Ingen merker samsvarer med \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3170,6 +3617,7 @@ msgstr ""
 "merk linje kol fil/tekst"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3178,6 +3626,7 @@ msgstr ""
 " hopp linje kol fil/tekst"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3185,7 +3634,7 @@ msgstr ""
 "\n"
 "forand linje kol tekst"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3194,7 +3643,7 @@ msgstr ""
 "# Filmerker:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3202,7 +3651,7 @@ msgstr ""
 "\n"
 "# Hoppliste (nyeste først):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3210,95 +3659,84 @@ msgstr ""
 "\n"
 "# Historie for merker inne i filer (yngst til eldst):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Mangler '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Er ikke en gyldig codepage"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Kan ikke sette IC-verdier (\"Input Context\")"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Klarte ikke opprette inndatakontekst"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Klarte ikke åpne inndatametode"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Advarsel: Klarte ikke sette \"destroy callback\" til inndatametode"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Inndatametode støtter ikke enhver stil"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: Inndatametode støtter ikke min \"preedit\" type"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: \"over-the-spot\"-stil trenger et skrifttypesett"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Din GTK+ er eldre enn 1.2.3. Statusområde deaktivert"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Inndatametodetjener kjører ikke"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Blokken var ikke låst"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Søkefeil i lesing av swapfil"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Lesefeil i swapfil"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Søkefeil i skriving til swapfil"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Skrivefeil i swapfil"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Swapfilen finnes allerede (symlenke-angrep?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Hentet ikke blokk nummer 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Hentet ikke blokk nummer 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Hentet ikke blokk nummer 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Opps, mistet swapfilen!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Klarte ikke skifte navn på swapfil"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Klarte ikke åpne swapfil for \"%s\", gjenoppretting umulig"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Hentet ikke blokk 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Ingen swapfil funnet for %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Skriv nummeret på swapfil som skal brukes (0 for å avslutte): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Kan ikke åpne %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Klarte ikke lese blokk 0 fra "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3307,22 +3745,28 @@ msgstr ""
 "Det er mulig ingen forandringer ble gjort, eller Vim oppdaterte ikke "
 "swapfilen."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " kan ikke brukes med denne Vim-versjonen.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Bruk Vim versjon 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ser ikke ut som en Vim-swapfil"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " kan ikke brukes på denne maskinen.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Filen ble laget på "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3330,63 +3774,85 @@ msgstr ""
 ",\n"
 "eller filen er blitt ødelagt."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Bruker swapfilen \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Originalfil \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Advarsel: Originalfilen kan ha blitt forandret"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Klarte ikke lese blokk 1 fra %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???MANGE LINJER MANGLER"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???FEIL LINJEANTALL"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???TOM BLOKK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LINJER MANGLER"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID til blokk 1 er feil (%s ikke en \".swp\"-fil?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOKK MANGLER"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? Herfra til ???SLUTT kan linjer være rotet til"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? Herfra til ???SLUTT kan linjer ha blitt lagt til eller slettet"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???SLUTT"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Gjenoppretting avbrutt"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Feil oppdaget under gjenoppretting; se etter linjer som starter med ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Se \":help E312\" for mer informasjon."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Gjenoppretting komplett. Du bør sjekke at alt er i orden."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3394,50 +3860,71 @@ msgstr ""
 "\n"
 "(Du vil kanskje lagre denne filen under et annet navn\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "og sammenligne den mot den originale filen for å finne forandringer)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Slett \".swp\"-filen etterpå.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Swapfiler funnet:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   I nåværende katalog:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Bruker spesifisert navn:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   I katalog "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- ingen --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          eies av: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   datert: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             datert: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [fra Vim versjon 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ser ikke ut som en Vim-swapfil]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         filnavn: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3445,12 +3932,15 @@ msgstr ""
 "\n"
 "          modifisert: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nei"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3458,9 +3948,11 @@ msgstr ""
 "\n"
 "         brukernavn: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   vertsnavn: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3468,6 +3960,7 @@ msgstr ""
 "\n"
 "         vertsnavn: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3475,16 +3968,11 @@ msgstr ""
 "\n"
 "        prosess-ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (kjører fortsatt)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [ikke brukbar med denne Vim-versjonen]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3492,75 +3980,97 @@ msgstr ""
 "\n"
 "         [ikke brukbar på denne maskinen]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [kan ikke leses]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [kan ikke åpnes]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Kan ikke bevare, swapfil mangler"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Fil bevart"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Bevaring feilet"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: Ugyldig lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: Kan ikke finne linje %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Pekerblokk-id feil 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx skulle være 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Oppdaterte for mange blokker?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Pekerblokk-id feil 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "slettet blokk 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Kan ikke finne linje %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Pekerblokk-id feil"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count er null"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Linjenummer utenfor område: %<PRId64> forbi slutten"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Linjeantall feil i blokk %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Stackstørrelse øker"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Pekerblokk-id feil 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Symlenkesløyfe for \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: VIKTIG"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3568,38 +4078,44 @@ msgstr ""
 "\n"
 "Fant en swapfil ved navn \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Under åpning av filen \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NYERE enn swapfil!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Det er mulig et annet program redigerer den samme filen.\n"
 "    Hvis det er tilfelle, vær forsiktig så du ikke ender opp med to\n"
 "    forskjellige utgaver av den samme filen når du gjør forandringer.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Avslutt, eller fortsett med varsomhet.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) En økt for denne filen kræsjet.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Hvis det er tilfelle, bruk \":recover\" eller \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3607,9 +4123,11 @@ msgstr ""
 "\"\n"
 "    for å gjenopprette forandringene (se \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Hvis du har gjort dette allerede, slett swapfilen \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3617,18 +4135,23 @@ msgstr ""
 "\"\n"
 "    for å unngå denne meldingen.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Swapfilen \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" finnes allerede!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - VIKTIG"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Swapfilen eksisterer allerede!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3642,6 +4165,7 @@ msgstr ""
 "&Avslutt\n"
 "Av&bryt"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3657,34 +4181,56 @@ msgstr ""
 "&Avslutt\n"
 "Av&bryt"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: For mange swapfiler funnet"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %<PRIu64> bytes)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Del av menyelement er ikke undermeny"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menyen eksisterer bare i en annen modus"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Ingen \"%s\"-meny"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Tomt menynavn"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Menysti kan ikke lede til en undermeny"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Kan ikke legge til menyelementer direkte på menylinjen"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Skilletegn kan ikke være del av en menysti"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3692,61 +4238,74 @@ msgstr ""
 "\n"
 "--- Menyer ---"
 
-msgid "Tear off this menu"
-msgstr "Riv av denne menyen"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Menystien må lede til et menyvalg"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Fant ikke menyen: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menyen er ikke definert for %s-modus"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Menystien må lede til en undermeny"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Fant ikke menyen - sjekk menynavnet"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Feil oppdaget under prosessering av %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "linje %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ugyldig registernavn: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "Vedlikeholder for norsk oversettelse: Øyvind A. Holm <sunny@sunbase.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Avbryt: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Trykk ENTER eller skriv kommando for å fortsette"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s linje %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Mer --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " MELLOMROM/d/j: Skjerm/side/linje ned, b/u/k: Opp, q: Avslutt "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Spørsmål"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3754,6 +4313,17 @@ msgstr ""
 "&Ja\n"
 "&Nei"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ja\n"
+"&Nei\n"
+"&Avbryt"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3767,260 +4337,177 @@ msgstr ""
 "&Forkast alle\n"
 "&Avbryt"
 
-msgid "Select Directory dialog"
-msgstr "\"Velge katalog\"-dialogvindu"
-
-msgid "Save File dialog"
-msgstr "\"Lagre fil\"-dialogvindu"
-
-msgid "Open File dialog"
-msgstr "\"Åpne fil\"-dialogvindu"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Dessverre ingen filbehandler i konsollmodus"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Ikke nok parametre for printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Ikke nok parametre for printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: For mange parametere for printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Advarsel: Forandrer en skrivebeskyttet fil"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Skriv nummer eller velg med musen (<Enter> avbryter)"
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Valgnummer (<Enter> avbryter)"
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 linje lagt til"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 linje fjernet"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> linjer lagt til"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> linjer fjernet"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Avbrutt)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Pip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: Bevarer filer ...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Ferdig.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "FEIL: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bytes] totalt alloc-frigjort %<PRIu64>-%<PRIu64>, i bruk %<PRIu64>, topp-bruk %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[kall] totale \"re/malloc()\"-er %<PRIu64>, totale \"free()\"-er %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Linjen blir for lang"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %<PRIu64> bytes)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Kaller skall for å utføre \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Mangler kolon"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Ulovlig modus"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Ulovlig utseende på musepekeren"
-
-msgid "E548: digit expected"
-msgstr "E548: Siffer forventet"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Ulovlig prosent"
-
-msgid "Enter encryption key: "
-msgstr "Skriv krypteringsnøkkel: "
-
-msgid "Enter same key again: "
-msgstr "Gjenta krypteringsnøkkelen: "
-
-msgid "Keys don't match!"
-msgstr "Krypteringsnøklene stemmer ikke overens!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Ugyldig sti: '**[nummer]' må være på slutten av stien eller bli "
-"etterfulgt av '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Kan ikke finne katalogen \"%s\" i \"cdpath\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Kan ikke finne filen \"%s\" i stien"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Ingen flere katalog-\"%s\" funnet i \"cdpath\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Ingen flere fil-\"%s\" funnet i stien"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Kan ikke koble til Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Kan ikke koble til Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Feil tilgangsmodus for infofilen til NetBeans-forbindelse: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "les fra Netbeans-socket"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Mistet NetBeans-forbindelse for buffer %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' er tomt"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval-funksjonaliteten er ikke tilgjengelig"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Advarsel: Terminalen kan ikke utheve"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Ingen streng under markør"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Ingen identifikator under markør"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' er tomt"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Advarsel: Terminalen kan ikke utheve"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Ingen streng under markør"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Kan ikke slette folder med nåværende 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Forandringslisten er tom"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Ved starten av forandringsliste"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 linje \"%s\"-et 1 gang"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 linje \"%s\"-et %d ganger"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> linjer \"%s\"-et 1 gang"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> linjer \"%s\"-et %d ganger"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> linjer å rykke inn ... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 linje rykket inn "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> linjer rykket inn "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Register ikke tidligere brukt"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "kan ikke kopiere til utklippstavle; slett likevel"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 linje forandret"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> linjer forandret"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "frigjør %<PRId64> linjer"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "blokk med 1 linje kopiert til utklippstavlen"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 linje kopiert til utklippstavlen"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "blokk med %<PRId64> linjer kopiert til utklippstavlen"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> linjer kopiert til utklippstavlen"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Ingenting i register %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4028,10 +4515,11 @@ msgstr ""
 "\n"
 "--- Registere ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Ulovlig registernavn"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4039,156 +4527,194 @@ msgstr ""
 "\n"
 "# Registere:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Ukjent registertype %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kol; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> bytes"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> tegn; %<PRId64> av %<PRId64> bytes"
+"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; "
+"%<PRId64> av %<PRId64> bytes"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s av %s; Linje %<PRId64> av %<PRId64>; Ord %<PRId64> av %<PRId64>; Byte %<PRId64> av %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s av %s; linje %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tegn %<PRId64> av %<PRId64>; byte %<PRId64> av "
-"%<PRId64>"
+"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; "
+"%<PRId64> av %<PRId64> tegn; %<PRId64> av %<PRId64> bytes"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s av %s; Linje %<PRId64> av %<PRId64>; Ord %<PRId64> av %<PRId64>; Byte "
+"%<PRId64> av %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s av %s; linje %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tegn "
+"%<PRId64> av %<PRId64>; byte %<PRId64> av %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Side %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Takk for at du fløy Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Ukjent valg"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Valget er ikke støttet"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Ikke tillatt i moduslinje"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Nummer nødvendig etter ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Ikke funnet i termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Ulovlig tegn <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Kan ikke sette 'term' til tom streng"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Kan ikke forandre \"term\" i grafisk brukergrensesnitt"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Bruk \":gui\" for å starte med grafisk brukergrensesnitt"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' og 'patchmode' er like"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Kan ikke forandres i GTK+ 2 GUI"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Mangler kolon"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Tom streng"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Mangler nummer etter <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Mangler komma"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Må spesifisere en \"'\"-verdi"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Inneholder uskrivelige eller brede tegn"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Ugyldig(e) skrifttype(r)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Kan ikke velge skrifttypesett"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Ugyldig skrifttypesett"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Kan ikke velge bred skrifttype"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Ugyldig bred skrifttype"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ulovlig tegn etter <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Komma nødvendig"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' må være tom eller inneholde %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Ingen støtte for mus"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Uttrykkssekvens som ikke er lukket"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: For mange elementer"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Ubalanserte grupper"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Det finnes allerede et forhåndsvisningsvindu"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabisk trenger UTF-8, utfør ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Trenger minst %d linjer"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Trenger minst %d kolonner"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Ukjent valg: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Nummer nødvendig etter ="
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4196,6 +4722,7 @@ msgstr ""
 "\n"
 "--- Terminalkoder ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4203,6 +4730,7 @@ msgstr ""
 "\n"
 "--- Globale valgverdier ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4210,6 +4738,7 @@ msgstr ""
 "\n"
 "--- Lokale valgverdier ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4217,126 +4746,21 @@ msgstr ""
 "\n"
 "--- Valg ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: \"get_varp\"-FEIL"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Samsvarende tegn mangler for %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Ekstra tegn etter semikolon: %s"
 
-msgid "cannot open "
-msgstr "kan ikke åpne "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Kan ikke åpne vindu!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Trenger Amigados versjon 2.04 eller nyere\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Trenger %s versjon %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Kan ikke åpne NIL:\n"
-
-msgid "Cannot create "
-msgstr "Kan ikke opprette "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim avslutter med %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "kan ikke forandre konsollmodus ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: Ikke et konsoll??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Kan ikke kjøre skall med \"-f\"-valg"
-
-msgid "Cannot execute "
-msgstr "Kan ikke utføre "
-
-msgid "shell "
-msgstr "skall "
-
-msgid " returned\n"
-msgstr " returnerte\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE for liten."
-
-msgid "I/O ERROR"
-msgstr "I/U-FEIL"
-
-msgid "Message"
-msgstr "Melding"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' er ikke 80, kan ikke utføre eksterne kommandoer"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Valg av skriver feilet"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "til %s på %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Ukjent skrifttype for skriver: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Feil under utskrift: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Skriver ut '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Ulovlig navn på tegnsett \"%s\" i skrifttypenavn \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Ulovlig tegn '%c' i skrifttypenavn \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Dobbelt signal, avslutter\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Mottok dødelig signal %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Mottok dødelig signal\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Åpning av X-display tok %<PRId64> millisekunder"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Mottok X-feil\n"
-
-msgid "Testing the X display failed"
-msgstr "Test av X-display feilet"
-
-msgid "Opening the X display timed out"
-msgstr "Tidsavbrudd for åpning av X-display"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4344,13 +4768,7 @@ msgstr ""
 "\n"
 "Kan ikke kjøre skall "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Kan ikke kjøre skallet sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4358,749 +4776,953 @@ msgstr ""
 "\n"
 "skallet returnerte "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Kan ikke opprette rør (\"pipe\")\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Kan ikke opprette tvillingprosess (\"fork\")\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Kommando avsluttet\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP mistet ICE-forbindelsen"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Åpning av X-display feilet"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP håndterer \"redd-deg-selv\"-forespørsel"
-
-msgid "XSMP opening connection"
-msgstr "XSMP åpner forbindelse"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Overvåkning av XSMP ICE-forbindelse feilet"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection feilet: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Kan ikke finne filen \"%s\" i stien"
 
-msgid "At line"
-msgstr "På linje"
-
-msgid "Could not load vim32.dll!"
-msgstr "Klarte ikke laste vim32.dll!"
-
-msgid "VIM Error"
-msgstr "VIM-feil"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Klarte ikke ordne opp i funksjonspekere til DLL-en!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "skallet returnerte %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Mottok \"%s\"-hendelse\n"
-
-msgid "close"
-msgstr "lukk"
-
-msgid "logoff"
-msgstr "logg av"
-
-msgid "shutdown"
-msgstr "kjør ned"
-
-msgid "E371: Command not found"
-msgstr "E371: Kommando ikke funnet"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE ikke funnet i $PATH.\n"
-"Eksterne kommandoer kommer ikke til å vente etter fullføring.\n"
-"Se \":help win32-vimrun\" for mer informasjon."
-
-msgid "Vim Warning"
-msgstr "Vim-advarsel"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: For mange %%%c i formatstreng"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Uventet %%%c i formatstreng"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Mangler ] i formatstreng"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c ikke støttet i formatstreng"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Ugyldig %%%c i formatstreng-prefiks"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Ugyldig %%%c i formatstreng"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' inneholder ikke søkestreng"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Manglende eller tomt katalognavn"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Ingen flere elementer"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d av %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (linjen slettet)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: På bunnen av quickfix-stack"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: På toppen av quickfix-stack"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "feilliste %d av %d; %d feil"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Kan ikke lagre, 'buftype'-valget er satt"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Filnavn mangler eller ugyldig søkestreng"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Kan ikke åpne filen \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Bufferen er ikke lastet"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Streng eller liste forventet"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Ugyldig element i %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Søkestrengen er for lang"
-
-msgid "E50: Too many \\z("
-msgstr "E50: For mange \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: For mange %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Usamsvarende \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Usamsvarende %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Usamsvarende %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Usamsvarende %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Ugyldig tegn etter %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: For mange komplekse %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Nøstede %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Nøstede %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: Ugyldig bruk av \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c etterfølger ingenting"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Ulovlig tilbakereferanse"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( ikke tillatt her"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 med venner er ikke tillatt her"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Ugyldig tegn etter \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Mangler ] etter %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Tom %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Ugyldig tegn etter %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Ugyldig tegn etter %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Mangler ] etter %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Usamsvarende %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Usamsvarende %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Usamsvarende %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( ikke tillatt her"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 med venner er ikke tillatt her"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Mangler ] etter %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Tom %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Søkestrengen er for lang"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: For mange \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: For mange %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Usamsvarende \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: Ugyldig tegn etter %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: For mange komplekse %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Nøstede %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Nøstede %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Ugyldig bruk av \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c etterfølger ingenting"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Ulovlig tilbakereferanse"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Ugyldig tegn etter \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Ugyldig tegn etter %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Ugyldig tegn etter %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaksfeil i %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Eksterne deltreff:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: For mange \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Kan ikke finne midlertidig fil for skriving"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-ERSTATT"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ERSTATT"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " OMVENDT"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " SETT INN"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (sett inn)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (erstatt)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-erstatt)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " hebraisk"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " arabisk"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (lang)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (lim inn)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUELL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUELL LINJE"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUELL BLOKK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " VELG"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " VELG LINJE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " VELG BLOKK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "spiller inn"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Ugyldig søkestreng: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Søket kom til TOPPEN uten treff på: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Søket kom til BUNNEN uten treff på: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Forventet '?' eller '/' etter ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (inkluderer tidligere utlistede treff)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Inkluderte filer "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "ikke funnet "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "i sti ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Allerede listet)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  IKKE FUNNET"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Leter gjennom inkludert fil: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Leter gjennom inkludert fil %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Treffet er på nåværende linje"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Alle inkluderte filer ble funnet"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Ingen inkluderte filer"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Fant ikke definisjonen"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Fant ikke søketeksten"
 
-#, c-format
-#~ msgid ""
-#~ "\n"
-#~ "# Last %sSearch Pattern:\n"
-#~ "~"
-#~ msgstr ""
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 erstatning"
 
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Formateringsfeil i stavefil"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Valg av skriver feilet"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Etterfølgende tekst i %s linje %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affiksnavn for langt i %s linje %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Formatfeil i affiksfil FOL, LOW eller UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Tegn i FOL, LOW eller UPP er utenfor område"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Pakker ordtre ..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Stavekontroll er ikke aktivisert"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Advarsel: Kan ikke finne ordliste \"%s.%s.spl\" eller \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Leser stavefil \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Dette ser ikke ut som en stavefil"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Gammel stavefil, trenger oppdatering"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Stavefilen er for en nyere versjon av Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Ustøttet seksjon i stavefil"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Advarsel: Region %s ikke støttet"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Leser affiksfil %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konverteringsfeil for ord i %s linje %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konvertering i %s ikke støttet: Fra %s til %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konvertering i %s ikke støttet"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Ugyldig verdi for FLAG i %s linje %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG etter bruk av flagg i %s linje %d: %s"
 
+#: ../spell.c:4723
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "Feil COMPOUNDMIN-verdi i %s linje %d: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Feil COMPOUNDWORDMAX-verdi i %s linje %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Feil COMPOUNDMIN-verdi i %s linje %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Feil COMPOUNDSYLMAX-verdi i %s linje %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Feil CHECKCOMPOUNDPATTERN-verdi i %s linje %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Forskjellig kombinasjonsflagg i affiksblokk som fortsetter i %s linje %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Duplisert affiks i %s linje %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
 "line %d: %s"
 msgstr ""
-"Affiks også brukt for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST i %"
-"s linje %d: %s"
+"Affiks også brukt for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST i "
+"%s linje %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Forventet Y eller N i %s linje %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Brutt betingelse i %s linje %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Forventet REP(SAL)-antall i %s linje %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Forventet MAP-antall i %s linje %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Duplisert tegn i MAP i %s linje %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Ukjent eller duplisert element i %s linje %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Mangler FOL/LOW/UPP-linje i %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX brukt uten SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "For mange utsatte forstavelser"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "For mange sammensatte flagg"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "For mange utsatte forstavelser og/eller sammensatte flagg"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Mangler SOFO%s-linje i %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Både SAL- og SOFO-linjer i %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flagg er ikke et tall i %s linje %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Ulovlig flagg i %s linje %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s-verdi er forskjellig fra det som er bruk i en annen .aff-fil"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Leser ordlistefil %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Ingen ord-antall i %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "linje %6d, ord %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Duplisert ord i %s linje %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Første dupliserte ord i %s linje %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d duplisert(e) ord i %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ignorerte %d ord med ikke-ASCII-tegn i %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Leser ordfil %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Duplisert '/encoding='-linje ignorert i %s linje %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "'/encoding='-linje etter ord ignorert i %s linje %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Duplisert '/regions='-linje ignorert i %s linje %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "For mange regioner i %s linje %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "'/'-linje ignorert i %s linje %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Ugyldig regionnummer i %s linje %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Ukjent flagg i %s linje %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignorerte %d ord med ikke-ASCII-tegn"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Pakket %d av %d noder; %d (%d%%) igjen"
 
+#: ../spell.c:7340
 #, fuzzy
-#~ msgid "Reading back spell file..."
-#~ msgstr "Leser stavefil \"%s\""
+msgid "Reading back spell file..."
+msgstr "Leser stavefil \"%s\""
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
-#~ msgid "Performing soundfolding..."
-#~ msgstr ""
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
 
+#: ../spell.c:7368
 #, c-format
-#~ msgid "Number of words after soundfolding: %<PRId64>"
-#~ msgstr ""
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Totalt antall ord: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Skriver forslagsfil %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Anslått hukommelsesbruk under kjøring: %d bytes"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Utdatafilnavn må ikke ha regionnavn"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Kun opp til 8 regioner er støttet"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Ugyldig region i %s"
 
-#~ msgid "Warning: both compounding and NOBREAK specified"
-#~ msgstr ""
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Lagrer stavefil %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Ferdig!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' har ikke %<PRId64> poster"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Ord fjernet fra %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Ord lagt til %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Tegn i ord varierer mellom stavefiler"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Dessverre, ingen forslag"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Dessverre bare %<PRId64> forslag"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Forandre \"%.*s\" til:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Ingen tidligere staveerstatninger"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Ikke funnet: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Dette ser ikke ut som en .sug-fil: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Gammel .sug-fil, trenger oppdatering: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug-fila er for en nyere versjon av Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug-fil samsvarer ikke med .spl-fil: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Feil under lesing av .sug-fil: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Duplisert tegn i MAP-oppføring"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Ingen syntakselementer er definert for denne bufferen"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Ulovlig parameter: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaksklyngen finnes ikke: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Ingen syntakselementer er definert for denne bufferen"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synkroniserer C-lignende kommentarer"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "ingen synkronisering"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synkronisering starter "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " linjer før topplinje"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5108,6 +5730,7 @@ msgstr ""
 "\n"
 "--- \"Syntax sync\"-elementer ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5115,6 +5738,7 @@ msgstr ""
 "\n"
 "synkroniserer på elementer"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5122,199 +5746,275 @@ msgstr ""
 "\n"
 "--- Syntakselementer ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Syntaksklyngen finnes ikke: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksimal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; samsvarer med "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " linjeskift"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: \"contains\"-parameter aksepteres ikke her"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: \"containedin\"-parameter aksepteres ikke her"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Ugyldig parameter"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: \"group[t]here\" aksepteres ikke her"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Fant ikke regionelement for %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Trenger filnavn"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: For mange filnavn"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Mangler ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Mangler '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Ikke nok parametere: syntax region %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaksklyngen finnes ikke: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Ingen klynge er spesifisert"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Skilletegn for søketekst ble ikke funnet: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Søppel etter søketekst: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: syntax sync: Søkestreng for linjefortsettelser er spesifisert to ganger"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Ulovlige parametere: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Mangler \"er lik\"-tegn: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Tomt parameter: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s er ikke tillatt her"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s må være først i \"contains\"-liste"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Ukjent gruppenavn: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Ugyldig \":syntax\"-delkommando: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Rekursiv løkke laster syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Fant ikke uthevingsgruppe: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Ikke nok parametere: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: For mange parametere: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Syntaxgruppen har oppsett, uthevingslenke ignoreres"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Uventet \"er lik\"-tegn: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Mangler \"er lik\"-tegn: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Mangler parameter: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Ulovlig verdi: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Ukjent forgrunnsfarge"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Ukjent bakgrunnsfarge"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Kjenner ikke til fargenavnet eller -nummeret: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Terminalkoden er for lang: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Ulovlig parameter: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: For mange forskjellige uthevingsattributter i bruk"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ikke-skrivbart tegn i gruppenavn"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Ugyldig tegn i gruppenavn"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: På bunnen av tag-stack"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: På toppen av tag-stack"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Kan ikke gå før første samsvarende tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Fant ikke tag: %s"
 
-#~ msgid "  # pri kind tag"
-#~ msgstr ""
+#: ../tag.c:528
+msgid "  # pri kind tag"
+msgstr ""
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "fil\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Det finnes bare en samsvarende tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Kan ikke gå forbi siste samsvarende tag"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Filen \"%s\" finnes ikke"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d av %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " eller mer"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Bruker tag med forskjellig bokstavstørrelse!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Filen \"%s\" finnes ikke"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5322,59 +6022,79 @@ msgstr ""
 "\n"
 "  # TIL tag        FRA  linje i fil/tekst"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Leter i tagfil %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Sti til tagfil kuttet for %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formatfeil i tagfil \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Før byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tagfil ikke sortert: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Ingen tagfil"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Kan ikke finne tagsøkestreng"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Kunne ikke finne tag, bare gjetter!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Duplisert affiks i %s linje %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' ikke kjent. Tilgjengelige innebygde terminaler er:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "faller tilbake på '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Kan ikke åpne termcap-fil"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Fant ikke terminaloppføring i terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Fant ikke terminaloppføring i termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Ingen \"%s\"-oppføring i termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminalfunksjonen \"cm\" nødvendig"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5382,160 +6102,169 @@ msgstr ""
 "\n"
 "--- Terminaltaster ---"
 
-msgid "new shell started\n"
-msgstr "nytt skall startet\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Feil under lesing av inndata, avslutter ...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Ingen angremuligheter; fortsett likevel"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: Uventet forandring i buffer"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Kan ikke åpne fil for skriving"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Lagrer viminfo-fil \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Skrivefeil i swapfil"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Leser ordfil %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Kan ikke åpne viminfo-fil for lesing"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Ikke funnet: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Kan ikke åpne filen %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "ferdig med kjøring av %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Allerede ved eldste forandring"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Allerede ved nyeste forandring"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "Angrenummer %<PRId64> ikke funnet"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: Gale linjenummer"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "linje lagt til"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "linjer lagt til"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "linje fjernet"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "linjer fjernet"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "forandring"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "forandringer"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "før"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "etter"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Ingenting å angre"
 
-msgid "number changes  time"
-msgstr "nummer forandringer tidspunkt"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekunder siden"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin er ikke tillatt etter undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: Angrelisten er skadet"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Angrelisten mangler"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS Windows 16/32-bits grafisk versjon"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS Windows 64-bits grafisk versjon"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32-bits GUI-versjon"
-
-msgid " in Win32s mode"
-msgstr " i Win32s-modus"
-
-msgid " with OLE support"
-msgstr " med OLE-støtte"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bits konsollversjon"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16-bits versjon"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32-bits MS-DOS-versjon"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16-bits MS-DOS-versjon"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix)-versjon"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X-versjon"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS-versjon"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS-versjon"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5543,9 +6272,18 @@ msgstr ""
 "\n"
 "Inkluderte patcher: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Eksterne deltreff:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modifisert av "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5553,9 +6291,11 @@ msgstr ""
 "\n"
 "Kompilert "
 
+#: ../version.c:649
 msgid "by "
 msgstr "av "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5563,604 +6303,1622 @@ msgstr ""
 "\n"
 "Diger (\"huge\") versjon "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Stor (\"big\") versjon "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normal versjon "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Liten (\"small\") versjon "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Spinkel (\"tiny\") versjon "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "uten GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "med GTK2-GNOME GUI."
-
-msgid "with GTK-GNOME GUI."
-msgstr "med GTK-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "med GTK2 GUI."
-
-msgid "with GTK GUI."
-msgstr "med GTK GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "med X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "med X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "med X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "med Photon GUI."
-
-msgid "with GUI."
-msgstr "med GUI."
-
-msgid "with Carbon GUI."
-msgstr "med Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "med Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "med (klassisk) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Funksjoner inkludert (+) eller ikke (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "        vimrc-fil på systemet: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        vimrc-fil for brukere: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  vimrc-fil nr. 2 for brukere: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  vimrc-fil nr. 3 for brukere: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         exrc-fil for brukere: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   exrc-fil nr. 2 for brukere: \""
 
-msgid "  system gvimrc file: \""
-msgstr "       gvimrc-fil på systemet: \""
-
-msgid "    user gvimrc file: \""
-msgstr "       gvimrc-fil for brukere: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr " gvimrc-fil nr. 2 for brukere: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr " gvimrc-fil nr. 3 for brukere: \""
-
-msgid "    system menu file: \""
-msgstr "          menyfil på systemet: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       $VIM faller tilbake på: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "$VIMRUNTIME faller tilbake på: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilering: "
 
-msgid "Compiler: "
-msgstr "Kompilator: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Linking: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  DEBUGGINGSVERSJON"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved - Forbedret Vi"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versjon "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "av Bram Moolenaar med flere"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim er åpen kildekode og kan fritt distribueres"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Hjelp fattige barn i Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "skriv  :help iccf<Enter>          for informasjon  "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "skriv  :q<Enter>                  for å avslutte   "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "skriv  :help<Enter>  eller  <F1>  for on-line hjelp"
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "skriv  :help version7<Enter>      for versjonsinfo "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Kjører i Vi-kompatibel modus"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "skriv  :set nocp<Enter>           for standard Vim "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "skriv  :help cp-default<Enter>    for informasjon  "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "meny:  Hjelp->Foreldreløse        for informasjon  "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Kjører uten modus, tastetrykk blir lagt inn i teksten"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "meny:  Rediger->Globale innstillinger->Innsettingsmodus av/på"
-
-msgid "                              for two modes      "
-msgstr "                                  for to moduser   "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "meny:  Rediger->Globale innstillinger->Vi-kompatibilitet av/på"
-
-msgid "                              for Vim defaults   "
-msgstr "                                  for standard Vim "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Støtt utviklingen av Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Bli registrert bruker av Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "skriv  :help sponsor<Enter>       for informasjon  "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "skriv  :help register<Enter>      for informasjon  "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "meny:  Hjelp->Støtte/Registrering  for informasjon "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ADVARSEL: Windows 95/98/ME oppdaget"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "skriv  :help windows95<Enter>     for informasjon  "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Allerede bare ett vindu"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Vindu for forhåndsvisning finnes ikke"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Kan ikke splitte \"topleft\" og \"botright\" på en gang"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Kan ikke rotere når et annet vindu er splittet"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Kan ikke lukke det siste vinduet"
 
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Kan ikke lukke det siste vinduet"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Kan ikke lukke det siste vinduet"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Annet vindu inneholder forandringer"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Ingen filnavn under markøren"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Kan ikke finne filen \"%s\" i stien"
+#~ msgid "Patch file"
+#~ msgstr "Patch fil"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Klarte ikke laste bibliotek %s"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Avbryt"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Denne kommandoen er deaktivert, Perl-biblioteket kunne ikke lastes."
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Ingen forbindelse med Vim-tjeneren"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Evaluering av Perl er ikke tillatt i sandkassen uten \"Safe\"-modulen"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Klarer ikke sende til %s"
 
-msgid "Edit with &multiple Vims"
-msgstr "Rediger med &flere Vim-er"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Klarer ikke lese svar fra tjeneren"
 
-msgid "Edit with single &Vim"
-msgstr "Rediger med enkel &Vim"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Klarer ikke sende til klienten"
 
-msgid "Diff with Vim"
-msgstr "Differanse med Vim"
+#~ msgid "Save As"
+#~ msgstr "Lagre som"
 
-msgid "Edit with &Vim"
-msgstr "Rediger med &Vim"
+#~ msgid "Edit File"
+#~ msgstr "Rediger fil"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Rediger med eksisterende Vim - "
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (IKKE FUNNET)"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Redigerer de(n) valgte filen(e) med Vim"
+#~ msgid "Source Vim script"
+#~ msgstr "Kjør Vim-skript"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Klarte ikke lage prosess: Sjekk at gvim er i stien!"
+#~ msgid "Edit File in new window"
+#~ msgstr "Rediger fil i nytt vindu"
 
-msgid "gvimext.dll error"
-msgstr "Feil i gvimext.dll"
+#~ msgid "Append File"
+#~ msgstr "Legg til fil"
 
-msgid "Path length too long!"
-msgstr "Lengden på stien er for lang!"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Vindusposisjon: X %d, Y %d"
 
-msgid "--No lines in buffer--"
-msgstr "--Ingen linjer i bufferen--"
+#~ msgid "Save Redirection"
+#~ msgstr "Lagre omdirigering"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Kommandoen avbrutt"
+#~ msgid "Save View"
+#~ msgstr "Lagre utseende"
 
-msgid "E471: Argument required"
-msgstr "E471: Parameter nødvendig"
+#~ msgid "Save Session"
+#~ msgstr "Lagre økt"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ skulle ha vært fulgt av /, ? eller &"
+#~ msgid "Save Setup"
+#~ msgstr "Lagre oppsett"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ugyldig i kommandolinjevindu; <ENTER> utfører, CTRL-C avslutter"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Ingen spesialtegn i denne versjonen"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Kommandoen er ikke tillatt fra exrc/vimrc i nåværende katalog eller "
-"tagsøk"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "er en enhet (frakoblet med 'opendevice'-valg)"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Mangler :endif"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Leser fra stdin ..."
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Mangler :endtry"
+#~ msgid "[NL found]"
+#~ msgstr "[NL funnet]"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Mangler :endwhile"
+#~ msgid "[crypted]"
+#~ msgstr "[kryptert]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Mangler :endfor"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans forbyr lagring av buffere som ikke er forandret"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile uten :while"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Delvis lagring ikke tillatt for NetBeans-buffere"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor uten :for"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "skriving til enhet er slått av med 'opendevice'-valg"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Filen finnes (legg til ! for å overstyre)"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Ressursforgreningen ville gått tapt (legg til ! for å overstyre)"
 
-msgid "E472: Command failed"
-msgstr "E472: Kommandoen feilet"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Kan ikke starte grafisk brukergrensesnitt (GUI)"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Ukjent skrifttypesett: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Kan ikke lese fra \"%s\""
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Ukjent skrifttype: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Kan ikke starte grafisk brukergrensesnitt, fant ingen gyldig font"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Skrifttypen \"%s\" har ikke fast bredde"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' ugyldig"
 
-msgid "E473: Internal error"
-msgstr "E473: Intern feil"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Verdien for 'imactivatekey' er ugyldig"
 
-msgid "Interrupted"
-msgstr "Avbrutt"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Kan ikke reservere farge %s"
 
-msgid "E14: Invalid address"
-msgstr "E14: Ugyldig adresse"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Ingen treff ved markøren, finner neste"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Ugyldig parameter"
+#~ msgid "<cannot open> "
+#~ msgstr "<kan ikke åpne> "
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Ugyldig paramter: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: Kan ikke bruke skrifttypen %s"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Ugyldig uttrykk: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: Kan ikke returnere til nåværende katalog"
 
-msgid "E16: Invalid range"
-msgstr "E16: Ugyldig område"
+#~ msgid "Pathname:"
+#~ msgstr "Sti:"
 
-msgid "E476: Invalid command"
-msgstr "E476: Ugyldig kommando"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: Kan ikke finne nåværende katalog"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" er en katalog"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Bibliotek-kall feilet for \"%s()\""
+#~ msgid "Cancel"
+#~ msgstr "Avbryt"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Klarte ikke laste biblioteksfunksjon %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Rullefeltelement: Klarte ikke hente dimensjoner på \"thumb pixmap\"."
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Merket har et ugyldig linjenummer"
+#~ msgid "Vim dialog"
+#~ msgstr "Dialogvindu for Vim"
 
-msgid "E20: Mark not set"
-msgstr "E20: Merket ble ikke satt"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Kan ikke lage BalloonEval med både melding og tilbakekall"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Kan ikke gjøre forandringer, 'modifiable' er av"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialogvindu ..."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skripts nøstet for dypt"
+#~ msgid "Input _Methods"
+#~ msgstr "Inndata-_metoder"
 
-msgid "E23: No alternate file"
-msgstr "E23: Ingen alternativ fil"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Søk og erstatt ..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Forkortelsen finnes ikke"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Søk ..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: Ingen ! tillatt"
+#~ msgid "Find what:"
+#~ msgstr "Finn hva:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI kan ikke brukes: Ikke slått på under kompilering"
+#~ msgid "Replace with:"
+#~ msgstr "Erstatt med:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebraisk kan ikke brukes: Ikke slått på under kompilering\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Finn kun hele ord"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E27: Persisk (Farsi) kan ikke brukes: Ikke slått på under kompilering\n"
+#~ msgid "Match case"
+#~ msgstr "Forskjell på store/små bokstaver"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabisk kan ikke brukes: Ikke slått på under kompilering\n"
+#~ msgid "Direction"
+#~ msgstr "Retning"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Uthevingsgruppe finnes ikke: %s"
+#~ msgid "Up"
+#~ msgstr "Opp"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Ingen innlagt tekst enda"
+#~ msgid "Down"
+#~ msgstr "Ned"
 
-msgid "E30: No previous command line"
-msgstr "E30: Ingen tidligere kommandolinje"
+#~ msgid "Find Next"
+#~ msgstr "Finn neste"
 
-msgid "E31: No such mapping"
-msgstr "E31: Mappingen finnes ikke"
+#~ msgid "Replace"
+#~ msgstr "Erstatt"
 
-msgid "E479: No match"
-msgstr "E479: Ingen treff"
+#~ msgid "Replace All"
+#~ msgstr "Erstatt alle"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Ingen treff: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Mottok \"dø\"-forespørsel fra øktbehandleren\n"
 
-msgid "E32: No file name"
-msgstr "E32: Mangler filnavn"
+#~ msgid "Close"
+#~ msgstr "Lukk"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Ingen tidligere erstatninger med regulære uttrykk"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Uventet ødeleggelse av hovedvinduet\n"
 
-msgid "E34: No previous command"
-msgstr "E34: Ingen tidligere kommando"
+#~ msgid "Font Selection"
+#~ msgstr "Velge skrifttype"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Ingen tidligere regulære uttrykk"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Brukte CUT_BUFFER0 istedenfor tomt valg"
 
-msgid "E481: No range allowed"
-msgstr "E481: Område er ikke tillatt"
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
 
-msgid "E36: Not enough room"
-msgstr "E36: Ikke nok plass"
+#~ msgid "&Cancel"
+#~ msgstr "&Avbryt"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Ingen registrert tjener kalt \"%s\""
+#~ msgid "Directories"
+#~ msgstr "Kataloger"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Kan ikke opprette filen %s"
+#~ msgid "Filter"
+#~ msgstr "Filter"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Kan ikke hente navn på midlertidig fil"
+#~ msgid "&Help"
+#~ msgstr "&Hjelp"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Kan ikke åpne filen %s"
+#~ msgid "Files"
+#~ msgstr "Filer"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Kan ikke lese filen %s"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Ikke lagret siden forrige forandring (legg til ! for å overstyre)"
+#~ msgid "Selection"
+#~ msgstr "Valg"
 
-msgid "E38: Null argument"
-msgstr "E38: Nullparameter"
+#~ msgid "Find &Next"
+#~ msgstr "Finn &neste"
 
-msgid "E39: Number expected"
-msgstr "E39: Nummer forventet"
+#~ msgid "&Replace"
+#~ msgstr "E&rstatt"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Kan ikke åpne feilfilen %s"
+#~ msgid "Replace &All"
+#~ msgstr "Erstatt &alle"
 
-msgid "E233: cannot open display"
-msgstr "E233: Kan ikke åpne display"
+#~ msgid "&Undo"
+#~ msgstr "&Angre"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Ikke mer ledig hukommelse!"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Fant ikke vindutittel \"%s\""
 
-msgid "Pattern not found"
-msgstr "Fant ikke søketeksten"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Parameter ikke støttet: \"-%s\"; Bruk OLE-versjonen."
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Fant ikke søketeksten: %s"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Klarer ikke åpne vindu inne i MDI-applikasjon"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Parameteret må være positivt"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Finn streng (bruk '\\\\' for å finne en '\\')"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Kan ikke gå tilbake til tidligere katalog"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Søk og erstatt (bruk '\\\\' for å finne en '\\')"
 
-msgid "E42: No Errors"
-msgstr "E42: Ingen feil"
+#~ msgid "Not Used"
+#~ msgstr "Ikke brukt"
 
-msgid "E776: No location list"
-msgstr "E776: Ingen plassliste"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Katalog\t*.ingenting\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Ødelagt søkestreng"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: Kan ikke reservere fargekart, noen farger kan være feil"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Skadet program med regulært uttrykk"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Skrifttyper for de følgende tegnsett mangler i fontsett %s:"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly'-valget er satt (legg til ! for å overstyre)"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Navn på skrifttypesett: %s"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Kan ikke forandre skrivebeskyttet variabel \"%s\""
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Skrifttypen '%s' har ikke konstant bredde"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Kan ikke sette variabel i sandkassen: \"%s\""
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Navn på skrifttypesett: %s\n"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Feil under lesing av feilfilen"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Ikke tillatt i sandkassen"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Ikke tillatt her"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Font%<PRId64>-bredde er ikke to ganger bredden av font0\n"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Forandring av skjermmodus er ikke støttet"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Font0-bredde: %<PRId64>\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Ugyldig \"scroll\"-verdi"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Font1-bredde: %<PRId64>\n"
+#~ "\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell'-valget er tomt"
+#~ msgid "Invalid font specification"
+#~ msgstr "Ugyldig skrifttypespesifisering"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Kunne ikke lese inn skiltdata!"
+#~ msgid "&Dismiss"
+#~ msgstr "&Forkast"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Feil under lukking av swapfil"
+#~ msgid "no specific match"
+#~ msgstr "ingen spesifikke treff"
 
-msgid "E73: tag stack empty"
-msgstr "E73: Tag-stack tom"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Skrifttypevelger"
 
-msgid "E74: Command too complex"
-msgstr "E74: Kommandoen er for kompleks"
+#~ msgid "Name:"
+#~ msgstr "Navn:"
 
-msgid "E75: Name too long"
-msgstr "E75: Navnet er for langt"
+#~ msgid "Show size in Points"
+#~ msgstr "Vis størrelse i punkter"
 
-msgid "E76: Too many ["
-msgstr "E76: For mange ["
+#~ msgid "Encoding:"
+#~ msgstr "Koding:"
 
-msgid "E77: Too many file names"
-msgstr "E77: For mange filnavn"
+#~ msgid "Font:"
+#~ msgstr "Skrifttype:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Etterfølgende tegn"
+#~ msgid "Style:"
+#~ msgstr "Stil:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Ukjent merke"
+#~ msgid "Size:"
+#~ msgstr "Størrelse:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Klarte ikke utvide jokertegn"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: \"stat\"-feil"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' kan ikke være mindre enn 'winminheight'"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Kan ikke åpne cscope-database: %s"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' kan ikke være mindre enn 'winminwidth'"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Kan ikke hente informasjon om cscope-database"
 
-msgid "E80: Error while writing"
-msgstr "E80: Feil under skriving"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: Maksimum antall cscope-forbindelser nådd"
 
-msgid "Zero count"
-msgstr "Antall repeteringer er null"
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Denne kommandoen er deaktivert, MzScheme-biblioteket kunne ikke "
+#~ "lastes."
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Bruker <SID> utenom skript-kontekst"
+#~ msgid "invalid expression"
+#~ msgstr "ugyldig uttrykk"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Ugyldig uttrykk mottatt"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "uttrykk deaktivert på kompileringsstadiet"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Regionen er beskyttet og kan ikke modifiseres"
+#~ msgid "hidden option"
+#~ msgstr "skjult valg"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans tillater ikke forandringer i skrivebeskyttede filer"
+#~ msgid "unknown option"
+#~ msgstr "ukjent valg"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Intern feil: %s"
+#~ msgid "window index is out of range"
+#~ msgstr "indeks for vindu er utenfor område"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Søkestrengen bruker mer hukommelse enn 'maxmempattern'"
+#~ msgid "couldn't open buffer"
+#~ msgstr "klarte ikke å åpne buffer"
 
-msgid "E749: empty buffer"
-msgstr "E749: Tom buffer"
+#~ msgid "cannot save undo information"
+#~ msgstr "kan ikke lagre angre-informasjon"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Ugyldig søkestreng eller skilletegn"
+#~ msgid "cannot delete line"
+#~ msgstr "kan ikke slette linje"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Filen er lastet i en annen buffer"
+#~ msgid "cannot replace line"
+#~ msgstr "kan ikke erstatte linje"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Valget '%s' er ikke satt"
+#~ msgid "cannot insert line"
+#~ msgstr "kan ikke sette inn linje"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Søket traff TOPPEN, fortsetter fra BUNNEN"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "streng kan ikke inneholde linjeskift"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Søket traff BUNNEN, fortsetter fra TOPPEN"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim-feil: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim-feil"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer er ugyldig"
+
+#~ msgid "window is invalid"
+#~ msgstr "vindu er ugyldig"
+
+#~ msgid "linenr out of range"
+#~ msgstr "linjenummer utenfor område"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "ikke tillatt i Vim-sandkassen"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Denne kommandoen er deaktivert, Python-biblioteket kunne ikke "
+#~ "lastes."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Kan ikke starte Python rekursivt"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "Kan ikke slette \"OutputObject\"-attributter"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "\"softspace\" må være et heltall"
+
+#~ msgid "invalid attribute"
+#~ msgstr "ugyldig attributt"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() krever en liste av strenger"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Feil under initialisering av I/U-objekter"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "forsøk på å referere til slettet buffer"
+
+#~ msgid "line number out of range"
+#~ msgstr "linjenummer utenfor område"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<bufferobjekt (slettet) ved %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "ugyldig merkenavn"
+
+#~ msgid "no such buffer"
+#~ msgstr "bufferen finnes ikke"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "forsøk på å referere til slettet vindu"
+
+#~ msgid "readonly attribute"
+#~ msgstr "skrivebeskyttet attributt"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "markørposisjon utenfor buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<vindusobjekt (slettet) ved %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<vindusobjekt (ukjent) ved %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<vindu %d>"
+
+#~ msgid "no such window"
+#~ msgstr "vinduet finnes ikke"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Denne kommandoen er deaktivert, Ruby-biblioteket kunne ikke lastes."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: Uventet return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: Uvented next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: Uventet break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: Uventet redo"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Ubehandlet unntak"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Ukjent longjmp-status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Bytt mellom implementasjon/definisjon"
+
+#~ msgid "Show base class of"
+#~ msgstr "Vis basisklasse av"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Vis overstyrt medlemsfunksjon"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Hent fra fil"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Hent fra prosjekt"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Hent fra alle prosjekter"
+
+#~ msgid "Retrieve"
+#~ msgstr "Hent"
+
+#~ msgid "Show source of"
+#~ msgstr "Vis kilde til"
+
+#~ msgid "Find symbol"
+#~ msgstr "Finn symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Bla gjennom klasse"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Vis klasse i hierarki"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Vis klasse i begrenset hierarki"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref refererer til"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref referert av"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref har en"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref brukt av"
+
+#~ msgid "Show docu of"
+#~ msgstr "Vis docu av"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generer docu for"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Kan ikke koble til SNiFF+. Sjekk miljøet (\"environment\") (sniffemacs må "
+#~ "bli funnet i $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Feil under lesing. Frakoblet"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ er for øyeblikket "
+
+#~ msgid "not "
+#~ msgstr "ikke "
+
+#~ msgid "connected"
+#~ msgstr "oppkoblet"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Ukjent SNiFF+-forespørsel: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Feil ved oppkobling til SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ ikke tilkoblet"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Ikke en SNiFF+-buffer"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Feil under skriving. Frakoblet"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "ugyldig buffernummer"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ikke implementert enda"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "kan ikke sette linje(r)"
+
+#~ msgid "mark not set"
+#~ msgstr "merke ikke satt"
+
+#~ msgid "row %d column %d"
+#~ msgstr "rad %d kolonne %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "kan ikke sette inn/legge til linje"
+
+#~ msgid "unknown flag: "
+#~ msgstr "ukjent flagg: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "ukjent vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "tastaturavbrudd"
+
+#~ msgid "vim error"
+#~ msgstr "vim-feil"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "kan ikke opprette buffer/vindukommando: Objektet slettes"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "kan ikke registrere callback-kommando: Buffer/vindu er allerede slettet"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL KRITISK FEIL: reflist skadet!? Vennligst rapporter dette til "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "kan ikke registrere callback-kommando: Buffer/vindureferanse ikke funnet"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Denne kommandoen er deaktivert, Tcl-biblioteket kunne ikke lastes."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL-FEIL: Avslutningskode er ikke int!? Vennligst rapporter dette "
+#~ "til vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Avslutningskode %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "kan ikke hente linje"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Klarer ikke registrere kommandotjenernavn"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Klarte ikke sende kommando til destinasjonsprogrammet"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Ugyldig tjener-id brukt: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Registry-egenskapen for VIM-oppføringen er ikke korrekt. Slettet!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Denne Vim-versjonen er kompilert uten differansefunksjonen."
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Feil: Feil under start av gvim fra NetBeans\n"
+
+#~ msgid "where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "der bokstavstørrelse ignoreres, legg til / i begynnelsen for\n"
+#~ "å gjøre flagget om til stor bokstav"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistrer gvim for OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tFjern OLE-registrering for gvim"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tKjør med GUI (som \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  eller  --nofork\tForgrunn: Ikke fork når GUI-et startes"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tInformasjonsnivå (\"Verbose\")"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tIkke bruk newcli for å åpne vindu"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <enhet>\t\tBruk <enhet> for I/U"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tBruk <gvimrc> istedenfor eventuell .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tRediger krypterte filer"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tKoble vim til denne spesielle X-tjeneren"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tUnngå oppkobling til X-tjener"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <filer>\tRediger <filer> på en Vim-tjener hvis mulig"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <filer>  Samme, ikke klag hvis tjeneren mangler"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <files>  Samme, ikke klag hvis tjeneren mangler"
+
+#, fuzzy
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr ""
+#~ "--remote-wait <filer>  Som --remote men vent på filer som blir redigert"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <nøkler>\tSend <nøkler> til en Vim-tjener og avslutt"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <uttrykk>\tEvaluer <uttrykk> på en Vim-tjener og skriv "
+#~ "resultatet"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tList navn på tilgjengelige Vim-tjenere og avslutt"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <navn>\tSend til/bli Vim-tjeneren <navn>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (Motif-versjon):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (neXtaw-versjon):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (Athena-versjon):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tKjør vim på <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tStart vim som ikon"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <navn>\t\tBruk ressurs som om Vim var <navn>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Ikke implementert)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <farge>\tBruk <farge> på bakgrunnen (også: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <farge>\tBruk <farge> på normal tekst (også: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <skrifttype>\t\tBruk <skrifttype> på normal tekst (også: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <skrifttype>\tBruk <skrifttype> på fet skrift"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <skrifttype>\tBruk <skrifttype> på skrå tekst"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tBruk <geom> for innledende vindusplassering (også: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <bredde>\tBruk en rammebredde tilsvarende <bredde> (også: -"
+#~ "bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <bredde>  Bruk en rullefeltbredde tilsvarende <bredde> "
+#~ "(også: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <høyde>\tBruk en menyblokkhøyde tilsvarende <høyde> (også: -"
+#~ "mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tBruk invers video (også: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tIkke bruk invers video (også: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ressurs>\tSett den spesifiserte ressursen"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (RISC OS-versjon):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <antall>\tInnledende bredde på vindu i kolonner"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <antall>\tInnledende høyde på vindu i rader"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Parametere gjenkjent av gvim (GTK+-versjon):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tKjør vim på <display> (også: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <role>\tSett en unik \"role\" for å identifisere hovedvinduet"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tÅpne Vim innenfor et annet GTK-skjermelement"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <foreldretittel>\tStart Vim innenfor et foreldreprogram"
+
+#~ msgid "No display"
+#~ msgstr "Ingen display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Send feilet.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Send feilet. Prøver å utføre lokalt\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d av %d redigert"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Ingen display: Sending av uttrykk feilet.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Sending av uttrykk feilet.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Er ikke en gyldig codepage"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Klarte ikke opprette inndatakontekst"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Klarte ikke åpne inndatametode"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Advarsel: Klarte ikke sette \"destroy callback\" til inndatametode"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Inndatametode støtter ikke enhver stil"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: Inndatametode støtter ikke min \"preedit\" type"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: \"over-the-spot\"-stil trenger et skrifttypesett"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Din GTK+ er eldre enn 1.2.3. Statusområde deaktivert"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Inndatametodetjener kjører ikke"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [ikke brukbar med denne Vim-versjonen]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Riv av denne menyen"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "\"Velge katalog\"-dialogvindu"
+
+#~ msgid "Save File dialog"
+#~ msgstr "\"Lagre fil\"-dialogvindu"
+
+#~ msgid "Open File dialog"
+#~ msgstr "\"Åpne fil\"-dialogvindu"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Dessverre ingen filbehandler i konsollmodus"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: Bevarer filer ...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Ferdig.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "FEIL: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] totalt alloc-frigjort %<PRIu64>-%<PRIu64>, i bruk %<PRIu64>, topp-"
+#~ "bruk %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[kall] totale \"re/malloc()\"-er %<PRIu64>, totale \"free()\"-er "
+#~ "%<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Linjen blir for lang"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Ulovlig utseende på musepekeren"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Skriv krypteringsnøkkel: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Gjenta krypteringsnøkkelen: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Krypteringsnøklene stemmer ikke overens!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Kan ikke koble til Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Kan ikke koble til Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Feil tilgangsmodus for infofilen til NetBeans-forbindelse: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "les fra Netbeans-socket"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Mistet NetBeans-forbindelse for buffer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval-funksjonaliteten er ikke tilgjengelig"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "frigjør %<PRId64> linjer"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Kan ikke forandre \"term\" i grafisk brukergrensesnitt"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Bruk \":gui\" for å starte med grafisk brukergrensesnitt"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Kan ikke forandres i GTK+ 2 GUI"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Ugyldig(e) skrifttype(r)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Kan ikke velge skrifttypesett"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Ugyldig skrifttypesett"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Kan ikke velge bred skrifttype"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Ugyldig bred skrifttype"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Ingen støtte for mus"
+
+#~ msgid "cannot open "
+#~ msgstr "kan ikke åpne "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Kan ikke åpne vindu!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Trenger Amigados versjon 2.04 eller nyere\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Trenger %s versjon %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Kan ikke åpne NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Kan ikke opprette "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim avslutter med %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "kan ikke forandre konsollmodus ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: Ikke et konsoll??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Kan ikke kjøre skall med \"-f\"-valg"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Kan ikke utføre "
+
+#~ msgid "shell "
+#~ msgstr "skall "
+
+#~ msgid " returned\n"
+#~ msgstr " returnerte\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE for liten."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/U-FEIL"
+
+#~ msgid "Message"
+#~ msgstr "Melding"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' er ikke 80, kan ikke utføre eksterne kommandoer"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Valg av skriver feilet"
+
+#~ msgid "to %s on %s"
+#~ msgstr "til %s på %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Ukjent skrifttype for skriver: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Feil under utskrift: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Skriver ut '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Ulovlig navn på tegnsett \"%s\" i skrifttypenavn \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Ulovlig tegn '%c' i skrifttypenavn \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Dobbelt signal, avslutter\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Mottok dødelig signal %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Mottok dødelig signal\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Åpning av X-display tok %<PRId64> millisekunder"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Mottok X-feil\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test av X-display feilet"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Tidsavbrudd for åpning av X-display"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan ikke kjøre skallet sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan ikke opprette rør (\"pipe\")\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan ikke opprette tvillingprosess (\"fork\")\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kommando avsluttet\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP mistet ICE-forbindelsen"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Åpning av X-display feilet"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP håndterer \"redd-deg-selv\"-forespørsel"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP åpner forbindelse"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Overvåkning av XSMP ICE-forbindelse feilet"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection feilet: %s"
+
+#~ msgid "At line"
+#~ msgstr "På linje"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Klarte ikke laste vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM-feil"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Klarte ikke ordne opp i funksjonspekere til DLL-en!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "skallet returnerte %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Mottok \"%s\"-hendelse\n"
+
+#~ msgid "close"
+#~ msgstr "lukk"
+
+#~ msgid "logoff"
+#~ msgstr "logg av"
+
+#~ msgid "shutdown"
+#~ msgstr "kjør ned"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Kommando ikke funnet"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE ikke funnet i $PATH.\n"
+#~ "Eksterne kommandoer kommer ikke til å vente etter fullføring.\n"
+#~ "Se \":help win32-vimrun\" for mer informasjon."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim-advarsel"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konvertering i %s ikke støttet"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: \"containedin\"-parameter aksepteres ikke her"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Sti til tagfil kuttet for %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "nytt skall startet\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Ingen angremuligheter; fortsett likevel"
+
+#~ msgid "number changes  time"
+#~ msgstr "nummer forandringer tidspunkt"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS Windows 16/32-bits grafisk versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS Windows 64-bits grafisk versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bits GUI-versjon"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " i Win32s-modus"
+
+#~ msgid " with OLE support"
+#~ msgstr " med OLE-støtte"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bits konsollversjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16-bits versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32-bits MS-DOS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16-bits MS-DOS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix)-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS-versjon"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Stor (\"big\") versjon "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normal versjon "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Liten (\"small\") versjon "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Spinkel (\"tiny\") versjon "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "med GTK2-GNOME GUI."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "med GTK-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "med GTK2 GUI."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "med GTK GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "med X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "med X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "med X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "med Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "med GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "med Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "med Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "med (klassisk) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "       gvimrc-fil på systemet: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "       gvimrc-fil for brukere: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr " gvimrc-fil nr. 2 for brukere: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr " gvimrc-fil nr. 3 for brukere: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "          menyfil på systemet: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompilator: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "meny:  Hjelp->Foreldreløse        for informasjon  "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Kjører uten modus, tastetrykk blir lagt inn i teksten"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "meny:  Rediger->Globale innstillinger->Innsettingsmodus av/på"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                                  for to moduser   "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "meny:  Rediger->Globale innstillinger->Vi-kompatibilitet av/på"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                  for standard Vim "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ADVARSEL: Windows 95/98/ME oppdaget"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "skriv  :help windows95<Enter>     for informasjon  "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Klarte ikke laste bibliotek %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "Denne kommandoen er deaktivert, Perl-biblioteket kunne ikke lastes."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Evaluering av Perl er ikke tillatt i sandkassen uten \"Safe\"-"
+#~ "modulen"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Rediger med &flere Vim-er"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Rediger med enkel &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Differanse med Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Rediger med &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Rediger med eksisterende Vim - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Redigerer de(n) valgte filen(e) med Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Klarte ikke lage prosess: Sjekk at gvim er i stien!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "Feil i gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Lengden på stien er for lang!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Ukjent skrifttypesett: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Ukjent skrifttype: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Skrifttypen \"%s\" har ikke fast bredde"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Klarte ikke laste biblioteksfunksjon %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hebraisk kan ikke brukes: Ikke slått på under kompilering\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Persisk (Farsi) kan ikke brukes: Ikke slått på under kompilering\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabisk kan ikke brukes: Ikke slått på under kompilering\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Ingen registrert tjener kalt \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Kan ikke åpne display"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Ugyldig uttrykk mottatt"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Regionen er beskyttet og kan ikke modifiseres"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans tillater ikke forandringer i skrivebeskyttede filer"

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -9,175 +9,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-06 19:33+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-08-10 18:15+0200\n"
 "Last-Translator: Mikolaj Machowski <mikmach@wp.pl>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 1.0\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() wywołany z pustym hasłem"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "nie mogę pobrać wartości opcji"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "błąd wewnętrzny: nieznany typ opcji"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish używa błędnej kolejności bajtów"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: test sha256 nie powiódł się"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: test Blowfisha nie powiódł się"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Lista lokacji]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Lista quickfix]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Autokomendy spowodowały porzucenie komendy"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nie mogę zarezerwować bufora; zakończenie..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nie mogę zarezerwować bufora; używam innego..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Nie wyładowano żadnego bufora"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Nie skasowano żadnego bufora"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Nie wyrzucono żadnego bufora"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 bufor wyładowany"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "wyładowano %d buforów"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 bufor skasowany"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buforów skasowano"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "wyrzucono 1 bufor "
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "wyrzucono %d buforów"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Nie mogę wyładować ostatniego bufora"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nie znaleziono zmienionych buforów"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nie ma wylistowanych buforów"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Bufor \"%<PRId64>\" nie istnieje"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Nie mogę przejść poza ostatni bufor"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Nie mogę przejść przed pierwszy bufor"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Nie zapisano zmian w buforze %<PRId64> (wymuś przez !)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Nie mogę wyładować ostatniego bufora"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: OSTRZEŻENIE: Przepełnienie listy nazw plików"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Nie znaleziono bufora %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Wielokrotne dopasowania dla %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Żaden bufor nie pasuje do %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "wiersz %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufor o tej nazwie już istnieje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmieniony]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Nie edytowany]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nowy Plik]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Błąd odczytu]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[RO]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[tylko odczyt]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 wiersz --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> wiersze --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "wiersz %<PRId64> z %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Bez nazwy]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "pomoc"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Pomoc]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Podgląd]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Wszystko"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Dół"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Góra"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -185,9 +225,11 @@ msgstr ""
 "\n"
 "# Lista buforów:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Notka]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -195,144 +237,200 @@ msgstr ""
 "\n"
 "--- Znaki ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaki dla %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    wiersz=%<PRId64>  id=%d  nazwa=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Brak dwukropka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Niedozwolony tryb"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: oczekiwałem na cyfrę"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Niedozwolony procent"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nie mogę zróżnicować więcej niż %<PRId64> buforów"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Nie mogę otworzyć lub zapisać plików tymczasowych"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nie mogę stworzyć różnic"
 
-msgid "Patch file"
-msgstr "Plik łata"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Nie mogę odczytać wyjścia pliku łaty"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nie mogę wczytać wyjścia różnicy"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Bieżący bufor nie jest w trybie różnic"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Żaden inny bufor w trybie diff nie jest modyfikowalny"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Brak innego bufora w trybie różnic"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Więcej niż jeden bufor w trybie różnicowania, nie wiem którego użyć"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nie mogę znaleźć bufora \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bufor \"%s\" nie jest w trybie różnicowania"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Nieoczekiwana zmiana bufora"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape jest niedozwolone w dwugrafie"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Nie znaleziono pliku rozkładu klawiszy"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Zastosowano :loadkeymap w niewczytanym pliku"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Pusty wpis keymap"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Dopełnianie słów kluczowych (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X tryb (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Dopełnianie pełnych wierszy (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Dopełnianie nazw plików (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Dopełnianie znaczników (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Dopełnianie wzorców tropów (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Dopełnianie definicji (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dopełnianie ze słowników (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Dopełnianie z tezaurusa (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Dopełnianie wiersza poleceń (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr "Dopełnianie zdefiniowane przez użytkownika (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupełnianie (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr "Propozycja pisowni (^L^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokalne dopełnianie słów kluczowych (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Dobiłem do końca akapitu"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Funkcja uzupełniania zmieniła okno"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Funkcja uzupełnania usunęła tekst"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "opcja 'dictionary' jest pusta"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "opcja 'thesaurus' jest pusta"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Przeglądam słownik: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (wprowadzanie) Przewijanie (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (zamiana) Przewijanie (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Przeglądam: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Przeglądam znaczniki."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Dodaję"
 
@@ -340,459 +438,576 @@ msgstr " Dodaję"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Szukam..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Z powrotem na pierwotnym"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Wyraz z innego wiersza"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jedyne dopasowanie"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "pasuje %d z %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "pasuje %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Nieoczekiwane znaki w :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Indeks listy poza zakresem: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nieokreślona zmienna: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Brak ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument %s musi być Listą"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument %s musi być Listą lub Słownikiem"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Nie można użyć pustego klucza dla Słownika"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: wymagana Lista"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: wymagany Słownik"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Zbyt wiele argumentów dla funkcji: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Klucz nie istnieje w Słowniku: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkcja %s już istnieje; aby ją zamienić użyj !"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: istnieje już taki element Słownika"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: wymagana Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Nie można użyć [:] przy Słowniku"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Zły typ zmiennej dla %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Nieznana funkcja: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Niedozwolona nazwa zmiennej: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: Użycie Zmiennoprzecinkowej jako Łańcucha"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Mniej celów niż elementów Listy"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Więcej celów niż elementów Listy"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Podwójny ; w liście zmiennych"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Nie mogę wypisać zmiennych dla %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Indeks może istnieć tylko dla Listy lub Słownika"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] musi być ostatnie"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] wymaga wartości listy"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Lista ma więcej elementów niż cel"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Lista nie ma wystarczającej ilości elementów"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Brak \"in\" po :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Brak nawiasów: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Nie istnieje zmienna: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: zmienna zagnieżdżona zbyt głęboko dla (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Brak ':' po '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Listę mogę porównać tylko z Listą"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Nieprawidłowa operacja dla Listy"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Słownik mogę porównać tylko ze Słownikiem"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Nieprawidłowa operacja dla Słownika"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref mogę porównać tylko z Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Nieprawidłowa operacja dla Funcref"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Nie mogę użyć '%' w Zmiennoprzecinkowej"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Brak ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Nie można zindeksować Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Brak nazwy opcji: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Nieznana opcja: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Brak cudzysłowu: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Brak cudzysłowu: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Brakujący przecinek w Liście: '%s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Brak zakończenia Listy ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Brak dwukropka w Słowniku: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Powtórzony klucz w Słowniku: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Brakujący przecinek w Słowniku: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Brak końca w Słowniku '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Zmienna zagnieżdżona zbyt głęboko by pokazać"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Zbyt wiele argumentów dla funkcji %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Zbyt wiele argumentów dla funkcji %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Nieznana funkcja: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Za mało argumentów dla funkcji: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Użycie <SID> poza kontekstem skryptu: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Wywołanie funkcji \"dict\" bez Słownika: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Wymagana Liczba lub Zmiennoprzecinkowa"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "argument add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Za dużo argumentów"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() może być użyte tylko w trybie Wprowadzania"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Klucz już istnieje: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "argument extend()"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "argument map()"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "argument filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld wierszy: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Nieznana funkcja: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zakończ"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "wywołano inputrestore() więcej razy niż inputsave()"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "argument insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Zakres niedozwolony"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Nieprawidłowy typ dla len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Skok to zero"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Początek po końcu"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<pusty>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Brak połączenia z serwerem Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nie mogę wysłać do %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nie mogę czytać odpowiedzi serwera"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "argument remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Za dużo dowiązań symbolicznych (pętla?)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "argument reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Nie mogę wysłać do klienta"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "argument sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argument add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funkcja porównywania w sort nie powiodła się"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funkcja porównywania w sort nie powiodła się"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Niewłaściwe)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Błąd zapisywania pliku tymczasowego"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Użycie Zmiennoprzecinkowej jako Liczby"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Użycie Funcref jako Liczby"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Użycie Listy jako Liczby"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Użycie Słownika jako Liczby"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Użycie Funcref jako Łańcucha"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Użycie Listy jako Łańcucha"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Użycie Słownika jako Łańcucha"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Nieprawidłowy typ zmiennej dla: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Nie mogę usunąć zmiennej %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Nazwa Funcref musi się zaczynać wielką literą: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Nazwa zmiennej jest w konflikcie z istniejącą funkcją: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Wartość jest zablokowana: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Nieznane"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Nie mogę zmienić wartości %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Zmienna zagnieżdżona zbyt głęboko by zrobić kopię"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Nieznana funkcja: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Brak '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Nie można tutaj użyć g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Niedozwolony argument: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Powtórzona nazwa argumentu: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Brak :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Nazwa funkcji jest w konflikcie ze zmienną: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Nie mogę redefiniować funkcji %s: jest w użyciu"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Nazwa funkcji nie pasuje do nazwy skryptu: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Wymagana jest nazwa funkcji"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Nazwa funkcji musi rozpoczynać się wielką literą lub zawierać "
 "dwukropek: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Nazwa funkcji musi rozpoczynać się wielką literą lub zawierać "
+"dwukropek: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nie mogę skasować funkcji %s: jest w użyciu"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zagnieżdżenie wywołań funkcji ponad 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "wywołuję %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "porzucono %s"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s zwraca #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s zwraca %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "kontynuacja w %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return poza funkcją"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -800,6 +1015,7 @@ msgstr ""
 "\n"
 "# zmienne globalne:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -807,212 +1023,104 @@ msgstr ""
 "\n"
 "\tOstatnie ustawienie przez "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Brak starych plików"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Wchodzę w tryb odpluskwiania. Wprowadź \"cont\" aby kontynuować."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "wiersz %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "cmd: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Nie znaleziono punktu kontrolnego: %s"
-
-msgid "No breakpoints defined"
-msgstr "Nie określono żadnych punktów kontrolnych"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  wiersz %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Pierwsze użycie \":profile start {fname}\""
-
-msgid "Save As"
-msgstr "Zapisz jako"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Zachować zmiany w \"%s\"?"
-
-msgid "Untitled"
-msgstr "Bez Tytułu"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Nie zapisano zmian w buforze \"%s\""
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "OSTRZEŻENIE: Nieoczekiwane wejście w inny bufor (sprawdź autokomendy)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Tylko jeden plik w edycji"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Nie można przejść przed pierwszy plik"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Nie można przejść za ostatni plik"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: nie wspierany kompilator: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Szukanie \"%s\" w \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Szukanie \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "nie znaleziono w 'runtimepath': \"%s\""
-
-msgid "Source Vim script"
-msgstr "Wczytaj skrypt Vima"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Nie można wczytać katalogu: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "nie mogłem wczytać \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "wiersz: %<PRId64> nie mogłem wczytać \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "wczytywanie \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "skończono wczytywanie %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-msgid "--cmd argument"
-msgstr "--cmd argument"
-
-msgid "-c argument"
-msgstr "-c argument"
-
-msgid "environment variable"
-msgstr "zmienna środowiskowa"
-
-msgid "error handler"
-msgstr "obsługa błędu"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: OSTRZEŻENIE: Niewłaściwy separator wierszy, pewnie brak ^M"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: użyto :scriptencoding poza wczytywanym plikiem"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: użyto :finish poza wczytywanym plikiem"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Bieżący %sjęzyk: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Nie mogę ustawić języka na \"%s\""
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x,  Oktal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Przeniesienie wierszy na siebie samych"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 wiersz przeniesiony"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> wiersze przeniesione"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> wierszy przefiltrowanych"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Autokomendy *Filter* nie mogą zmieniać bieżącego bufora"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Brak zapisu od czasu ostatniej zmiany]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s w wierszu: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Zbyt wiele błędów; pomijam resztę pliku"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Wczytuję plik viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informacja"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " zakładki"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " stare pliki"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " NIE POWIODŁO SIĘ"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Plik viminfo jest niezapisywalny: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nie mogę zapisać pliku viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Zapisuję plik viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Ten plik viminfo został wygenerowany przez Vima %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1020,37 +1128,47 @@ msgstr ""
 "# Możesz go ostrożnie edytować!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Wartość 'encoding' w czasie zapisu tego pliku\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Niedopuszczalny początkowy znak"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Zapisać częściowo plik?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Stosuj ! do zapisania częściowo bufora"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Nadpisać istniejący plik \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Plik wymiany \"%s\" istnieje, czy go nadpisać?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Plik wymiany istnieje: %s (wymuś poprzez :silent!)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Brak nazwy pliku dla bufora %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Plik niezapisany: Zapis jest wyłączony opcją 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1059,6 +1177,7 @@ msgstr ""
 "opcja 'readonly' nastawiona dla \"%s\".\n"
 "Czy chcesz go pomimo tego zapisać?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1069,69 +1188,84 @@ msgstr ""
 "Mimo to być może uda się zmienić ten plik.\n"
 "Chcesz spróbować?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" jest tylko do odczytu (dodaj ! aby wymusić)"
 
-msgid "Edit File"
-msgstr "Edytuj Plik"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokomendy nieoczekiwanie skasowały nowy bufor %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nienumeryczny argument dla :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Komendy powłoki są niedozwolone w rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Wzorce regularne nie mogą być rozgraniczane literami"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "zamień na %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Przerwane) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 pasuje"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 podstawienie "
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> dopasowań"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> podstawień"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " w 1 wierszu"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " w %<PRId64> wierszach"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Nie mogę wykonać :global rekursywnie"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Brak wzorca regularnego w :global"
 
 # c-format
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Wzorzec znaleziono w każdym wierszu: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Nie znaleziono wzorca: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1141,137 +1275,335 @@ msgstr ""
 "# Ostatni podstawiany ciąg:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Nie panikuj!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Przykro mi, brak '%s' pomocy dla %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Przykro mi, ale brak pomocy o %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Przykro mi, nie ma pliku pomocy \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Nie jest katalogiem: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Nie mogę otworzyć %s do zapisu"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Nie mogę otworzyć %s do odczytu"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Mieszanka kodowań w pliku pomocy w ramach języka: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Powtórzony znacznik \"%s\" w pliku %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Nieznana komenda znaku: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Brak nazwy znaku"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Zbyt wiele nazw znaków"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Niewłaściwy tekst znaku: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Nieznany znak: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Brak numeru znaku"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Niewłaściwa nazwa bufora: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Niewłaściwe ID znaku: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NIE ZNALEZIONO)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr "(nie wspomagane)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Skasowano]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Wchodzę w tryb odpluskwiania. Wprowadź \"cont\" aby kontynuować."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "wiersz %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "cmd: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Nie znaleziono punktu kontrolnego: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Nie określono żadnych punktów kontrolnych"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  wiersz %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Pierwsze użycie \":profile start {fname}\""
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Zachować zmiany w \"%s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Bez Tytułu"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Nie zapisano zmian w buforze \"%s\""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "OSTRZEŻENIE: Nieoczekiwane wejście w inny bufor (sprawdź autokomendy)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Tylko jeden plik w edycji"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Nie można przejść przed pierwszy plik"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Nie można przejść za ostatni plik"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: nie wspierany kompilator: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Szukanie \"%s\" w \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Szukanie \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "nie znaleziono w 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Nie można wczytać katalogu: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "nie mogłem wczytać \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "wiersz: %<PRId64> nie mogłem wczytać \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "wczytywanie \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "skończono wczytywanie %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd argument"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "zmienna środowiskowa"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "obsługa błędu"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: OSTRZEŻENIE: Niewłaściwy separator wierszy, pewnie brak ^M"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: użyto :scriptencoding poza wczytywanym plikiem"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: użyto :finish poza wczytywanym plikiem"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Bieżący %sjęzyk: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Nie mogę ustawić języka na \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Wchodzę w tryb Ex. Wprowadź \"visual\" aby przejść do trybu Normal."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Na końcu pliku"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Komenda zbyt rekursywna"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Nie znaleziono wyjątku: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Koniec wczytywanego pliku"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Koniec funkcji"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr ""
 "E464: Niejednoznaczne zastosowanie komendy zdefiniowanej przez użytkownika"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Nie jest komendą edytora"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Dano wsteczny zakres"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Dano wsteczny zakres; zamiana jest możliwa"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Stosuj w lub w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Przykro mi, ale ta komenda nie jest dostępna w tej wersji"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Tylko pojedyncza nazwa pliku dozwolona"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 więcej plik do edycji.  Mimo to wyjść?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "jeszcze %d plików do edycji.  Mimo to wyjść?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 więcej plik do edycji"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: jeszcze %<PRId64> plików do edycji"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komenda już istnieje; aby ją przedefiniować stosuj !"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1279,296 +1611,341 @@ msgstr ""
 "\n"
 "    Nazwa       Arg. Zak.  Gotowość  Definicja"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Nie znaleziono komend zdefiniowanych przez użytkownika"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nie określono atrybutu"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Niewłaściwa ilość argumentów"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Mnożnik nie może być podany dwukrotnie"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Niewłaściwa domyślna wartość mnożnika"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete wymaga argumentu"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Niewłaściwy atrybut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Niewłaściwa nazwa komendy"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr ""
 "E183: Komendy zdefiniowane przez użytkownika muszą rozpoczynać się dużą "
 "literą"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr ""
-"E841: Nazwa zastrzeżona, nie można jej użyć w komendzie użytkownika"
+msgstr "E841: Nazwa zastrzeżona, nie można jej użyć w komendzie użytkownika"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Nie ma takiej komendy użytkownika: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Niewłaściwa wartość dopełniania: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Argument depełniania dozwolony wyłącznie dla dopełniania użytkownika"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Dopełnianie użytkownika wymaga funkcji jako argumentu"
 
-msgid "unknown"
-msgstr "nieznany"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Nie mogę znaleźć zestawu kolorów '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Witaj użytkowniku Vima!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Nie mogę zamknąć ostatniej karty"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Jest już tylko jedna karta"
 
-msgid "Edit File in new window"
-msgstr "Edytuj plik w nowym oknie"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Karta %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Brak pliku wymiany"
 
-msgid "Append File"
-msgstr "Dołącz plik"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Nie mogę zmienić katalogu, bufor został zmodyfikowany (dodaj ! aby "
 "wymusić)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Nie ma poprzedniego katalogu"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Nieznany"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize wymaga dwóch argumentów numerycznych"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Pozycja okna: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Pozyskiwanie pozycji okna nie jest zaimplementowane dla tego systemu"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos wymaga dwóch argumentów numerycznych"
 
-msgid "Save Redirection"
-msgstr "Zapisz przekierowanie"
-
-msgid "Save View"
-msgstr "Zapisz widok"
-
-msgid "Save Session"
-msgstr "Zapisz sesję"
-
-msgid "Save Setup"
-msgstr "Zapisz ustawienia"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Nie mogę utworzyć katalogu: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" istnieje (wymuś poprzez !)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Nie mogę otworzyć \"%s\" do zapisu"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argument musi być literą albo cudzysłowem w przód/tył"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursywne zastosowanie :normal za głębokie"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< nie jest dostępne bez właściwości +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Brak nazwy zamiennego pliku do podstawienia pod '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: brak nazwy pliku autokomend do podstawienia pod \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: brak numeru bufora autokomend do podstawienia pod  \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: brak nazwy dopasowania autokomend pod \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: brak nazwy pliku :source do postawienia pod \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: brak numeru linii by użyć z \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Pusta nazwa pliku dla '%' lub '#', działa tylko z \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Wynikiem jest pusty ciąg"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Nie mogę otworzyć pliku viminfo do odczytu"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Brak dwugrafów w tej wersji"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Nie można ':throw' wyjątków z prefiksem 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Wyjątek: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Wyjątek zakończony: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Wyjątek odrzucony: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, wiersz %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Wyjątek przechwycony: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s został zawieszony"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s przywrócony"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s odrzucony"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Wyjątek"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Błąd i przerwanie"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Błąd"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Przerwanie"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: zbyt głębokie zagnieżdżenie :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif bez :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else bez :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif bez :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: wielokrotne :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif po :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: zbyt głębokie zagnieżdżenie :while/:for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue bez :while lub :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break bez :while lub :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Użycie :endfor z :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Użycie :endwhile z :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: zbyt głębokie zagnieżdżenie :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch bez :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch za :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally bez :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: wielokrotne :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry bez :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction poza funkcją"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Nie można teraz edytować innego bufora"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Nie można teraz zmieniać informacji o buforze"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nazwa znacznika"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " pokrewny plik\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "opcja 'history' jest zerowa"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1577,230 +1954,304 @@ msgstr ""
 "\n"
 "# %s Historia (od najnowszych po najstarsze):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Wiersz poleceń"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Szukany ciąg"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Wyrażenie"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Wiersz wprowadzeń"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar przekracza długość polecenia"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktywny widok lub bufor skasowany"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: ścieżka za długa by uzupełnić"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Niewłaściwy trop: '**[numer]' musi być na końcu tropu lub po nim musi "
+"być '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Nie mogę znaleźć katalogu \"%s\" w cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Nie mogę znaleźć pliku \"%s\" w tropie"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Katalogu \"%s\" nie ma więcej w cdpath"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Pliku \"%s\" nie ma więcej w tropie"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autokomendy zmieniły bufor lub jego nazwę"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Niedopuszczalna nazwa pliku"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "jest katalogiem"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "nie jest plikiem"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "jest urządzeniem (wyłączonym w opcji 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nowy Plik]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nowy KATALOG]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Za duży plik]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Nie dozwolono]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Autokomendy *ReadPre zrobiły plik nieodczytywalnym"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Autokomendy *ReadPre nie mogą zmieniać bieżącego bufora"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Wczytywanie ze stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Wczytywanie ze stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Nie można otworzyć pliku utworzonego przez przemianę!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[specjalny znak]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[brak CR]'"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[długie wiersze rozdzielane]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NIE przemienione]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[przemienione]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[zakodowane]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[BŁĄD W PRZEMIANIE w linii %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[NIEDOZWOLONY BAJT w wierszu %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[BŁĘDY W ODCZYCIE]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nie mogę znaleźć pliku tymczasowego w celu przemiany"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Nieudana przemiana z 'charconvert'"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nie mogę odczytać wyjścia z 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Plik zaszyfrowano w nieznany sposób"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Brak pasujących autokomend dla bufora acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Autokomendy skasowały lub wyładowały bufor przeznaczony do zapisu"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autokomenda zmieniła liczbę wierszy w nieoczekiwany sposób"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans nie pozwala na zapis niezmodyfikowanych buforów"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Częściowy zapis niemożliwy dla buforów NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "nie jest plikiem lub zapisywalnym przyrządem"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "zapisywanie do urządzenia wyłączone w opcji 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "jest tylko do odczytu (wymuś poprzez !)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Nie mogę zapisać do pliku zabezpieczenia (wymuś przez !)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Błąd podczas zamykania pliku zabezpieczenia (wymuś przez !)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Nie mogę odczytać pliku w celu zabezpieczenia (wymuś przez !)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Nie mogę stworzyć pliku zabezpieczenia (wymuś przez !)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Nie mogę zrobić pliku zabezpieczenia (wymuś przez !)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Rozdział zasobów zostanie utracony (wymuś przez !)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nie mogę znaleźć pliku tymczasowego do zapisania"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nie mogę przemienić (użyj ! by zapisać bez przemiany)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Nie mogę otworzyć podłączonego pliku do zapisu"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Nie mogę otworzyć pliku do zapisu"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync nie powiódł się"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Zamknięcie się nie powiodło"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Błąd zapisu, przemiana się nie powiodła (opróżnij 'fenc' aby wymusić)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Błąd zapisu, przemiana się nie powiodła w wierszu %<PRId64> (opróżnij 'fenc' "
-"by wymusić)"
+"E513: Błąd zapisu, przemiana się nie powiodła w wierszu %<PRId64> (opróżnij "
+"'fenc' by wymusić)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: błąd w zapisie (może system plików jest przepełniony?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " BŁĄD W PRZEMIANIE"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " w wierszu %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Urządzenie]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nowy]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " dołączono"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " zapisano"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: nie mogę zapisać oryginalnego pliku"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nie mogę stworzyć pustego oryginalnego pliku"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nie mogę skasować pliku zabezpieczenia"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1808,80 +2259,96 @@ msgstr ""
 "\n"
 "OSTRZEŻENIE: Oryginalny plik może zostać utracony lub uszkodzony\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "nie wychodź edytora, dopóki plik nie został poprawnie zapisany!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[format dos-a]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[format maca]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[format unixa]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 wiersz, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> wierszy, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znaków"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> znaków"
-
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Niekompletny ostatni wiersz]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "OSTRZEŻENIE: Plik zmienił się od czasu ostatniego odczytu!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Czy naprawdę chcesz go zapisać"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Błąd zapisywania do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Błąd w trakcie zamykania \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Błąd odczytu \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Autokomenda FileChangedShell skasowała bufor"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Plik \"%s\" nie jest dłużej dostępny"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1890,31 +2357,39 @@ msgstr ""
 "W12: OSTRZEŻENIE: Plik \"%s\" zmienił się od czasu rozpoczęcia edycji, bufor "
 "w Vimie również został zmieniony"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Zobacz \":help W12\"  dla dalszych informacji."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: OSTRZEŻENIE: Plik \"%s\" zmienił się od czasu rozpoczęcia edycji"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Zobacz \":help W11\"  dla dalszych informacji."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: OSTRZEŻENIE: Tryb pliku \"%s\" zmienił się od czasu rozpoczęcia edycji"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Zobacz \":help W16\"  dla dalszych informacji."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: OSTRZEŻENIE: Plik \"%s\" został stworzony po rozpoczęciu edycji"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "OSTRZEŻENIE"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1922,39 +2397,48 @@ msgstr ""
 "&OK\n"
 "&Załaduj Plik"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Nie można przygotować przeładowania \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Nie można przeładować \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Skasowano--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "auto-usuwanie autokomendy: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Nie ma takiej grupy: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Niedopuszczalny znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Nie ma takiego wydarzenia: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Nie ma takiej grupy lub wydarzenia: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1962,538 +2446,761 @@ msgstr ""
 "\n"
 "--- Autokomendy ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: niewłaściwy numer bufora"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Nie można wykonywać autokomend dla wydarzeń ALL"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Brak pasujących autokomend"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: zbyt głębokie zagnieżdżenie autokomend"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokomend dla \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Wykonuję %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autokomenda %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Brak {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Brak }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Nie znaleziono zwinięcia"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Nie można utworzyć zwinięcia przy bieżącej 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Nie można skasować zwinięcia przy bieżącej 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld wierszy zwinięto "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Dodaj do bufora odczytu"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursywne przyporządkowanie"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: istnieje już globalny skrót dla %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: istnieje już globalne przyporządkowanie dla %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: istnieje już skrót dla %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: istnieje już przyporządkowanie dla %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Nie znaleziono skrótu"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Nie znaleziono przyporządkowania"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Niedopuszczalny tryb"
 
-msgid "<cannot open> "
-msgstr "<nie mogę otworzyć> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Brak wierszy w buforze--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: nie mogę otrzymać czcionki %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Przerwanie komendy"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: nie mogę powrócić do bieżącego katalogu"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: wymagany argument"
 
-msgid "Pathname:"
-msgstr "Trop:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ powinno być /, ? lub &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: nie mogę otrzymać bieżącego katalogu"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Zakończ"
-
-msgid "Vim dialog"
-msgstr "VIM - Dialog"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Nie mogłem otrzymać rozmiarów rysunku na przycisku."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Nie mogę stworzyć BalloonEval z powiadomieniem i wywołaniem"
-
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Nie mogłem stworzyć nowego procesu dla GUI"
-
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Proces potomny nie mógł uruchomić GUI"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nie mogę odpalić GUI"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nie mogę czytać z \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Nie można uruchomić GUI, brak prawidłowej czcionki"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Niewłaściwe 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Nieprawidłowa wartość 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Nie mogę zarezerwować koloru %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Brak dopasowania przy kursorze, szukam dalej"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"&Tak\n"
-"&Nie\n"
-"&Zakończ"
+"E11: Niedozwolone w oknie wiersza poleceń; <CR> wykonuje, CTRL-C opuszcza"
 
-msgid "Input _Methods"
-msgstr "Input _Methods"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Szukaj i Zamień..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Szukaj..."
-
-msgid "Find what:"
-msgstr "Znajdź:"
-
-msgid "Replace with:"
-msgstr "Zamień na:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Dopasuj tylko całe wyrazy"
-
-#. match case button
-msgid "Match case"
-msgstr "Dopasuj wielkość liter"
-
-msgid "Direction"
-msgstr "Kierunek"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "W górę"
-
-msgid "Down"
-msgstr "W dół"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Znajdź następne"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Zamień"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Zamień wszystkie"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: otrzymano żądanie \"die\" od menedżera sesji\n"
-
-msgid "Close"
-msgstr "Zamknij"
-
-msgid "New tab"
-msgstr "Nowa karta"
-
-msgid "Open Tab..."
-msgstr "Otwórz kartę..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Główne okno nieoczekiwanie zniszczone\n"
-
-msgid "&Filter"
-msgstr "&Filtr"
-
-msgid "&Cancel"
-msgstr "&Anuluj"
-
-msgid "Directories"
-msgstr "Katalogi"
-
-msgid "Filter"
-msgstr "Filtr"
-
-msgid "&Help"
-msgstr "&Pomoc"
-
-msgid "Files"
-msgstr "Pliki"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Wybór"
-
-msgid "Find &Next"
-msgstr "Znajdź &następne"
-
-msgid "&Replace"
-msgstr "&Zamień"
-
-msgid "Replace &All"
-msgstr "Zamień &wszystko"
-
-msgid "&Undo"
-msgstr "&Cofnij"
-
-#, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Nie mogę znaleźć tytułu okna \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nie jest wspomagany: \"-%s\"; Używaj wersji OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Nie można otworzyć okna wewnątrz aplikacji MDI"
-
-msgid "Close tab"
-msgstr "Zamknij kartę"
-
-msgid "Open tab..."
-msgstr "Otwórz kartę..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Znajdź ciąg (użyj '\\\\' do szukania '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Szukanie i Zamiana (użyj '\\\\' do szukania '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Nie używany"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Katalog\t*.nic\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Vim E458: Nie mogę zarezerwować mapy kolorów, pewne kolory mogą być "
-"nieprawidłowe"
+"E12: Komenda niedozwolona z exrc/vimrc w bieżącym szukaniu katalogu lub "
+"znacznika"
 
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Brak :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Brak :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Brak :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Brak :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile bez :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor bez :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Plik istnieje (wymuś poprzez !)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Komenda nie powiodła się"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Błąd wewnętrzny"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Przerwane"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Niewłaściwy adres"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Niewłaściwy argument"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Niewłaściwy argument: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Niewłaściwe wyrażenie: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Niewłaściwy zakres"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Niewłaściwa komenda"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" jest katalogiem"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Niewłaściwa wielkość przewinięcia"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"E250: Brak czcionek dla następujących zestawów znaków w zestawie czcionek %s:"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nazwa zestawu czcionek: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Czcionka '%s' nie posiada znaków jednolitej szerokości"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Wywołanie z biblioteki nie powiodło się dla \"%s()\""
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Zakładka ma niewłaściwy numer wiersza"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Zakładka nienastawiona"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nie mogę wykonać zmian, 'modifiable' jest wyłączone"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Zbyt głębokie zagnieżdżenie skryptów"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Brak pliku zamiany"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Nie ma takiego skrótu"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Niedozwolone !"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI nie może być użyte: Nie włączono podczas kompilacji"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Nazwa zestawu czcionek: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Brak takiej nazwy grupy podświetlania: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Nie wprowadzono jeszcze żadnego tekstu"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Nie ma poprzedniego wiersza poleceń"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Nie ma takiego przyporządkowania"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Brak dopasowań"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font0: %s"
-msgstr "Font0: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Brak dopasowań: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Brak nazwy pliku"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Brak poprzedniego podstawieniowego wyrażenia regularnego"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Brak poprzedniej komendy"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Brak poprzedniego wyrażenia regularnego"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Zakres niedozwolony"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Brak miejsca"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font1: %s"
-msgstr "Font1: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Nie mogę stworzyć pliku %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Nie mogę pobrać nazwy pliku tymczasowego"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Szerokość font%<PRId64> nie jest podwójną szerokością font0"
+msgid "E484: Can't open file %s"
+msgstr "E484: Nie mogę otworzyć pliku %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Szerokość font0: %<PRId64>"
+msgid "E485: Can't read file %s"
+msgstr "E485: Nie mogę odczytać pliku %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Nie zapisano od ostatniej zmiany (wymuś przez !)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Brak zapisu od czasu ostatniej zmiany]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Zerowy argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oczekuję liczby"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Szerokość font1: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nie mogę otworzyć pliku błędów %s"
 
-msgid "Invalid font specification"
-msgstr "Nieprawidłowy opis czcionki"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Pamięć wyczerpana!"
 
-msgid "&Dismiss"
-msgstr "&Anuluj"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Nie znaleziono wzorca"
 
-msgid "no specific match"
-msgstr "brak określonego dopasowania"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Nie znaleziono wzorca: %s"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - wybór czcionki"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument musi być dodatni"
 
-msgid "Name:"
-msgstr "Nazwa:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Nie można przejść do poprzedniego katalogu"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Pokaż wielkość w punktach"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Brak Błędów"
 
-msgid "Encoding:"
-msgstr "Kodowanie:"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Brak listy lokacji"
 
-msgid "Font:"
-msgstr "Czcionka:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Popsuty ciąg wzorca"
 
-msgid "Style:"
-msgstr "Styl:"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Zepsuty program wyrażeń regularnych"
 
-msgid "Size:"
-msgstr "Wielkość:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: opcja 'readonly' jest ustawiona (wymuś poprzez !)"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: BŁĄD w automacie Hangul"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nie mogę zmienić zmiennej tylko do odczytu \"%s\""
 
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Nie mogę ustawić zmiennej w piaskownicy: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Błąd w trakcie czytania pliku błędów"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Niedozwolone w piaskownicy"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Niedozwolone w tym miejscu"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Ustawianie trybu ekranu niewspomagane"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Niewłaściwa wielkość przewinięcia"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: opcja 'shell' jest pusta"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Nie mogłem wczytać danych znaku!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Błąd podczas zamykania pliku wymiany"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: stos znaczników jest pusty"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Komenda jest zbyt skomplikowana"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Zbyt długa nazwa"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Zbyt wiele ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Zbyt wiele nazw plików"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Nadstępne znaczki"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Nieznana zakładka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nie mogą rozwinąć znaków wieloznacznych"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' nie może być mniejsze niż 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' nie może być mniejsze niż 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Błąd w trakcie zapisu"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Zerowy licznik"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Użycie <SID> poza kontekstem skryptu"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Błąd wewnętrzny: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Wzorzec używa więcej pamięci niż 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: pusty bufor"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Niewłaściwy wzorzec wyszukiwania lub delimiter"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Plik jest załadowany w innym buforze"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Nie ustawiono opcji '%s'"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Niewłaściwa nazwa rejestru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "szukanie dobiło GÓRY; kontynuacja od KOŃCA"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "szukanie dobiło KOŃCA; kontynuacja od GÓRY"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Brak dwukropka"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Niedozwolona część"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: oczekiwałem na cyfrę"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Strona %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Brak tekstu do drukowania"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Drukuję stronę %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopia %d z %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Wydrukowano: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Drukowanie odwołane"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Nie można zapisać do wyjściowego pliku PostScriptu"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Nie mogę otworzyć pliku \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Nie można odczytać pliku zasobów PostScriptu \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: plik \"%s\" nie jest plikiem zasobów PostScriptu"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: plik \"%s\" nie jest wspieranym plikiem zasobów PostScriptu"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" nieprawidłowa wersja pliku zasobów"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Niekompatybilne kodowanie wielobajtowe i zestaw znaków."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset nie może być pusty przy kodowaniu wielobajtowym."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Nie określono domyślnej czcionki dla drukowania wielobajtowego."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Nie można otworzyć pliku PostScript do wyjścia"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Nie mogę otworzyć pliku \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Nie można znaleźć pliku zasobów PostScriptu \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Nie można znaleźć pliku zasobów PostScriptu \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Nie można znaleźć pliku zasobów PostScriptu \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Nie można przekonwertować by drukować kodowanie \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Przesyłam do drukarki..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Drukowanie pliku PostScript nie powiodło się"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Zadanie drukowanie przesłane."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Dodaj nową bazę danych"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Zapytane o wzorzec"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Pokaż ten komunikat"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Zabij połączenie"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Ponów wszelkie połączenia"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Pokaż połączenia"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Zastosowanie: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Ta komenda cscope nie wspomaga podzielenia okna.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Zastosowanie: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: nie znaleziono znacznika"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) błąd: %d"
 
-msgid "E563: stat error"
-msgstr "E563: błąd stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s nie jest katalogiem lub poprawną bazą danych cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Dodano bazę danych cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: błąd odczytu połączenia z cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: nieznany typ szukania cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Nie mogłem stworzyć potoku do cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Nie mogłem utworzyć rozwidlenia dla cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "nie powiodło się setpgid cs_create_connection"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "wykonanie cs_create_connection nie powiodło się"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen dla to_fp nie powiodło się"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen dla fr_fp nie powiodło się"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Nie mogłem stworzyć procesu cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: brak połączenia z cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: nieprawidłowa flaga cscopequickfix %c dla %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: brak dopasowań dla zapytania cscope %s o %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "komendy cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Użycie: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2515,32 +3222,31 @@ msgstr ""
 "       s: znajdź ten symbol C\n"
 "       t: znajdź ten łańcuch znaków\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: nie mogę otworzyć bazy danych cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: nie mogę uzyskać informacji z bazy danych cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: nie dodano duplikatu bazy danych cscope"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: nie ma połączenia %s z cscope"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "połączenie %s z cscope zostało zamknięte"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: błąd krytyczny w cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Znacznik cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2548,367 +3254,88 @@ msgstr ""
 "\n"
 "   #   wiersz"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "nazwa pliku  / kontekst / wiersz\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Błąd cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Wszystkie bazy danych cscope przeładowano"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "brak połączeń z cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid   nazwa bazy danych               przedsionek tropu\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Nie można wczytać biblioteki Lua."
-
-msgid "cannot save undo information"
-msgstr "nie mogę zachować informacji cofania"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Przykro mi, ta komenda jest wyłączona, biblioteka MzScheme nie może "
-"być załadowana."
-
-msgid "invalid expression"
-msgstr "niepoprawne wyrażenie"
-
-msgid "expressions disabled at compile time"
-msgstr "wyrażenia wyłączone podczas kompilacji"
-
-msgid "hidden option"
-msgstr "ukryta opcja"
-
-msgid "unknown option"
-msgstr "nieznana opcja"
-
-msgid "window index is out of range"
-msgstr "indeks okna poza zakresem"
-
-msgid "couldn't open buffer"
-msgstr "nie mogę otworzyć bufora"
-
-msgid "cannot delete line"
-msgstr "nie mogę skasować wiersza"
-
-msgid "cannot replace line"
-msgstr "nie mogę zamienić wiersza"
-
-msgid "cannot insert line"
-msgstr "nie mogę wprowadzić wiersza"
-
-msgid "string cannot contain newlines"
-msgstr "ciąg nie może zawierać znaków nowego wiersza"
-
-msgid "error converting Scheme values to Vim"
-msgstr "błąd przy konwersji wartości Scheme do Vima"
-
-msgid "Vim error: ~a"
-msgstr "Błąd vima: ~a"
-
-msgid "Vim error"
-msgstr "Błąd Vima"
-
-msgid "buffer is invalid"
-msgstr "bufor jest nieważny"
-
-msgid "window is invalid"
-msgstr "okno jest nieważne"
-
-msgid "linenr out of range"
-msgstr "numer wiersza poza zakresem"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "Niedozwolone w piaskownicy Vima"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Python: nie można używać :py i :py3 w czasie jednej sesji"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Przykro mi, ta komenda jest wyłączona, bo nie można załadować "
-"biblioteki Pythona"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: nie można używać :py i :py3 w czasie jednej sesji"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Nie można wywołać Pythona rekursywnie"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ musi być reprezentacją Łańcucha"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Przykro mi, ta komenda jest wyłączona, bo nie można załadować "
-"biblioteki Ruby."
-
-msgid "E267: unexpected return"
-msgstr "E267: nieoczekiwany return"
-
-msgid "E268: unexpected next"
-msgstr "E268: nieoczekiwany next"
-
-msgid "E269: unexpected break"
-msgstr "E269: nieoczekiwany break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: nieoczekiwane redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: ponowna próba poza klauzulą ratunku"
-
-msgid "E272: unhandled exception"
-msgstr "E272: nieobsługiwany wyjątek"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Nieznany status longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Przełącz między implementacją/określeniem"
-
-msgid "Show base class of"
-msgstr "Pokaż bazę klasy"
-
-msgid "Show overridden member function"
-msgstr "Pokaż przepisaną funkcję członową"
-
-msgid "Retrieve from file"
-msgstr "Pobieraj z pliku"
-
-msgid "Retrieve from project"
-msgstr "Pobieraj z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Pobieraj z wszystkich projektów"
-
-msgid "Retrieve"
-msgstr "Pobierz"
-
-msgid "Show source of"
-msgstr "Pokaż źródło dla"
-
-msgid "Find symbol"
-msgstr "Znajdź symbol"
-
-msgid "Browse class"
-msgstr "Przejrzyj klasę"
-
-msgid "Show class in hierarchy"
-msgstr "Pokaż klasę w hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Pokaż klasę w ograniczonej hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odnosi się do"
-
-msgid "Xref referred by"
-msgstr "Xref ma odniesienia od"
-
-msgid "Xref has a"
-msgstr "Xref ma"
-
-msgid "Xref used by"
-msgstr "Xref użyte przez"
-
-msgid "Show docu of"
-msgstr "Pokaż dokumentację dla"
-
-msgid "Generate docu for"
-msgstr "Utwórz dokumentację dla"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Nie mogę podłączyć do SNiFF+. Sprawdź środowisko (sniffemacs musi być "
-"odnaleziony w $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Błąd podczas czytania. Rozłączenie"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ jest obecnie "
-
-msgid "not "
-msgstr "nie "
-
-msgid "connected"
-msgstr "podłączony"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Nieznane zapytanie SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Błąd w trakcie podłączania do SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ niepodłączony"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Nie jest buforem SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Błąd w trakcie zapisu. Rozłączony"
-
-msgid "invalid buffer number"
-msgstr "niewłaściwy numer bufora"
-
-msgid "not implemented yet"
-msgstr "obecnie nie zaimplementowano"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nie mogę ustawić wiersza(y)"
-
-msgid "invalid mark name"
-msgstr "niepoprawna nazwa zakładki"
-
-msgid "mark not set"
-msgstr "zakładka nie ustawiona"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "wiersz %d kolumna %d"
-
-msgid "cannot insert/append line"
-msgstr "nie mogę wprowadzić/dołączyć wiersza"
-
-msgid "line number out of range"
-msgstr "numer wiersza poza zakresem"
-
-msgid "unknown flag: "
-msgstr "nieznana flaga: "
-
-msgid "unknown vimOption"
-msgstr "nieznane vimOption"
-
-msgid "keyboard interrupt"
-msgstr "przerwanie klawiatury"
-
-msgid "vim error"
-msgstr "błąd vima"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nie mogę stworzyć bufora/okna komendy: obiekt jest kasowany"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nie mogę zarejestrować wstecznego wywołania komendy: bufor/okno już została "
-"skasowana"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATALNY BŁĄD: reflist zepsuta!? Proszę złożyć raport o tym na vim-"
-"dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nie mogę zarejestrować wstecznego wywołania komendy: brak odniesienia do "
-"bufora/okna"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Przykro mi, ta komenda jest wyłączona, bo nie można załadować "
-"biblioteki Tcl."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: kod wyjścia %d"
-
-msgid "cannot get line"
-msgstr "nie mogę dostać wiersza"
-
-msgid "Unable to register a command server name"
-msgstr "Nie mogę zarejestrować nazwy serwera komend"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Wysłanie komendy do programu docelowego nie powiodło się"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Użyto niewłaściwego id serwera: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: wcielenia instancji rejestru Vima jest źle sformowane.  Skasowano!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Nieznany argument opcji"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Zbyt wiele argumentów"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Brak argumentu po"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Śmiecie po argumencie opcji"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Zbyt wiele argumentów \"+komenda\", \"-c komenda\" lub \"--cmd komenda\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Niewłaściwy argument dla"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d plików do edycji\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans nie są obsługiwane przez to GUI\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Ta wersja Vima nie była skompilowanego z opcją różnic (diff)."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' - nie może być użyte: nie włączone przy kompilacji\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Próba ponownego otworzenia pliku skryptu: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Nie mogę otworzyć do odczytu: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Nie mogę otworzyć dla wyjścia skryptu: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Błąd: Nie można uruchomić gvim z NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: OSTRZEŻENIE: Wyjście nie jest terminalem\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: OSTRZEŻENIE: Wejście nie pochodzi z terminala\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "linia poleceń pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nie mogę czytać z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2916,18 +3343,23 @@ msgstr ""
 "\n"
 "Dalsze informacje poprzez: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[plik ..]       edytuj zadane pliki"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               czytaj tekst ze stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t znacznik   edytuj plik, w którym dany znacznik jest zdefiniowany"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  edytuj plik, zawierający pierwszy błąd"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2937,9 +3369,11 @@ msgstr ""
 "\n"
 "użycie:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumenty]"
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2947,14 +3381,7 @@ msgstr ""
 "\n"
 "   lub:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"gdzie wielkość znaków jest ignorowana dodaj na początku / by flaga była "
-"wielką literą"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2964,327 +3391,196 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tTylko nazwy plików po tym"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNie rozwijaj znaków specjalnych"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tZarejestruj tego gvima w OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tWyrejestruj gvima z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tStartuj w GUI (tak jak \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  lub --nofork\tPierwszy plan: Nie wydzielaj przy odpalaniu GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tTryb vi (jak \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tTryb ex (jak \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tUsprawniony tryb Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tCichy tryb (tła) (tylko dla \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tTryb różnic (jak \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tTryb łatwy (jak \"evim\", bez trybów)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tTryb wyłącznie do odczytu (jak \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tTryb ograniczenia (jak \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModyfikacje (zapisywanie plików) niedozwolone"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZakaz modyfikacji tekstu"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tTryb binarny"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tTryb lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tBądź zgodny z Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tBądź niezupełnie zgodny z Vi: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][nazwap]\t\tGadatliwy [poziom N] [zapisuj wiadomości do nazwap]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tTryb odpluskwiania"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tZamiast pliku wymiany, używaj tylko pamięci"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tWylicz pliki wymiany i zakończ"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (z nazwą pliku)\tOdtwórz załamaną sesję"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tTożsame z -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNie stosuj newcli do otwierania okien"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tUżywaj <device> do I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\trozpocznij w trybie arabskim"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\trozpocznij w trybie hebrajskim"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\trozpocznij w trybie farsi"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tUstaw typ terminala na <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tUżyj <vimrc> zamiast jakiegokolwiek .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tUżyj <gvimrc> zamiast jakiegokolwiek .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNie ładuj skryptów wtyczek"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tOtwórz N kart (domyślnie: po jednej dla każdego pliku)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtwórz N okien (domyślnie: po jednym dla każdego pliku)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\ttak samo jak -o tylko dziel okno pionowo"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tZacznij na końcu pliku"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tZacznij w wierszu <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr ""
 "-cmd <command>\t\tWykonaj komendę <command> przed załadowaniem "
 "jakiegokolwiek pliku vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr ""
 "-c <command>\t\tWykonaj komendę <command> po załadowaniu pierwszego pliku"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <sesja>\t\tWczytaj plik <sesja> po załadowaniu pierwszego pliku"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tWczytuj komendy trybu normalnego z pliku <scriptin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr ""
 "-w <scriptout>\tDołącz wszystkie wprowadzane komendy do pliku <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr ""
 "-W <scriptout>\tZapisuj wszystkie wprowadzane komendy do pliku <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEdytuj zakodowane pliki"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tPodłącz vima to danego X-serwera"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNie łącz z serwerem X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <pliki>\tEdytuj pliki w serwerze Vima jeśli możliwe"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <pliki> To samo, nie narzekaj jeśli nie ma serwera"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <pliki>\tTak jak --remote, lecz czekaj na pliki przed edycją"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <pliki>  To samo, nie narzekaj jeśli nie ma serwera"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <pliki>  tak jak --remote ale używa jednej "
-"karty na plik"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <klawisze>\tWyślij <klawisze> do serwera Vima i zakończ"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <wyr>\tWykonaj <wyrażenie> w serwerze i wypisz wynik"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tWymień nazwy dostępnych serwerów Vima i zakończ"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nazwa>\t\tOdsyłaj do/stań się serwerem Vim <nazwa>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <plik>\n"
 "Zapisz wiadomości o długości startu do <plik>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUżywaj <viminfo> zamiast .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  lub  --help\twyświetl Pomoc (czyli tę wiadomość) i zakończ"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\twyświetl informację o wersji i zakończ"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tZaładuj vim na <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tZacznij Vim jako ikonę"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <kolor>\tUżywaj <kolor> dla tła (również: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <kolor>\tUżywaj <kolor> dla normalnego tekstu (również: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tUżywaj <font> dla normalnego tekstu (również: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\tUżywaj <font> dla wytłuszczonego tekstu"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\tUżywaj <font> dla pochyłego"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tUżywaj <geom> dla początkowych rozmiarów (również: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <szer>\tUżyj ramki o grubości <szer> (również: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <szer>  Używaj przewijacza o szerokości <szer> (również: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <height>\tStosuj belkę menu o wysokości <height> (również: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tStosuj negatyw kolorów (również: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNie stosuj negatywu kolorów (również: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tUstaw określony zasób"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tZastartuj vim na <display> (również: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tUstaw unikatową rolę do identyfikacji głównego okna"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtwórz Vim wewnątrz innego widgetu GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "-echo-wid\t\tGvim wypisze Window ID na wyjście standardowe"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <tytuł rodzica>\tOtwórz Vima wewnątrz rodzicielskiej aplikacji"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tOtwórz Vima wewnątrz innego elementu win32"
-
-msgid "No display"
-msgstr "Brak display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Wysłanie nie powiodło się.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Wysłanie nie powiodło się. Próbuję wykonać na miejscu\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "otworzono %d z %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Brak terminala: Wysłanie wyrażenia nie powiodło się.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Wysłanie wyrażenia nie powiodło się.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Brak zakładek"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Żadna zakładka nie pasuje do \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3293,6 +3589,7 @@ msgstr ""
 "zakł. wiersz kol plik/tekst"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3301,6 +3598,7 @@ msgstr ""
 " skok wiersz kol plik/tekst"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3308,6 +3606,7 @@ msgstr ""
 "\n"
 "zmień wrsz. kol tekst"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3316,6 +3615,7 @@ msgstr ""
 "# Zakładki w plikach:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3323,6 +3623,7 @@ msgstr ""
 "\n"
 "# Lista odniesień (począwszy od najnowszych):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3330,89 +3631,85 @@ msgstr ""
 "\n"
 "# Historia zakładek w plikach (od najnowszych po najstarsze):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Brak '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: To nie jest ważna strona kodowa"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nie mogę nastawić wartości IC"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nie mogłem stworzyć kontekstu wprowadzeń"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nie mogłem otworzyć sposobu wprowadzeń"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: OSTRZEŻENIE: Nie mogłem zlikwidować wywołania dla IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: metoda wprowadzeń nie wspomaga żadnego stylu"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: metoda wprowadzeń nie wspomaga mojego typu preedit"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nie był zablokowany"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Błąd w trakcie czytania pliku wymiany"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Błąd odczytu pliku wymiany"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Błąd szukania w pliku wymiany"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Błąd zapisu w pliku wymiany"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Plik wymiany już istnieje (atak symlink?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nie otrzymałem bloku nr 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nie otrzymałem bloku nr 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Nie otrzymałem bloku nr 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Błąd w czasie uaktualniania szyfrowania pliku wymiany"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ojej, zgubiłem plik wymiany!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nie mogłem zmienić nazwy pliku wymiany"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Nie mogę otworzyć pliku wymiany dla \"%s\"; odtworzenie niemożliwe"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block(): Nie otrzymałem bloku 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Nie znaleziono pliku wymiany dla %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Wprowadź numer pliku wymiany, którego użyć (0 by wyjść): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nie mogę otworzyć %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nie mogę odczytać bloku 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3420,22 +3717,28 @@ msgstr ""
 "\n"
 "Może nie wykonano zmian albo Vim nie zaktualizował pliku wymiany."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nie może być stosowany z tą wersją Vima.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Użyj Vima w wersji 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s nie wygląda na plik wymiany Vima"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nie może być stosowany na tym komputerze.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Ten plik został stworzony na "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3443,104 +3746,86 @@ msgstr ""
 ",\n"
 "lub plik został uszkodzony."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s jest zaszyfrowany a ta wersja Vima nie wspiera szyfrowania"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr ""
 " został uszkodzony (wielkość strony jest mniejsza niż najmniejsza wartość).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Używam pliku wymiany \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Oryginalny plik \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: OSTRZEŻENIE: Oryginalny plik mógł być zmieniony"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Zaszyfrowany plik wymiany: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Jeśli podano nowy klucz szyfrujący, ale nie zapisano pliku tekstowego,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"wprowadź nowy klucz szyfrujący."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Jeśli zapisano plik tekstowy po zmianie klucza szyfrującego wciśnij Enter"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"aby użyć tego samego klucza dla pliku tekstowego i wymiany"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nie mogę odczytać bloku 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???BRAKUJE WIELU WIERSZY"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???LICZNIK WIERSZY NIEZGODNY"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PUSTY BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???BRAKUJE WIERSZY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Niewłaściwe ID bloku 1 (może %s nie jest plikiem .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BRAK BLOKU"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? od tego miejsca po ???KONIEC wiersze mogą być pomieszane"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? od tego miejsca po ???KONIEC wiersze mogą być włożone/skasowane"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONIEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Przerwanie odtwarzania"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Wykryto błędy podczas odtwarzania; od których wierszy zacząć ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Zobacz \":help E312\" dla dalszych informacji."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr ""
 "Odtwarzanie zakończono. Powinieneś sprawdzić czy wszystko jest w porządku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3548,12 +3833,15 @@ msgstr ""
 "\n"
 "(Możesz chcieć zapisać ten plik pod inną nazwą\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "i wykonać diff z oryginalnym plikiem aby sprawdzić zmiany)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Odzyskiwanie zakończone. Zawartość bufora jest równa zawartości pliku."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3563,43 +3851,52 @@ msgstr ""
 "Możesz teraz chcieć usunąć plik .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Używam klucza szyfrującego z pliku wymiany do pliku tekstowego.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Znalezione pliki wymiany:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   W bieżącym katalogu:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Używam podanej nazwy:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   W katalogu "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "     -- żaden --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "   posiadany przez: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   data: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              data: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [po Vimie wersja 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nie wygląda na plik wymiany Vima]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "       nazwa pliku: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3607,12 +3904,15 @@ msgstr ""
 "\n"
 "         zmieniono: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "TAK"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nie"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3620,9 +3920,11 @@ msgstr ""
 "\n"
 "        użytkownik: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   nazwa hosta: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3630,6 +3932,7 @@ msgstr ""
 "\n"
 "      nazwa hosta: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3637,16 +3940,11 @@ msgstr ""
 "\n"
 "        ID procesu: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (dalej działa)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nie nadaje się dla tej wersji Vima]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3654,75 +3952,97 @@ msgstr ""
 "\n"
 "     [nie do użytku na tym komputerze]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "        [nieodczytywalny]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "            [nieotwieralny]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nie mogę zabezpieczyć, bo brak pliku wymiany"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Plik zabezpieczono"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Nieudane zabezpieczenie"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: niewłaściwy lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nie znaleziono wiersza %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: niepoprawne id wskaźnika bloku 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx powinien być 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Zaktualizowano zbyt wiele bloków?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: niepoprawne id wskaźnika bloku 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "blok nr 1 skasowany?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nie mogę znaleźć wiersza %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: niepoprawne id bloku odniesienia"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count wynosi zero"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: numer wiersza poza zakresem: %<PRId64> jest poza końcem"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: liczba wierszy niepoprawna w bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Wielkość stosu wzrasta"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: niepoprawne id bloku odniesienia 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Pętla dowiązań dla \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: UWAGA"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3730,34 +4050,40 @@ msgstr ""
 "\n"
 "Znalazłem plik wymiany o nazwie \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Podczas otwierania pliku \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOWSZE od pliku wymiany!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
 "    be careful not to end up with two different instances of the same\n"
-"    file when making changes.\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Pewnie inny program obrabia ten sam plik.\n"
 "    Jeśli tak, bądź ostrożny, aby nie skończyć z dwoma\n"
 "    różnymi wersjami tego samego pliku po zmianach.\n"
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Zakończ lub ostrożnie kontynuuj.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Sesja edycji dla pliku załamała się.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Jeśli tak, to użyj \":recover\" lub \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3765,9 +4091,11 @@ msgstr ""
 "\"\n"
 "    aby odzyskać zmiany (zobacz \":help recovery)\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Jeśli już to zrobiłeś, usuń plik wymiany \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3775,18 +4103,23 @@ msgstr ""
 "\"\n"
 "    aby uniknąć tej wiadomości.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Plik wymiany \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" już istnieje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - UWAGA"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Plik wymiany już istnieje!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3800,6 +4133,7 @@ msgstr ""
 "&Zakończ\n"
 "&Porzuć"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3815,34 +4149,56 @@ msgstr ""
 "&Zakończ\n"
 "&Porzuć"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Znaleziono zbyt wiele plików wymiany"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Brak pamięci!  (rezerwacja %<PRIu64> bajtów)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Część tropu punktu menu nie określa podmenu"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menu istnieje tylko w innym trybie"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Nie ma menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Pusta nazwa menu"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Trop menu nie może prowadzić do podmenu"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Nie wolno dodawać punktów menu wprost do paska menu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Separator nie może być częścią tropu menu"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3850,60 +4206,73 @@ msgstr ""
 "\n"
 "--- Menu ---"
 
-msgid "Tear off this menu"
-msgstr "Oderwij to menu"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Trop menu musi prowadzić do punktu menu"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Nie znaleziono menu: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menu nie jest zdefiniowane dla trybu %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Trop menu musi prowadzić do podmenu"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Nie znaleziono menu - sprawdź nazwy menu"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Wykryto błąd podczas przetwarzania %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "wiersz %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Niewłaściwa nazwa rejestru: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Opiekun komunikatów: Mikołaj Machowski <mikmach@wp.pl>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Przerwanie: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Naciśnij ENTER lub wprowadź komendę aby kontynuować"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s wiersz %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Więcej --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: ekran/strona/wiersz w dół, b/u/k: do góry, q: zakończ"
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Pytanie"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3911,6 +4280,17 @@ msgstr ""
 "&Tak\n"
 "&Nie"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Tak\n"
+"&Nie\n"
+"&Zakończ"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3924,271 +4304,174 @@ msgstr ""
 "&Odrzuć wszystkie\n"
 "&Zakończ"
 
-msgid "Select Directory dialog"
-msgstr "Dialog wyboru katalogu"
-
-msgid "Save File dialog"
-msgstr "Dialog zapisywania pliku"
-
-msgid "Open File dialog"
-msgstr "Dialog otwierania pliku"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Przykro mi, nie ma przeglądarki plików w trybie konsoli"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Za mało argumentów dla printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Spodziewany argument Zmiennoprzecinkowy w printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Za dużo argumentów dla printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: OSTRZEŻENIE: Zmiany w pliku tylko do odczytu"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Wpisz numer i <Enter> lub wybierz myszą (pusta wartość anuluje): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Wpisz numer i <Enter> (puste anuluje): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 wiersz więcej"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 wiersz mniej"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "dodano %<PRId64> wierszy"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "usunięto %<PRId64> wierszy"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Przerwane)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Biiip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachowuję plik...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Zakończono.\n"
-
-msgid "ERROR: "
-msgstr "BŁĄD: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w użytku %<PRIu64>, maksymalne "
-"użycie %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[wywołania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Wiersz staje się zbyt długi"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Wewnętrzny błąd: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Brak pamięci!  (rezerwacja %<PRIu64> bajtów)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Wywołuję powłokę do wykonania: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Brak dwukropka"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Niedozwolony tryb"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Niedozwolony obrys myszki"
-
-msgid "E548: digit expected"
-msgstr "E548: oczekiwałem na cyfrę"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Niedozwolony procent"
-
-msgid "Enter encryption key: "
-msgstr "Wprowadź klucz do odkodowania: "
-
-msgid "Enter same key again: "
-msgstr "Wprowadź ponownie ten sam klucz: "
-
-msgid "Keys don't match!"
-msgstr "Klucze nie pasują do siebie!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: ścieżka za długa by uzupełnić"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Niewłaściwy trop: '**[numer]' musi być na końcu tropu lub po nim musi "
-"być '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Nie mogę znaleźć katalogu \"%s\" w cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Nie mogę znaleźć pliku \"%s\" w tropie"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Katalogu \"%s\" nie ma więcej w cdpath"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Pliku \"%s\" nie ma więcej w tropie"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Nie można połączyć z Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Nie można połączyć z Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Błędny tryb dostępu pliku info połączenia NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "odczyt z gniazda Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Bufor %<PRId64> utracił połączenie z NetBeans"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans nie są obsługiwane przez to GUI"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans już podłączone"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s jest tylko do odczytu (dodaj ! aby wymusić)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Brak identyfikatora pod kursorem"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' jest pusta"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Funkcjonalność eval nie jest dostępna"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "OSTRZEŻENIE: terminal nie wykonuje podświetlania"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Brak ciągu pod kursorem"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Nie mogę skasować zwinięcia z bieżącą 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: lista zmian (changelist) jest pusta"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Na początku listy zmian"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Na końcu listy zmian"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "wprowadź  :quit<Enter>    zakończenie programu"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 wiersz %sed 1 raz"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 wiersz %sed %d razy"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> wierszy %sed 1 raz"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> wierszy %sed %d razy"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> wierszy do wcięcia... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 wiersz wcięty "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> wierszy wciętych "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Brak poprzednio użytego rejestru"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nie mogę skopiować, mimo to kasuję"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 wiersz zmieniono"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> wierszy zmieniono"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "zwalniam %<PRId64> wierszy"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "skopiowano blok 1 wiersza"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 wiersz skopiowano"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "%<PRId64> wierszy skopiowanych"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> wierszy skopiowanych"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Pusty rejestr %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4196,9 +4479,11 @@ msgstr ""
 "\n"
 "--- Rejestry ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Niedozwolona nazwa rejestru"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4206,162 +4491,181 @@ msgstr ""
 "\n"
 "# Rejestry:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Nieznany typ rejestru %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kolumn; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> Słów; %<PRId64> z %<PRId64> Bajtów"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> Słów; %<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> "
-"Bajtów"
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> Słów; "
+"%<PRId64> z %<PRId64> Bajtów"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; Słowo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; Słowo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z "
-"%<PRId64>"
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> Słów; "
+"%<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> Bajtów"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; Słowo %<PRId64> z %<PRId64>; Bajt "
+"%<PRId64> z %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; Słowo %<PRId64> z %<PRId64>; Znak "
+"%<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> dla BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strona %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dzięki za lot Vimem"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Nieznana opcja"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opcja nie jest wspomagana"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Niedozwolone w modeline"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Kod klucza nie jest ustawiony"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Po = wymagany jest numer"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nie znaleziono w termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Niedozwolony znak <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Nie mogę ustawić 'term' na pusty ciąg"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Nie mogę zmienić term w GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Użyj \":gui\" do odpalenia GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' i 'patchmode' są tożsame"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Konflikty wartości 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Konflikty wartości 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Nie mogę zmienić w GTK+2 GUI"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Brak dwukropka"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Ciąg o zerowej długości"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Brak numeru po <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Brak przecinka"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Musi określać wartość '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: zawiera niewyświetlalny lub szeroki znak"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Niedozwolona czcionka/ki"
-
-msgid "E597: can't select fontset"
-msgstr "E597: nie mogę wybrać zestawu czcionek"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Niedozwolony zestaw czcionek"
-
-msgid "E533: can't select wide font"
-msgstr "E533: nie mogę wybrać szerokiej czcionki"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Niedozwolona szeroka czcionka"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Niedozwolony znak po <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: wymagany przecinek"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' musi być pusty lub zawierać %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Brak wspomagania myszki"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Niedomknięty ciąg wyrażeń"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: zbyt wiele elementów"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: niezbalansowane grupy"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: okno podglądu już istnieje"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabski wymaga UTF-8, zrób ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Potrzebuję przynajmniej %d wierszy"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Potrzebuję przynajmniej %d kolumn"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Nieznana opcja: %s"
@@ -4369,10 +4673,12 @@ msgstr "E355: Nieznana opcja: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Wymagana Liczba: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4380,6 +4686,7 @@ msgstr ""
 "\n"
 "--- Kody terminala ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4387,6 +4694,7 @@ msgstr ""
 "\n"
 "--- Globalne wartości opcji ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4394,6 +4702,7 @@ msgstr ""
 "\n"
 "--- Lokalne wartości opcji ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4401,141 +4710,21 @@ msgstr ""
 "\n"
 "--- Opcje ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: BŁĄD get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Brak pasującego znaku dla %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Dodatkowe znaki po średniku: %s"
 
-msgid "cannot open "
-msgstr "nie mogę otworzyć "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nie mogę otworzyć okna!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Potrzebuję Amigados w wersji 2.04 lub późniejszą\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Potrzebuję %s w wersji %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nie mogę otworzyć NIL:\n"
-
-msgid "Cannot create "
-msgstr "Nie mogę stworzyć "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim kończy pracę z %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "nie mogę zmienić trybu konsoli ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: nie jest konsolą??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nie mogę wykonać powłoki z opcją -f"
-
-msgid "Cannot execute "
-msgstr "Nie mogę wykonać "
-
-msgid "shell "
-msgstr "powłoka "
-
-msgid " returned\n"
-msgstr " zwrócił\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE zbyt niskie."
-
-msgid "I/O ERROR"
-msgstr "BŁĄD I/O"
-
-msgid "Message"
-msgstr "Wiadomość"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' nie wynosi 80, nie mogę wykonać zewnętrznych komend"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Wybór drukarki nie powiódł się"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "do %s z %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Nieznana czcionka drukarki: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Błąd drukarki: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Wydrukowano '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr ""
-"E244: Niedozwolona nazwa zestawu znaków \"%s\" w nazwie czcionki \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Niedozwolony znak '%c' w nazwie czcionki \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Podwójny sygnał, wychodzę\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Załapał śmiertelny sygnał %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Załapał śmiertelny sygnał\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Otwieranie ekranu X trwało %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Dostał błąd X\n"
-
-msgid "Testing the X display failed"
-msgstr "Test ekranu X nie powiódł się"
-
-msgid "Opening the X display timed out"
-msgstr "Próba otwarcia ekranu X trwała zbyt długo"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Nie mogę uzyskać kontekstu bezpieczeństwa dla"
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Nie można uzyskać kontekstu bezpieczeństwa dla"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4543,13 +4732,7 @@ msgstr ""
 "\n"
 "Nie mogę wykonać powłoki "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nie mogę wykonać powłoki sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4557,437 +4740,476 @@ msgstr ""
 "\n"
 "powłoka zwróciła "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Nie mogę stworzyć potoków\n"
+"Nie mogę uzyskać kontekstu bezpieczeństwa dla"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Nie mogę rozdzielić się\n"
+"Nie można uzyskać kontekstu bezpieczeństwa dla"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Komenda zakończona\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP stracił połączenie ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Otwarcie ekranu X nie powiodło się"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP obsługuje żądanie samozapisu"
-
-msgid "XSMP opening connection"
-msgstr "XSMP otwiera połączenie"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Obserwacja połączenia XSMP ICE nie powiodła się"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection nie powiodło się: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Nie mogę znaleźć pliku \"%s\" w tropie"
 
-msgid "At line"
-msgstr "W wierszu"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nie mogę załadować vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Błąd VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nie zdołałem poprawić wskaźników funkcji w DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "powłoka zwróciła %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Załapał wydarzenie %s\n"
-
-msgid "close"
-msgstr "zamknij"
-
-msgid "logoff"
-msgstr "wyloguj"
-
-msgid "shutdown"
-msgstr "zakończ"
-
-msgid "E371: Command not found"
-msgstr "E371: Nie znaleziono komendy"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE nie znaleziono w twoim $PATH.\n"
-"Zewnętrzne komendy nie będą wstrzymane po wykonaniu.\n"
-"Zobacz  :help wim32-vimrun  aby otrzymać więcej informacji."
-
-msgid "Vim Warning"
-msgstr "Vim Ostrzeżenie"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Zbyt wiele %%%c w ciągu formatującym"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Nieoczekiwane %%%c w ciągu formatującym"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Brak ] w ciągu formatującym"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Niewspomagane %%%c w ciągu formatującym"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Niepoprawne %%%c w prefiksie ciągu formatującego"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Niepoprawne %%%c w ciągu formatującym"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' nie zawiera wzorca"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Pusta nazwa katalogu lub jej brak"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Nie ma więcej elementów"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d z %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (wiersz skasowany)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Na dole stosu quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Na górze stosu quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "lista błędów %d z %d; %d błędów"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nie mogę zapisać, opcja 'buftype' jest ustawiona"
 
-msgid "Error file"
-msgstr "Plik błędu"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Brak nazwy pliku lub niewłaściwa ścieżka"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Nie mogę otworzyć pliku \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Bufor nie jest załadowany"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Oczekiwałem na łańcuch lub listę"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Niewłaściwy element w %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Brak ] po %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Niesparowany %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Niesparowany %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Niesparowany %s)"
 
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( jest niedozwolone w tym miejscu"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 i podobne są niedozwolone w tym miejscu"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Brak ] po %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: Pusty %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Zbyt długi wzorzec"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Zbyt wiele \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Zbyt wiele %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Niesparowany \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: niedozwolony znak po %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Zbyt wiele złożonych %s{...}"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Zagnieżdżone %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Zagnieżdżone %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Niedozwolone użycie \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c po niczym"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Niewłaściwe odwołanie wsteczne"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: niedopuszczalny znak po \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Niedozwolony znak po %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Niedozwolony znak po %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Błąd składni w %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Zewnętrzne poddopasowania:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
-msgstr "E:864: \\%#= może być tylko przed 0, 1 lub 2. Zostanie użyty silnik automatyczny"
+msgstr ""
+"E:864: \\%#= może być tylko przed 0, 1 lub 2. Zostanie użyty silnik "
+"automatyczny"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) przedwczesny koniec wyrażenia regularnego"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (wyrażenie regularne NFA) Niepoprawnie umieszczone %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) przedwczesny koniec wyrażenia regularnego"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Nieznany operator '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) Nieznany operator '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Błąd przy budowwaniu NFA z klasą ekwiwalencji"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Nieznany operator '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
-msgstr "E870: (wyrażenie regularne NFA) Błąd przy odczytywaniu limitów powtórzeń"
+msgstr ""
+"E870: (wyrażenie regularne NFA) Błąd przy odczytywaniu limitów powtórzeń"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
-msgstr "E871: (wyrażenie regularne NFA) wielokrotne nie może być po wielokrotnym!"
+msgstr ""
+"E871: (wyrażenie regularne NFA) wielokrotne nie może być po wielokrotnym!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (wyrażenie regularne NFA) Zbyt dużo '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (wyrażenie regularne NFA) Za dużo \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (wyrażenie regularne NFA) błąd poprawnego zakończenia"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Nie można zdjąć elementu ze stosu!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
-msgstr "E875: (wyrażenie regularne NFA) (w trakcie konwersji postfix do NFA), za wiele stanów na stosie"
+msgstr ""
+"E875: (wyrażenie regularne NFA) (w trakcie konwersji postfix do NFA), za "
+"wiele stanów na stosie"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (wyrażenie regularne NFA) Nie ma miejsca na całe NFA "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Nie można przydzielić pamięci do przejścia przez gałęzie!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
-msgstr "Nie można otworzyć do zapisu tymczasowego pliku, pokazuję na stderr... "
+msgstr ""
+"Nie można otworzyć do zapisu tymczasowego pliku, pokazuję na stderr... "
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) NIE MOŻNA OTWORZYĆ %s !"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Nie można otworzyć do zapisu tymczasowego pliku logowania"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-ZAMIANA"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ZAMIANA"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " NEGATYW"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " WPROWADZANIE"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (wprowadzanie)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (zamiana)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-zamiana)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrajski"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabski"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (język)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (wklejanie)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " WIZUALNY"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " WIZUALNY LINIOWY"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " WIZUALNY BLOKOWY"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ZAZNACZANIE"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ZAZNACZANIE LINIOWE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ZAZNACZANIE BLOKOWE"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "zapis"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Niewłaściwy ciąg do szukania: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: szukanie dobiło GÓRY bez znalezienia: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: szukanie dobiło KOŃCA bez znalezienia : %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Oczekuję '?' lub '/' po ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (zawiera poprzednio wymienione dopasowanie)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Zawarte pliki "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "nie znaleziono"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "w tropie ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Już wymienione)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NIE ZNALEZIONO"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Przegląd włączonego pliku: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Przeszukiwanie włączonego pliku %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Wzorzec pasuje w bieżącym wierszu"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Wszelkie włączane pliki odnaleziono"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Brak włączanych plików"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nie znalazłem definicji"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nie znalazłem wzorca"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Podstawienie "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4998,86 +5220,98 @@ msgstr ""
 "# Ostatni %sWyszukiwany wzorzec:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Nieprawidłowy format pliku sprawdzania pisowni"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Obcięty plik sprawdzania pisowni"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Zbędny tekst w %s wiersz %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Za długa nazwa afiksu w %s wiersz %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Błąd formatu w pliku afiksów FOL, LOW lub UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Znak w FOL, LOW lub UPP jest poza zasięgiem"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Kompresja drzewa słów..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Sprawdzanie pisowni nie jest włączone"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Ostrzeżenie: Nie mogę znaleźć listy słów \"%s_%s.spl\" lub \"%s_ascii.spl\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Ostrzeżenie: Nie mogę znaleźć listy słów \"%s.%s.spl\" lub \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Odczytuję plik sprawdzania pisowni \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: To nie wygląda na plik sprawdzania pisowni"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Stary plik sprawdzania pisowni, wymagane uaktualnienie"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Plik sprawdzania pisowni dla nowszej wersji Vima"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Niewspierana sekcja w pliku sprawdzania pisowni"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Ostrzeżenie: region %s nie jest wspierany"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Czytam plik afiksów %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konwersja nie powiodła się dla wyrazu w %s wierszu %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konwersja w %s nie jest wspierana: od %s do %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konwersja w %s nie jest wspierana"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Nieprawidłowa wartość FLAG w %s wierz %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG po użyciu flag w %s wiersz %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5086,6 +5320,7 @@ msgstr ""
 "Definiowanie COMPOUNDFORBIDFLAG po PFX może skutkować złym wynikiem w %s "
 "wiersz %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5094,34 +5329,42 @@ msgstr ""
 "Definiowanie COMPOUNDPERMITFLAG po PFX może skutkować złym wynikiem w %s "
 "wiersz %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Zła wartość COMPOUNDRULES w %s wiersz %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Zła wartość COMPOUNDWORDMAX w %s wiersz %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Zła wartość COMPOUNDMIM w %s wiersz %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Zła wartość COMPOUNDSYLMAX w %s wiersz %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Zła wartość CHECKCOMPOUNDPATTERN w %s wiersz %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "Różne flagi złożeń w kontynuowanym bloku afiksu w %s wiersz %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Powtórzony afiks w %s wiersz %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5130,273 +5373,337 @@ msgstr ""
 "Afiks użyty także dla BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST w "
 "%s wiersz %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Oczekiwano Y lub N w %s wierszu %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Błędny warunek w %s wiersz %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Oczekiwano ilości REP(SAL) w %s wierszu %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Oczekiwano ilości MAP w %s wierszu %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Powtórzony znak w MAP w %s wierszu %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Nieznany lub powtórzony element w %s wierszu %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Brak wiersza FOL/LOW/UPP w %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX użyty bez SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Zbyt wiele opóźnionych prefiksów"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Zbyt wiele flag złożeń"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Zbyt wiele opóźnionych prefiksów i/lub flag złożeń"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Brak wiersza SOFO%s wiersz w %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Wiersze SAL i SOFO w %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flaga nie jest liczbą w %s wiersz %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Nieprawidłowa flaga w %s wiersz %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Wartość %s różni się od tej użytej w innym pliku .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Czytam plik słownika %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Brak ilości słów w %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "wiersz %6d, słowo %6d - %s"
 
 # c-format
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Powtórzony wyraz w %s wierszu %d: %s"
 
 # c-format
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Pierwszy powtórzony wyraz w %s wiersz %d: %s"
 
 # c-format
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d powtórzony(ch) wyraz(ów) w %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Zignorowałem %d słów ze znakami nie ASCII w %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Odczytuję plik wyrazów %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Zignorowano powtórzony wiersz /encoding= w %s wierszu %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Zignorowano wiersz /encoding= po wyrazie w %s wierszu %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Powtórzony wiersz /regions= zignorowano w %s wierszu %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Za dużo regionów w %s wiersz %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "wiersz / zignorowano w %s wierszu %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Nieprawidłowy numer regionu w %s wierszu %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nieznane flagi w %s wiersz %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Zignorowałem %d słów ze znakami nie ASCII"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Nie wystarczająca ilość pamięci, lista słów będzie niekompletna"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Skompresowano %d z %d węzłów; pozostaje %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Odczytuję plik sprawdzania pisowni..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Wykonuję kompresję dźwiękową..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Liczba słów po kompresji dźwiękowej: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Całkowita liczba słów: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Zapisuję plik sugestii %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Oczekiwane zużycie pamięci: %d bajtów"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Nazwa pliku wynikowego nie może być nazwą regionu"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Wspieram tylko 8 regionów"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Nieprawidłowy region w %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Ostrzeżenie: określono zarówno złożenia jak i NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Zapisuję plik sprawdzania pisowni %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Zrobione!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' nie posiada wpisów %<PRId64>"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Usunięto słowo z %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Dodano słowo do %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaki wyrazów różnią się między plikami sprawdzania pisowni"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Przykro mi, brak podpowiedzi"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Przykro mi, tylko %<PRId64> podpowiedzi"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Zmień \"%.*s\" na:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Brak poprzednich podmian sprawdzania pisowni"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Nie znaleziono: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Ten plik nie wygląda na plik .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Stary plik .sug, konieczne jest uaktualnienie: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Plik .sug dla nowszej wersji Vima: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Plik .sug nie pasuje do pliku .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Błąd w czasie odczytu pliku .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Podwojony znak we wpisie MAP"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Brak elementów składni określonych dla tego bufora"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Niedozwolony argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Nie ma takiego klastra składni: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizacja komentarzy w stylu C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "brak synchronizacji"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "początek synchronizacji"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " wierszy przed górną linią"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5404,6 +5711,7 @@ msgstr ""
 "\n"
 "--- Elementy synchronizacji składni ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5411,6 +5719,7 @@ msgstr ""
 "\n"
 "synchronizuję na elementach"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5418,212 +5727,272 @@ msgstr ""
 "\n"
 "--- Elementy składni ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Nie ma takiego klastra składni: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimalnie "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksymalnie "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; pasuje "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr "znaków nowego wiersza"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: argument contains niedozwolony w tym miejscu"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Niewłaściwa wartość cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here niedozwolone w tym miejscu"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Nie znalazłem elementów regionu dla %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Wymagana nazwa pliku"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Za dużo włączonych składni"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Brak ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Brak '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Za mało argumentów: syntax region %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Za dużo klastrów składni"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Brak specyfikacji klastra"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Brak ogranicznika wzorca: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Śmieci po wzorcu: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: wielokrotnie podane wzorce kontynuacji wiersza"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Niedozwolone argumenty: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Brak znaku równości: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Pusty argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s jest niedozwolone w tym miejscu"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musi być pierwsze w liście contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nieznana nazwa grupy: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Niewłaściwa podkomenda :syntax : %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  WSZYTKO    ILOŚĆ  PASUJE  NAJWOLN.    ŚREDNIO   NAZWA              WZORZEC"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursywna pętla wczytująca syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: nie znaleziono grupy podświetlania: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Zbyt mało argumentów: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Zbyt wiele argumentów: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: grupa ma ustawienia; zignorowane podłączenie podświetlania"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: nieoczekiwany znak równości: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: brak znaku równości: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: brak argumentu: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Niedozwolona wartość: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Kolor FG nieznany"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Kolor BG nieznany"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nazwa lub liczba koloru nierozpoznana: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: za długi kod terminala: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Niedozwolony argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Zbyt wiele różnych atrybutów podkreślania w użyciu"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Niedrukowalny znak w nazwie grupy"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: nieprawidłowy znak w nazwie grupy"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Za dużo grup podświetlania i składni"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: na dole stosu znaczników"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: na górze stosu znaczników"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Nie można przejść przed pierwszy pasujący znacznik"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: nie znaleziono znacznika: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri rodzaj znacznik"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "plik\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Pasuje tylko jeden znacznik"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Nie można przejść za ostatni pasujący znacznik"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Plik \"%s\" nie istnieje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "znacznik %d z %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " lub więcej"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Używam znacznika o odmiennej wielkości liter!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Plik \"%s\" nie istnieje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5631,66 +6000,79 @@ msgstr ""
 "\n"
 "  # DO znacznik  OD wiersza      w pliku/tekście"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Szukam w pliku znaczników %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Trop szukania pliku znaczników obcięty dla %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ignoruję długie wiersze w pliku znaczników"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Błąd formatu w pliku znaczników \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Przed bajtem %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Plik znaczników nieuporządkowany: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Brak pliku znaczników"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nie mogę znaleźć wzorca znacznika"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Nie znalazłem znacznika - tylko zgaduję!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Powtórzona nazwa pola: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' nieznany. Możliwe typy wbudowanych terminali:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "domyślnie jest '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Nie mogę otworzyć pliku termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Nie ma opisu takiego terminala w terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Nie ma opisu takiego terminala w termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Brak opisu \"%s\" w termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: wymagana zdolność \"cm\" terminala"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5698,244 +6080,169 @@ msgstr ""
 "\n"
 "--- Klawisze terminala ---"
 
-msgid "new shell started\n"
-msgstr "uruchomiono nową powłokę\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Błąd podczas wczytywania wejścia, kończę...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Używam CUT_BUFFER0 zamiast pustego wyboru"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Niespodziewana zmiana ilości linii"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Cofnięcie niemożliwe; mimo to kontynuuję"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Nie mogę otworzyć do zapisu pliku undo: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Uszkodzony plik undo (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Nie można zapisać pliku undo w żadnym katalogu z 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Nie nadpiszę plikiem undo, nie mogę odczytać: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Nie nadpiszę, to nie jest plik undo: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Pomijam zapis pliku undo, nic do cofnięcia"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Zapisuję plik undo: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Błąd zapisu w pliku undo: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Nie wczytuję pliku undo, inny właściciel: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Wczytuję plik undo: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Nie mogę otworzyć pliku undo do odczytu: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: To nie jest plik undo: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Nie zaszyfrowany plik ma zaszyfrowany plik undo: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Nie powiodło się odszyfrowywanie pliku undo: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Plik undo jest zaszyfrowany: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Niekompatybilny plik undo: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Zawartość pliku się zmieniła, nie mogę użyć pliku undo"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Skończono wczytywanie pliku undo %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Już w miejscu ostatniej zmiany"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Już w miejscu najnowszej zmiany"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Nie znaleziono numeru cofnięcia %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: niewłaściwe numery wierszy"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "1 wiersz więcej"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "więcej wierszy"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "1 wiersz mniej"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "mniej wierszy"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "1 zmiana"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "zmiany"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "przed"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "za"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nie ma zmian do cofnięcia"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "liczba zmiany   kiedy              zapisano"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekund temu"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin nie jest dozwolone po undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: uszkodzona lista cofania"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: brak wiersza cofania"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32-bit wersja GUI dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"64 bitowa wersja GUI dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitowa wersja GUI dla MS-Windows"
-
-msgid " in Win32s mode"
-msgstr " w trybie Win32s"
-
-msgid " with OLE support"
-msgstr " ze wspomaganiem OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"32 bitowa wersja na konsolę dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitowa wersja na konsolę dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitowa wersja dla MS-Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitowa wersja dla MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitowa wersja dla MS-DOS"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"wersja dla MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"wersja dla MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"wersja dla MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"wersja dla OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5943,6 +6250,7 @@ msgstr ""
 "\n"
 "Zadane łaty: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5950,9 +6258,11 @@ msgstr ""
 "\n"
 "Ekstra łaty: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Zmieniony przez "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5960,9 +6270,11 @@ msgstr ""
 "\n"
 "Skompilowany "
 
+#: ../version.c:649
 msgid "by "
 msgstr "przez "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5970,854 +6282,1902 @@ msgstr ""
 "\n"
 "Olbrzymia wersja "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Duża wersja "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normalna wersja "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Mała wersja "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Malutka wersja "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "z GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "z GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "z X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "z X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "z X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "z Photon GUI."
-
-msgid "with GUI."
-msgstr "z GUI."
-
-msgid "with Carbon GUI."
-msgstr "z Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "z Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "z (klasycznym) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Opcje włączone (+) lub nie (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "       vimrc systemu: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "   vimrc użytkownika: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2-gi plik vimrc użytkownika: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3-ci plik vimrc użytkownika: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "    exrc użytkownika: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2-gi plik exrc użytkownika: \""
 
-msgid "  system gvimrc file: \""
-msgstr "     gvimrc systemu: \""
-
-msgid "    user gvimrc file: \""
-msgstr "  gvimrc użytkownika: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2-gi plik gvimrc użytkownika: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3-ci plik gvimrc użytkownika: \""
-
-msgid "    system menu file: \""
-msgstr " systemowy plik menu: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "   odwet dla $VIM-a: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "f-b dla $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilacja: "
 
-msgid "Compiler: "
-msgstr "Kompilator: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Konsolidacja: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  KOMPILACJA DEBUG"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi rozbudowany"
 
+#: ../version.c:769
 msgid "version "
 msgstr "wersja "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Autor: Bram Moolenaar i Inni."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim jest open source i rozprowadzany darmowo"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomóż biednym dzieciom w Ugandzie!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "wprowadź :help iccf<Enter>        dla informacji o tym  "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "wprowadź :q<Enter>                zakończenie programu   "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "wprowadź :help<Enter>  lub  <F1>  pomoc na bieżąco       "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "wprowadź :help version7<Enter>    dla informacji o wersji"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Działam w trybie zgodności z Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "wprowadź :set nocp<Enter>         wartości domyślne Vim-a"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "wprowadź :help cp-default<Enter>  dla informacji to tym  "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu Pomoc->Sieroty        dla informacji to tym  "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Uruchomiony bez trybów, wpisany tekst jest wprowadzany"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menu  Edytuj->Ustawienia globalne->Tryb wstawiania"
-
-msgid "                              for two modes      "
-msgstr "                  dla dwóch trybów           "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menu Edytuj->Ustawienia globalne->Kompatybilność z Vi"
-
-msgid "                              for Vim defaults   "
-msgstr "     dla domyślnych ustawień Vima   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Sponsoruj rozwój Vima!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Zostań zarejestrowanym użytkownikiem Vima!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "wprowadź :help sponsor<Enter>        dla informacji"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "wprowadź :help register<Enter>        dla informacji"
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu Pomoc->Sponsoruj/Zarejestruj się dla informacji"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "OSTRZEŻENIE: wykryto Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "wprowadź :help windows95<Enter>   dla informacji to tym  "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Już jest tylko jeden widok"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Nie ma okna podglądu"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Nie mogę rozdzielić lewo-górnego i prawo-dolnego jednocześnie"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Nie mogę przekręcić, gdy inne okno jest rozdzielone"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Nie mogę zamknąć ostatniego okna"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Nie można zamknąć okna autocmd"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Nie można zamknąć okna, zostałoby tylko okno autocmd"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Inne okno zawiera zmiany"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Brak nazwy pliku pod kursorem"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Nie mogę znaleźć pliku \"%s\" w tropie"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() wywołany z pustym hasłem"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Nie mogłem załadować biblioteki %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Przykro mi, ta komenda jest wyłączona: nie mogłem załadować biblioteki Perla."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish używa błędnej kolejności bajtów"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: wyliczenie Perla zabronione w piaskownicy bez modułu Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: test sha256 nie powiódł się"
 
-msgid "Edit with &multiple Vims"
-msgstr "Edytuj w &wielu Vimach"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: test Blowfisha nie powiódł się"
 
-msgid "Edit with single &Vim"
-msgstr "Edytuj w pojedynczym &Vimie"
+#~ msgid "Patch file"
+#~ msgstr "Plik łata"
 
-msgid "Diff with Vim"
-msgstr "Diff z Vimem"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zakończ"
 
-msgid "Edit with &Vim"
-msgstr "Edytuj w &Vimie"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Brak połączenia z serwerem Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Edytuj z istniejącym Vimem - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nie mogę wysłać do %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Edytuj wybrane pliki w Vimie"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nie mogę czytać odpowiedzi serwera"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Błąd tworzenia procesu: Sprawdź czy gvim jest w twojej ścieżce!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Nie mogę wysłać do klienta"
 
-msgid "gvimext.dll error"
-msgstr "błąd gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Zapisz jako"
 
-msgid "Path length too long!"
-msgstr "Za długa ścieżka!"
+#~ msgid "Source Vim script"
+#~ msgstr "Wczytaj skrypt Vima"
 
-msgid "--No lines in buffer--"
-msgstr "--Brak wierszy w buforze--"
+#~ msgid "Edit File"
+#~ msgstr "Edytuj Plik"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Przerwanie komendy"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NIE ZNALEZIONO)"
 
-msgid "E471: Argument required"
-msgstr "E471: wymagany argument"
+#~ msgid "unknown"
+#~ msgstr "nieznany"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ powinno być /, ? lub &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Edytuj plik w nowym oknie"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Niedozwolone w oknie wiersza poleceń; <CR> wykonuje, CTRL-C opuszcza"
+#~ msgid "Append File"
+#~ msgstr "Dołącz plik"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Komenda niedozwolona z exrc/vimrc w bieżącym szukaniu katalogu lub "
-"znacznika"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Pozycja okna: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Brak :endif"
+#~ msgid "Save Redirection"
+#~ msgstr "Zapisz przekierowanie"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Brak :endtry"
+#~ msgid "Save View"
+#~ msgstr "Zapisz widok"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Brak :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Zapisz sesję"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Brak :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Zapisz ustawienia"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile bez :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< nie jest dostępne bez właściwości +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor bez :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Brak dwugrafów w tej wersji"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Plik istnieje (wymuś poprzez !)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "jest urządzeniem (wyłączonym w opcji 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Komenda nie powiodła się"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Wczytywanie ze stdin..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Nieznany zestaw czcionek: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Nieznana czcionka: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[zakodowane]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Czcionka \"%s\" nie ma stałej szerokości znaków"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Plik zaszyfrowano w nieznany sposób"
 
-msgid "E473: Internal error"
-msgstr "E473: Błąd wewnętrzny"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans nie pozwala na zapis niezmodyfikowanych buforów"
 
-msgid "Interrupted"
-msgstr "Przerwane"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Częściowy zapis niemożliwy dla buforów NetBeans"
 
-msgid "E14: Invalid address"
-msgstr "E14: Niewłaściwy adres"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "zapisywanie do urządzenia wyłączone w opcji 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Niewłaściwy argument"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Rozdział zasobów zostanie utracony (wymuś przez !)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Niewłaściwy argument: %s"
+#~ msgid "<cannot open> "
+#~ msgstr "<nie mogę otworzyć> "
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Niewłaściwe wyrażenie: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: nie mogę otrzymać czcionki %s"
 
-msgid "E16: Invalid range"
-msgstr "E16: Niewłaściwy zakres"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: nie mogę powrócić do bieżącego katalogu"
 
-msgid "E476: Invalid command"
-msgstr "E476: Niewłaściwa komenda"
+#~ msgid "Pathname:"
+#~ msgstr "Trop:"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" jest katalogiem"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: nie mogę otrzymać bieżącego katalogu"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Wywołanie z biblioteki nie powiodło się dla \"%s()\""
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Nie można załadować funkcji biblioteki %s"
+#~ msgid "Cancel"
+#~ msgstr "Zakończ"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Zakładka ma niewłaściwy numer wiersza"
+#~ msgid "Vim dialog"
+#~ msgstr "VIM - Dialog"
 
-msgid "E20: Mark not set"
-msgstr "E20: Zakładka nienastawiona"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Scrollbar Widget: Nie mogłem otrzymać rozmiarów rysunku na przycisku."
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nie mogę wykonać zmian, 'modifiable' jest wyłączone"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Nie mogę stworzyć BalloonEval z powiadomieniem i wywołaniem"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Zbyt głębokie zagnieżdżenie skryptów"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Nie mogłem stworzyć nowego procesu dla GUI"
 
-msgid "E23: No alternate file"
-msgstr "E23: Brak pliku zamiany"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Proces potomny nie mógł uruchomić GUI"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Nie ma takiego skrótu"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nie mogę odpalić GUI"
 
-msgid "E477: No ! allowed"
-msgstr "E477: Niedozwolone !"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nie mogę czytać z \"%s\""
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI nie może być użyte: Nie włączono podczas kompilacji"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Nie można uruchomić GUI, brak prawidłowej czcionki"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebrajski nie może być użyty: Nie włączono podczas kompilacji\n"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Niewłaściwe 'guifontwide'"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi nie może być użyty: Nie włączono podczas kompilacji\n"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Nieprawidłowa wartość 'imactivatekey'"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabski nie może być użyty: Nie włączono podczas kompilacji\n"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Nie mogę zarezerwować koloru %s"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Brak takiej nazwy grupy podświetlania: %s"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Brak dopasowania przy kursorze, szukam dalej"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Nie wprowadzono jeszcze żadnego tekstu"
+#~ msgid "Input _Methods"
+#~ msgstr "Input _Methods"
 
-msgid "E30: No previous command line"
-msgstr "E30: Nie ma poprzedniego wiersza poleceń"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Szukaj i Zamień..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Nie ma takiego przyporządkowania"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Szukaj..."
 
-msgid "E479: No match"
-msgstr "E479: Brak dopasowań"
+#~ msgid "Find what:"
+#~ msgstr "Znajdź:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Brak dopasowań: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Zamień na:"
 
-msgid "E32: No file name"
-msgstr "E32: Brak nazwy pliku"
+#~ msgid "Match whole word only"
+#~ msgstr "Dopasuj tylko całe wyrazy"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Brak poprzedniego podstawieniowego wyrażenia regularnego"
+#~ msgid "Match case"
+#~ msgstr "Dopasuj wielkość liter"
 
-msgid "E34: No previous command"
-msgstr "E34: Brak poprzedniej komendy"
+#~ msgid "Direction"
+#~ msgstr "Kierunek"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Brak poprzedniego wyrażenia regularnego"
+#~ msgid "Up"
+#~ msgstr "W górę"
 
-msgid "E481: No range allowed"
-msgstr "E481: Zakres niedozwolony"
+#~ msgid "Down"
+#~ msgstr "W dół"
 
-msgid "E36: Not enough room"
-msgstr "E36: Brak miejsca"
+#~ msgid "Find Next"
+#~ msgstr "Znajdź następne"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: brak zarejestrowanego serwera o nazwie \"%s\""
+#~ msgid "Replace"
+#~ msgstr "Zamień"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Nie mogę stworzyć pliku %s"
+#~ msgid "Replace All"
+#~ msgstr "Zamień wszystkie"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Nie mogę pobrać nazwy pliku tymczasowego"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: otrzymano żądanie \"die\" od menedżera sesji\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Nie mogę otworzyć pliku %s"
+#~ msgid "Close"
+#~ msgstr "Zamknij"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Nie mogę odczytać pliku %s"
+#~ msgid "New tab"
+#~ msgstr "Nowa karta"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Nie zapisano od ostatniej zmiany (wymuś przez !)"
+#~ msgid "Open Tab..."
+#~ msgstr "Otwórz kartę..."
 
-msgid "E38: Null argument"
-msgstr "E38: Zerowy argument"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Główne okno nieoczekiwanie zniszczone\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Oczekuję liczby"
+#~ msgid "&Filter"
+#~ msgstr "&Filtr"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nie mogę otworzyć pliku błędów %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Anuluj"
 
-msgid "E233: cannot open display"
-msgstr "E233: nie mogę otworzyć ekranu"
+#~ msgid "Directories"
+#~ msgstr "Katalogi"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Pamięć wyczerpana!"
+#~ msgid "Filter"
+#~ msgstr "Filtr"
 
-msgid "Pattern not found"
-msgstr "Nie znaleziono wzorca"
+#~ msgid "&Help"
+#~ msgstr "&Pomoc"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Nie znaleziono wzorca: %s"
+#~ msgid "Files"
+#~ msgstr "Pliki"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument musi być dodatni"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Nie można przejść do poprzedniego katalogu"
+#~ msgid "Selection"
+#~ msgstr "Wybór"
 
-msgid "E42: No Errors"
-msgstr "E42: Brak Błędów"
+#~ msgid "Find &Next"
+#~ msgstr "Znajdź &następne"
 
-msgid "E776: No location list"
-msgstr "E776: Brak listy lokacji"
+#~ msgid "&Replace"
+#~ msgstr "&Zamień"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Popsuty ciąg wzorca"
+#~ msgid "Replace &All"
+#~ msgstr "Zamień &wszystko"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Zepsuty program wyrażeń regularnych"
+#~ msgid "&Undo"
+#~ msgstr "&Cofnij"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: opcja 'readonly' jest ustawiona (wymuś poprzez !)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Nie mogę znaleźć tytułu okna \"%s\""
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Nie mogę zmienić zmiennej tylko do odczytu \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nie jest wspomagany: \"-%s\"; Używaj wersji OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Nie mogę ustawić zmiennej w piaskownicy: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Nie można otworzyć okna wewnątrz aplikacji MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Błąd w trakcie czytania pliku błędów"
+#~ msgid "Close tab"
+#~ msgstr "Zamknij kartę"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Niedozwolone w piaskownicy"
+#~ msgid "Open tab..."
+#~ msgstr "Otwórz kartę..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Niedozwolone w tym miejscu"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Znajdź ciąg (użyj '\\\\' do szukania '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Ustawianie trybu ekranu niewspomagane"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Szukanie i Zamiana (użyj '\\\\' do szukania '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Niewłaściwa wielkość przewinięcia"
+#~ msgid "Not Used"
+#~ msgstr "Nie używany"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: opcja 'shell' jest pusta"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Katalog\t*.nic\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Nie mogłem wczytać danych znaku!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Nie mogę zarezerwować mapy kolorów, pewne kolory mogą być "
+#~ "nieprawidłowe"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Błąd podczas zamykania pliku wymiany"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Brak czcionek dla następujących zestawów znaków w zestawie czcionek "
+#~ "%s:"
 
-msgid "E73: tag stack empty"
-msgstr "E73: stos znaczników jest pusty"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nazwa zestawu czcionek: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Komenda jest zbyt skomplikowana"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Czcionka '%s' nie posiada znaków jednolitej szerokości"
 
-msgid "E75: Name too long"
-msgstr "E75: Zbyt długa nazwa"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Nazwa zestawu czcionek: %s"
 
-msgid "E76: Too many ["
-msgstr "E76: Zbyt wiele ["
+#~ msgid "Font0: %s"
+#~ msgstr "Font0: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: Zbyt wiele nazw plików"
+#~ msgid "Font1: %s"
+#~ msgstr "Font1: %s"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Nadstępne znaczki"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "Szerokość font%<PRId64> nie jest podwójną szerokością font0"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Nieznana zakładka"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Szerokość font0: %<PRId64>"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nie mogą rozwinąć znaków wieloznacznych"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Szerokość font1: %<PRId64>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' nie może być mniejsze niż 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Nieprawidłowy opis czcionki"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' nie może być mniejsze niż 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "&Anuluj"
 
-msgid "E80: Error while writing"
-msgstr "E80: Błąd w trakcie zapisu"
+#~ msgid "no specific match"
+#~ msgstr "brak określonego dopasowania"
 
-msgid "Zero count"
-msgstr "Zerowy licznik"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - wybór czcionki"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Użycie <SID> poza kontekstem skryptu"
+#~ msgid "Name:"
+#~ msgstr "Nazwa:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Odebrałem niewłaściwe wyrażenie"
+#~ msgid "Show size in Points"
+#~ msgstr "Pokaż wielkość w punktach"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Region jest chroniony, nie mogę zmienić"
+#~ msgid "Encoding:"
+#~ msgstr "Kodowanie:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans nie zezwala na zmiany w plikach tylko do odczytu"
+#~ msgid "Font:"
+#~ msgstr "Czcionka:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Błąd wewnętrzny: %s"
+#~ msgid "Style:"
+#~ msgstr "Styl:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Wzorzec używa więcej pamięci niż 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Wielkość:"
 
-msgid "E749: empty buffer"
-msgstr "E749: pusty bufor"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: BŁĄD w automacie Hangul"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Niewłaściwy wzorzec wyszukiwania lub delimiter"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: błąd stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Plik jest załadowany w innym buforze"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: nie mogę otworzyć bazy danych cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Nie ustawiono opcji '%s'"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: nie mogę uzyskać informacji z bazy danych cscope"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Niewłaściwa nazwa rejestru"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Nie można wczytać biblioteki Lua."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "szukanie dobiło GÓRY; kontynuacja od KOŃCA"
+#~ msgid "cannot save undo information"
+#~ msgstr "nie mogę zachować informacji cofania"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "szukanie dobiło KOŃCA; kontynuacja od GÓRY"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Przykro mi, ta komenda jest wyłączona, biblioteka MzScheme nie może "
+#~ "być załadowana."
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Potrzebuję klucza szyfrowania dla \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "niepoprawne wyrażenie"
 
-msgid "empty keys are not allowed"
-msgstr "puste klucze nie są dozwolone"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "wyrażenia wyłączone podczas kompilacji"
 
-msgid "dictionary is locked"
-msgstr "słownik jest zablokowany"
+#~ msgid "hidden option"
+#~ msgstr "ukryta opcja"
 
-msgid "list is locked"
-msgstr "lista jest zablokowana"
+#~ msgid "unknown option"
+#~ msgstr "nieznana opcja"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "nie powiodło się dodanie klucza '%s' do słownika"
+#~ msgid "window index is out of range"
+#~ msgstr "indeks okna poza zakresem"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "indeks musi być liczbą lub wycinkiem, nie %s"
+#~ msgid "couldn't open buffer"
+#~ msgstr "nie mogę otworzyć bufora"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "czekałem na str() lub unicode(), a dostałem %s"
+#~ msgid "cannot delete line"
+#~ msgstr "nie mogę skasować wiersza"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "czekałem na bytes() lub str(), a dostałem %s"
+#~ msgid "cannot replace line"
+#~ msgstr "nie mogę zamienić wiersza"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr ""
-"czekałem na int(), long() lub coś co można zmienić na long(), ale dostałem %s"
+#~ msgid "cannot insert line"
+#~ msgstr "nie mogę wprowadzić wiersza"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "czekałem na int() lub coś co można zmienić na int(), ale dostałem %s"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "ciąg nie może zawierać znaków nowego wiersza"
 
-msgid "value is too large to fit into C int type"
-msgstr "wartość zbyt duża by zmieściła się w typie int C"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "błąd przy konwersji wartości Scheme do Vima"
 
-msgid "value is too small to fit into C int type"
-msgstr "wartość jest zbyt mała by zmieściła się w typie int C"
+#~ msgid "Vim error: ~a"
+#~ msgstr "Błąd vima: ~a"
 
-msgid "number must be greater then zero"
-msgstr "liczba musi być większa niż zero"
+#~ msgid "Vim error"
+#~ msgstr "Błąd Vima"
 
-msgid "number must be greater or equal to zero"
-msgstr "liczba musi być większa lub mniejsza niż zero"
+#~ msgid "buffer is invalid"
+#~ msgstr "bufor jest nieważny"
 
-msgid "can't delete OutputObject attributes"
-msgstr "nie mogę skasować atrybutów OutputObject"
+#~ msgid "window is invalid"
+#~ msgstr "okno jest nieważne"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "niepoprawny atrybut: %s"
+#~ msgid "linenr out of range"
+#~ msgstr "numer wiersza poza zakresem"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Błąd w uruchomieniu obiektów I/O"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "Niedozwolone w piaskownicy Vima"
 
-msgid "failed to change directory"
-msgstr "nie powiodła się zmiana katalogu"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Python: nie można używać :py i :py3 w czasie jednej sesji"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "czekałem na 3-krotkę jako wynik imp.find_module(), a dostałem %s"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Przykro mi, ta komenda jest wyłączona, bo nie można załadować "
+#~ "biblioteki Pythona"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "czekałem na 3-krotkę jako wynik imp.find_module(), a dostałem krotkę o wielkości %d"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Python: nie można używać :py i :py3 w czasie jednej sesji"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "wewnętrzny błąd: imp.find_module zwrócił krotkę z NULL"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Nie można wywołać Pythona rekursywnie"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "nie mogę usunąć atrybutów vim.Dictionary"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ musi być reprezentacją Łańcucha"
 
-msgid "cannot modify fixed dictionary"
-msgstr "nie mogę zmienić zablokowanego słownika"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Przykro mi, ta komenda jest wyłączona, bo nie można załadować "
+#~ "biblioteki Ruby."
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "nie mogę ustawić atrybutu %s"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: nieoczekiwany return"
 
-msgid "hashtab changed during iteration"
-msgstr "hashtab zmienił się w czasie iteracji"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: nieoczekiwany next"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "czekałem na element sekwencyjny od długości 2, a dostałem sekwencję o długości %d"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: nieoczekiwany break"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "konstruktor listy nie akceptuje słów kluczowych jako argumentów"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: nieoczekiwane redo"
 
-msgid "list index out of range"
-msgstr "indeks listy poza zakresem"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: ponowna próba poza klauzulą ratunku"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "błąd wewnętrzny: nie powiodło się pobranie z listy Vima elementu %d"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: nieobsługiwany wyjątek"
 
-msgid "failed to add item to list"
-msgstr "nie powiodło się dodanie elementu do listy"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Nieznany status longjmp %d"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "błąd wewnętrzny: w liście Vima brak elementu %d"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Przełącz między implementacją/określeniem"
 
-msgid "internal error: failed to add item to list"
-msgstr "błąd wewnętrzny: nie powiodło się dodanie elementu do listy"
+#~ msgid "Show base class of"
+#~ msgstr "Pokaż bazę klasy"
 
-msgid "cannot delete vim.List attributes"
-msgstr "nie mogę usunąć atrybutów vim.List"
+#~ msgid "Show overridden member function"
+#~ msgstr "Pokaż przepisaną funkcję członową"
 
-msgid "cannot modify fixed list"
-msgstr "nie mogę zmienić zablokowanej listy"
+#~ msgid "Retrieve from file"
+#~ msgstr "Pobieraj z pliku"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "nie nazwana funkcja %s nie istnieje"
+#~ msgid "Retrieve from project"
+#~ msgstr "Pobieraj z projektu"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "funkcja %s nie istnieje"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Pobieraj z wszystkich projektów"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "konstruktor funkcji nie akceptuje słów kluczowych jako argumentów"
+#~ msgid "Retrieve"
+#~ msgstr "Pobierz"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "nie mogę uruchomić funkcji %s"
+#~ msgid "Show source of"
+#~ msgstr "Pokaż źródło dla"
 
-msgid "unable to get option value"
-msgstr "nie mogę pobrać wartości opcji"
+#~ msgid "Find symbol"
+#~ msgstr "Znajdź symbol"
 
-msgid "internal error: unknown option type"
-msgstr "błąd wewnętrzny: nieznany typ opcji"
+#~ msgid "Browse class"
+#~ msgstr "Przejrzyj klasę"
 
-msgid "problem while switching windows"
-msgstr "wystąpił problem w czasie zmiany okien"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Pokaż klasę w hierarchii"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "nie mogę wyzerować opcji globalnej %s"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Pokaż klasę w ograniczonej hierarchii"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "nie mogę wyzerować opcji %s, która nie ma wartości globalnej"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odnosi się do"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "próba odniesienia do skasowanej karty"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref ma odniesienia od"
 
-msgid "no such tab page"
-msgstr "nie ma takiej karty"
+#~ msgid "Xref has a"
+#~ msgstr "Xref ma"
 
-msgid "attempt to refer to deleted window"
-msgstr "próba odniesienia do skasowanego okna"
+#~ msgid "Xref used by"
+#~ msgstr "Xref użyte przez"
 
-msgid "readonly attribute: buffer"
-msgstr "atrybut tylko do odczytu: bufor"
+#~ msgid "Show docu of"
+#~ msgstr "Pokaż dokumentację dla"
 
-msgid "cursor position outside buffer"
-msgstr "pozycja kursora poza buforem"
+#~ msgid "Generate docu for"
+#~ msgstr "Utwórz dokumentację dla"
 
-msgid "no such window"
-msgstr "nie ma takiego okna"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Nie mogę podłączyć do SNiFF+. Sprawdź środowisko (sniffemacs musi być "
+#~ "odnaleziony w $PATH).\n"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "próba odniesienia do skasowanego bufora"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Błąd podczas czytania. Rozłączenie"
 
-msgid "failed to rename buffer"
-msgstr "nie powiodła się zmiana nazwy bufora"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ jest obecnie "
 
-msgid "mark name must be a single character"
-msgstr "nazwa zakładki musi być pojedynczym znakiem"
+#~ msgid "not "
+#~ msgstr "nie "
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "oczekiwałem na obiekt vim.Buffer, a dostałem %s"
+#~ msgid "connected"
+#~ msgstr "podłączony"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "nie przeszedłem do bufora %d"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Nieznane zapytanie SNiFF+: %s"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "oczekiwałem na obiekt vim.Window, a dostałem %s"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Błąd w trakcie podłączania do SNiFF+"
 
-msgid "failed to find window in the current tab page"
-msgstr "nie znaleziono okna na bieżącej karcie"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ niepodłączony"
 
-msgid "did not switch to the specified window"
-msgstr "nie przeszedłem do określonego okna"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Nie jest buforem SNiFF+"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "oczekiwałem na obiekt vim.TabPage, a dostałem %s"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Błąd w trakcie zapisu. Rozłączony"
 
-msgid "did not switch to the specified tab page"
-msgstr "nie przeszedłem do określonej karty"
+#~ msgid "invalid buffer number"
+#~ msgstr "niewłaściwy numer bufora"
 
-msgid "failed to run the code"
-msgstr "uruchomienie kodu się nie powiodło"
+#~ msgid "not implemented yet"
+#~ msgstr "obecnie nie zaimplementowano"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: eval nie zwróciło odpowiedniego obiektu pythona"
+#~ msgid "cannot set line(s)"
+#~ msgstr "nie mogę ustawić wiersza(y)"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Nie powiodła się konwersja obiektu pythona do wartości Vima"
+#~ msgid "invalid mark name"
+#~ msgstr "niepoprawna nazwa zakładki"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "nie można konwertować %s do słownika Vima"
+#~ msgid "mark not set"
+#~ msgstr "zakładka nie ustawiona"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "nie można konwertować %s do struktury Vima"
+#~ msgid "row %d column %d"
+#~ msgstr "wiersz %d kolumna %d"
 
-msgid "internal error: NULL reference passed"
-msgstr "błąd wewnętrzny: przekazano referencję NULL"
+#~ msgid "cannot insert/append line"
+#~ msgstr "nie mogę wprowadzić/dołączyć wiersza"
 
-msgid "internal error: invalid value type"
-msgstr "błąd wewnętrzny: błędny typ wartości"
+#~ msgid "line number out of range"
+#~ msgstr "numer wiersza poza zakresem"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Nie mogę ustawić haka ścieżki: sys.path_hooks nie jest listą\n"
-"Powinieneś teraz wykonać następujące czynności:\n"
-"- dodać vim.path_hook do sys.path_hooks\n"
-"- dodać vim.VIM_SPECIAL_PATH do sys.path\n"
+#~ msgid "unknown flag: "
+#~ msgstr "nieznana flaga: "
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Nie mogę ustawić ścieżki: sys.path nie jest listą\n"
-"Powinno się teraz dodać vim.VIM_SPECIAL_PATH do sys.path"
+#~ msgid "unknown vimOption"
+#~ msgstr "nieznane vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "przerwanie klawiatury"
+
+#~ msgid "vim error"
+#~ msgstr "błąd vima"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nie mogę stworzyć bufora/okna komendy: obiekt jest kasowany"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nie mogę zarejestrować wstecznego wywołania komendy: bufor/okno już "
+#~ "została skasowana"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATALNY BŁĄD: reflist zepsuta!? Proszę złożyć raport o tym na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nie mogę zarejestrować wstecznego wywołania komendy: brak odniesienia do "
+#~ "bufora/okna"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Przykro mi, ta komenda jest wyłączona, bo nie można załadować "
+#~ "biblioteki Tcl."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: kod wyjścia %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "nie mogę dostać wiersza"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Nie mogę zarejestrować nazwy serwera komend"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Wysłanie komendy do programu docelowego nie powiodło się"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Użyto niewłaściwego id serwera: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: wcielenia instancji rejestru Vima jest źle sformowane.  Skasowano!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans nie są obsługiwane przez to GUI\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Ta wersja Vima nie była skompilowanego z opcją różnic (diff)."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' - nie może być użyte: nie włączone przy kompilacji\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Błąd: Nie można uruchomić gvim z NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "gdzie wielkość znaków jest ignorowana dodaj na początku / by flaga była "
+#~ "wielką literą"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tZarejestruj tego gvima w OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tWyrejestruj gvima z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tStartuj w GUI (tak jak \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  lub --nofork\tPierwszy plan: Nie wydzielaj przy odpalaniu GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNie stosuj newcli do otwierania okien"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tUżywaj <device> do I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tUżyj <gvimrc> zamiast jakiegokolwiek .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEdytuj zakodowane pliki"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tPodłącz vima to danego X-serwera"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNie łącz z serwerem X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <pliki>\tEdytuj pliki w serwerze Vima jeśli możliwe"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <pliki> To samo, nie narzekaj jeśli nie ma serwera"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <pliki>\tTak jak --remote, lecz czekaj na pliki przed edycją"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <pliki>  To samo, nie narzekaj jeśli nie ma serwera"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <pliki>  tak jak --remote ale używa jednej "
+#~ "karty na plik"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <klawisze>\tWyślij <klawisze> do serwera Vima i zakończ"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <wyr>\tWykonaj <wyrażenie> w serwerze i wypisz wynik"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tWymień nazwy dostępnych serwerów Vima i zakończ"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nazwa>\t\tOdsyłaj do/stań się serwerem Vim <nazwa>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tZaładuj vim na <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tZacznij Vim jako ikonę"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <kolor>\tUżywaj <kolor> dla tła (również: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <kolor>\tUżywaj <kolor> dla normalnego tekstu (również: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tUżywaj <font> dla normalnego tekstu (również: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\tUżywaj <font> dla wytłuszczonego tekstu"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\tUżywaj <font> dla pochyłego"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tUżywaj <geom> dla początkowych rozmiarów (również: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <szer>\tUżyj ramki o grubości <szer> (również: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <szer>  Używaj przewijacza o szerokości <szer> (również: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <height>\tStosuj belkę menu o wysokości <height> (również: -"
+#~ "mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tStosuj negatyw kolorów (również: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNie stosuj negatywu kolorów (również: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tUstaw określony zasób"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tZastartuj vim na <display> (również: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\tUstaw unikatową rolę do identyfikacji głównego okna"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtwórz Vim wewnątrz innego widgetu GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "-echo-wid\t\tGvim wypisze Window ID na wyjście standardowe"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <tytuł rodzica>\tOtwórz Vima wewnątrz rodzicielskiej aplikacji"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tOtwórz Vima wewnątrz innego elementu win32"
+
+#~ msgid "No display"
+#~ msgstr "Brak display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Wysłanie nie powiodło się.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Wysłanie nie powiodło się. Próbuję wykonać na miejscu\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "otworzono %d z %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Brak terminala: Wysłanie wyrażenia nie powiodło się.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Wysłanie wyrażenia nie powiodło się.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: To nie jest ważna strona kodowa"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Nie mogę nastawić wartości IC"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nie mogłem stworzyć kontekstu wprowadzeń"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nie mogłem otworzyć sposobu wprowadzeń"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: OSTRZEŻENIE: Nie mogłem zlikwidować wywołania dla IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: metoda wprowadzeń nie wspomaga żadnego stylu"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: metoda wprowadzeń nie wspomaga mojego typu preedit"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Błąd w czasie uaktualniania szyfrowania pliku wymiany"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s jest zaszyfrowany a ta wersja Vima nie wspiera szyfrowania"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Zaszyfrowany plik wymiany: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Jeśli podano nowy klucz szyfrujący, ale nie zapisano pliku tekstowego,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "wprowadź nowy klucz szyfrujący."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Jeśli zapisano plik tekstowy po zmianie klucza szyfrującego wciśnij Enter"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "aby użyć tego samego klucza dla pliku tekstowego i wymiany"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "Używam klucza szyfrującego z pliku wymiany do pliku tekstowego.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nie nadaje się dla tej wersji Vima]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Oderwij to menu"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialog wyboru katalogu"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialog zapisywania pliku"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialog otwierania pliku"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Przykro mi, nie ma przeglądarki plików w trybie konsoli"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachowuję plik...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Zakończono.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "BŁĄD: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w użytku "
+#~ "%<PRIu64>, maksymalne użycie %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[wywołania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów "
+#~ "%<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Wiersz staje się zbyt długi"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Wewnętrzny błąd: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Niedozwolony obrys myszki"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Wprowadź klucz do odkodowania: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Wprowadź ponownie ten sam klucz: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Klucze nie pasują do siebie!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Nie można połączyć z Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Nie można połączyć z Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: Błędny tryb dostępu pliku info połączenia NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "odczyt z gniazda Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Bufor %<PRId64> utracił połączenie z NetBeans"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans nie są obsługiwane przez to GUI"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans już podłączone"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s jest tylko do odczytu (dodaj ! aby wymusić)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Funkcjonalność eval nie jest dostępna"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "zwalniam %<PRId64> wierszy"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Nie mogę zmienić term w GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Użyj \":gui\" do odpalenia GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Nie mogę zmienić w GTK+2 GUI"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Niedozwolona czcionka/ki"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: nie mogę wybrać zestawu czcionek"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Niedozwolony zestaw czcionek"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: nie mogę wybrać szerokiej czcionki"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Niedozwolona szeroka czcionka"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Brak wspomagania myszki"
+
+#~ msgid "cannot open "
+#~ msgstr "nie mogę otworzyć "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nie mogę otworzyć okna!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Potrzebuję Amigados w wersji 2.04 lub późniejszą\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Potrzebuję %s w wersji %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nie mogę otworzyć NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Nie mogę stworzyć "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim kończy pracę z %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "nie mogę zmienić trybu konsoli ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: nie jest konsolą??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Nie mogę wykonać powłoki z opcją -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nie mogę wykonać "
+
+#~ msgid "shell "
+#~ msgstr "powłoka "
+
+#~ msgid " returned\n"
+#~ msgstr " zwrócił\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE zbyt niskie."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "BŁĄD I/O"
+
+#~ msgid "Message"
+#~ msgstr "Wiadomość"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' nie wynosi 80, nie mogę wykonać zewnętrznych komend"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Wybór drukarki nie powiódł się"
+
+#~ msgid "to %s on %s"
+#~ msgstr "do %s z %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Nieznana czcionka drukarki: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Błąd drukarki: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Wydrukowano '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: Niedozwolona nazwa zestawu znaków \"%s\" w nazwie czcionki \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Niedozwolony znak '%c' w nazwie czcionki \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Podwójny sygnał, wychodzę\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Załapał śmiertelny sygnał %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Załapał śmiertelny sygnał\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Otwieranie ekranu X trwało %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Dostał błąd X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test ekranu X nie powiódł się"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Próba otwarcia ekranu X trwała zbyt długo"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogę wykonać powłoki sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogę stworzyć potoków\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogę rozdzielić się\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Komenda zakończona\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP stracił połączenie ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otwarcie ekranu X nie powiodło się"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP obsługuje żądanie samozapisu"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP otwiera połączenie"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Obserwacja połączenia XSMP ICE nie powiodła się"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection nie powiodło się: %s"
+
+#~ msgid "At line"
+#~ msgstr "W wierszu"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nie mogę załadować vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Błąd VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nie zdołałem poprawić wskaźników funkcji w DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "powłoka zwróciła %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Załapał wydarzenie %s\n"
+
+#~ msgid "close"
+#~ msgstr "zamknij"
+
+#~ msgid "logoff"
+#~ msgstr "wyloguj"
+
+#~ msgid "shutdown"
+#~ msgstr "zakończ"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Nie znaleziono komendy"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE nie znaleziono w twoim $PATH.\n"
+#~ "Zewnętrzne komendy nie będą wstrzymane po wykonaniu.\n"
+#~ "Zobacz  :help wim32-vimrun  aby otrzymać więcej informacji."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Ostrzeżenie"
+
+#~ msgid "Error file"
+#~ msgstr "Plik błędu"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: Błąd przy budowwaniu NFA z klasą ekwiwalencji"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr ""
+#~ "E878: (NFA) Nie można przydzielić pamięci do przejścia przez gałęzie!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Ostrzeżenie: Nie mogę znaleźć listy słów \"%s_%s.spl\" lub \"%s_ascii.spl"
+#~ "\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konwersja w %s nie jest wspierana"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr ""
+#~ "E845: Nie wystarczająca ilość pamięci, lista słów będzie niekompletna"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Trop szukania pliku znaczników obcięty dla %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "uruchomiono nową powłokę\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Używam CUT_BUFFER0 zamiast pustego wyboru"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Cofnięcie niemożliwe; mimo to kontynuuję"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Nie zaszyfrowany plik ma zaszyfrowany plik undo: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Nie powiodło się odszyfrowywanie pliku undo: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Plik undo jest zaszyfrowany: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32-bit wersja GUI dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "64 bitowa wersja GUI dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja GUI dla MS-Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " w trybie Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " ze wspomaganiem OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja na konsolę dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja na konsolę dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitowa wersja dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja dla MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitowa wersja dla MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Duża wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normalna wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Mała wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malutka wersja "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "z GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "z GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "z X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "z X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "z X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "z Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "z GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "z Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "z Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "z (klasycznym) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "     gvimrc systemu: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "  gvimrc użytkownika: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2-gi plik gvimrc użytkownika: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3-ci plik gvimrc użytkownika: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr " systemowy plik menu: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompilator: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu Pomoc->Sieroty        dla informacji to tym  "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Uruchomiony bez trybów, wpisany tekst jest wprowadzany"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menu  Edytuj->Ustawienia globalne->Tryb wstawiania"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                  dla dwóch trybów           "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menu Edytuj->Ustawienia globalne->Kompatybilność z Vi"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "     dla domyślnych ustawień Vima   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "OSTRZEŻENIE: wykryto Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "wprowadź :help windows95<Enter>   dla informacji to tym  "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Nie mogłem załadować biblioteki %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Przykro mi, ta komenda jest wyłączona: nie mogłem załadować biblioteki "
+#~ "Perla."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: wyliczenie Perla zabronione w piaskownicy bez modułu Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Edytuj w &wielu Vimach"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Edytuj w pojedynczym &Vimie"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diff z Vimem"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Edytuj w &Vimie"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Edytuj z istniejącym Vimem - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Edytuj wybrane pliki w Vimie"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Błąd tworzenia procesu: Sprawdź czy gvim jest w twojej ścieżce!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "błąd gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Za długa ścieżka!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Nieznany zestaw czcionek: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Nieznana czcionka: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Czcionka \"%s\" nie ma stałej szerokości znaków"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Nie można załadować funkcji biblioteki %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Hebrajski nie może być użyty: Nie włączono podczas kompilacji\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsi nie może być użyty: Nie włączono podczas kompilacji\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabski nie może być użyty: Nie włączono podczas kompilacji\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: brak zarejestrowanego serwera o nazwie \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nie mogę otworzyć ekranu"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Odebrałem niewłaściwe wyrażenie"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Region jest chroniony, nie mogę zmienić"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans nie zezwala na zmiany w plikach tylko do odczytu"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Potrzebuję klucza szyfrowania dla \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "puste klucze nie są dozwolone"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "słownik jest zablokowany"
+
+#~ msgid "list is locked"
+#~ msgstr "lista jest zablokowana"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "nie powiodło się dodanie klucza '%s' do słownika"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "indeks musi być liczbą lub wycinkiem, nie %s"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "czekałem na str() lub unicode(), a dostałem %s"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "czekałem na bytes() lub str(), a dostałem %s"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "czekałem na int(), long() lub coś co można zmienić na long(), ale "
+#~ "dostałem %s"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr ""
+#~ "czekałem na int() lub coś co można zmienić na int(), ale dostałem %s"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "wartość zbyt duża by zmieściła się w typie int C"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "wartość jest zbyt mała by zmieściła się w typie int C"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "liczba musi być większa niż zero"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "liczba musi być większa lub mniejsza niż zero"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nie mogę skasować atrybutów OutputObject"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "niepoprawny atrybut: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Błąd w uruchomieniu obiektów I/O"
+
+#~ msgid "failed to change directory"
+#~ msgstr "nie powiodła się zmiana katalogu"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "czekałem na 3-krotkę jako wynik imp.find_module(), a dostałem %s"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr ""
+#~ "czekałem na 3-krotkę jako wynik imp.find_module(), a dostałem krotkę o "
+#~ "wielkości %d"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "wewnętrzny błąd: imp.find_module zwrócił krotkę z NULL"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "nie mogę usunąć atrybutów vim.Dictionary"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "nie mogę zmienić zablokowanego słownika"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "nie mogę ustawić atrybutu %s"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "hashtab zmienił się w czasie iteracji"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "czekałem na element sekwencyjny od długości 2, a dostałem sekwencję o "
+#~ "długości %d"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "konstruktor listy nie akceptuje słów kluczowych jako argumentów"
+
+#~ msgid "list index out of range"
+#~ msgstr "indeks listy poza zakresem"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "błąd wewnętrzny: nie powiodło się pobranie z listy Vima elementu %d"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "nie powiodło się dodanie elementu do listy"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "błąd wewnętrzny: w liście Vima brak elementu %d"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "błąd wewnętrzny: nie powiodło się dodanie elementu do listy"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "nie mogę usunąć atrybutów vim.List"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "nie mogę zmienić zablokowanej listy"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "nie nazwana funkcja %s nie istnieje"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "funkcja %s nie istnieje"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "konstruktor funkcji nie akceptuje słów kluczowych jako argumentów"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "nie mogę uruchomić funkcji %s"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "wystąpił problem w czasie zmiany okien"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "nie mogę wyzerować opcji globalnej %s"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "nie mogę wyzerować opcji %s, która nie ma wartości globalnej"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "próba odniesienia do skasowanej karty"
+
+#~ msgid "no such tab page"
+#~ msgstr "nie ma takiej karty"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "próba odniesienia do skasowanego okna"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "atrybut tylko do odczytu: bufor"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "pozycja kursora poza buforem"
+
+#~ msgid "no such window"
+#~ msgstr "nie ma takiego okna"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "próba odniesienia do skasowanego bufora"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "nie powiodła się zmiana nazwy bufora"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "nazwa zakładki musi być pojedynczym znakiem"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "oczekiwałem na obiekt vim.Buffer, a dostałem %s"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "nie przeszedłem do bufora %d"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "oczekiwałem na obiekt vim.Window, a dostałem %s"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "nie znaleziono okna na bieżącej karcie"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "nie przeszedłem do określonego okna"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "oczekiwałem na obiekt vim.TabPage, a dostałem %s"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "nie przeszedłem do określonej karty"
+
+#~ msgid "failed to run the code"
+#~ msgstr "uruchomienie kodu się nie powiodło"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: eval nie zwróciło odpowiedniego obiektu pythona"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Nie powiodła się konwersja obiektu pythona do wartości Vima"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "nie można konwertować %s do słownika Vima"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "nie można konwertować %s do struktury Vima"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "błąd wewnętrzny: przekazano referencję NULL"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "błąd wewnętrzny: błędny typ wartości"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Nie mogę ustawić haka ścieżki: sys.path_hooks nie jest listą\n"
+#~ "Powinieneś teraz wykonać następujące czynności:\n"
+#~ "- dodać vim.path_hook do sys.path_hooks\n"
+#~ "- dodać vim.VIM_SPECIAL_PATH do sys.path\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Nie mogę ustawić ścieżki: sys.path nie jest listą\n"
+#~ "Powinno się teraz dodać vim.VIM_SPECIAL_PATH do sys.path"
 
 #~ msgid "softspace must be an integer"
 #~ msgstr "softspace musi być liczbą całkowitą"

--- a/src/nvim/po/pl.cp1250.po
+++ b/src/nvim/po/pl.cp1250.po
@@ -9,175 +9,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-06 19:33+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-08-10 18:15+0200\n"
 "Last-Translator: Mikolaj Machowski <mikmach@wp.pl>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CP1250\n"
+"Content-Type: text/plain; charset=cp1250\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 1.0\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() wywo³any z pustym has³em"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "nie mogê pobraæ wartoœci opcji"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "b³¹d wewnêtrzny: nieznany typ opcji"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish u¿ywa b³êdnej kolejnoœci bajtów"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: test sha256 nie powiód³ siê"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: test Blowfisha nie powiód³ siê"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Lista lokacji]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Lista quickfix]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Autokomendy spowodowa³y porzucenie komendy"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nie mogê zarezerwowaæ bufora; zakoñczenie..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nie mogê zarezerwowaæ bufora; u¿ywam innego..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Nie wy³adowano ¿adnego bufora"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Nie skasowano ¿adnego bufora"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Nie wyrzucono ¿adnego bufora"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 bufor wy³adowany"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "wy³adowano %d buforów"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 bufor skasowany"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buforów skasowano"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "wyrzucono 1 bufor "
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "wyrzucono %d buforów"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Nie mogê wy³adowaæ ostatniego bufora"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nie znaleziono zmienionych buforów"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nie ma wylistowanych buforów"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Bufor \"%<PRId64>\" nie istnieje"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Nie mogê przejœæ poza ostatni bufor"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Nie mogê przejœæ przed pierwszy bufor"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Nie zapisano zmian w buforze %<PRId64> (wymuœ przez !)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Nie mogê wy³adowaæ ostatniego bufora"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: OSTRZE¯ENIE: Przepe³nienie listy nazw plików"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Nie znaleziono bufora %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Wielokrotne dopasowania dla %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: ¯aden bufor nie pasuje do %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "wiersz %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufor o tej nazwie ju¿ istnieje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmieniony]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Nie edytowany]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nowy Plik]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[B³¹d odczytu]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[RO]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[tylko odczyt]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 wiersz --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> wiersze --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "wiersz %<PRId64> z %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Bez nazwy]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "pomoc"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Pomoc]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Podgl¹d]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Wszystko"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Dó³"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Góra"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -185,9 +225,11 @@ msgstr ""
 "\n"
 "# Lista buforów:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Notka]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -195,144 +237,200 @@ msgstr ""
 "\n"
 "--- Znaki ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaki dla %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    wiersz=%<PRId64>  id=%d  nazwa=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Brak dwukropka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Niedozwolony tryb"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: oczekiwa³em na cyfrê"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Niedozwolony procent"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nie mogê zró¿nicowaæ wiêcej ni¿ %<PRId64> buforów"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Nie mogê otworzyæ lub zapisaæ plików tymczasowych"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nie mogê stworzyæ ró¿nic"
 
-msgid "Patch file"
-msgstr "Plik ³ata"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Nie mogê odczytaæ wyjœcia pliku ³aty"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nie mogê wczytaæ wyjœcia ró¿nicy"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Bie¿¹cy bufor nie jest w trybie ró¿nic"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: ¯aden inny bufor w trybie diff nie jest modyfikowalny"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Brak innego bufora w trybie ró¿nic"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Wiêcej ni¿ jeden bufor w trybie ró¿nicowania, nie wiem którego u¿yæ"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nie mogê znaleŸæ bufora \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bufor \"%s\" nie jest w trybie ró¿nicowania"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Nieoczekiwana zmiana bufora"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape jest niedozwolone w dwugrafie"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Nie znaleziono pliku rozk³adu klawiszy"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Zastosowano :loadkeymap w niewczytanym pliku"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Pusty wpis keymap"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Dope³nianie s³ów kluczowych (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X tryb (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Dope³nianie pe³nych wierszy (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Dope³nianie nazw plików (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Dope³nianie znaczników (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Dope³nianie wzorców tropów (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Dope³nianie definicji (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dope³nianie ze s³owników (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Dope³nianie z tezaurusa (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Dope³nianie wiersza poleceñ (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr "Dope³nianie zdefiniowane przez u¿ytkownika (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupe³nianie (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr "Propozycja pisowni (^L^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokalne dope³nianie s³ów kluczowych (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Dobi³em do koñca akapitu"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Funkcja uzupe³niania zmieni³a okno"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Funkcja uzupe³nania usunê³a tekst"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "opcja 'dictionary' jest pusta"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "opcja 'thesaurus' jest pusta"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Przegl¹dam s³ownik: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (wprowadzanie) Przewijanie (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (zamiana) Przewijanie (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Przegl¹dam: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Przegl¹dam znaczniki."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Dodajê"
 
@@ -340,459 +438,576 @@ msgstr " Dodajê"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Szukam..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Z powrotem na pierwotnym"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Wyraz z innego wiersza"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jedyne dopasowanie"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "pasuje %d z %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "pasuje %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Nieoczekiwane znaki w :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Indeks listy poza zakresem: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nieokreœlona zmienna: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Brak ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument %s musi byæ List¹"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument %s musi byæ List¹ lub S³ownikiem"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Nie mo¿na u¿yæ pustego klucza dla S³ownika"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: wymagana Lista"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: wymagany S³ownik"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Zbyt wiele argumentów dla funkcji: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Klucz nie istnieje w S³owniku: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkcja %s ju¿ istnieje; aby j¹ zamieniæ u¿yj !"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: istnieje ju¿ taki element S³ownika"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: wymagana Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Nie mo¿na u¿yæ [:] przy S³owniku"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Z³y typ zmiennej dla %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Nieznana funkcja: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Niedozwolona nazwa zmiennej: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: U¿ycie Zmiennoprzecinkowej jako £añcucha"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Mniej celów ni¿ elementów Listy"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Wiêcej celów ni¿ elementów Listy"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Podwójny ; w liœcie zmiennych"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Nie mogê wypisaæ zmiennych dla %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Indeks mo¿e istnieæ tylko dla Listy lub S³ownika"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] musi byæ ostatnie"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] wymaga wartoœci listy"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Lista ma wiêcej elementów ni¿ cel"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Lista nie ma wystarczaj¹cej iloœci elementów"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Brak \"in\" po :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Brak nawiasów: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Nie istnieje zmienna: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: zmienna zagnie¿d¿ona zbyt g³êboko dla (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Brak ':' po '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Listê mogê porównaæ tylko z List¹"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Nieprawid³owa operacja dla Listy"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: S³ownik mogê porównaæ tylko ze S³ownikiem"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Nieprawid³owa operacja dla S³ownika"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref mogê porównaæ tylko z Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Nieprawid³owa operacja dla Funcref"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Nie mogê u¿yæ '%' w Zmiennoprzecinkowej"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Brak ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Nie mo¿na zindeksowaæ Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Brak nazwy opcji: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Nieznana opcja: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Brak cudzys³owu: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Brak cudzys³owu: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Brakuj¹cy przecinek w Liœcie: '%s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Brak zakoñczenia Listy ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Brak dwukropka w S³owniku: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Powtórzony klucz w S³owniku: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Brakuj¹cy przecinek w S³owniku: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Brak koñca w S³owniku '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Zmienna zagnie¿d¿ona zbyt g³êboko by pokazaæ"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Zbyt wiele argumentów dla funkcji %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Zbyt wiele argumentów dla funkcji %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Nieznana funkcja: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Za ma³o argumentów dla funkcji: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: U¿ycie <SID> poza kontekstem skryptu: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Wywo³anie funkcji \"dict\" bez S³ownika: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Wymagana Liczba lub Zmiennoprzecinkowa"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "argument add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Za du¿o argumentów"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() mo¿e byæ u¿yte tylko w trybie Wprowadzania"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Klucz ju¿ istnieje: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "argument extend()"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "argument map()"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "argument filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld wierszy: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Nieznana funkcja: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zakoñcz"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "wywo³ano inputrestore() wiêcej razy ni¿ inputsave()"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "argument insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Zakres niedozwolony"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Nieprawid³owy typ dla len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Skok to zero"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Pocz¹tek po koñcu"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<pusty>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Brak po³¹czenia z serwerem Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nie mogê wys³aæ do %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nie mogê czytaæ odpowiedzi serwera"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "argument remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Za du¿o dowi¹zañ symbolicznych (pêtla?)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "argument reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Nie mogê wys³aæ do klienta"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "argument sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argument add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funkcja porównywania w sort nie powiod³a siê"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funkcja porównywania w sort nie powiod³a siê"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Niew³aœciwe)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: B³¹d zapisywania pliku tymczasowego"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: U¿ycie Zmiennoprzecinkowej jako Liczby"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: U¿ycie Funcref jako Liczby"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: U¿ycie Listy jako Liczby"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: U¿ycie S³ownika jako Liczby"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: U¿ycie Funcref jako £añcucha"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: U¿ycie Listy jako £añcucha"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: U¿ycie S³ownika jako £añcucha"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Nieprawid³owy typ zmiennej dla: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Nie mogê usun¹æ zmiennej %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Nazwa Funcref musi siê zaczynaæ wielk¹ liter¹: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Nazwa zmiennej jest w konflikcie z istniej¹c¹ funkcj¹: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Wartoœæ jest zablokowana: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Nieznane"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Nie mogê zmieniæ wartoœci %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Zmienna zagnie¿d¿ona zbyt g³êboko by zrobiæ kopiê"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Nieznana funkcja: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Brak '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Nie mo¿na tutaj u¿yæ g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Niedozwolony argument: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Powtórzona nazwa argumentu: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Brak :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Nazwa funkcji jest w konflikcie ze zmienn¹: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Nie mogê redefiniowaæ funkcji %s: jest w u¿yciu"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Nazwa funkcji nie pasuje do nazwy skryptu: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Wymagana jest nazwa funkcji"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Nazwa funkcji musi rozpoczynaæ siê wielk¹ liter¹ lub zawieraæ "
 "dwukropek: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Nazwa funkcji musi rozpoczynaæ siê wielk¹ liter¹ lub zawieraæ "
+"dwukropek: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nie mogê skasowaæ funkcji %s: jest w u¿yciu"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zagnie¿d¿enie wywo³añ funkcji ponad 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "wywo³ujê %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "porzucono %s"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s zwraca #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s zwraca %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "kontynuacja w %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return poza funkcj¹"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -800,6 +1015,7 @@ msgstr ""
 "\n"
 "# zmienne globalne:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -807,212 +1023,104 @@ msgstr ""
 "\n"
 "\tOstatnie ustawienie przez "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Brak starych plików"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Wchodzê w tryb odpluskwiania. WprowadŸ \"cont\" aby kontynuowaæ."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "wiersz %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "cmd: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Nie znaleziono punktu kontrolnego: %s"
-
-msgid "No breakpoints defined"
-msgstr "Nie okreœlono ¿adnych punktów kontrolnych"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  wiersz %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Pierwsze u¿ycie \":profile start {fname}\""
-
-msgid "Save As"
-msgstr "Zapisz jako"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Zachowaæ zmiany w \"%s\"?"
-
-msgid "Untitled"
-msgstr "Bez Tytu³u"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Nie zapisano zmian w buforze \"%s\""
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "OSTRZE¯ENIE: Nieoczekiwane wejœcie w inny bufor (sprawdŸ autokomendy)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Tylko jeden plik w edycji"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Nie mo¿na przejœæ przed pierwszy plik"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Nie mo¿na przejœæ za ostatni plik"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: nie wspierany kompilator: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Szukanie \"%s\" w \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Szukanie \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "nie znaleziono w 'runtimepath': \"%s\""
-
-msgid "Source Vim script"
-msgstr "Wczytaj skrypt Vima"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Nie mo¿na wczytaæ katalogu: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "nie mog³em wczytaæ \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "wiersz: %<PRId64> nie mog³em wczytaæ \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "wczytywanie \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "skoñczono wczytywanie %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-msgid "--cmd argument"
-msgstr "--cmd argument"
-
-msgid "-c argument"
-msgstr "-c argument"
-
-msgid "environment variable"
-msgstr "zmienna œrodowiskowa"
-
-msgid "error handler"
-msgstr "obs³uga b³êdu"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: OSTRZE¯ENIE: Niew³aœciwy separator wierszy, pewnie brak ^M"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: u¿yto :scriptencoding poza wczytywanym plikiem"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: u¿yto :finish poza wczytywanym plikiem"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Bie¿¹cy %sjêzyk: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Nie mogê ustawiæ jêzyka na \"%s\""
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x,  Oktal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Przeniesienie wierszy na siebie samych"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 wiersz przeniesiony"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> wiersze przeniesione"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> wierszy przefiltrowanych"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Autokomendy *Filter* nie mog¹ zmieniaæ bie¿¹cego bufora"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Brak zapisu od czasu ostatniej zmiany]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s w wierszu: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Zbyt wiele b³êdów; pomijam resztê pliku"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Wczytujê plik viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informacja"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " zak³adki"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " stare pliki"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " NIE POWIOD£O SIÊ"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Plik viminfo jest niezapisywalny: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nie mogê zapisaæ pliku viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Zapisujê plik viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Ten plik viminfo zosta³ wygenerowany przez Vima %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1020,37 +1128,47 @@ msgstr ""
 "# Mo¿esz go ostro¿nie edytowaæ!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Wartoœæ 'encoding' w czasie zapisu tego pliku\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Niedopuszczalny pocz¹tkowy znak"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Zapisaæ czêœciowo plik?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Stosuj ! do zapisania czêœciowo bufora"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Nadpisaæ istniej¹cy plik \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Plik wymiany \"%s\" istnieje, czy go nadpisaæ?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Plik wymiany istnieje: %s (wymuœ poprzez :silent!)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Brak nazwy pliku dla bufora %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Plik niezapisany: Zapis jest wy³¹czony opcj¹ 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1059,6 +1177,7 @@ msgstr ""
 "opcja 'readonly' nastawiona dla \"%s\".\n"
 "Czy chcesz go pomimo tego zapisaæ?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1069,69 +1188,84 @@ msgstr ""
 "Mimo to byæ mo¿e uda siê zmieniæ ten plik.\n"
 "Chcesz spróbowaæ?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" jest tylko do odczytu (dodaj ! aby wymusiæ)"
 
-msgid "Edit File"
-msgstr "Edytuj Plik"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokomendy nieoczekiwanie skasowa³y nowy bufor %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nienumeryczny argument dla :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Komendy pow³oki s¹ niedozwolone w rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Wzorce regularne nie mog¹ byæ rozgraniczane literami"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "zamieñ na %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Przerwane) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 pasuje"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 podstawienie "
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> dopasowañ"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> podstawieñ"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " w 1 wierszu"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " w %<PRId64> wierszach"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Nie mogê wykonaæ :global rekursywnie"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Brak wzorca regularnego w :global"
 
 # c-format
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Wzorzec znaleziono w ka¿dym wierszu: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Nie znaleziono wzorca: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1141,137 +1275,335 @@ msgstr ""
 "# Ostatni podstawiany ci¹g:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Nie panikuj!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Przykro mi, brak '%s' pomocy dla %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Przykro mi, ale brak pomocy o %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Przykro mi, nie ma pliku pomocy \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Nie jest katalogiem: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Nie mogê otworzyæ %s do zapisu"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Nie mogê otworzyæ %s do odczytu"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Mieszanka kodowañ w pliku pomocy w ramach jêzyka: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Powtórzony znacznik \"%s\" w pliku %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Nieznana komenda znaku: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Brak nazwy znaku"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Zbyt wiele nazw znaków"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Niew³aœciwy tekst znaku: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Nieznany znak: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Brak numeru znaku"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Niew³aœciwa nazwa bufora: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Niew³aœciwe ID znaku: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NIE ZNALEZIONO)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr "(nie wspomagane)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Skasowano]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Wchodzê w tryb odpluskwiania. WprowadŸ \"cont\" aby kontynuowaæ."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "wiersz %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "cmd: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Nie znaleziono punktu kontrolnego: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Nie okreœlono ¿adnych punktów kontrolnych"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  wiersz %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Pierwsze u¿ycie \":profile start {fname}\""
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Zachowaæ zmiany w \"%s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Bez Tytu³u"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Nie zapisano zmian w buforze \"%s\""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "OSTRZE¯ENIE: Nieoczekiwane wejœcie w inny bufor (sprawdŸ autokomendy)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Tylko jeden plik w edycji"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Nie mo¿na przejœæ przed pierwszy plik"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Nie mo¿na przejœæ za ostatni plik"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: nie wspierany kompilator: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Szukanie \"%s\" w \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Szukanie \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "nie znaleziono w 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Nie mo¿na wczytaæ katalogu: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "nie mog³em wczytaæ \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "wiersz: %<PRId64> nie mog³em wczytaæ \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "wczytywanie \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "skoñczono wczytywanie %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd argument"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "zmienna œrodowiskowa"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "obs³uga b³êdu"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: OSTRZE¯ENIE: Niew³aœciwy separator wierszy, pewnie brak ^M"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: u¿yto :scriptencoding poza wczytywanym plikiem"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: u¿yto :finish poza wczytywanym plikiem"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Bie¿¹cy %sjêzyk: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Nie mogê ustawiæ jêzyka na \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Wchodzê w tryb Ex. WprowadŸ \"visual\" aby przejœæ do trybu Normal."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Na koñcu pliku"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Komenda zbyt rekursywna"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Nie znaleziono wyj¹tku: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Koniec wczytywanego pliku"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Koniec funkcji"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr ""
 "E464: Niejednoznaczne zastosowanie komendy zdefiniowanej przez u¿ytkownika"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Nie jest komend¹ edytora"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Dano wsteczny zakres"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Dano wsteczny zakres; zamiana jest mo¿liwa"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Stosuj w lub w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Przykro mi, ale ta komenda nie jest dostêpna w tej wersji"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Tylko pojedyncza nazwa pliku dozwolona"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 wiêcej plik do edycji.  Mimo to wyjœæ?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "jeszcze %d plików do edycji.  Mimo to wyjœæ?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 wiêcej plik do edycji"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: jeszcze %<PRId64> plików do edycji"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komenda ju¿ istnieje; aby j¹ przedefiniowaæ stosuj !"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1279,296 +1611,341 @@ msgstr ""
 "\n"
 "    Nazwa       Arg. Zak.  Gotowoœæ  Definicja"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Nie znaleziono komend zdefiniowanych przez u¿ytkownika"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nie okreœlono atrybutu"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Niew³aœciwa iloœæ argumentów"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Mno¿nik nie mo¿e byæ podany dwukrotnie"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Niew³aœciwa domyœlna wartoœæ mno¿nika"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete wymaga argumentu"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Niew³aœciwy atrybut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Niew³aœciwa nazwa komendy"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr ""
 "E183: Komendy zdefiniowane przez u¿ytkownika musz¹ rozpoczynaæ siê du¿¹ "
 "liter¹"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr ""
-"E841: Nazwa zastrze¿ona, nie mo¿na jej u¿yæ w komendzie u¿ytkownika"
+msgstr "E841: Nazwa zastrze¿ona, nie mo¿na jej u¿yæ w komendzie u¿ytkownika"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Nie ma takiej komendy u¿ytkownika: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Niew³aœciwa wartoœæ dope³niania: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Argument depe³niania dozwolony wy³¹cznie dla dope³niania u¿ytkownika"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Dope³nianie u¿ytkownika wymaga funkcji jako argumentu"
 
-msgid "unknown"
-msgstr "nieznany"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Nie mogê znaleŸæ zestawu kolorów '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Witaj u¿ytkowniku Vima!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Nie mogê zamkn¹æ ostatniej karty"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Jest ju¿ tylko jedna karta"
 
-msgid "Edit File in new window"
-msgstr "Edytuj plik w nowym oknie"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Karta %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Brak pliku wymiany"
 
-msgid "Append File"
-msgstr "Do³¹cz plik"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Nie mogê zmieniæ katalogu, bufor zosta³ zmodyfikowany (dodaj ! aby "
 "wymusiæ)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Nie ma poprzedniego katalogu"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Nieznany"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize wymaga dwóch argumentów numerycznych"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Pozycja okna: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Pozyskiwanie pozycji okna nie jest zaimplementowane dla tego systemu"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos wymaga dwóch argumentów numerycznych"
 
-msgid "Save Redirection"
-msgstr "Zapisz przekierowanie"
-
-msgid "Save View"
-msgstr "Zapisz widok"
-
-msgid "Save Session"
-msgstr "Zapisz sesjê"
-
-msgid "Save Setup"
-msgstr "Zapisz ustawienia"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Nie mogê utworzyæ katalogu: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" istnieje (wymuœ poprzez !)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Nie mogê otworzyæ \"%s\" do zapisu"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argument musi byæ liter¹ albo cudzys³owem w przód/ty³"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursywne zastosowanie :normal za g³êbokie"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< nie jest dostêpne bez w³aœciwoœci +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Brak nazwy zamiennego pliku do podstawienia pod '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: brak nazwy pliku autokomend do podstawienia pod \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: brak numeru bufora autokomend do podstawienia pod  \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: brak nazwy dopasowania autokomend pod \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: brak nazwy pliku :source do postawienia pod \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: brak numeru linii by u¿yæ z \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Pusta nazwa pliku dla '%' lub '#', dzia³a tylko z \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Wynikiem jest pusty ci¹g"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Nie mogê otworzyæ pliku viminfo do odczytu"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Brak dwugrafów w tej wersji"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Nie mo¿na ':throw' wyj¹tków z prefiksem 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Wyj¹tek: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Wyj¹tek zakoñczony: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Wyj¹tek odrzucony: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, wiersz %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Wyj¹tek przechwycony: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s zosta³ zawieszony"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s przywrócony"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s odrzucony"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Wyj¹tek"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "B³¹d i przerwanie"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "B³¹d"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Przerwanie"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: zbyt g³êbokie zagnie¿d¿enie :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif bez :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else bez :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif bez :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: wielokrotne :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif po :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: zbyt g³êbokie zagnie¿d¿enie :while/:for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue bez :while lub :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break bez :while lub :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: U¿ycie :endfor z :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: U¿ycie :endwhile z :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: zbyt g³êbokie zagnie¿d¿enie :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch bez :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch za :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally bez :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: wielokrotne :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry bez :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction poza funkcj¹"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Nie mo¿na teraz edytowaæ innego bufora"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Nie mo¿na teraz zmieniaæ informacji o buforze"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nazwa znacznika"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " pokrewny plik\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "opcja 'history' jest zerowa"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1577,230 +1954,304 @@ msgstr ""
 "\n"
 "# %s Historia (od najnowszych po najstarsze):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Wiersz poleceñ"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Szukany ci¹g"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Wyra¿enie"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Wiersz wprowadzeñ"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar przekracza d³ugoœæ polecenia"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktywny widok lub bufor skasowany"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: œcie¿ka za d³uga by uzupe³niæ"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Niew³aœciwy trop: '**[numer]' musi byæ na koñcu tropu lub po nim musi "
+"byæ '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Nie mogê znaleŸæ katalogu \"%s\" w cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Nie mogê znaleŸæ pliku \"%s\" w tropie"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Katalogu \"%s\" nie ma wiêcej w cdpath"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Pliku \"%s\" nie ma wiêcej w tropie"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autokomendy zmieni³y bufor lub jego nazwê"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Niedopuszczalna nazwa pliku"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "jest katalogiem"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "nie jest plikiem"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "jest urz¹dzeniem (wy³¹czonym w opcji 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nowy Plik]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nowy KATALOG]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Za du¿y plik]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Nie dozwolono]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Autokomendy *ReadPre zrobi³y plik nieodczytywalnym"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Autokomendy *ReadPre nie mog¹ zmieniaæ bie¿¹cego bufora"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Wczytywanie ze stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Wczytywanie ze stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Nie mo¿na otworzyæ pliku utworzonego przez przemianê!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[specjalny znak]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[brak CR]'"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[d³ugie wiersze rozdzielane]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NIE przemienione]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[przemienione]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[zakodowane]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[B£¥D W PRZEMIANIE w linii %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[NIEDOZWOLONY BAJT w wierszu %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[B£ÊDY W ODCZYCIE]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nie mogê znaleŸæ pliku tymczasowego w celu przemiany"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Nieudana przemiana z 'charconvert'"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nie mogê odczytaæ wyjœcia z 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Plik zaszyfrowano w nieznany sposób"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Brak pasuj¹cych autokomend dla bufora acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Autokomendy skasowa³y lub wy³adowa³y bufor przeznaczony do zapisu"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autokomenda zmieni³a liczbê wierszy w nieoczekiwany sposób"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans nie pozwala na zapis niezmodyfikowanych buforów"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Czêœciowy zapis niemo¿liwy dla buforów NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "nie jest plikiem lub zapisywalnym przyrz¹dem"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "zapisywanie do urz¹dzenia wy³¹czone w opcji 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "jest tylko do odczytu (wymuœ poprzez !)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Nie mogê zapisaæ do pliku zabezpieczenia (wymuœ przez !)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: B³¹d podczas zamykania pliku zabezpieczenia (wymuœ przez !)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Nie mogê odczytaæ pliku w celu zabezpieczenia (wymuœ przez !)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Nie mogê stworzyæ pliku zabezpieczenia (wymuœ przez !)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Nie mogê zrobiæ pliku zabezpieczenia (wymuœ przez !)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Rozdzia³ zasobów zostanie utracony (wymuœ przez !)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nie mogê znaleŸæ pliku tymczasowego do zapisania"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nie mogê przemieniæ (u¿yj ! by zapisaæ bez przemiany)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Nie mogê otworzyæ pod³¹czonego pliku do zapisu"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Nie mogê otworzyæ pliku do zapisu"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync nie powiód³ siê"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Zamkniêcie siê nie powiod³o"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: B³¹d zapisu, przemiana siê nie powiod³a (opró¿nij 'fenc' aby wymusiæ)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: B³¹d zapisu, przemiana siê nie powiod³a w wierszu %<PRId64> (opró¿nij 'fenc' "
-"by wymusiæ)"
+"E513: B³¹d zapisu, przemiana siê nie powiod³a w wierszu %<PRId64> (opró¿nij "
+"'fenc' by wymusiæ)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: b³¹d w zapisie (mo¿e system plików jest przepe³niony?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " B£¥D W PRZEMIANIE"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " w wierszu %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Urz¹dzenie]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nowy]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " do³¹czono"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " zapisano"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: nie mogê zapisaæ oryginalnego pliku"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nie mogê stworzyæ pustego oryginalnego pliku"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nie mogê skasowaæ pliku zabezpieczenia"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1808,80 +2259,96 @@ msgstr ""
 "\n"
 "OSTRZE¯ENIE: Oryginalny plik mo¿e zostaæ utracony lub uszkodzony\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "nie wychodŸ edytora, dopóki plik nie zosta³ poprawnie zapisany!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[format dos-a]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[format maca]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[format unixa]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 wiersz, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> wierszy, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znaków"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> znaków"
-
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Niekompletny ostatni wiersz]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "OSTRZE¯ENIE: Plik zmieni³ siê od czasu ostatniego odczytu!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Czy naprawdê chcesz go zapisaæ"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: B³¹d zapisywania do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: B³¹d w trakcie zamykania \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: B³¹d odczytu \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Autokomenda FileChangedShell skasowa³a bufor"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Plik \"%s\" nie jest d³u¿ej dostêpny"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1890,31 +2357,39 @@ msgstr ""
 "W12: OSTRZE¯ENIE: Plik \"%s\" zmieni³ siê od czasu rozpoczêcia edycji, bufor "
 "w Vimie równie¿ zosta³ zmieniony"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Zobacz \":help W12\"  dla dalszych informacji."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: OSTRZE¯ENIE: Plik \"%s\" zmieni³ siê od czasu rozpoczêcia edycji"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Zobacz \":help W11\"  dla dalszych informacji."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: OSTRZE¯ENIE: Tryb pliku \"%s\" zmieni³ siê od czasu rozpoczêcia edycji"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Zobacz \":help W16\"  dla dalszych informacji."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: OSTRZE¯ENIE: Plik \"%s\" zosta³ stworzony po rozpoczêciu edycji"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "OSTRZE¯ENIE"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1922,39 +2397,48 @@ msgstr ""
 "&OK\n"
 "&Za³aduj Plik"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Nie mo¿na przygotowaæ prze³adowania \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Nie mo¿na prze³adowaæ \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Skasowano--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "auto-usuwanie autokomendy: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Nie ma takiej grupy: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Niedopuszczalny znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Nie ma takiego wydarzenia: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Nie ma takiej grupy lub wydarzenia: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1962,538 +2446,761 @@ msgstr ""
 "\n"
 "--- Autokomendy ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: niew³aœciwy numer bufora"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Nie mo¿na wykonywaæ autokomend dla wydarzeñ ALL"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Brak pasuj¹cych autokomend"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: zbyt g³êbokie zagnie¿d¿enie autokomend"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokomend dla \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Wykonujê %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autokomenda %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Brak {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Brak }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Nie znaleziono zwiniêcia"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Nie mo¿na utworzyæ zwiniêcia przy bie¿¹cej 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Nie mo¿na skasowaæ zwiniêcia przy bie¿¹cej 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld wierszy zwiniêto "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Dodaj do bufora odczytu"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursywne przyporz¹dkowanie"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: istnieje ju¿ globalny skrót dla %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: istnieje ju¿ globalne przyporz¹dkowanie dla %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: istnieje ju¿ skrót dla %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: istnieje ju¿ przyporz¹dkowanie dla %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Nie znaleziono skrótu"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Nie znaleziono przyporz¹dkowania"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Niedopuszczalny tryb"
 
-msgid "<cannot open> "
-msgstr "<nie mogê otworzyæ> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Brak wierszy w buforze--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: nie mogê otrzymaæ czcionki %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Przerwanie komendy"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: nie mogê powróciæ do bie¿¹cego katalogu"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: wymagany argument"
 
-msgid "Pathname:"
-msgstr "Trop:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ powinno byæ /, ? lub &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: nie mogê otrzymaæ bie¿¹cego katalogu"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Zakoñcz"
-
-msgid "Vim dialog"
-msgstr "VIM - Dialog"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Nie mog³em otrzymaæ rozmiarów rysunku na przycisku."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Nie mogê stworzyæ BalloonEval z powiadomieniem i wywo³aniem"
-
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Nie mog³em stworzyæ nowego procesu dla GUI"
-
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Proces potomny nie móg³ uruchomiæ GUI"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nie mogê odpaliæ GUI"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nie mogê czytaæ z \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Nie mo¿na uruchomiæ GUI, brak prawid³owej czcionki"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Niew³aœciwe 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Nieprawid³owa wartoœæ 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Nie mogê zarezerwowaæ koloru %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Brak dopasowania przy kursorze, szukam dalej"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"&Tak\n"
-"&Nie\n"
-"&Zakoñcz"
+"E11: Niedozwolone w oknie wiersza poleceñ; <CR> wykonuje, CTRL-C opuszcza"
 
-msgid "Input _Methods"
-msgstr "Input _Methods"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Szukaj i Zamieñ..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Szukaj..."
-
-msgid "Find what:"
-msgstr "ZnajdŸ:"
-
-msgid "Replace with:"
-msgstr "Zamieñ na:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Dopasuj tylko ca³e wyrazy"
-
-#. match case button
-msgid "Match case"
-msgstr "Dopasuj wielkoœæ liter"
-
-msgid "Direction"
-msgstr "Kierunek"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "W górê"
-
-msgid "Down"
-msgstr "W dó³"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "ZnajdŸ nastêpne"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Zamieñ"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Zamieñ wszystkie"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: otrzymano ¿¹danie \"die\" od mened¿era sesji\n"
-
-msgid "Close"
-msgstr "Zamknij"
-
-msgid "New tab"
-msgstr "Nowa karta"
-
-msgid "Open Tab..."
-msgstr "Otwórz kartê..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: G³ówne okno nieoczekiwanie zniszczone\n"
-
-msgid "&Filter"
-msgstr "&Filtr"
-
-msgid "&Cancel"
-msgstr "&Anuluj"
-
-msgid "Directories"
-msgstr "Katalogi"
-
-msgid "Filter"
-msgstr "Filtr"
-
-msgid "&Help"
-msgstr "&Pomoc"
-
-msgid "Files"
-msgstr "Pliki"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Wybór"
-
-msgid "Find &Next"
-msgstr "ZnajdŸ &nastêpne"
-
-msgid "&Replace"
-msgstr "&Zamieñ"
-
-msgid "Replace &All"
-msgstr "Zamieñ &wszystko"
-
-msgid "&Undo"
-msgstr "&Cofnij"
-
-#, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Nie mogê znaleŸæ tytu³u okna \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nie jest wspomagany: \"-%s\"; U¿ywaj wersji OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Nie mo¿na otworzyæ okna wewn¹trz aplikacji MDI"
-
-msgid "Close tab"
-msgstr "Zamknij kartê"
-
-msgid "Open tab..."
-msgstr "Otwórz kartê..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "ZnajdŸ ci¹g (u¿yj '\\\\' do szukania '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Szukanie i Zamiana (u¿yj '\\\\' do szukania '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Nie u¿ywany"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Katalog\t*.nic\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Vim E458: Nie mogê zarezerwowaæ mapy kolorów, pewne kolory mog¹ byæ "
-"nieprawid³owe"
+"E12: Komenda niedozwolona z exrc/vimrc w bie¿¹cym szukaniu katalogu lub "
+"znacznika"
 
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Brak :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Brak :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Brak :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Brak :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile bez :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor bez :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Plik istnieje (wymuœ poprzez !)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Komenda nie powiod³a siê"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: B³¹d wewnêtrzny"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Przerwane"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Niew³aœciwy adres"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Niew³aœciwy argument"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Niew³aœciwy argument: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Niew³aœciwe wyra¿enie: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Niew³aœciwy zakres"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Niew³aœciwa komenda"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" jest katalogiem"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Niew³aœciwa wielkoœæ przewiniêcia"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"E250: Brak czcionek dla nastêpuj¹cych zestawów znaków w zestawie czcionek %s:"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nazwa zestawu czcionek: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Czcionka '%s' nie posiada znaków jednolitej szerokoœci"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Wywo³anie z biblioteki nie powiod³o siê dla \"%s()\""
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Zak³adka ma niew³aœciwy numer wiersza"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Zak³adka nienastawiona"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nie mogê wykonaæ zmian, 'modifiable' jest wy³¹czone"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Zbyt g³êbokie zagnie¿d¿enie skryptów"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Brak pliku zamiany"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Nie ma takiego skrótu"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Niedozwolone !"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI nie mo¿e byæ u¿yte: Nie w³¹czono podczas kompilacji"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Nazwa zestawu czcionek: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Brak takiej nazwy grupy podœwietlania: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Nie wprowadzono jeszcze ¿adnego tekstu"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Nie ma poprzedniego wiersza poleceñ"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Nie ma takiego przyporz¹dkowania"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Brak dopasowañ"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font0: %s"
-msgstr "Font0: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Brak dopasowañ: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Brak nazwy pliku"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Brak poprzedniego podstawieniowego wyra¿enia regularnego"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Brak poprzedniej komendy"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Brak poprzedniego wyra¿enia regularnego"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Zakres niedozwolony"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Brak miejsca"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font1: %s"
-msgstr "Font1: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Nie mogê stworzyæ pliku %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Nie mogê pobraæ nazwy pliku tymczasowego"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Szerokoœæ font%<PRId64> nie jest podwójn¹ szerokoœci¹ font0"
+msgid "E484: Can't open file %s"
+msgstr "E484: Nie mogê otworzyæ pliku %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Szerokoœæ font0: %<PRId64>"
+msgid "E485: Can't read file %s"
+msgstr "E485: Nie mogê odczytaæ pliku %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Nie zapisano od ostatniej zmiany (wymuœ przez !)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Brak zapisu od czasu ostatniej zmiany]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Zerowy argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oczekujê liczby"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Szerokoœæ font1: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nie mogê otworzyæ pliku b³êdów %s"
 
-msgid "Invalid font specification"
-msgstr "Nieprawid³owy opis czcionki"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Pamiêæ wyczerpana!"
 
-msgid "&Dismiss"
-msgstr "&Anuluj"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Nie znaleziono wzorca"
 
-msgid "no specific match"
-msgstr "brak okreœlonego dopasowania"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Nie znaleziono wzorca: %s"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - wybór czcionki"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument musi byæ dodatni"
 
-msgid "Name:"
-msgstr "Nazwa:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Nie mo¿na przejœæ do poprzedniego katalogu"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Poka¿ wielkoœæ w punktach"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Brak B³êdów"
 
-msgid "Encoding:"
-msgstr "Kodowanie:"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Brak listy lokacji"
 
-msgid "Font:"
-msgstr "Czcionka:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Popsuty ci¹g wzorca"
 
-msgid "Style:"
-msgstr "Styl:"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Zepsuty program wyra¿eñ regularnych"
 
-msgid "Size:"
-msgstr "Wielkoœæ:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: opcja 'readonly' jest ustawiona (wymuœ poprzez !)"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: B£¥D w automacie Hangul"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nie mogê zmieniæ zmiennej tylko do odczytu \"%s\""
 
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Nie mogê ustawiæ zmiennej w piaskownicy: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: B³¹d w trakcie czytania pliku b³êdów"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Niedozwolone w piaskownicy"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Niedozwolone w tym miejscu"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Ustawianie trybu ekranu niewspomagane"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Niew³aœciwa wielkoœæ przewiniêcia"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: opcja 'shell' jest pusta"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Nie mog³em wczytaæ danych znaku!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: B³¹d podczas zamykania pliku wymiany"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: stos znaczników jest pusty"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Komenda jest zbyt skomplikowana"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Zbyt d³uga nazwa"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Zbyt wiele ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Zbyt wiele nazw plików"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Nadstêpne znaczki"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Nieznana zak³adka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nie mog¹ rozwin¹æ znaków wieloznacznych"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' nie mo¿e byæ mniejsze ni¿ 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' nie mo¿e byæ mniejsze ni¿ 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: B³¹d w trakcie zapisu"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Zerowy licznik"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: U¿ycie <SID> poza kontekstem skryptu"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: B³¹d wewnêtrzny: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Wzorzec u¿ywa wiêcej pamiêci ni¿ 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: pusty bufor"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Niew³aœciwy wzorzec wyszukiwania lub delimiter"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Plik jest za³adowany w innym buforze"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Nie ustawiono opcji '%s'"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Niew³aœciwa nazwa rejestru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "szukanie dobi³o GÓRY; kontynuacja od KOÑCA"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "szukanie dobi³o KOÑCA; kontynuacja od GÓRY"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Brak dwukropka"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Niedozwolona czêœæ"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: oczekiwa³em na cyfrê"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Strona %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Brak tekstu do drukowania"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Drukujê stronê %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopia %d z %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Wydrukowano: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Drukowanie odwo³ane"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Nie mo¿na zapisaæ do wyjœciowego pliku PostScriptu"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Nie mogê otworzyæ pliku \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Nie mo¿na odczytaæ pliku zasobów PostScriptu \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: plik \"%s\" nie jest plikiem zasobów PostScriptu"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: plik \"%s\" nie jest wspieranym plikiem zasobów PostScriptu"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" nieprawid³owa wersja pliku zasobów"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Niekompatybilne kodowanie wielobajtowe i zestaw znaków."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset nie mo¿e byæ pusty przy kodowaniu wielobajtowym."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Nie okreœlono domyœlnej czcionki dla drukowania wielobajtowego."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Nie mo¿na otworzyæ pliku PostScript do wyjœcia"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Nie mogê otworzyæ pliku \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Nie mo¿na znaleŸæ pliku zasobów PostScriptu \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Nie mo¿na znaleŸæ pliku zasobów PostScriptu \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Nie mo¿na znaleŸæ pliku zasobów PostScriptu \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Nie mo¿na przekonwertowaæ by drukowaæ kodowanie \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Przesy³am do drukarki..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Drukowanie pliku PostScript nie powiod³o siê"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Zadanie drukowanie przes³ane."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Dodaj now¹ bazê danych"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Zapytane o wzorzec"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Poka¿ ten komunikat"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Zabij po³¹czenie"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Ponów wszelkie po³¹czenia"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Poka¿ po³¹czenia"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Zastosowanie: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Ta komenda cscope nie wspomaga podzielenia okna.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Zastosowanie: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: nie znaleziono znacznika"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) b³¹d: %d"
 
-msgid "E563: stat error"
-msgstr "E563: b³¹d stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s nie jest katalogiem lub poprawn¹ baz¹ danych cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Dodano bazê danych cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: b³¹d odczytu po³¹czenia z cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: nieznany typ szukania cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Nie mog³em stworzyæ potoku do cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Nie mog³em utworzyæ rozwidlenia dla cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "nie powiod³o siê setpgid cs_create_connection"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "wykonanie cs_create_connection nie powiod³o siê"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen dla to_fp nie powiod³o siê"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen dla fr_fp nie powiod³o siê"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Nie mog³em stworzyæ procesu cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: brak po³¹czenia z cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: nieprawid³owa flaga cscopequickfix %c dla %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: brak dopasowañ dla zapytania cscope %s o %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "komendy cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (U¿ycie: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2515,32 +3222,31 @@ msgstr ""
 "       s: znajdŸ ten symbol C\n"
 "       t: znajdŸ ten ³añcuch znaków\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: nie mogê otworzyæ bazy danych cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: nie mogê uzyskaæ informacji z bazy danych cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: nie dodano duplikatu bazy danych cscope"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: nie ma po³¹czenia %s z cscope"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "po³¹czenie %s z cscope zosta³o zamkniête"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: b³¹d krytyczny w cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Znacznik cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2548,367 +3254,88 @@ msgstr ""
 "\n"
 "   #   wiersz"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "nazwa pliku  / kontekst / wiersz\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: B³¹d cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Wszystkie bazy danych cscope prze³adowano"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "brak po³¹czeñ z cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid   nazwa bazy danych               przedsionek tropu\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Nie mo¿na wczytaæ biblioteki Lua."
-
-msgid "cannot save undo information"
-msgstr "nie mogê zachowaæ informacji cofania"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Przykro mi, ta komenda jest wy³¹czona, biblioteka MzScheme nie mo¿e "
-"byæ za³adowana."
-
-msgid "invalid expression"
-msgstr "niepoprawne wyra¿enie"
-
-msgid "expressions disabled at compile time"
-msgstr "wyra¿enia wy³¹czone podczas kompilacji"
-
-msgid "hidden option"
-msgstr "ukryta opcja"
-
-msgid "unknown option"
-msgstr "nieznana opcja"
-
-msgid "window index is out of range"
-msgstr "indeks okna poza zakresem"
-
-msgid "couldn't open buffer"
-msgstr "nie mogê otworzyæ bufora"
-
-msgid "cannot delete line"
-msgstr "nie mogê skasowaæ wiersza"
-
-msgid "cannot replace line"
-msgstr "nie mogê zamieniæ wiersza"
-
-msgid "cannot insert line"
-msgstr "nie mogê wprowadziæ wiersza"
-
-msgid "string cannot contain newlines"
-msgstr "ci¹g nie mo¿e zawieraæ znaków nowego wiersza"
-
-msgid "error converting Scheme values to Vim"
-msgstr "b³¹d przy konwersji wartoœci Scheme do Vima"
-
-msgid "Vim error: ~a"
-msgstr "B³¹d vima: ~a"
-
-msgid "Vim error"
-msgstr "B³¹d Vima"
-
-msgid "buffer is invalid"
-msgstr "bufor jest niewa¿ny"
-
-msgid "window is invalid"
-msgstr "okno jest niewa¿ne"
-
-msgid "linenr out of range"
-msgstr "numer wiersza poza zakresem"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "Niedozwolone w piaskownicy Vima"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Przykro mi, ta komenda jest wy³¹czona, bo nie mo¿na za³adowaæ "
-"biblioteki Pythona"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Nie mo¿na wywo³aæ Pythona rekursywnie"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ musi byæ reprezentacj¹ £añcucha"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Przykro mi, ta komenda jest wy³¹czona, bo nie mo¿na za³adowaæ "
-"biblioteki Ruby."
-
-msgid "E267: unexpected return"
-msgstr "E267: nieoczekiwany return"
-
-msgid "E268: unexpected next"
-msgstr "E268: nieoczekiwany next"
-
-msgid "E269: unexpected break"
-msgstr "E269: nieoczekiwany break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: nieoczekiwane redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: ponowna próba poza klauzul¹ ratunku"
-
-msgid "E272: unhandled exception"
-msgstr "E272: nieobs³ugiwany wyj¹tek"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Nieznany status longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Prze³¹cz miêdzy implementacj¹/okreœleniem"
-
-msgid "Show base class of"
-msgstr "Poka¿ bazê klasy"
-
-msgid "Show overridden member function"
-msgstr "Poka¿ przepisan¹ funkcjê cz³onow¹"
-
-msgid "Retrieve from file"
-msgstr "Pobieraj z pliku"
-
-msgid "Retrieve from project"
-msgstr "Pobieraj z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Pobieraj z wszystkich projektów"
-
-msgid "Retrieve"
-msgstr "Pobierz"
-
-msgid "Show source of"
-msgstr "Poka¿ Ÿród³o dla"
-
-msgid "Find symbol"
-msgstr "ZnajdŸ symbol"
-
-msgid "Browse class"
-msgstr "Przejrzyj klasê"
-
-msgid "Show class in hierarchy"
-msgstr "Poka¿ klasê w hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Poka¿ klasê w ograniczonej hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odnosi siê do"
-
-msgid "Xref referred by"
-msgstr "Xref ma odniesienia od"
-
-msgid "Xref has a"
-msgstr "Xref ma"
-
-msgid "Xref used by"
-msgstr "Xref u¿yte przez"
-
-msgid "Show docu of"
-msgstr "Poka¿ dokumentacjê dla"
-
-msgid "Generate docu for"
-msgstr "Utwórz dokumentacjê dla"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Nie mogê pod³¹czyæ do SNiFF+. SprawdŸ œrodowisko (sniffemacs musi byæ "
-"odnaleziony w $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: B³¹d podczas czytania. Roz³¹czenie"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ jest obecnie "
-
-msgid "not "
-msgstr "nie "
-
-msgid "connected"
-msgstr "pod³¹czony"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Nieznane zapytanie SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: B³¹d w trakcie pod³¹czania do SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ niepod³¹czony"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Nie jest buforem SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: B³¹d w trakcie zapisu. Roz³¹czony"
-
-msgid "invalid buffer number"
-msgstr "niew³aœciwy numer bufora"
-
-msgid "not implemented yet"
-msgstr "obecnie nie zaimplementowano"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nie mogê ustawiæ wiersza(y)"
-
-msgid "invalid mark name"
-msgstr "niepoprawna nazwa zak³adki"
-
-msgid "mark not set"
-msgstr "zak³adka nie ustawiona"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "wiersz %d kolumna %d"
-
-msgid "cannot insert/append line"
-msgstr "nie mogê wprowadziæ/do³¹czyæ wiersza"
-
-msgid "line number out of range"
-msgstr "numer wiersza poza zakresem"
-
-msgid "unknown flag: "
-msgstr "nieznana flaga: "
-
-msgid "unknown vimOption"
-msgstr "nieznane vimOption"
-
-msgid "keyboard interrupt"
-msgstr "przerwanie klawiatury"
-
-msgid "vim error"
-msgstr "b³¹d vima"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nie mogê stworzyæ bufora/okna komendy: obiekt jest kasowany"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nie mogê zarejestrowaæ wstecznego wywo³ania komendy: bufor/okno ju¿ zosta³a "
-"skasowana"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATALNY B£¥D: reflist zepsuta!? Proszê z³o¿yæ raport o tym na vim-"
-"dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nie mogê zarejestrowaæ wstecznego wywo³ania komendy: brak odniesienia do "
-"bufora/okna"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Przykro mi, ta komenda jest wy³¹czona, bo nie mo¿na za³adowaæ "
-"biblioteki Tcl."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: kod wyjœcia %d"
-
-msgid "cannot get line"
-msgstr "nie mogê dostaæ wiersza"
-
-msgid "Unable to register a command server name"
-msgstr "Nie mogê zarejestrowaæ nazwy serwera komend"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Wys³anie komendy do programu docelowego nie powiod³o siê"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: U¿yto niew³aœciwego id serwera: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: wcielenia instancji rejestru Vima jest Ÿle sformowane.  Skasowano!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Nieznany argument opcji"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Zbyt wiele argumentów"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Brak argumentu po"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Œmiecie po argumencie opcji"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Zbyt wiele argumentów \"+komenda\", \"-c komenda\" lub \"--cmd komenda\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Niew³aœciwy argument dla"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d plików do edycji\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans nie s¹ obs³ugiwane przez to GUI\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Ta wersja Vima nie by³a skompilowanego z opcj¹ ró¿nic (diff)."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' - nie mo¿e byæ u¿yte: nie w³¹czone przy kompilacji\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Próba ponownego otworzenia pliku skryptu: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Nie mogê otworzyæ do odczytu: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Nie mogê otworzyæ dla wyjœcia skryptu: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: B³¹d: Nie mo¿na uruchomiæ gvim z NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: OSTRZE¯ENIE: Wyjœcie nie jest terminalem\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: OSTRZE¯ENIE: Wejœcie nie pochodzi z terminala\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "linia poleceñ pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nie mogê czytaæ z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2916,18 +3343,23 @@ msgstr ""
 "\n"
 "Dalsze informacje poprzez: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[plik ..]       edytuj zadane pliki"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               czytaj tekst ze stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t znacznik   edytuj plik, w którym dany znacznik jest zdefiniowany"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  edytuj plik, zawieraj¹cy pierwszy b³¹d"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2937,9 +3369,11 @@ msgstr ""
 "\n"
 "u¿ycie:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumenty]"
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2947,14 +3381,7 @@ msgstr ""
 "\n"
 "   lub:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"gdzie wielkoœæ znaków jest ignorowana dodaj na pocz¹tku / by flaga by³a "
-"wielk¹ liter¹"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2964,327 +3391,196 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tTylko nazwy plików po tym"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNie rozwijaj znaków specjalnych"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tZarejestruj tego gvima w OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tWyrejestruj gvima z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tStartuj w GUI (tak jak \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  lub --nofork\tPierwszy plan: Nie wydzielaj przy odpalaniu GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tTryb vi (jak \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tTryb ex (jak \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tUsprawniony tryb Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tCichy tryb (t³a) (tylko dla \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tTryb ró¿nic (jak \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tTryb ³atwy (jak \"evim\", bez trybów)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tTryb wy³¹cznie do odczytu (jak \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tTryb ograniczenia (jak \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModyfikacje (zapisywanie plików) niedozwolone"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZakaz modyfikacji tekstu"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tTryb binarny"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tTryb lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tB¹dŸ zgodny z Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tB¹dŸ niezupe³nie zgodny z Vi: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][nazwap]\t\tGadatliwy [poziom N] [zapisuj wiadomoœci do nazwap]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tTryb odpluskwiania"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tZamiast pliku wymiany, u¿ywaj tylko pamiêci"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tWylicz pliki wymiany i zakoñcz"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (z nazw¹ pliku)\tOdtwórz za³aman¹ sesjê"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tTo¿same z -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNie stosuj newcli do otwierania okien"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tU¿ywaj <device> do I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\trozpocznij w trybie arabskim"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\trozpocznij w trybie hebrajskim"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\trozpocznij w trybie farsi"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tUstaw typ terminala na <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tU¿yj <vimrc> zamiast jakiegokolwiek .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tU¿yj <gvimrc> zamiast jakiegokolwiek .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNie ³aduj skryptów wtyczek"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tOtwórz N kart (domyœlnie: po jednej dla ka¿dego pliku)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtwórz N okien (domyœlnie: po jednym dla ka¿dego pliku)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\ttak samo jak -o tylko dziel okno pionowo"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tZacznij na koñcu pliku"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tZacznij w wierszu <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr ""
 "-cmd <command>\t\tWykonaj komendê <command> przed za³adowaniem "
 "jakiegokolwiek pliku vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr ""
 "-c <command>\t\tWykonaj komendê <command> po za³adowaniu pierwszego pliku"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <sesja>\t\tWczytaj plik <sesja> po za³adowaniu pierwszego pliku"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tWczytuj komendy trybu normalnego z pliku <scriptin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr ""
 "-w <scriptout>\tDo³¹cz wszystkie wprowadzane komendy do pliku <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr ""
 "-W <scriptout>\tZapisuj wszystkie wprowadzane komendy do pliku <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEdytuj zakodowane pliki"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tPod³¹cz vima to danego X-serwera"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNie ³¹cz z serwerem X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <pliki>\tEdytuj pliki w serwerze Vima jeœli mo¿liwe"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <pliki> To samo, nie narzekaj jeœli nie ma serwera"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <pliki>\tTak jak --remote, lecz czekaj na pliki przed edycj¹"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <pliki>  To samo, nie narzekaj jeœli nie ma serwera"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <pliki>  tak jak --remote ale u¿ywa jednej "
-"karty na plik"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <klawisze>\tWyœlij <klawisze> do serwera Vima i zakoñcz"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <wyr>\tWykonaj <wyra¿enie> w serwerze i wypisz wynik"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tWymieñ nazwy dostêpnych serwerów Vima i zakoñcz"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nazwa>\t\tOdsy³aj do/stañ siê serwerem Vim <nazwa>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <plik>\n"
 "Zapisz wiadomoœci o d³ugoœci startu do <plik>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tU¿ywaj <viminfo> zamiast .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  lub  --help\twyœwietl Pomoc (czyli tê wiadomoœæ) i zakoñcz"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\twyœwietl informacjê o wersji i zakoñcz"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tZa³aduj vim na <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tZacznij Vim jako ikonê"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <kolor>\tU¿ywaj <kolor> dla t³a (równie¿: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <kolor>\tU¿ywaj <kolor> dla normalnego tekstu (równie¿: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tU¿ywaj <font> dla normalnego tekstu (równie¿: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\tU¿ywaj <font> dla wyt³uszczonego tekstu"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\tU¿ywaj <font> dla pochy³ego"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tU¿ywaj <geom> dla pocz¹tkowych rozmiarów (równie¿: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <szer>\tU¿yj ramki o gruboœci <szer> (równie¿: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <szer>  U¿ywaj przewijacza o szerokoœci <szer> (równie¿: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <height>\tStosuj belkê menu o wysokoœci <height> (równie¿: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tStosuj negatyw kolorów (równie¿: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNie stosuj negatywu kolorów (równie¿: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tUstaw okreœlony zasób"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tZastartuj vim na <display> (równie¿: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tUstaw unikatow¹ rolê do identyfikacji g³ównego okna"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtwórz Vim wewn¹trz innego widgetu GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "-echo-wid\t\tGvim wypisze Window ID na wyjœcie standardowe"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <tytu³ rodzica>\tOtwórz Vima wewn¹trz rodzicielskiej aplikacji"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tOtwórz Vima wewn¹trz innego elementu win32"
-
-msgid "No display"
-msgstr "Brak display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Wys³anie nie powiod³o siê.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Wys³anie nie powiod³o siê. Próbujê wykonaæ na miejscu\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "otworzono %d z %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Brak terminala: Wys³anie wyra¿enia nie powiod³o siê.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Wys³anie wyra¿enia nie powiod³o siê.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Brak zak³adek"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: ¯adna zak³adka nie pasuje do \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3293,6 +3589,7 @@ msgstr ""
 "zak³. wiersz kol plik/tekst"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3301,6 +3598,7 @@ msgstr ""
 " skok wiersz kol plik/tekst"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3308,6 +3606,7 @@ msgstr ""
 "\n"
 "zmieñ wrsz. kol tekst"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3316,6 +3615,7 @@ msgstr ""
 "# Zak³adki w plikach:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3323,6 +3623,7 @@ msgstr ""
 "\n"
 "# Lista odniesieñ (pocz¹wszy od najnowszych):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3330,89 +3631,85 @@ msgstr ""
 "\n"
 "# Historia zak³adek w plikach (od najnowszych po najstarsze):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Brak '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: To nie jest wa¿na strona kodowa"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nie mogê nastawiæ wartoœci IC"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nie mog³em stworzyæ kontekstu wprowadzeñ"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nie mog³em otworzyæ sposobu wprowadzeñ"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: OSTRZE¯ENIE: Nie mog³em zlikwidowaæ wywo³ania dla IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: metoda wprowadzeñ nie wspomaga ¿adnego stylu"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: metoda wprowadzeñ nie wspomaga mojego typu preedit"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nie by³ zablokowany"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: B³¹d w trakcie czytania pliku wymiany"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: B³¹d odczytu pliku wymiany"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: B³¹d szukania w pliku wymiany"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: B³¹d zapisu w pliku wymiany"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Plik wymiany ju¿ istnieje (atak symlink?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nie otrzyma³em bloku nr 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nie otrzyma³em bloku nr 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Nie otrzyma³em bloku nr 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: B³¹d w czasie uaktualniania szyfrowania pliku wymiany"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ojej, zgubi³em plik wymiany!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nie mog³em zmieniæ nazwy pliku wymiany"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Nie mogê otworzyæ pliku wymiany dla \"%s\"; odtworzenie niemo¿liwe"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block(): Nie otrzyma³em bloku 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Nie znaleziono pliku wymiany dla %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "WprowadŸ numer pliku wymiany, którego u¿yæ (0 by wyjœæ): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nie mogê otworzyæ %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nie mogê odczytaæ bloku 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3420,22 +3717,28 @@ msgstr ""
 "\n"
 "Mo¿e nie wykonano zmian albo Vim nie zaktualizowa³ pliku wymiany."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nie mo¿e byæ stosowany z t¹ wersj¹ Vima.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "U¿yj Vima w wersji 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s nie wygl¹da na plik wymiany Vima"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nie mo¿e byæ stosowany na tym komputerze.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Ten plik zosta³ stworzony na "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3443,104 +3746,86 @@ msgstr ""
 ",\n"
 "lub plik zosta³ uszkodzony."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s jest zaszyfrowany a ta wersja Vima nie wspiera szyfrowania"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr ""
 " zosta³ uszkodzony (wielkoœæ strony jest mniejsza ni¿ najmniejsza wartoœæ).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "U¿ywam pliku wymiany \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Oryginalny plik \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: OSTRZE¯ENIE: Oryginalny plik móg³ byæ zmieniony"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Zaszyfrowany plik wymiany: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Jeœli podano nowy klucz szyfruj¹cy, ale nie zapisano pliku tekstowego,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"wprowadŸ nowy klucz szyfruj¹cy."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Jeœli zapisano plik tekstowy po zmianie klucza szyfruj¹cego wciœnij Enter"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"aby u¿yæ tego samego klucza dla pliku tekstowego i wymiany"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nie mogê odczytaæ bloku 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???BRAKUJE WIELU WIERSZY"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???LICZNIK WIERSZY NIEZGODNY"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PUSTY BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???BRAKUJE WIERSZY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Niew³aœciwe ID bloku 1 (mo¿e %s nie jest plikiem .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BRAK BLOKU"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? od tego miejsca po ???KONIEC wiersze mog¹ byæ pomieszane"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? od tego miejsca po ???KONIEC wiersze mog¹ byæ w³o¿one/skasowane"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONIEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Przerwanie odtwarzania"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Wykryto b³êdy podczas odtwarzania; od których wierszy zacz¹æ ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Zobacz \":help E312\" dla dalszych informacji."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr ""
 "Odtwarzanie zakoñczono. Powinieneœ sprawdziæ czy wszystko jest w porz¹dku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3548,12 +3833,15 @@ msgstr ""
 "\n"
 "(Mo¿esz chcieæ zapisaæ ten plik pod inn¹ nazw¹\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "i wykonaæ diff z oryginalnym plikiem aby sprawdziæ zmiany)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Odzyskiwanie zakoñczone. Zawartoœæ bufora jest równa zawartoœci pliku."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3563,43 +3851,52 @@ msgstr ""
 "Mo¿esz teraz chcieæ usun¹æ plik .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "U¿ywam klucza szyfruj¹cego z pliku wymiany do pliku tekstowego.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Znalezione pliki wymiany:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   W bie¿¹cym katalogu:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   U¿ywam podanej nazwy:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   W katalogu "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "     -- ¿aden --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "   posiadany przez: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   data: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              data: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [po Vimie wersja 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nie wygl¹da na plik wymiany Vima]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "       nazwa pliku: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3607,12 +3904,15 @@ msgstr ""
 "\n"
 "         zmieniono: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "TAK"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nie"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3620,9 +3920,11 @@ msgstr ""
 "\n"
 "        u¿ytkownik: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   nazwa hosta: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3630,6 +3932,7 @@ msgstr ""
 "\n"
 "      nazwa hosta: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3637,16 +3940,11 @@ msgstr ""
 "\n"
 "        ID procesu: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (dalej dzia³a)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nie nadaje siê dla tej wersji Vima]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3654,75 +3952,97 @@ msgstr ""
 "\n"
 "     [nie do u¿ytku na tym komputerze]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "        [nieodczytywalny]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "            [nieotwieralny]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nie mogê zabezpieczyæ, bo brak pliku wymiany"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Plik zabezpieczono"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Nieudane zabezpieczenie"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: niew³aœciwy lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nie znaleziono wiersza %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: niepoprawne id wskaŸnika bloku 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx powinien byæ 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Zaktualizowano zbyt wiele bloków?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: niepoprawne id wskaŸnika bloku 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "blok nr 1 skasowany?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nie mogê znaleŸæ wiersza %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: niepoprawne id bloku odniesienia"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count wynosi zero"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: numer wiersza poza zakresem: %<PRId64> jest poza koñcem"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: liczba wierszy niepoprawna w bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Wielkoœæ stosu wzrasta"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: niepoprawne id bloku odniesienia 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Pêtla dowi¹zañ dla \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: UWAGA"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3730,34 +4050,40 @@ msgstr ""
 "\n"
 "Znalaz³em plik wymiany o nazwie \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Podczas otwierania pliku \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOWSZE od pliku wymiany!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
 "    be careful not to end up with two different instances of the same\n"
-"    file when making changes.\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Pewnie inny program obrabia ten sam plik.\n"
 "    Jeœli tak, b¹dŸ ostro¿ny, aby nie skoñczyæ z dwoma\n"
 "    ró¿nymi wersjami tego samego pliku po zmianach.\n"
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Zakoñcz lub ostro¿nie kontynuuj.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Sesja edycji dla pliku za³ama³a siê.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Jeœli tak, to u¿yj \":recover\" lub \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3765,9 +4091,11 @@ msgstr ""
 "\"\n"
 "    aby odzyskaæ zmiany (zobacz \":help recovery)\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Jeœli ju¿ to zrobi³eœ, usuñ plik wymiany \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3775,18 +4103,23 @@ msgstr ""
 "\"\n"
 "    aby unikn¹æ tej wiadomoœci.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Plik wymiany \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ju¿ istnieje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - UWAGA"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Plik wymiany ju¿ istnieje!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3800,6 +4133,7 @@ msgstr ""
 "&Zakoñcz\n"
 "&Porzuæ"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3815,34 +4149,56 @@ msgstr ""
 "&Zakoñcz\n"
 "&Porzuæ"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Znaleziono zbyt wiele plików wymiany"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Brak pamiêci!  (rezerwacja %<PRIu64> bajtów)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Czêœæ tropu punktu menu nie okreœla podmenu"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menu istnieje tylko w innym trybie"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Nie ma menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Pusta nazwa menu"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Trop menu nie mo¿e prowadziæ do podmenu"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Nie wolno dodawaæ punktów menu wprost do paska menu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Separator nie mo¿e byæ czêœci¹ tropu menu"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3850,60 +4206,73 @@ msgstr ""
 "\n"
 "--- Menu ---"
 
-msgid "Tear off this menu"
-msgstr "Oderwij to menu"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Trop menu musi prowadziæ do punktu menu"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Nie znaleziono menu: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menu nie jest zdefiniowane dla trybu %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Trop menu musi prowadziæ do podmenu"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Nie znaleziono menu - sprawdŸ nazwy menu"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Wykryto b³¹d podczas przetwarzania %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "wiersz %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Niew³aœciwa nazwa rejestru: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Opiekun komunikatów: Miko³aj Machowski <mikmach@wp.pl>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Przerwanie: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Naciœnij ENTER lub wprowadŸ komendê aby kontynuowaæ"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s wiersz %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Wiêcej --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: ekran/strona/wiersz w dó³, b/u/k: do góry, q: zakoñcz"
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Pytanie"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3911,6 +4280,17 @@ msgstr ""
 "&Tak\n"
 "&Nie"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Tak\n"
+"&Nie\n"
+"&Zakoñcz"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3924,271 +4304,174 @@ msgstr ""
 "&Odrzuæ wszystkie\n"
 "&Zakoñcz"
 
-msgid "Select Directory dialog"
-msgstr "Dialog wyboru katalogu"
-
-msgid "Save File dialog"
-msgstr "Dialog zapisywania pliku"
-
-msgid "Open File dialog"
-msgstr "Dialog otwierania pliku"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Przykro mi, nie ma przegl¹darki plików w trybie konsoli"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Za ma³o argumentów dla printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Spodziewany argument Zmiennoprzecinkowy w printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Za du¿o argumentów dla printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: OSTRZE¯ENIE: Zmiany w pliku tylko do odczytu"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Wpisz numer i <Enter> lub wybierz mysz¹ (pusta wartoœæ anuluje): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Wpisz numer i <Enter> (puste anuluje): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 wiersz wiêcej"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 wiersz mniej"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "dodano %<PRId64> wierszy"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "usuniêto %<PRId64> wierszy"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Przerwane)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Biiip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachowujê plik...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Zakoñczono.\n"
-
-msgid "ERROR: "
-msgstr "B£¥D: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w u¿ytku %<PRIu64>, maksymalne "
-"u¿ycie %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[wywo³ania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Wiersz staje siê zbyt d³ugi"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Wewnêtrzny b³¹d: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Brak pamiêci!  (rezerwacja %<PRIu64> bajtów)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Wywo³ujê pow³okê do wykonania: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Brak dwukropka"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Niedozwolony tryb"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Niedozwolony obrys myszki"
-
-msgid "E548: digit expected"
-msgstr "E548: oczekiwa³em na cyfrê"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Niedozwolony procent"
-
-msgid "Enter encryption key: "
-msgstr "WprowadŸ klucz do odkodowania: "
-
-msgid "Enter same key again: "
-msgstr "WprowadŸ ponownie ten sam klucz: "
-
-msgid "Keys don't match!"
-msgstr "Klucze nie pasuj¹ do siebie!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: œcie¿ka za d³uga by uzupe³niæ"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Niew³aœciwy trop: '**[numer]' musi byæ na koñcu tropu lub po nim musi "
-"byæ '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Nie mogê znaleŸæ katalogu \"%s\" w cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Nie mogê znaleŸæ pliku \"%s\" w tropie"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Katalogu \"%s\" nie ma wiêcej w cdpath"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Pliku \"%s\" nie ma wiêcej w tropie"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Nie mo¿na po³¹czyæ z Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Nie mo¿na po³¹czyæ z Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: B³êdny tryb dostêpu pliku info po³¹czenia NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "odczyt z gniazda Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Bufor %<PRId64> utraci³ po³¹czenie z NetBeans"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans nie s¹ obs³ugiwane przez to GUI"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans ju¿ pod³¹czone"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s jest tylko do odczytu (dodaj ! aby wymusiæ)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Brak identyfikatora pod kursorem"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' jest pusta"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Funkcjonalnoœæ eval nie jest dostêpna"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "OSTRZE¯ENIE: terminal nie wykonuje podœwietlania"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Brak ci¹gu pod kursorem"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Nie mogê skasowaæ zwiniêcia z bie¿¹c¹ 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: lista zmian (changelist) jest pusta"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Na pocz¹tku listy zmian"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "wprowadŸ  :quit<Enter>    zakoñczenie programu"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 wiersz %sed 1 raz"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 wiersz %sed %d razy"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> wierszy %sed 1 raz"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> wierszy %sed %d razy"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> wierszy do wciêcia... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 wiersz wciêty "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> wierszy wciêtych "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Brak poprzednio u¿ytego rejestru"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nie mogê skopiowaæ, mimo to kasujê"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 wiersz zmieniono"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> wierszy zmieniono"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "zwalniam %<PRId64> wierszy"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "skopiowano blok 1 wiersza"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 wiersz skopiowano"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "%<PRId64> wierszy skopiowanych"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> wierszy skopiowanych"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Pusty rejestr %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4196,9 +4479,11 @@ msgstr ""
 "\n"
 "--- Rejestry ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Niedozwolona nazwa rejestru"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4206,162 +4491,181 @@ msgstr ""
 "\n"
 "# Rejestry:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Nieznany typ rejestru %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kolumn; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Bajtów"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> "
-"Bajtów"
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; "
+"%<PRId64> z %<PRId64> Bajtów"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z "
-"%<PRId64>"
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; "
+"%<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> Bajtów"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Bajt "
+"%<PRId64> z %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Znak "
+"%<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> dla BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strona %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dziêki za lot Vimem"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Nieznana opcja"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opcja nie jest wspomagana"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Niedozwolone w modeline"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Kod klucza nie jest ustawiony"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Po = wymagany jest numer"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nie znaleziono w termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Niedozwolony znak <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Nie mogê ustawiæ 'term' na pusty ci¹g"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Nie mogê zmieniæ term w GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: U¿yj \":gui\" do odpalenia GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' i 'patchmode' s¹ to¿same"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Konflikty wartoœci 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Konflikty wartoœci 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Nie mogê zmieniæ w GTK+2 GUI"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Brak dwukropka"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Ci¹g o zerowej d³ugoœci"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Brak numeru po <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Brak przecinka"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Musi okreœlaæ wartoœæ '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: zawiera niewyœwietlalny lub szeroki znak"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Niedozwolona czcionka/ki"
-
-msgid "E597: can't select fontset"
-msgstr "E597: nie mogê wybraæ zestawu czcionek"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Niedozwolony zestaw czcionek"
-
-msgid "E533: can't select wide font"
-msgstr "E533: nie mogê wybraæ szerokiej czcionki"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Niedozwolona szeroka czcionka"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Niedozwolony znak po <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: wymagany przecinek"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' musi byæ pusty lub zawieraæ %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Brak wspomagania myszki"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Niedomkniêty ci¹g wyra¿eñ"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: zbyt wiele elementów"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: niezbalansowane grupy"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: okno podgl¹du ju¿ istnieje"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabski wymaga UTF-8, zrób ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Potrzebujê przynajmniej %d wierszy"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Potrzebujê przynajmniej %d kolumn"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Nieznana opcja: %s"
@@ -4369,10 +4673,12 @@ msgstr "E355: Nieznana opcja: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Wymagana Liczba: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4380,6 +4686,7 @@ msgstr ""
 "\n"
 "--- Kody terminala ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4387,6 +4694,7 @@ msgstr ""
 "\n"
 "--- Globalne wartoœci opcji ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4394,6 +4702,7 @@ msgstr ""
 "\n"
 "--- Lokalne wartoœci opcji ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4401,141 +4710,21 @@ msgstr ""
 "\n"
 "--- Opcje ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: B£¥D get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Brak pasuj¹cego znaku dla %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Dodatkowe znaki po œredniku: %s"
 
-msgid "cannot open "
-msgstr "nie mogê otworzyæ "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nie mogê otworzyæ okna!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Potrzebujê Amigados w wersji 2.04 lub póŸniejsz¹\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Potrzebujê %s w wersji %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nie mogê otworzyæ NIL:\n"
-
-msgid "Cannot create "
-msgstr "Nie mogê stworzyæ "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim koñczy pracê z %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "nie mogê zmieniæ trybu konsoli ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: nie jest konsol¹??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nie mogê wykonaæ pow³oki z opcj¹ -f"
-
-msgid "Cannot execute "
-msgstr "Nie mogê wykonaæ "
-
-msgid "shell "
-msgstr "pow³oka "
-
-msgid " returned\n"
-msgstr " zwróci³\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE zbyt niskie."
-
-msgid "I/O ERROR"
-msgstr "B£¥D I/O"
-
-msgid "Message"
-msgstr "Wiadomoœæ"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' nie wynosi 80, nie mogê wykonaæ zewnêtrznych komend"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Wybór drukarki nie powiód³ siê"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "do %s z %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Nieznana czcionka drukarki: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: B³¹d drukarki: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Wydrukowano '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr ""
-"E244: Niedozwolona nazwa zestawu znaków \"%s\" w nazwie czcionki \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Niedozwolony znak '%c' w nazwie czcionki \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Podwójny sygna³, wychodzê\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Za³apa³ œmiertelny sygna³ %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Za³apa³ œmiertelny sygna³\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Otwieranie ekranu X trwa³o %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Dosta³ b³¹d X\n"
-
-msgid "Testing the X display failed"
-msgstr "Test ekranu X nie powiód³ siê"
-
-msgid "Opening the X display timed out"
-msgstr "Próba otwarcia ekranu X trwa³a zbyt d³ugo"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Nie mogê uzyskaæ kontekstu bezpieczeñstwa dla"
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Nie mo¿na uzyskaæ kontekstu bezpieczeñstwa dla"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4543,13 +4732,7 @@ msgstr ""
 "\n"
 "Nie mogê wykonaæ pow³oki "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nie mogê wykonaæ pow³oki sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4557,437 +4740,476 @@ msgstr ""
 "\n"
 "pow³oka zwróci³a "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Nie mogê stworzyæ potoków\n"
+"Nie mogê uzyskaæ kontekstu bezpieczeñstwa dla"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Nie mogê rozdzieliæ siê\n"
+"Nie mo¿na uzyskaæ kontekstu bezpieczeñstwa dla"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Komenda zakoñczona\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP straci³ po³¹czenie ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Otwarcie ekranu X nie powiod³o siê"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP obs³uguje ¿¹danie samozapisu"
-
-msgid "XSMP opening connection"
-msgstr "XSMP otwiera po³¹czenie"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Obserwacja po³¹czenia XSMP ICE nie powiod³a siê"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection nie powiod³o siê: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Nie mogê znaleŸæ pliku \"%s\" w tropie"
 
-msgid "At line"
-msgstr "W wierszu"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nie mogê za³adowaæ vim32.dll!"
-
-msgid "VIM Error"
-msgstr "B³¹d VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nie zdo³a³em poprawiæ wskaŸników funkcji w DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "pow³oka zwróci³a %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Za³apa³ wydarzenie %s\n"
-
-msgid "close"
-msgstr "zamknij"
-
-msgid "logoff"
-msgstr "wyloguj"
-
-msgid "shutdown"
-msgstr "zakoñcz"
-
-msgid "E371: Command not found"
-msgstr "E371: Nie znaleziono komendy"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE nie znaleziono w twoim $PATH.\n"
-"Zewnêtrzne komendy nie bêd¹ wstrzymane po wykonaniu.\n"
-"Zobacz  :help wim32-vimrun  aby otrzymaæ wiêcej informacji."
-
-msgid "Vim Warning"
-msgstr "Vim Ostrze¿enie"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Zbyt wiele %%%c w ci¹gu formatuj¹cym"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Nieoczekiwane %%%c w ci¹gu formatuj¹cym"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Brak ] w ci¹gu formatuj¹cym"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Niewspomagane %%%c w ci¹gu formatuj¹cym"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Niepoprawne %%%c w prefiksie ci¹gu formatuj¹cego"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Niepoprawne %%%c w ci¹gu formatuj¹cym"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' nie zawiera wzorca"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Pusta nazwa katalogu lub jej brak"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Nie ma wiêcej elementów"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d z %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (wiersz skasowany)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Na dole stosu quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Na górze stosu quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "lista b³êdów %d z %d; %d b³êdów"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nie mogê zapisaæ, opcja 'buftype' jest ustawiona"
 
-msgid "Error file"
-msgstr "Plik b³êdu"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Brak nazwy pliku lub niew³aœciwa œcie¿ka"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Nie mogê otworzyæ pliku \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Bufor nie jest za³adowany"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Oczekiwa³em na ³añcuch lub listê"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Niew³aœciwy element w %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Brak ] po %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Niesparowany %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Niesparowany %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Niesparowany %s)"
 
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( jest niedozwolone w tym miejscu"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 i podobne s¹ niedozwolone w tym miejscu"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Brak ] po %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: Pusty %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Zbyt d³ugi wzorzec"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Zbyt wiele \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Zbyt wiele %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Niesparowany \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: niedozwolony znak po %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Zbyt wiele z³o¿onych %s{...}"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Zagnie¿d¿one %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Zagnie¿d¿one %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Niedozwolone u¿ycie \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c po niczym"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Niew³aœciwe odwo³anie wsteczne"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: niedopuszczalny znak po \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Niedozwolony znak po %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Niedozwolony znak po %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: B³¹d sk³adni w %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Zewnêtrzne poddopasowania:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
-msgstr "E:864: \\%#= mo¿e byæ tylko przed 0, 1 lub 2. Zostanie u¿yty silnik automatyczny"
+msgstr ""
+"E:864: \\%#= mo¿e byæ tylko przed 0, 1 lub 2. Zostanie u¿yty silnik "
+"automatyczny"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) przedwczesny koniec wyra¿enia regularnego"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (wyra¿enie regularne NFA) Niepoprawnie umieszczone %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) przedwczesny koniec wyra¿enia regularnego"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Nieznany operator '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) Nieznany operator '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: B³¹d przy budowwaniu NFA z klas¹ ekwiwalencji"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Nieznany operator '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
-msgstr "E870: (wyra¿enie regularne NFA) B³¹d przy odczytywaniu limitów powtórzeñ"
+msgstr ""
+"E870: (wyra¿enie regularne NFA) B³¹d przy odczytywaniu limitów powtórzeñ"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
-msgstr "E871: (wyra¿enie regularne NFA) wielokrotne nie mo¿e byæ po wielokrotnym!"
+msgstr ""
+"E871: (wyra¿enie regularne NFA) wielokrotne nie mo¿e byæ po wielokrotnym!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (wyra¿enie regularne NFA) Zbyt du¿o '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (wyra¿enie regularne NFA) Za du¿o \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (wyra¿enie regularne NFA) b³¹d poprawnego zakoñczenia"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Nie mo¿na zdj¹æ elementu ze stosu!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
-msgstr "E875: (wyra¿enie regularne NFA) (w trakcie konwersji postfix do NFA), za wiele stanów na stosie"
+msgstr ""
+"E875: (wyra¿enie regularne NFA) (w trakcie konwersji postfix do NFA), za "
+"wiele stanów na stosie"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (wyra¿enie regularne NFA) Nie ma miejsca na ca³e NFA "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Nie mo¿na przydzieliæ pamiêci do przejœcia przez ga³êzie!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
-msgstr "Nie mo¿na otworzyæ do zapisu tymczasowego pliku, pokazujê na stderr... "
+msgstr ""
+"Nie mo¿na otworzyæ do zapisu tymczasowego pliku, pokazujê na stderr... "
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) NIE MO¯NA OTWORZYÆ %s !"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Nie mo¿na otworzyæ do zapisu tymczasowego pliku logowania"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-ZAMIANA"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ZAMIANA"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " NEGATYW"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " WPROWADZANIE"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (wprowadzanie)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (zamiana)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-zamiana)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrajski"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabski"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (jêzyk)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (wklejanie)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " WIZUALNY"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " WIZUALNY LINIOWY"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " WIZUALNY BLOKOWY"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ZAZNACZANIE"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ZAZNACZANIE LINIOWE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ZAZNACZANIE BLOKOWE"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "zapis"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Niew³aœciwy ci¹g do szukania: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: szukanie dobi³o GÓRY bez znalezienia: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: szukanie dobi³o KOÑCA bez znalezienia : %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Oczekujê '?' lub '/' po ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (zawiera poprzednio wymienione dopasowanie)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Zawarte pliki "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "nie znaleziono"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "w tropie ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Ju¿ wymienione)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NIE ZNALEZIONO"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Przegl¹d w³¹czonego pliku: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Przeszukiwanie w³¹czonego pliku %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Wzorzec pasuje w bie¿¹cym wierszu"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Wszelkie w³¹czane pliki odnaleziono"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Brak w³¹czanych plików"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nie znalaz³em definicji"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nie znalaz³em wzorca"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Podstawienie "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4998,86 +5220,98 @@ msgstr ""
 "# Ostatni %sWyszukiwany wzorzec:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Nieprawid³owy format pliku sprawdzania pisowni"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Obciêty plik sprawdzania pisowni"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Zbêdny tekst w %s wiersz %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Za d³uga nazwa afiksu w %s wiersz %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: B³¹d formatu w pliku afiksów FOL, LOW lub UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Znak w FOL, LOW lub UPP jest poza zasiêgiem"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Kompresja drzewa s³ów..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Sprawdzanie pisowni nie jest w³¹czone"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Ostrze¿enie: Nie mogê znaleŸæ listy s³ów \"%s_%s.spl\" lub \"%s_ascii.spl\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Ostrze¿enie: Nie mogê znaleŸæ listy s³ów \"%s.%s.spl\" lub \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Odczytujê plik sprawdzania pisowni \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: To nie wygl¹da na plik sprawdzania pisowni"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Stary plik sprawdzania pisowni, wymagane uaktualnienie"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Plik sprawdzania pisowni dla nowszej wersji Vima"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Niewspierana sekcja w pliku sprawdzania pisowni"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Ostrze¿enie: region %s nie jest wspierany"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Czytam plik afiksów %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konwersja nie powiod³a siê dla wyrazu w %s wierszu %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konwersja w %s nie jest wspierana: od %s do %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konwersja w %s nie jest wspierana"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Nieprawid³owa wartoœæ FLAG w %s wierz %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG po u¿yciu flag w %s wiersz %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5086,6 +5320,7 @@ msgstr ""
 "Definiowanie COMPOUNDFORBIDFLAG po PFX mo¿e skutkowaæ z³ym wynikiem w %s "
 "wiersz %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5094,34 +5329,42 @@ msgstr ""
 "Definiowanie COMPOUNDPERMITFLAG po PFX mo¿e skutkowaæ z³ym wynikiem w %s "
 "wiersz %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Z³a wartoœæ COMPOUNDRULES w %s wiersz %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Z³a wartoœæ COMPOUNDWORDMAX w %s wiersz %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Z³a wartoœæ COMPOUNDMIM w %s wiersz %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Z³a wartoœæ COMPOUNDSYLMAX w %s wiersz %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Z³a wartoœæ CHECKCOMPOUNDPATTERN w %s wiersz %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "Ró¿ne flagi z³o¿eñ w kontynuowanym bloku afiksu w %s wiersz %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Powtórzony afiks w %s wiersz %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5130,273 +5373,337 @@ msgstr ""
 "Afiks u¿yty tak¿e dla BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST w "
 "%s wiersz %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Oczekiwano Y lub N w %s wierszu %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "B³êdny warunek w %s wiersz %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Oczekiwano iloœci REP(SAL) w %s wierszu %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Oczekiwano iloœci MAP w %s wierszu %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Powtórzony znak w MAP w %s wierszu %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Nieznany lub powtórzony element w %s wierszu %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Brak wiersza FOL/LOW/UPP w %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX u¿yty bez SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Zbyt wiele opóŸnionych prefiksów"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Zbyt wiele flag z³o¿eñ"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Zbyt wiele opóŸnionych prefiksów i/lub flag z³o¿eñ"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Brak wiersza SOFO%s wiersz w %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Wiersze SAL i SOFO w %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flaga nie jest liczb¹ w %s wiersz %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Nieprawid³owa flaga w %s wiersz %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Wartoœæ %s ró¿ni siê od tej u¿ytej w innym pliku .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Czytam plik s³ownika %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Brak iloœci s³ów w %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "wiersz %6d, s³owo %6d - %s"
 
 # c-format
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Powtórzony wyraz w %s wierszu %d: %s"
 
 # c-format
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Pierwszy powtórzony wyraz w %s wiersz %d: %s"
 
 # c-format
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d powtórzony(ch) wyraz(ów) w %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Zignorowa³em %d s³ów ze znakami nie ASCII w %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Odczytujê plik wyrazów %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Zignorowano powtórzony wiersz /encoding= w %s wierszu %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Zignorowano wiersz /encoding= po wyrazie w %s wierszu %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Powtórzony wiersz /regions= zignorowano w %s wierszu %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Za du¿o regionów w %s wiersz %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "wiersz / zignorowano w %s wierszu %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Nieprawid³owy numer regionu w %s wierszu %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nieznane flagi w %s wiersz %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Zignorowa³em %d s³ów ze znakami nie ASCII"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Nie wystarczaj¹ca iloœæ pamiêci, lista s³ów bêdzie niekompletna"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Skompresowano %d z %d wêz³ów; pozostaje %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Odczytujê plik sprawdzania pisowni..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Wykonujê kompresjê dŸwiêkow¹..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Liczba s³ów po kompresji dŸwiêkowej: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Ca³kowita liczba s³ów: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Zapisujê plik sugestii %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Oczekiwane zu¿ycie pamiêci: %d bajtów"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Nazwa pliku wynikowego nie mo¿e byæ nazw¹ regionu"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Wspieram tylko 8 regionów"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Nieprawid³owy region w %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Ostrze¿enie: okreœlono zarówno z³o¿enia jak i NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Zapisujê plik sprawdzania pisowni %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Zrobione!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' nie posiada wpisów %<PRId64>"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Usuniêto s³owo z %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Dodano s³owo do %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaki wyrazów ró¿ni¹ siê miêdzy plikami sprawdzania pisowni"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Przykro mi, brak podpowiedzi"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Przykro mi, tylko %<PRId64> podpowiedzi"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Zmieñ \"%.*s\" na:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Brak poprzednich podmian sprawdzania pisowni"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Nie znaleziono: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Ten plik nie wygl¹da na plik .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Stary plik .sug, konieczne jest uaktualnienie: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Plik .sug dla nowszej wersji Vima: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Plik .sug nie pasuje do pliku .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: B³¹d w czasie odczytu pliku .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Podwojony znak we wpisie MAP"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Brak elementów sk³adni okreœlonych dla tego bufora"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Niedozwolony argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Nie ma takiego klastra sk³adni: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizacja komentarzy w stylu C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "brak synchronizacji"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "pocz¹tek synchronizacji"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " wierszy przed górn¹ lini¹"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5404,6 +5711,7 @@ msgstr ""
 "\n"
 "--- Elementy synchronizacji sk³adni ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5411,6 +5719,7 @@ msgstr ""
 "\n"
 "synchronizujê na elementach"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5418,212 +5727,272 @@ msgstr ""
 "\n"
 "--- Elementy sk³adni ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Nie ma takiego klastra sk³adni: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimalnie "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksymalnie "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; pasuje "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr "znaków nowego wiersza"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: argument contains niedozwolony w tym miejscu"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Niew³aœciwa wartoœæ cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here niedozwolone w tym miejscu"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Nie znalaz³em elementów regionu dla %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Wymagana nazwa pliku"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Za du¿o w³¹czonych sk³adni"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Brak ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Brak '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Za ma³o argumentów: syntax region %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Za du¿o klastrów sk³adni"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Brak specyfikacji klastra"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Brak ogranicznika wzorca: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Œmieci po wzorcu: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: wielokrotnie podane wzorce kontynuacji wiersza"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Niedozwolone argumenty: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Brak znaku równoœci: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Pusty argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s jest niedozwolone w tym miejscu"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musi byæ pierwsze w liœcie contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nieznana nazwa grupy: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Niew³aœciwa podkomenda :syntax : %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  WSZYTKO    ILOŒÆ  PASUJE  NAJWOLN.    ŒREDNIO   NAZWA              WZORZEC"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursywna pêtla wczytuj¹ca syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: nie znaleziono grupy podœwietlania: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Zbyt ma³o argumentów: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Zbyt wiele argumentów: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: grupa ma ustawienia; zignorowane pod³¹czenie podœwietlania"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: nieoczekiwany znak równoœci: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: brak znaku równoœci: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: brak argumentu: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Niedozwolona wartoœæ: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Kolor FG nieznany"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Kolor BG nieznany"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nazwa lub liczba koloru nierozpoznana: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: za d³ugi kod terminala: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Niedozwolony argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Zbyt wiele ró¿nych atrybutów podkreœlania w u¿yciu"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Niedrukowalny znak w nazwie grupy"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: nieprawid³owy znak w nazwie grupy"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Za du¿o grup podœwietlania i sk³adni"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: na dole stosu znaczników"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: na górze stosu znaczników"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Nie mo¿na przejœæ przed pierwszy pasuj¹cy znacznik"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: nie znaleziono znacznika: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri rodzaj znacznik"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "plik\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Pasuje tylko jeden znacznik"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Nie mo¿na przejœæ za ostatni pasuj¹cy znacznik"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Plik \"%s\" nie istnieje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "znacznik %d z %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " lub wiêcej"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  U¿ywam znacznika o odmiennej wielkoœci liter!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Plik \"%s\" nie istnieje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5631,66 +6000,79 @@ msgstr ""
 "\n"
 "  # DO znacznik  OD wiersza      w pliku/tekœcie"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Szukam w pliku znaczników %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Trop szukania pliku znaczników obciêty dla %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ignorujê d³ugie wiersze w pliku znaczników"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: B³¹d formatu w pliku znaczników \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Przed bajtem %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Plik znaczników nieuporz¹dkowany: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Brak pliku znaczników"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nie mogê znaleŸæ wzorca znacznika"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Nie znalaz³em znacznika - tylko zgadujê!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Powtórzona nazwa pola: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' nieznany. Mo¿liwe typy wbudowanych terminali:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "domyœlnie jest '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Nie mogê otworzyæ pliku termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Nie ma opisu takiego terminala w terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Nie ma opisu takiego terminala w termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Brak opisu \"%s\" w termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: wymagana zdolnoœæ \"cm\" terminala"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5698,244 +6080,169 @@ msgstr ""
 "\n"
 "--- Klawisze terminala ---"
 
-msgid "new shell started\n"
-msgstr "uruchomiono now¹ pow³okê\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: B³¹d podczas wczytywania wejœcia, koñczê...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "U¿ywam CUT_BUFFER0 zamiast pustego wyboru"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Niespodziewana zmiana iloœci linii"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Cofniêcie niemo¿liwe; mimo to kontynuujê"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Nie mogê otworzyæ do zapisu pliku undo: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Uszkodzony plik undo (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Nie mo¿na zapisaæ pliku undo w ¿adnym katalogu z 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Nie nadpiszê plikiem undo, nie mogê odczytaæ: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Nie nadpiszê, to nie jest plik undo: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Pomijam zapis pliku undo, nic do cofniêcia"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Zapisujê plik undo: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: B³¹d zapisu w pliku undo: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Nie wczytujê pliku undo, inny w³aœciciel: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Wczytujê plik undo: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Nie mogê otworzyæ pliku undo do odczytu: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: To nie jest plik undo: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Nie zaszyfrowany plik ma zaszyfrowany plik undo: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Nie powiod³o siê odszyfrowywanie pliku undo: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Plik undo jest zaszyfrowany: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Niekompatybilny plik undo: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Zawartoœæ pliku siê zmieni³a, nie mogê u¿yæ pliku undo"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Skoñczono wczytywanie pliku undo %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Ju¿ w miejscu ostatniej zmiany"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Ju¿ w miejscu najnowszej zmiany"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Nie znaleziono numeru cofniêcia %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: niew³aœciwe numery wierszy"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "1 wiersz wiêcej"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "wiêcej wierszy"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "1 wiersz mniej"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "mniej wierszy"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "1 zmiana"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "zmiany"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "przed"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "za"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nie ma zmian do cofniêcia"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "liczba zmiany   kiedy              zapisano"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekund temu"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin nie jest dozwolone po undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: uszkodzona lista cofania"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: brak wiersza cofania"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32-bit wersja GUI dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"64 bitowa wersja GUI dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitowa wersja GUI dla MS-Windows"
-
-msgid " in Win32s mode"
-msgstr " w trybie Win32s"
-
-msgid " with OLE support"
-msgstr " ze wspomaganiem OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"32 bitowa wersja na konsolê dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitowa wersja na konsolê dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitowa wersja dla MS-Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitowa wersja dla MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitowa wersja dla MS-DOS"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"wersja dla MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"wersja dla MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"wersja dla MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"wersja dla OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5943,6 +6250,7 @@ msgstr ""
 "\n"
 "Zadane ³aty: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5950,9 +6258,11 @@ msgstr ""
 "\n"
 "Ekstra ³aty: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Zmieniony przez "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5960,9 +6270,11 @@ msgstr ""
 "\n"
 "Skompilowany "
 
+#: ../version.c:649
 msgid "by "
 msgstr "przez "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5970,854 +6282,1902 @@ msgstr ""
 "\n"
 "Olbrzymia wersja "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Du¿a wersja "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normalna wersja "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Ma³a wersja "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Malutka wersja "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "z GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "z GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "z X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "z X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "z X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "z Photon GUI."
-
-msgid "with GUI."
-msgstr "z GUI."
-
-msgid "with Carbon GUI."
-msgstr "z Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "z Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "z (klasycznym) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Opcje w³¹czone (+) lub nie (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "       vimrc systemu: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "   vimrc u¿ytkownika: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2-gi plik vimrc u¿ytkownika: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3-ci plik vimrc u¿ytkownika: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "    exrc u¿ytkownika: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2-gi plik exrc u¿ytkownika: \""
 
-msgid "  system gvimrc file: \""
-msgstr "     gvimrc systemu: \""
-
-msgid "    user gvimrc file: \""
-msgstr "  gvimrc u¿ytkownika: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2-gi plik gvimrc u¿ytkownika: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3-ci plik gvimrc u¿ytkownika: \""
-
-msgid "    system menu file: \""
-msgstr " systemowy plik menu: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "   odwet dla $VIM-a: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "f-b dla $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilacja: "
 
-msgid "Compiler: "
-msgstr "Kompilator: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Konsolidacja: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  KOMPILACJA DEBUG"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi rozbudowany"
 
+#: ../version.c:769
 msgid "version "
 msgstr "wersja "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Autor: Bram Moolenaar i Inni."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim jest open source i rozprowadzany darmowo"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomó¿ biednym dzieciom w Ugandzie!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "wprowadŸ :help iccf<Enter>        dla informacji o tym  "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "wprowadŸ :q<Enter>                zakoñczenie programu   "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "wprowadŸ :help<Enter>  lub  <F1>  pomoc na bie¿¹co       "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "wprowadŸ :help version7<Enter>    dla informacji o wersji"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Dzia³am w trybie zgodnoœci z Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "wprowadŸ :set nocp<Enter>         wartoœci domyœlne Vim-a"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "wprowadŸ :help cp-default<Enter>  dla informacji to tym  "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu Pomoc->Sieroty        dla informacji to tym  "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Uruchomiony bez trybów, wpisany tekst jest wprowadzany"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menu  Edytuj->Ustawienia globalne->Tryb wstawiania"
-
-msgid "                              for two modes      "
-msgstr "                  dla dwóch trybów           "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menu Edytuj->Ustawienia globalne->Kompatybilnoœæ z Vi"
-
-msgid "                              for Vim defaults   "
-msgstr "     dla domyœlnych ustawieñ Vima   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Sponsoruj rozwój Vima!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Zostañ zarejestrowanym u¿ytkownikiem Vima!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "wprowadŸ :help sponsor<Enter>        dla informacji"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "wprowadŸ :help register<Enter>        dla informacji"
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu Pomoc->Sponsoruj/Zarejestruj siê dla informacji"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "OSTRZE¯ENIE: wykryto Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "wprowadŸ :help windows95<Enter>   dla informacji to tym  "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Ju¿ jest tylko jeden widok"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Nie ma okna podgl¹du"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Nie mogê rozdzieliæ lewo-górnego i prawo-dolnego jednoczeœnie"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Nie mogê przekrêciæ, gdy inne okno jest rozdzielone"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Nie mogê zamkn¹æ ostatniego okna"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Nie mo¿na zamkn¹æ okna autocmd"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Nie mo¿na zamkn¹æ okna, zosta³oby tylko okno autocmd"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Inne okno zawiera zmiany"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Brak nazwy pliku pod kursorem"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Nie mogê znaleŸæ pliku \"%s\" w tropie"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() wywo³any z pustym has³em"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Nie mog³em za³adowaæ biblioteki %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Przykro mi, ta komenda jest wy³¹czona: nie mog³em za³adowaæ biblioteki Perla."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish u¿ywa b³êdnej kolejnoœci bajtów"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: wyliczenie Perla zabronione w piaskownicy bez modu³u Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: test sha256 nie powiód³ siê"
 
-msgid "Edit with &multiple Vims"
-msgstr "Edytuj w &wielu Vimach"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: test Blowfisha nie powiód³ siê"
 
-msgid "Edit with single &Vim"
-msgstr "Edytuj w pojedynczym &Vimie"
+#~ msgid "Patch file"
+#~ msgstr "Plik ³ata"
 
-msgid "Diff with Vim"
-msgstr "Diff z Vimem"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zakoñcz"
 
-msgid "Edit with &Vim"
-msgstr "Edytuj w &Vimie"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Brak po³¹czenia z serwerem Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Edytuj z istniej¹cym Vimem - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nie mogê wys³aæ do %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Edytuj wybrane pliki w Vimie"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nie mogê czytaæ odpowiedzi serwera"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "B³¹d tworzenia procesu: SprawdŸ czy gvim jest w twojej œcie¿ce!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Nie mogê wys³aæ do klienta"
 
-msgid "gvimext.dll error"
-msgstr "b³¹d gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Zapisz jako"
 
-msgid "Path length too long!"
-msgstr "Za d³uga œcie¿ka!"
+#~ msgid "Source Vim script"
+#~ msgstr "Wczytaj skrypt Vima"
 
-msgid "--No lines in buffer--"
-msgstr "--Brak wierszy w buforze--"
+#~ msgid "Edit File"
+#~ msgstr "Edytuj Plik"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Przerwanie komendy"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NIE ZNALEZIONO)"
 
-msgid "E471: Argument required"
-msgstr "E471: wymagany argument"
+#~ msgid "unknown"
+#~ msgstr "nieznany"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ powinno byæ /, ? lub &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Edytuj plik w nowym oknie"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Niedozwolone w oknie wiersza poleceñ; <CR> wykonuje, CTRL-C opuszcza"
+#~ msgid "Append File"
+#~ msgstr "Do³¹cz plik"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Komenda niedozwolona z exrc/vimrc w bie¿¹cym szukaniu katalogu lub "
-"znacznika"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Pozycja okna: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Brak :endif"
+#~ msgid "Save Redirection"
+#~ msgstr "Zapisz przekierowanie"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Brak :endtry"
+#~ msgid "Save View"
+#~ msgstr "Zapisz widok"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Brak :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Zapisz sesjê"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Brak :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Zapisz ustawienia"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile bez :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< nie jest dostêpne bez w³aœciwoœci +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor bez :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Brak dwugrafów w tej wersji"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Plik istnieje (wymuœ poprzez !)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "jest urz¹dzeniem (wy³¹czonym w opcji 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Komenda nie powiod³a siê"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Wczytywanie ze stdin..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Nieznany zestaw czcionek: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Nieznana czcionka: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[zakodowane]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Czcionka \"%s\" nie ma sta³ej szerokoœci znaków"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Plik zaszyfrowano w nieznany sposób"
 
-msgid "E473: Internal error"
-msgstr "E473: B³¹d wewnêtrzny"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans nie pozwala na zapis niezmodyfikowanych buforów"
 
-msgid "Interrupted"
-msgstr "Przerwane"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Czêœciowy zapis niemo¿liwy dla buforów NetBeans"
 
-msgid "E14: Invalid address"
-msgstr "E14: Niew³aœciwy adres"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "zapisywanie do urz¹dzenia wy³¹czone w opcji 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Niew³aœciwy argument"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Rozdzia³ zasobów zostanie utracony (wymuœ przez !)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Niew³aœciwy argument: %s"
+#~ msgid "<cannot open> "
+#~ msgstr "<nie mogê otworzyæ> "
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Niew³aœciwe wyra¿enie: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: nie mogê otrzymaæ czcionki %s"
 
-msgid "E16: Invalid range"
-msgstr "E16: Niew³aœciwy zakres"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: nie mogê powróciæ do bie¿¹cego katalogu"
 
-msgid "E476: Invalid command"
-msgstr "E476: Niew³aœciwa komenda"
+#~ msgid "Pathname:"
+#~ msgstr "Trop:"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" jest katalogiem"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: nie mogê otrzymaæ bie¿¹cego katalogu"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Wywo³anie z biblioteki nie powiod³o siê dla \"%s()\""
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Nie mo¿na za³adowaæ funkcji biblioteki %s"
+#~ msgid "Cancel"
+#~ msgstr "Zakoñcz"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Zak³adka ma niew³aœciwy numer wiersza"
+#~ msgid "Vim dialog"
+#~ msgstr "VIM - Dialog"
 
-msgid "E20: Mark not set"
-msgstr "E20: Zak³adka nienastawiona"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Scrollbar Widget: Nie mog³em otrzymaæ rozmiarów rysunku na przycisku."
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nie mogê wykonaæ zmian, 'modifiable' jest wy³¹czone"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Nie mogê stworzyæ BalloonEval z powiadomieniem i wywo³aniem"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Zbyt g³êbokie zagnie¿d¿enie skryptów"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Nie mog³em stworzyæ nowego procesu dla GUI"
 
-msgid "E23: No alternate file"
-msgstr "E23: Brak pliku zamiany"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Proces potomny nie móg³ uruchomiæ GUI"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Nie ma takiego skrótu"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nie mogê odpaliæ GUI"
 
-msgid "E477: No ! allowed"
-msgstr "E477: Niedozwolone !"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nie mogê czytaæ z \"%s\""
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI nie mo¿e byæ u¿yte: Nie w³¹czono podczas kompilacji"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Nie mo¿na uruchomiæ GUI, brak prawid³owej czcionki"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebrajski nie mo¿e byæ u¿yty: Nie w³¹czono podczas kompilacji\n"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Niew³aœciwe 'guifontwide'"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi nie mo¿e byæ u¿yty: Nie w³¹czono podczas kompilacji\n"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Nieprawid³owa wartoœæ 'imactivatekey'"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabski nie mo¿e byæ u¿yty: Nie w³¹czono podczas kompilacji\n"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Nie mogê zarezerwowaæ koloru %s"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Brak takiej nazwy grupy podœwietlania: %s"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Brak dopasowania przy kursorze, szukam dalej"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Nie wprowadzono jeszcze ¿adnego tekstu"
+#~ msgid "Input _Methods"
+#~ msgstr "Input _Methods"
 
-msgid "E30: No previous command line"
-msgstr "E30: Nie ma poprzedniego wiersza poleceñ"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Szukaj i Zamieñ..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Nie ma takiego przyporz¹dkowania"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Szukaj..."
 
-msgid "E479: No match"
-msgstr "E479: Brak dopasowañ"
+#~ msgid "Find what:"
+#~ msgstr "ZnajdŸ:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Brak dopasowañ: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Zamieñ na:"
 
-msgid "E32: No file name"
-msgstr "E32: Brak nazwy pliku"
+#~ msgid "Match whole word only"
+#~ msgstr "Dopasuj tylko ca³e wyrazy"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Brak poprzedniego podstawieniowego wyra¿enia regularnego"
+#~ msgid "Match case"
+#~ msgstr "Dopasuj wielkoœæ liter"
 
-msgid "E34: No previous command"
-msgstr "E34: Brak poprzedniej komendy"
+#~ msgid "Direction"
+#~ msgstr "Kierunek"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Brak poprzedniego wyra¿enia regularnego"
+#~ msgid "Up"
+#~ msgstr "W górê"
 
-msgid "E481: No range allowed"
-msgstr "E481: Zakres niedozwolony"
+#~ msgid "Down"
+#~ msgstr "W dó³"
 
-msgid "E36: Not enough room"
-msgstr "E36: Brak miejsca"
+#~ msgid "Find Next"
+#~ msgstr "ZnajdŸ nastêpne"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: brak zarejestrowanego serwera o nazwie \"%s\""
+#~ msgid "Replace"
+#~ msgstr "Zamieñ"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Nie mogê stworzyæ pliku %s"
+#~ msgid "Replace All"
+#~ msgstr "Zamieñ wszystkie"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Nie mogê pobraæ nazwy pliku tymczasowego"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: otrzymano ¿¹danie \"die\" od mened¿era sesji\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Nie mogê otworzyæ pliku %s"
+#~ msgid "Close"
+#~ msgstr "Zamknij"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Nie mogê odczytaæ pliku %s"
+#~ msgid "New tab"
+#~ msgstr "Nowa karta"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Nie zapisano od ostatniej zmiany (wymuœ przez !)"
+#~ msgid "Open Tab..."
+#~ msgstr "Otwórz kartê..."
 
-msgid "E38: Null argument"
-msgstr "E38: Zerowy argument"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: G³ówne okno nieoczekiwanie zniszczone\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Oczekujê liczby"
+#~ msgid "&Filter"
+#~ msgstr "&Filtr"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nie mogê otworzyæ pliku b³êdów %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Anuluj"
 
-msgid "E233: cannot open display"
-msgstr "E233: nie mogê otworzyæ ekranu"
+#~ msgid "Directories"
+#~ msgstr "Katalogi"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Pamiêæ wyczerpana!"
+#~ msgid "Filter"
+#~ msgstr "Filtr"
 
-msgid "Pattern not found"
-msgstr "Nie znaleziono wzorca"
+#~ msgid "&Help"
+#~ msgstr "&Pomoc"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Nie znaleziono wzorca: %s"
+#~ msgid "Files"
+#~ msgstr "Pliki"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument musi byæ dodatni"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Nie mo¿na przejœæ do poprzedniego katalogu"
+#~ msgid "Selection"
+#~ msgstr "Wybór"
 
-msgid "E42: No Errors"
-msgstr "E42: Brak B³êdów"
+#~ msgid "Find &Next"
+#~ msgstr "ZnajdŸ &nastêpne"
 
-msgid "E776: No location list"
-msgstr "E776: Brak listy lokacji"
+#~ msgid "&Replace"
+#~ msgstr "&Zamieñ"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Popsuty ci¹g wzorca"
+#~ msgid "Replace &All"
+#~ msgstr "Zamieñ &wszystko"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Zepsuty program wyra¿eñ regularnych"
+#~ msgid "&Undo"
+#~ msgstr "&Cofnij"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: opcja 'readonly' jest ustawiona (wymuœ poprzez !)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Nie mogê znaleŸæ tytu³u okna \"%s\""
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Nie mogê zmieniæ zmiennej tylko do odczytu \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nie jest wspomagany: \"-%s\"; U¿ywaj wersji OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Nie mogê ustawiæ zmiennej w piaskownicy: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Nie mo¿na otworzyæ okna wewn¹trz aplikacji MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: B³¹d w trakcie czytania pliku b³êdów"
+#~ msgid "Close tab"
+#~ msgstr "Zamknij kartê"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Niedozwolone w piaskownicy"
+#~ msgid "Open tab..."
+#~ msgstr "Otwórz kartê..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Niedozwolone w tym miejscu"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "ZnajdŸ ci¹g (u¿yj '\\\\' do szukania '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Ustawianie trybu ekranu niewspomagane"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Szukanie i Zamiana (u¿yj '\\\\' do szukania '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Niew³aœciwa wielkoœæ przewiniêcia"
+#~ msgid "Not Used"
+#~ msgstr "Nie u¿ywany"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: opcja 'shell' jest pusta"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Katalog\t*.nic\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Nie mog³em wczytaæ danych znaku!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Nie mogê zarezerwowaæ mapy kolorów, pewne kolory mog¹ byæ "
+#~ "nieprawid³owe"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: B³¹d podczas zamykania pliku wymiany"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Brak czcionek dla nastêpuj¹cych zestawów znaków w zestawie czcionek "
+#~ "%s:"
 
-msgid "E73: tag stack empty"
-msgstr "E73: stos znaczników jest pusty"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nazwa zestawu czcionek: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Komenda jest zbyt skomplikowana"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Czcionka '%s' nie posiada znaków jednolitej szerokoœci"
 
-msgid "E75: Name too long"
-msgstr "E75: Zbyt d³uga nazwa"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Nazwa zestawu czcionek: %s"
 
-msgid "E76: Too many ["
-msgstr "E76: Zbyt wiele ["
+#~ msgid "Font0: %s"
+#~ msgstr "Font0: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: Zbyt wiele nazw plików"
+#~ msgid "Font1: %s"
+#~ msgstr "Font1: %s"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Nadstêpne znaczki"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "Szerokoœæ font%<PRId64> nie jest podwójn¹ szerokoœci¹ font0"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Nieznana zak³adka"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Szerokoœæ font0: %<PRId64>"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nie mog¹ rozwin¹æ znaków wieloznacznych"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Szerokoœæ font1: %<PRId64>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' nie mo¿e byæ mniejsze ni¿ 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Nieprawid³owy opis czcionki"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' nie mo¿e byæ mniejsze ni¿ 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "&Anuluj"
 
-msgid "E80: Error while writing"
-msgstr "E80: B³¹d w trakcie zapisu"
+#~ msgid "no specific match"
+#~ msgstr "brak okreœlonego dopasowania"
 
-msgid "Zero count"
-msgstr "Zerowy licznik"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - wybór czcionki"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: U¿ycie <SID> poza kontekstem skryptu"
+#~ msgid "Name:"
+#~ msgstr "Nazwa:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Odebra³em niew³aœciwe wyra¿enie"
+#~ msgid "Show size in Points"
+#~ msgstr "Poka¿ wielkoœæ w punktach"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Region jest chroniony, nie mogê zmieniæ"
+#~ msgid "Encoding:"
+#~ msgstr "Kodowanie:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans nie zezwala na zmiany w plikach tylko do odczytu"
+#~ msgid "Font:"
+#~ msgstr "Czcionka:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: B³¹d wewnêtrzny: %s"
+#~ msgid "Style:"
+#~ msgstr "Styl:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Wzorzec u¿ywa wiêcej pamiêci ni¿ 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Wielkoœæ:"
 
-msgid "E749: empty buffer"
-msgstr "E749: pusty bufor"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: B£¥D w automacie Hangul"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Niew³aœciwy wzorzec wyszukiwania lub delimiter"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: b³¹d stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Plik jest za³adowany w innym buforze"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: nie mogê otworzyæ bazy danych cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Nie ustawiono opcji '%s'"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: nie mogê uzyskaæ informacji z bazy danych cscope"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Niew³aœciwa nazwa rejestru"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Nie mo¿na wczytaæ biblioteki Lua."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "szukanie dobi³o GÓRY; kontynuacja od KOÑCA"
+#~ msgid "cannot save undo information"
+#~ msgstr "nie mogê zachowaæ informacji cofania"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "szukanie dobi³o KOÑCA; kontynuacja od GÓRY"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Przykro mi, ta komenda jest wy³¹czona, biblioteka MzScheme nie mo¿e "
+#~ "byæ za³adowana."
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Potrzebujê klucza szyfrowania dla \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "niepoprawne wyra¿enie"
 
-msgid "empty keys are not allowed"
-msgstr "puste klucze nie s¹ dozwolone"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "wyra¿enia wy³¹czone podczas kompilacji"
 
-msgid "dictionary is locked"
-msgstr "s³ownik jest zablokowany"
+#~ msgid "hidden option"
+#~ msgstr "ukryta opcja"
 
-msgid "list is locked"
-msgstr "lista jest zablokowana"
+#~ msgid "unknown option"
+#~ msgstr "nieznana opcja"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "nie powiod³o siê dodanie klucza '%s' do s³ownika"
+#~ msgid "window index is out of range"
+#~ msgstr "indeks okna poza zakresem"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "indeks musi byæ liczb¹ lub wycinkiem, nie %s"
+#~ msgid "couldn't open buffer"
+#~ msgstr "nie mogê otworzyæ bufora"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "czeka³em na str() lub unicode(), a dosta³em %s"
+#~ msgid "cannot delete line"
+#~ msgstr "nie mogê skasowaæ wiersza"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "czeka³em na bytes() lub str(), a dosta³em %s"
+#~ msgid "cannot replace line"
+#~ msgstr "nie mogê zamieniæ wiersza"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr ""
-"czeka³em na int(), long() lub coœ co mo¿na zmieniæ na long(), ale dosta³em %s"
+#~ msgid "cannot insert line"
+#~ msgstr "nie mogê wprowadziæ wiersza"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "czeka³em na int() lub coœ co mo¿na zmieniæ na int(), ale dosta³em %s"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "ci¹g nie mo¿e zawieraæ znaków nowego wiersza"
 
-msgid "value is too large to fit into C int type"
-msgstr "wartoœæ zbyt du¿a by zmieœci³a siê w typie int C"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "b³¹d przy konwersji wartoœci Scheme do Vima"
 
-msgid "value is too small to fit into C int type"
-msgstr "wartoœæ jest zbyt ma³a by zmieœci³a siê w typie int C"
+#~ msgid "Vim error: ~a"
+#~ msgstr "B³¹d vima: ~a"
 
-msgid "number must be greater then zero"
-msgstr "liczba musi byæ wiêksza ni¿ zero"
+#~ msgid "Vim error"
+#~ msgstr "B³¹d Vima"
 
-msgid "number must be greater or equal to zero"
-msgstr "liczba musi byæ wiêksza lub mniejsza ni¿ zero"
+#~ msgid "buffer is invalid"
+#~ msgstr "bufor jest niewa¿ny"
 
-msgid "can't delete OutputObject attributes"
-msgstr "nie mogê skasowaæ atrybutów OutputObject"
+#~ msgid "window is invalid"
+#~ msgstr "okno jest niewa¿ne"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "niepoprawny atrybut: %s"
+#~ msgid "linenr out of range"
+#~ msgstr "numer wiersza poza zakresem"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: B³¹d w uruchomieniu obiektów I/O"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "Niedozwolone w piaskownicy Vima"
 
-msgid "failed to change directory"
-msgstr "nie powiod³a siê zmiana katalogu"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em %s"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Przykro mi, ta komenda jest wy³¹czona, bo nie mo¿na za³adowaæ "
+#~ "biblioteki Pythona"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em krotkê o wielkoœci %d"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "wewnêtrzny b³¹d: imp.find_module zwróci³ krotkê z NULL"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Nie mo¿na wywo³aæ Pythona rekursywnie"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "nie mogê usun¹æ atrybutów vim.Dictionary"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ musi byæ reprezentacj¹ £añcucha"
 
-msgid "cannot modify fixed dictionary"
-msgstr "nie mogê zmieniæ zablokowanego s³ownika"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Przykro mi, ta komenda jest wy³¹czona, bo nie mo¿na za³adowaæ "
+#~ "biblioteki Ruby."
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "nie mogê ustawiæ atrybutu %s"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: nieoczekiwany return"
 
-msgid "hashtab changed during iteration"
-msgstr "hashtab zmieni³ siê w czasie iteracji"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: nieoczekiwany next"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "czeka³em na element sekwencyjny od d³ugoœci 2, a dosta³em sekwencjê o d³ugoœci %d"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: nieoczekiwany break"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "konstruktor listy nie akceptuje s³ów kluczowych jako argumentów"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: nieoczekiwane redo"
 
-msgid "list index out of range"
-msgstr "indeks listy poza zakresem"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: ponowna próba poza klauzul¹ ratunku"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "b³¹d wewnêtrzny: nie powiod³o siê pobranie z listy Vima elementu %d"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: nieobs³ugiwany wyj¹tek"
 
-msgid "failed to add item to list"
-msgstr "nie powiod³o siê dodanie elementu do listy"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Nieznany status longjmp %d"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "b³¹d wewnêtrzny: w liœcie Vima brak elementu %d"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Prze³¹cz miêdzy implementacj¹/okreœleniem"
 
-msgid "internal error: failed to add item to list"
-msgstr "b³¹d wewnêtrzny: nie powiod³o siê dodanie elementu do listy"
+#~ msgid "Show base class of"
+#~ msgstr "Poka¿ bazê klasy"
 
-msgid "cannot delete vim.List attributes"
-msgstr "nie mogê usun¹æ atrybutów vim.List"
+#~ msgid "Show overridden member function"
+#~ msgstr "Poka¿ przepisan¹ funkcjê cz³onow¹"
 
-msgid "cannot modify fixed list"
-msgstr "nie mogê zmieniæ zablokowanej listy"
+#~ msgid "Retrieve from file"
+#~ msgstr "Pobieraj z pliku"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "nie nazwana funkcja %s nie istnieje"
+#~ msgid "Retrieve from project"
+#~ msgstr "Pobieraj z projektu"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "funkcja %s nie istnieje"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Pobieraj z wszystkich projektów"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "konstruktor funkcji nie akceptuje s³ów kluczowych jako argumentów"
+#~ msgid "Retrieve"
+#~ msgstr "Pobierz"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "nie mogê uruchomiæ funkcji %s"
+#~ msgid "Show source of"
+#~ msgstr "Poka¿ Ÿród³o dla"
 
-msgid "unable to get option value"
-msgstr "nie mogê pobraæ wartoœci opcji"
+#~ msgid "Find symbol"
+#~ msgstr "ZnajdŸ symbol"
 
-msgid "internal error: unknown option type"
-msgstr "b³¹d wewnêtrzny: nieznany typ opcji"
+#~ msgid "Browse class"
+#~ msgstr "Przejrzyj klasê"
 
-msgid "problem while switching windows"
-msgstr "wyst¹pi³ problem w czasie zmiany okien"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Poka¿ klasê w hierarchii"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "nie mogê wyzerowaæ opcji globalnej %s"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Poka¿ klasê w ograniczonej hierarchii"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "nie mogê wyzerowaæ opcji %s, która nie ma wartoœci globalnej"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odnosi siê do"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "próba odniesienia do skasowanej karty"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref ma odniesienia od"
 
-msgid "no such tab page"
-msgstr "nie ma takiej karty"
+#~ msgid "Xref has a"
+#~ msgstr "Xref ma"
 
-msgid "attempt to refer to deleted window"
-msgstr "próba odniesienia do skasowanego okna"
+#~ msgid "Xref used by"
+#~ msgstr "Xref u¿yte przez"
 
-msgid "readonly attribute: buffer"
-msgstr "atrybut tylko do odczytu: bufor"
+#~ msgid "Show docu of"
+#~ msgstr "Poka¿ dokumentacjê dla"
 
-msgid "cursor position outside buffer"
-msgstr "pozycja kursora poza buforem"
+#~ msgid "Generate docu for"
+#~ msgstr "Utwórz dokumentacjê dla"
 
-msgid "no such window"
-msgstr "nie ma takiego okna"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Nie mogê pod³¹czyæ do SNiFF+. SprawdŸ œrodowisko (sniffemacs musi byæ "
+#~ "odnaleziony w $PATH).\n"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "próba odniesienia do skasowanego bufora"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: B³¹d podczas czytania. Roz³¹czenie"
 
-msgid "failed to rename buffer"
-msgstr "nie powiod³a siê zmiana nazwy bufora"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ jest obecnie "
 
-msgid "mark name must be a single character"
-msgstr "nazwa zak³adki musi byæ pojedynczym znakiem"
+#~ msgid "not "
+#~ msgstr "nie "
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "oczekiwa³em na obiekt vim.Buffer, a dosta³em %s"
+#~ msgid "connected"
+#~ msgstr "pod³¹czony"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "nie przeszed³em do bufora %d"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Nieznane zapytanie SNiFF+: %s"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "oczekiwa³em na obiekt vim.Window, a dosta³em %s"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: B³¹d w trakcie pod³¹czania do SNiFF+"
 
-msgid "failed to find window in the current tab page"
-msgstr "nie znaleziono okna na bie¿¹cej karcie"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ niepod³¹czony"
 
-msgid "did not switch to the specified window"
-msgstr "nie przeszed³em do okreœlonego okna"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Nie jest buforem SNiFF+"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "oczekiwa³em na obiekt vim.TabPage, a dosta³em %s"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: B³¹d w trakcie zapisu. Roz³¹czony"
 
-msgid "did not switch to the specified tab page"
-msgstr "nie przeszed³em do okreœlonej karty"
+#~ msgid "invalid buffer number"
+#~ msgstr "niew³aœciwy numer bufora"
 
-msgid "failed to run the code"
-msgstr "uruchomienie kodu siê nie powiod³o"
+#~ msgid "not implemented yet"
+#~ msgstr "obecnie nie zaimplementowano"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: eval nie zwróci³o odpowiedniego obiektu pythona"
+#~ msgid "cannot set line(s)"
+#~ msgstr "nie mogê ustawiæ wiersza(y)"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Nie powiod³a siê konwersja obiektu pythona do wartoœci Vima"
+#~ msgid "invalid mark name"
+#~ msgstr "niepoprawna nazwa zak³adki"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "nie mo¿na konwertowaæ %s do s³ownika Vima"
+#~ msgid "mark not set"
+#~ msgstr "zak³adka nie ustawiona"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "nie mo¿na konwertowaæ %s do struktury Vima"
+#~ msgid "row %d column %d"
+#~ msgstr "wiersz %d kolumna %d"
 
-msgid "internal error: NULL reference passed"
-msgstr "b³¹d wewnêtrzny: przekazano referencjê NULL"
+#~ msgid "cannot insert/append line"
+#~ msgstr "nie mogê wprowadziæ/do³¹czyæ wiersza"
 
-msgid "internal error: invalid value type"
-msgstr "b³¹d wewnêtrzny: b³êdny typ wartoœci"
+#~ msgid "line number out of range"
+#~ msgstr "numer wiersza poza zakresem"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Nie mogê ustawiæ haka œcie¿ki: sys.path_hooks nie jest list¹\n"
-"Powinieneœ teraz wykonaæ nastêpuj¹ce czynnoœci:\n"
-"- dodaæ vim.path_hook do sys.path_hooks\n"
-"- dodaæ vim.VIM_SPECIAL_PATH do sys.path\n"
+#~ msgid "unknown flag: "
+#~ msgstr "nieznana flaga: "
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Nie mogê ustawiæ œcie¿ki: sys.path nie jest list¹\n"
-"Powinno siê teraz dodaæ vim.VIM_SPECIAL_PATH do sys.path"
+#~ msgid "unknown vimOption"
+#~ msgstr "nieznane vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "przerwanie klawiatury"
+
+#~ msgid "vim error"
+#~ msgstr "b³¹d vima"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nie mogê stworzyæ bufora/okna komendy: obiekt jest kasowany"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nie mogê zarejestrowaæ wstecznego wywo³ania komendy: bufor/okno ju¿ "
+#~ "zosta³a skasowana"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATALNY B£¥D: reflist zepsuta!? Proszê z³o¿yæ raport o tym na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nie mogê zarejestrowaæ wstecznego wywo³ania komendy: brak odniesienia do "
+#~ "bufora/okna"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Przykro mi, ta komenda jest wy³¹czona, bo nie mo¿na za³adowaæ "
+#~ "biblioteki Tcl."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: kod wyjœcia %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "nie mogê dostaæ wiersza"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Nie mogê zarejestrowaæ nazwy serwera komend"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Wys³anie komendy do programu docelowego nie powiod³o siê"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: U¿yto niew³aœciwego id serwera: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: wcielenia instancji rejestru Vima jest Ÿle sformowane.  Skasowano!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans nie s¹ obs³ugiwane przez to GUI\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Ta wersja Vima nie by³a skompilowanego z opcj¹ ró¿nic (diff)."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' - nie mo¿e byæ u¿yte: nie w³¹czone przy kompilacji\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: B³¹d: Nie mo¿na uruchomiæ gvim z NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "gdzie wielkoœæ znaków jest ignorowana dodaj na pocz¹tku / by flaga by³a "
+#~ "wielk¹ liter¹"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tZarejestruj tego gvima w OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tWyrejestruj gvima z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tStartuj w GUI (tak jak \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  lub --nofork\tPierwszy plan: Nie wydzielaj przy odpalaniu GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNie stosuj newcli do otwierania okien"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tU¿ywaj <device> do I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tU¿yj <gvimrc> zamiast jakiegokolwiek .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEdytuj zakodowane pliki"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tPod³¹cz vima to danego X-serwera"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNie ³¹cz z serwerem X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <pliki>\tEdytuj pliki w serwerze Vima jeœli mo¿liwe"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <pliki> To samo, nie narzekaj jeœli nie ma serwera"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <pliki>\tTak jak --remote, lecz czekaj na pliki przed edycj¹"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <pliki>  To samo, nie narzekaj jeœli nie ma serwera"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <pliki>  tak jak --remote ale u¿ywa jednej "
+#~ "karty na plik"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <klawisze>\tWyœlij <klawisze> do serwera Vima i zakoñcz"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <wyr>\tWykonaj <wyra¿enie> w serwerze i wypisz wynik"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tWymieñ nazwy dostêpnych serwerów Vima i zakoñcz"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nazwa>\t\tOdsy³aj do/stañ siê serwerem Vim <nazwa>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tZa³aduj vim na <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tZacznij Vim jako ikonê"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <kolor>\tU¿ywaj <kolor> dla t³a (równie¿: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <kolor>\tU¿ywaj <kolor> dla normalnego tekstu (równie¿: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tU¿ywaj <font> dla normalnego tekstu (równie¿: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\tU¿ywaj <font> dla wyt³uszczonego tekstu"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\tU¿ywaj <font> dla pochy³ego"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tU¿ywaj <geom> dla pocz¹tkowych rozmiarów (równie¿: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <szer>\tU¿yj ramki o gruboœci <szer> (równie¿: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <szer>  U¿ywaj przewijacza o szerokoœci <szer> (równie¿: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <height>\tStosuj belkê menu o wysokoœci <height> (równie¿: -"
+#~ "mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tStosuj negatyw kolorów (równie¿: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNie stosuj negatywu kolorów (równie¿: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tUstaw okreœlony zasób"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tZastartuj vim na <display> (równie¿: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\tUstaw unikatow¹ rolê do identyfikacji g³ównego okna"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtwórz Vim wewn¹trz innego widgetu GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "-echo-wid\t\tGvim wypisze Window ID na wyjœcie standardowe"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <tytu³ rodzica>\tOtwórz Vima wewn¹trz rodzicielskiej aplikacji"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tOtwórz Vima wewn¹trz innego elementu win32"
+
+#~ msgid "No display"
+#~ msgstr "Brak display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Wys³anie nie powiod³o siê.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Wys³anie nie powiod³o siê. Próbujê wykonaæ na miejscu\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "otworzono %d z %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Brak terminala: Wys³anie wyra¿enia nie powiod³o siê.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Wys³anie wyra¿enia nie powiod³o siê.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: To nie jest wa¿na strona kodowa"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Nie mogê nastawiæ wartoœci IC"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nie mog³em stworzyæ kontekstu wprowadzeñ"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nie mog³em otworzyæ sposobu wprowadzeñ"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: OSTRZE¯ENIE: Nie mog³em zlikwidowaæ wywo³ania dla IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: metoda wprowadzeñ nie wspomaga ¿adnego stylu"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: metoda wprowadzeñ nie wspomaga mojego typu preedit"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: B³¹d w czasie uaktualniania szyfrowania pliku wymiany"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s jest zaszyfrowany a ta wersja Vima nie wspiera szyfrowania"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Zaszyfrowany plik wymiany: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Jeœli podano nowy klucz szyfruj¹cy, ale nie zapisano pliku tekstowego,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "wprowadŸ nowy klucz szyfruj¹cy."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Jeœli zapisano plik tekstowy po zmianie klucza szyfruj¹cego wciœnij Enter"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "aby u¿yæ tego samego klucza dla pliku tekstowego i wymiany"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "U¿ywam klucza szyfruj¹cego z pliku wymiany do pliku tekstowego.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nie nadaje siê dla tej wersji Vima]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Oderwij to menu"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialog wyboru katalogu"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialog zapisywania pliku"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialog otwierania pliku"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Przykro mi, nie ma przegl¹darki plików w trybie konsoli"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachowujê plik...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Zakoñczono.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "B£¥D: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w u¿ytku "
+#~ "%<PRIu64>, maksymalne u¿ycie %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[wywo³ania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów "
+#~ "%<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Wiersz staje siê zbyt d³ugi"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Wewnêtrzny b³¹d: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Niedozwolony obrys myszki"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "WprowadŸ klucz do odkodowania: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "WprowadŸ ponownie ten sam klucz: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Klucze nie pasuj¹ do siebie!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Nie mo¿na po³¹czyæ z Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Nie mo¿na po³¹czyæ z Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: B³êdny tryb dostêpu pliku info po³¹czenia NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "odczyt z gniazda Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Bufor %<PRId64> utraci³ po³¹czenie z NetBeans"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans nie s¹ obs³ugiwane przez to GUI"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans ju¿ pod³¹czone"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s jest tylko do odczytu (dodaj ! aby wymusiæ)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Funkcjonalnoœæ eval nie jest dostêpna"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "zwalniam %<PRId64> wierszy"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Nie mogê zmieniæ term w GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: U¿yj \":gui\" do odpalenia GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Nie mogê zmieniæ w GTK+2 GUI"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Niedozwolona czcionka/ki"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: nie mogê wybraæ zestawu czcionek"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Niedozwolony zestaw czcionek"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: nie mogê wybraæ szerokiej czcionki"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Niedozwolona szeroka czcionka"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Brak wspomagania myszki"
+
+#~ msgid "cannot open "
+#~ msgstr "nie mogê otworzyæ "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nie mogê otworzyæ okna!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Potrzebujê Amigados w wersji 2.04 lub póŸniejsz¹\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Potrzebujê %s w wersji %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nie mogê otworzyæ NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Nie mogê stworzyæ "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim koñczy pracê z %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "nie mogê zmieniæ trybu konsoli ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: nie jest konsol¹??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Nie mogê wykonaæ pow³oki z opcj¹ -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nie mogê wykonaæ "
+
+#~ msgid "shell "
+#~ msgstr "pow³oka "
+
+#~ msgid " returned\n"
+#~ msgstr " zwróci³\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE zbyt niskie."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "B£¥D I/O"
+
+#~ msgid "Message"
+#~ msgstr "Wiadomoœæ"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' nie wynosi 80, nie mogê wykonaæ zewnêtrznych komend"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Wybór drukarki nie powiód³ siê"
+
+#~ msgid "to %s on %s"
+#~ msgstr "do %s z %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Nieznana czcionka drukarki: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: B³¹d drukarki: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Wydrukowano '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: Niedozwolona nazwa zestawu znaków \"%s\" w nazwie czcionki \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Niedozwolony znak '%c' w nazwie czcionki \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Podwójny sygna³, wychodzê\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Za³apa³ œmiertelny sygna³ %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Za³apa³ œmiertelny sygna³\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Otwieranie ekranu X trwa³o %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Dosta³ b³¹d X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test ekranu X nie powiód³ siê"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Próba otwarcia ekranu X trwa³a zbyt d³ugo"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogê wykonaæ pow³oki sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogê stworzyæ potoków\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogê rozdzieliæ siê\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Komenda zakoñczona\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP straci³ po³¹czenie ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otwarcie ekranu X nie powiod³o siê"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP obs³uguje ¿¹danie samozapisu"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP otwiera po³¹czenie"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Obserwacja po³¹czenia XSMP ICE nie powiod³a siê"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection nie powiod³o siê: %s"
+
+#~ msgid "At line"
+#~ msgstr "W wierszu"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nie mogê za³adowaæ vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "B³¹d VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nie zdo³a³em poprawiæ wskaŸników funkcji w DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "pow³oka zwróci³a %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Za³apa³ wydarzenie %s\n"
+
+#~ msgid "close"
+#~ msgstr "zamknij"
+
+#~ msgid "logoff"
+#~ msgstr "wyloguj"
+
+#~ msgid "shutdown"
+#~ msgstr "zakoñcz"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Nie znaleziono komendy"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE nie znaleziono w twoim $PATH.\n"
+#~ "Zewnêtrzne komendy nie bêd¹ wstrzymane po wykonaniu.\n"
+#~ "Zobacz  :help wim32-vimrun  aby otrzymaæ wiêcej informacji."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Ostrze¿enie"
+
+#~ msgid "Error file"
+#~ msgstr "Plik b³êdu"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: B³¹d przy budowwaniu NFA z klas¹ ekwiwalencji"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr ""
+#~ "E878: (NFA) Nie mo¿na przydzieliæ pamiêci do przejœcia przez ga³êzie!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Ostrze¿enie: Nie mogê znaleŸæ listy s³ów \"%s_%s.spl\" lub \"%s_ascii.spl"
+#~ "\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konwersja w %s nie jest wspierana"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr ""
+#~ "E845: Nie wystarczaj¹ca iloœæ pamiêci, lista s³ów bêdzie niekompletna"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Trop szukania pliku znaczników obciêty dla %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "uruchomiono now¹ pow³okê\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "U¿ywam CUT_BUFFER0 zamiast pustego wyboru"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Cofniêcie niemo¿liwe; mimo to kontynuujê"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Nie zaszyfrowany plik ma zaszyfrowany plik undo: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Nie powiod³o siê odszyfrowywanie pliku undo: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Plik undo jest zaszyfrowany: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32-bit wersja GUI dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "64 bitowa wersja GUI dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja GUI dla MS-Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " w trybie Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " ze wspomaganiem OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja na konsolê dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja na konsolê dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitowa wersja dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja dla MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitowa wersja dla MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Du¿a wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normalna wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Ma³a wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malutka wersja "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "z GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "z GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "z X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "z X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "z X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "z Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "z GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "z Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "z Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "z (klasycznym) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "     gvimrc systemu: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "  gvimrc u¿ytkownika: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2-gi plik gvimrc u¿ytkownika: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3-ci plik gvimrc u¿ytkownika: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr " systemowy plik menu: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompilator: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu Pomoc->Sieroty        dla informacji to tym  "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Uruchomiony bez trybów, wpisany tekst jest wprowadzany"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menu  Edytuj->Ustawienia globalne->Tryb wstawiania"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                  dla dwóch trybów           "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menu Edytuj->Ustawienia globalne->Kompatybilnoœæ z Vi"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "     dla domyœlnych ustawieñ Vima   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "OSTRZE¯ENIE: wykryto Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "wprowadŸ :help windows95<Enter>   dla informacji to tym  "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Nie mog³em za³adowaæ biblioteki %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Przykro mi, ta komenda jest wy³¹czona: nie mog³em za³adowaæ biblioteki "
+#~ "Perla."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: wyliczenie Perla zabronione w piaskownicy bez modu³u Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Edytuj w &wielu Vimach"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Edytuj w pojedynczym &Vimie"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diff z Vimem"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Edytuj w &Vimie"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Edytuj z istniej¹cym Vimem - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Edytuj wybrane pliki w Vimie"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "B³¹d tworzenia procesu: SprawdŸ czy gvim jest w twojej œcie¿ce!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "b³¹d gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Za d³uga œcie¿ka!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Nieznany zestaw czcionek: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Nieznana czcionka: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Czcionka \"%s\" nie ma sta³ej szerokoœci znaków"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Nie mo¿na za³adowaæ funkcji biblioteki %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Hebrajski nie mo¿e byæ u¿yty: Nie w³¹czono podczas kompilacji\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsi nie mo¿e byæ u¿yty: Nie w³¹czono podczas kompilacji\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabski nie mo¿e byæ u¿yty: Nie w³¹czono podczas kompilacji\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: brak zarejestrowanego serwera o nazwie \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nie mogê otworzyæ ekranu"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Odebra³em niew³aœciwe wyra¿enie"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Region jest chroniony, nie mogê zmieniæ"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans nie zezwala na zmiany w plikach tylko do odczytu"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Potrzebujê klucza szyfrowania dla \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "puste klucze nie s¹ dozwolone"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "s³ownik jest zablokowany"
+
+#~ msgid "list is locked"
+#~ msgstr "lista jest zablokowana"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "nie powiod³o siê dodanie klucza '%s' do s³ownika"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "indeks musi byæ liczb¹ lub wycinkiem, nie %s"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "czeka³em na str() lub unicode(), a dosta³em %s"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "czeka³em na bytes() lub str(), a dosta³em %s"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "czeka³em na int(), long() lub coœ co mo¿na zmieniæ na long(), ale "
+#~ "dosta³em %s"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr ""
+#~ "czeka³em na int() lub coœ co mo¿na zmieniæ na int(), ale dosta³em %s"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "wartoœæ zbyt du¿a by zmieœci³a siê w typie int C"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "wartoœæ jest zbyt ma³a by zmieœci³a siê w typie int C"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "liczba musi byæ wiêksza ni¿ zero"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "liczba musi byæ wiêksza lub mniejsza ni¿ zero"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nie mogê skasowaæ atrybutów OutputObject"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "niepoprawny atrybut: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: B³¹d w uruchomieniu obiektów I/O"
+
+#~ msgid "failed to change directory"
+#~ msgstr "nie powiod³a siê zmiana katalogu"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em %s"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr ""
+#~ "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em krotkê o "
+#~ "wielkoœci %d"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "wewnêtrzny b³¹d: imp.find_module zwróci³ krotkê z NULL"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "nie mogê usun¹æ atrybutów vim.Dictionary"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "nie mogê zmieniæ zablokowanego s³ownika"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "nie mogê ustawiæ atrybutu %s"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "hashtab zmieni³ siê w czasie iteracji"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "czeka³em na element sekwencyjny od d³ugoœci 2, a dosta³em sekwencjê o "
+#~ "d³ugoœci %d"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "konstruktor listy nie akceptuje s³ów kluczowych jako argumentów"
+
+#~ msgid "list index out of range"
+#~ msgstr "indeks listy poza zakresem"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "b³¹d wewnêtrzny: nie powiod³o siê pobranie z listy Vima elementu %d"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "nie powiod³o siê dodanie elementu do listy"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "b³¹d wewnêtrzny: w liœcie Vima brak elementu %d"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "b³¹d wewnêtrzny: nie powiod³o siê dodanie elementu do listy"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "nie mogê usun¹æ atrybutów vim.List"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "nie mogê zmieniæ zablokowanej listy"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "nie nazwana funkcja %s nie istnieje"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "funkcja %s nie istnieje"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "konstruktor funkcji nie akceptuje s³ów kluczowych jako argumentów"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "nie mogê uruchomiæ funkcji %s"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "wyst¹pi³ problem w czasie zmiany okien"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "nie mogê wyzerowaæ opcji globalnej %s"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "nie mogê wyzerowaæ opcji %s, która nie ma wartoœci globalnej"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "próba odniesienia do skasowanej karty"
+
+#~ msgid "no such tab page"
+#~ msgstr "nie ma takiej karty"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "próba odniesienia do skasowanego okna"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "atrybut tylko do odczytu: bufor"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "pozycja kursora poza buforem"
+
+#~ msgid "no such window"
+#~ msgstr "nie ma takiego okna"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "próba odniesienia do skasowanego bufora"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "nie powiod³a siê zmiana nazwy bufora"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "nazwa zak³adki musi byæ pojedynczym znakiem"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "oczekiwa³em na obiekt vim.Buffer, a dosta³em %s"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "nie przeszed³em do bufora %d"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "oczekiwa³em na obiekt vim.Window, a dosta³em %s"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "nie znaleziono okna na bie¿¹cej karcie"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "nie przeszed³em do okreœlonego okna"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "oczekiwa³em na obiekt vim.TabPage, a dosta³em %s"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "nie przeszed³em do okreœlonej karty"
+
+#~ msgid "failed to run the code"
+#~ msgstr "uruchomienie kodu siê nie powiod³o"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: eval nie zwróci³o odpowiedniego obiektu pythona"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Nie powiod³a siê konwersja obiektu pythona do wartoœci Vima"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "nie mo¿na konwertowaæ %s do s³ownika Vima"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "nie mo¿na konwertowaæ %s do struktury Vima"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "b³¹d wewnêtrzny: przekazano referencjê NULL"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "b³¹d wewnêtrzny: b³êdny typ wartoœci"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Nie mogê ustawiæ haka œcie¿ki: sys.path_hooks nie jest list¹\n"
+#~ "Powinieneœ teraz wykonaæ nastêpuj¹ce czynnoœci:\n"
+#~ "- dodaæ vim.path_hook do sys.path_hooks\n"
+#~ "- dodaæ vim.VIM_SPECIAL_PATH do sys.path\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Nie mogê ustawiæ œcie¿ki: sys.path nie jest list¹\n"
+#~ "Powinno siê teraz dodaæ vim.VIM_SPECIAL_PATH do sys.path"
 
 #~ msgid "softspace must be an integer"
 #~ msgstr "softspace musi byæ liczb¹ ca³kowit¹"

--- a/src/nvim/po/pl.po
+++ b/src/nvim/po/pl.po
@@ -1839,10 +1839,6 @@ msgstr "%<PRId64> wierszy, "
 msgid "1 character"
 msgstr "1 znak"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> znaków"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/pl.po
+++ b/src/nvim/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-06 19:33+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-08-10 18:15+0200\n"
 "Last-Translator: Mikolaj Machowski <mikmach@wp.pl>\n"
 "Language: pl\n"
@@ -20,164 +20,204 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() wywo³any z pustym has³em"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "nie mogê pobraæ warto¶ci opcji"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "b³±d wewnêtrzny: nieznany typ opcji"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Blowfish u¿ywa b³êdnej kolejno¶ci bajtów"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: test sha256 nie powiód³ siê"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: test Blowfisha nie powiód³ siê"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Lista lokacji]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Lista quickfix]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Autokomendy spowodowa³y porzucenie komendy"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nie mogê zarezerwowaæ bufora; zakoñczenie..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nie mogê zarezerwowaæ bufora; u¿ywam innego..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Nie wy³adowano ¿adnego bufora"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Nie skasowano ¿adnego bufora"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Nie wyrzucono ¿adnego bufora"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 bufor wy³adowany"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "wy³adowano %d buforów"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 bufor skasowany"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buforów skasowano"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "wyrzucono 1 bufor "
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "wyrzucono %d buforów"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Nie mogê wy³adowaæ ostatniego bufora"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nie znaleziono zmienionych buforów"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nie ma wylistowanych buforów"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Bufor \"%<PRId64>\" nie istnieje"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Nie mogê przej¶æ poza ostatni bufor"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Nie mogê przej¶æ przed pierwszy bufor"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Nie zapisano zmian w buforze %<PRId64> (wymu¶ przez !)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Nie mogê wy³adowaæ ostatniego bufora"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: OSTRZE¯ENIE: Przepe³nienie listy nazw plików"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Nie znaleziono bufora %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Wielokrotne dopasowania dla %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: ¯aden bufor nie pasuje do %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "wiersz %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufor o tej nazwie ju¿ istnieje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmieniony]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Nie edytowany]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nowy Plik]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[B³±d odczytu]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[RO]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[tylko odczyt]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 wiersz --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> wiersze --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "wiersz %<PRId64> z %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Bez nazwy]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "pomoc"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Pomoc]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Podgl±d]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Wszystko"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Dó³"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Góra"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -185,9 +225,11 @@ msgstr ""
 "\n"
 "# Lista buforów:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Notka]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -195,144 +237,200 @@ msgstr ""
 "\n"
 "--- Znaki ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaki dla %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    wiersz=%<PRId64>  id=%d  nazwa=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Brak dwukropka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Niedozwolony tryb"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: oczekiwa³em na cyfrê"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Niedozwolony procent"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nie mogê zró¿nicowaæ wiêcej ni¿ %<PRId64> buforów"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Nie mogê otworzyæ lub zapisaæ plików tymczasowych"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nie mogê stworzyæ ró¿nic"
 
-msgid "Patch file"
-msgstr "Plik ³ata"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Nie mogê odczytaæ wyj¶cia pliku ³aty"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nie mogê wczytaæ wyj¶cia ró¿nicy"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Bie¿±cy bufor nie jest w trybie ró¿nic"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: ¯aden inny bufor w trybie diff nie jest modyfikowalny"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Brak innego bufora w trybie ró¿nic"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Wiêcej ni¿ jeden bufor w trybie ró¿nicowania, nie wiem którego u¿yæ"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nie mogê znale¼æ bufora \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bufor \"%s\" nie jest w trybie ró¿nicowania"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Nieoczekiwana zmiana bufora"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape jest niedozwolone w dwugrafie"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Nie znaleziono pliku rozk³adu klawiszy"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Zastosowano :loadkeymap w niewczytanym pliku"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Pusty wpis keymap"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Dope³nianie s³ów kluczowych (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X tryb (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Dope³nianie pe³nych wierszy (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Dope³nianie nazw plików (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Dope³nianie znaczników (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Dope³nianie wzorców tropów (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Dope³nianie definicji (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dope³nianie ze s³owników (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Dope³nianie z tezaurusa (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Dope³nianie wiersza poleceñ (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr "Dope³nianie zdefiniowane przez u¿ytkownika (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupe³nianie (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr "Propozycja pisowni (^L^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokalne dope³nianie s³ów kluczowych (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Dobi³em do koñca akapitu"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Funkcja uzupe³niania zmieni³a okno"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Funkcja uzupe³nania usunê³a tekst"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "opcja 'dictionary' jest pusta"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "opcja 'thesaurus' jest pusta"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Przegl±dam s³ownik: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (wprowadzanie) Przewijanie (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (zamiana) Przewijanie (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Przegl±dam: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Przegl±dam znaczniki."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Dodajê"
 
@@ -340,459 +438,576 @@ msgstr " Dodajê"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Szukam..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Z powrotem na pierwotnym"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Wyraz z innego wiersza"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jedyne dopasowanie"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "pasuje %d z %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "pasuje %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Nieoczekiwane znaki w :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Indeks listy poza zakresem: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nieokre¶lona zmienna: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Brak ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument %s musi byæ List±"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument %s musi byæ List± lub S³ownikiem"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Nie mo¿na u¿yæ pustego klucza dla S³ownika"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: wymagana Lista"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: wymagany S³ownik"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Zbyt wiele argumentów dla funkcji: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Klucz nie istnieje w S³owniku: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkcja %s ju¿ istnieje; aby j± zamieniæ u¿yj !"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: istnieje ju¿ taki element S³ownika"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: wymagana Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Nie mo¿na u¿yæ [:] przy S³owniku"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Z³y typ zmiennej dla %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Nieznana funkcja: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Niedozwolona nazwa zmiennej: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: U¿ycie Zmiennoprzecinkowej jako £añcucha"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Mniej celów ni¿ elementów Listy"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Wiêcej celów ni¿ elementów Listy"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Podwójny ; w li¶cie zmiennych"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Nie mogê wypisaæ zmiennych dla %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Indeks mo¿e istnieæ tylko dla Listy lub S³ownika"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] musi byæ ostatnie"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] wymaga warto¶ci listy"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Lista ma wiêcej elementów ni¿ cel"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Lista nie ma wystarczaj±cej ilo¶ci elementów"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Brak \"in\" po :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Brak nawiasów: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Nie istnieje zmienna: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: zmienna zagnie¿d¿ona zbyt g³êboko dla (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Brak ':' po '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Listê mogê porównaæ tylko z List±"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Nieprawid³owa operacja dla Listy"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: S³ownik mogê porównaæ tylko ze S³ownikiem"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Nieprawid³owa operacja dla S³ownika"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref mogê porównaæ tylko z Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Nieprawid³owa operacja dla Funcref"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Nie mogê u¿yæ '%' w Zmiennoprzecinkowej"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Brak ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Nie mo¿na zindeksowaæ Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Brak nazwy opcji: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Nieznana opcja: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Brak cudzys³owu: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Brak cudzys³owu: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Brakuj±cy przecinek w Li¶cie: '%s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Brak zakoñczenia Listy ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Brak dwukropka w S³owniku: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Powtórzony klucz w S³owniku: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Brakuj±cy przecinek w S³owniku: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Brak koñca w S³owniku '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Zmienna zagnie¿d¿ona zbyt g³êboko by pokazaæ"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Zbyt wiele argumentów dla funkcji %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Zbyt wiele argumentów dla funkcji %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Nieznana funkcja: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Za ma³o argumentów dla funkcji: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: U¿ycie <SID> poza kontekstem skryptu: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Wywo³anie funkcji \"dict\" bez S³ownika: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Wymagana Liczba lub Zmiennoprzecinkowa"
 
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "argument add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Za du¿o argumentów"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() mo¿e byæ u¿yte tylko w trybie Wprowadzania"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Klucz ju¿ istnieje: %s"
 
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "argument extend()"
 
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "argument map()"
 
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "argument filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld wierszy: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Nieznana funkcja: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zakoñcz"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "wywo³ano inputrestore() wiêcej razy ni¿ inputsave()"
 
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "argument insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Zakres niedozwolony"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Nieprawid³owy typ dla len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Skok to zero"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Pocz±tek po koñcu"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<pusty>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Brak po³±czenia z serwerem Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nie mogê wys³aæ do %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nie mogê czytaæ odpowiedzi serwera"
-
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "argument remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Za du¿o dowi±zañ symbolicznych (pêtla?)"
 
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "argument reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Nie mogê wys³aæ do klienta"
-
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "argument sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argument add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funkcja porównywania w sort nie powiod³a siê"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funkcja porównywania w sort nie powiod³a siê"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Niew³a¶ciwe)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: B³±d zapisywania pliku tymczasowego"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: U¿ycie Zmiennoprzecinkowej jako Liczby"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: U¿ycie Funcref jako Liczby"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: U¿ycie Listy jako Liczby"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: U¿ycie S³ownika jako Liczby"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: U¿ycie Funcref jako £añcucha"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: U¿ycie Listy jako £añcucha"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: U¿ycie S³ownika jako £añcucha"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Nieprawid³owy typ zmiennej dla: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Nie mogê usun±æ zmiennej %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Nazwa Funcref musi siê zaczynaæ wielk± liter±: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Nazwa zmiennej jest w konflikcie z istniej±c± funkcj±: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Warto¶æ jest zablokowana: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Nieznane"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Nie mogê zmieniæ warto¶ci %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Zmienna zagnie¿d¿ona zbyt g³êboko by zrobiæ kopiê"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Nieznana funkcja: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Brak '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Nie mo¿na tutaj u¿yæ g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Niedozwolony argument: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Powtórzona nazwa argumentu: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Brak :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Nazwa funkcji jest w konflikcie ze zmienn±: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Nie mogê redefiniowaæ funkcji %s: jest w u¿yciu"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Nazwa funkcji nie pasuje do nazwy skryptu: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Wymagana jest nazwa funkcji"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Nazwa funkcji musi rozpoczynaæ siê wielk± liter± lub zawieraæ "
 "dwukropek: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Nazwa funkcji musi rozpoczynaæ siê wielk± liter± lub zawieraæ "
+"dwukropek: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nie mogê skasowaæ funkcji %s: jest w u¿yciu"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zagnie¿d¿enie wywo³añ funkcji ponad 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "wywo³ujê %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "porzucono %s"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s zwraca #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s zwraca %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "kontynuacja w %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return poza funkcj±"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -800,6 +1015,7 @@ msgstr ""
 "\n"
 "# zmienne globalne:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -807,212 +1023,104 @@ msgstr ""
 "\n"
 "\tOstatnie ustawienie przez "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Brak starych plików"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Wchodzê w tryb odpluskwiania. Wprowad¼ \"cont\" aby kontynuowaæ."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "wiersz %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "cmd: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Nie znaleziono punktu kontrolnego: %s"
-
-msgid "No breakpoints defined"
-msgstr "Nie okre¶lono ¿adnych punktów kontrolnych"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  wiersz %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Pierwsze u¿ycie \":profile start {fname}\""
-
-msgid "Save As"
-msgstr "Zapisz jako"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Zachowaæ zmiany w \"%s\"?"
-
-msgid "Untitled"
-msgstr "Bez Tytu³u"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Nie zapisano zmian w buforze \"%s\""
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "OSTRZE¯ENIE: Nieoczekiwane wej¶cie w inny bufor (sprawd¼ autokomendy)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Tylko jeden plik w edycji"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Nie mo¿na przej¶æ przed pierwszy plik"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Nie mo¿na przej¶æ za ostatni plik"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: nie wspierany kompilator: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Szukanie \"%s\" w \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Szukanie \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "nie znaleziono w 'runtimepath': \"%s\""
-
-msgid "Source Vim script"
-msgstr "Wczytaj skrypt Vima"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Nie mo¿na wczytaæ katalogu: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "nie mog³em wczytaæ \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "wiersz: %<PRId64> nie mog³em wczytaæ \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "wczytywanie \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "skoñczono wczytywanie %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-msgid "--cmd argument"
-msgstr "--cmd argument"
-
-msgid "-c argument"
-msgstr "-c argument"
-
-msgid "environment variable"
-msgstr "zmienna ¶rodowiskowa"
-
-msgid "error handler"
-msgstr "obs³uga b³êdu"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: OSTRZE¯ENIE: Niew³a¶ciwy separator wierszy, pewnie brak ^M"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: u¿yto :scriptencoding poza wczytywanym plikiem"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: u¿yto :finish poza wczytywanym plikiem"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Bie¿±cy %sjêzyk: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Nie mogê ustawiæ jêzyka na \"%s\""
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x,  Oktal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Przeniesienie wierszy na siebie samych"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 wiersz przeniesiony"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> wiersze przeniesione"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> wierszy przefiltrowanych"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Autokomendy *Filter* nie mog± zmieniaæ bie¿±cego bufora"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Brak zapisu od czasu ostatniej zmiany]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s w wierszu: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Zbyt wiele b³êdów; pomijam resztê pliku"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Wczytujê plik viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informacja"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " zak³adki"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " stare pliki"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " NIE POWIOD£O SIÊ"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Plik viminfo jest niezapisywalny: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nie mogê zapisaæ pliku viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Zapisujê plik viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Ten plik viminfo zosta³ wygenerowany przez Vima %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1020,37 +1128,47 @@ msgstr ""
 "# Mo¿esz go ostro¿nie edytowaæ!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Warto¶æ 'encoding' w czasie zapisu tego pliku\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Niedopuszczalny pocz±tkowy znak"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Zapisaæ czê¶ciowo plik?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Stosuj ! do zapisania czê¶ciowo bufora"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Nadpisaæ istniej±cy plik \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Plik wymiany \"%s\" istnieje, czy go nadpisaæ?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Plik wymiany istnieje: %s (wymu¶ poprzez :silent!)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Brak nazwy pliku dla bufora %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Plik niezapisany: Zapis jest wy³±czony opcj± 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1059,6 +1177,7 @@ msgstr ""
 "opcja 'readonly' nastawiona dla \"%s\".\n"
 "Czy chcesz go pomimo tego zapisaæ?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1069,69 +1188,84 @@ msgstr ""
 "Mimo to byæ mo¿e uda siê zmieniæ ten plik.\n"
 "Chcesz spróbowaæ?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" jest tylko do odczytu (dodaj ! aby wymusiæ)"
 
-msgid "Edit File"
-msgstr "Edytuj Plik"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokomendy nieoczekiwanie skasowa³y nowy bufor %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nienumeryczny argument dla :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Komendy pow³oki s± niedozwolone w rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Wzorce regularne nie mog± byæ rozgraniczane literami"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "zamieñ na %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Przerwane) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 pasuje"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 podstawienie "
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> dopasowañ"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> podstawieñ"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " w 1 wierszu"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " w %<PRId64> wierszach"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Nie mogê wykonaæ :global rekursywnie"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Brak wzorca regularnego w :global"
 
 # c-format
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Wzorzec znaleziono w ka¿dym wierszu: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Nie znaleziono wzorca: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1141,137 +1275,335 @@ msgstr ""
 "# Ostatni podstawiany ci±g:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Nie panikuj!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Przykro mi, brak '%s' pomocy dla %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Przykro mi, ale brak pomocy o %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Przykro mi, nie ma pliku pomocy \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Nie jest katalogiem: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Nie mogê otworzyæ %s do zapisu"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Nie mogê otworzyæ %s do odczytu"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Mieszanka kodowañ w pliku pomocy w ramach jêzyka: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Powtórzony znacznik \"%s\" w pliku %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Nieznana komenda znaku: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Brak nazwy znaku"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Zbyt wiele nazw znaków"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Niew³a¶ciwy tekst znaku: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Nieznany znak: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Brak numeru znaku"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Niew³a¶ciwa nazwa bufora: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Niew³a¶ciwe ID znaku: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NIE ZNALEZIONO)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr "(nie wspomagane)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Skasowano]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Wchodzê w tryb odpluskwiania. Wprowad¼ \"cont\" aby kontynuowaæ."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "wiersz %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "cmd: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Nie znaleziono punktu kontrolnego: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Nie okre¶lono ¿adnych punktów kontrolnych"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  wiersz %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Pierwsze u¿ycie \":profile start {fname}\""
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Zachowaæ zmiany w \"%s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Bez Tytu³u"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Nie zapisano zmian w buforze \"%s\""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "OSTRZE¯ENIE: Nieoczekiwane wej¶cie w inny bufor (sprawd¼ autokomendy)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Tylko jeden plik w edycji"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Nie mo¿na przej¶æ przed pierwszy plik"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Nie mo¿na przej¶æ za ostatni plik"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: nie wspierany kompilator: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Szukanie \"%s\" w \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Szukanie \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "nie znaleziono w 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Nie mo¿na wczytaæ katalogu: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "nie mog³em wczytaæ \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "wiersz: %<PRId64> nie mog³em wczytaæ \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "wczytywanie \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "skoñczono wczytywanie %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd argument"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "zmienna ¶rodowiskowa"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "obs³uga b³êdu"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: OSTRZE¯ENIE: Niew³a¶ciwy separator wierszy, pewnie brak ^M"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: u¿yto :scriptencoding poza wczytywanym plikiem"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: u¿yto :finish poza wczytywanym plikiem"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Bie¿±cy %sjêzyk: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Nie mogê ustawiæ jêzyka na \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Wchodzê w tryb Ex. Wprowad¼ \"visual\" aby przej¶æ do trybu Normal."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Na koñcu pliku"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Komenda zbyt rekursywna"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Nie znaleziono wyj±tku: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Koniec wczytywanego pliku"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Koniec funkcji"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr ""
 "E464: Niejednoznaczne zastosowanie komendy zdefiniowanej przez u¿ytkownika"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Nie jest komend± edytora"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Dano wsteczny zakres"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Dano wsteczny zakres; zamiana jest mo¿liwa"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Stosuj w lub w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Przykro mi, ale ta komenda nie jest dostêpna w tej wersji"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Tylko pojedyncza nazwa pliku dozwolona"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 wiêcej plik do edycji.  Mimo to wyj¶æ?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "jeszcze %d plików do edycji.  Mimo to wyj¶æ?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 wiêcej plik do edycji"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: jeszcze %<PRId64> plików do edycji"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komenda ju¿ istnieje; aby j± przedefiniowaæ stosuj !"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1279,296 +1611,341 @@ msgstr ""
 "\n"
 "    Nazwa       Arg. Zak.  Gotowo¶æ  Definicja"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Nie znaleziono komend zdefiniowanych przez u¿ytkownika"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nie okre¶lono atrybutu"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Niew³a¶ciwa ilo¶æ argumentów"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Mno¿nik nie mo¿e byæ podany dwukrotnie"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Niew³a¶ciwa domy¶lna warto¶æ mno¿nika"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete wymaga argumentu"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Niew³a¶ciwy atrybut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Niew³a¶ciwa nazwa komendy"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr ""
 "E183: Komendy zdefiniowane przez u¿ytkownika musz± rozpoczynaæ siê du¿± "
 "liter±"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr ""
-"E841: Nazwa zastrze¿ona, nie mo¿na jej u¿yæ w komendzie u¿ytkownika"
+msgstr "E841: Nazwa zastrze¿ona, nie mo¿na jej u¿yæ w komendzie u¿ytkownika"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Nie ma takiej komendy u¿ytkownika: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Niew³a¶ciwa warto¶æ dope³niania: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Argument depe³niania dozwolony wy³±cznie dla dope³niania u¿ytkownika"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Dope³nianie u¿ytkownika wymaga funkcji jako argumentu"
 
-msgid "unknown"
-msgstr "nieznany"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Nie mogê znale¼æ zestawu kolorów '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Witaj u¿ytkowniku Vima!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Nie mogê zamkn±æ ostatniej karty"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Jest ju¿ tylko jedna karta"
 
-msgid "Edit File in new window"
-msgstr "Edytuj plik w nowym oknie"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Karta %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Brak pliku wymiany"
 
-msgid "Append File"
-msgstr "Do³±cz plik"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Nie mogê zmieniæ katalogu, bufor zosta³ zmodyfikowany (dodaj ! aby "
 "wymusiæ)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Nie ma poprzedniego katalogu"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Nieznany"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize wymaga dwóch argumentów numerycznych"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Pozycja okna: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Pozyskiwanie pozycji okna nie jest zaimplementowane dla tego systemu"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos wymaga dwóch argumentów numerycznych"
 
-msgid "Save Redirection"
-msgstr "Zapisz przekierowanie"
-
-msgid "Save View"
-msgstr "Zapisz widok"
-
-msgid "Save Session"
-msgstr "Zapisz sesjê"
-
-msgid "Save Setup"
-msgstr "Zapisz ustawienia"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Nie mogê utworzyæ katalogu: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" istnieje (wymu¶ poprzez !)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Nie mogê otworzyæ \"%s\" do zapisu"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argument musi byæ liter± albo cudzys³owem w przód/ty³"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursywne zastosowanie :normal za g³êbokie"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< nie jest dostêpne bez w³a¶ciwo¶ci +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Brak nazwy zamiennego pliku do podstawienia pod '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: brak nazwy pliku autokomend do podstawienia pod \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: brak numeru bufora autokomend do podstawienia pod  \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: brak nazwy dopasowania autokomend pod \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: brak nazwy pliku :source do postawienia pod \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: brak numeru linii by u¿yæ z \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Pusta nazwa pliku dla '%' lub '#', dzia³a tylko z \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Wynikiem jest pusty ci±g"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Nie mogê otworzyæ pliku viminfo do odczytu"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Brak dwugrafów w tej wersji"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Nie mo¿na ':throw' wyj±tków z prefiksem 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Wyj±tek: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Wyj±tek zakoñczony: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Wyj±tek odrzucony: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, wiersz %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Wyj±tek przechwycony: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s zosta³ zawieszony"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s przywrócony"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s odrzucony"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Wyj±tek"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "B³±d i przerwanie"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "B³±d"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Przerwanie"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: zbyt g³êbokie zagnie¿d¿enie :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif bez :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else bez :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif bez :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: wielokrotne :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif po :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: zbyt g³êbokie zagnie¿d¿enie :while/:for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue bez :while lub :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break bez :while lub :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: U¿ycie :endfor z :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: U¿ycie :endwhile z :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: zbyt g³êbokie zagnie¿d¿enie :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch bez :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch za :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally bez :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: wielokrotne :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry bez :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction poza funkcj±"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Nie mo¿na teraz edytowaæ innego bufora"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Nie mo¿na teraz zmieniaæ informacji o buforze"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "nazwa znacznika"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " pokrewny plik\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "opcja 'history' jest zerowa"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1577,230 +1954,304 @@ msgstr ""
 "\n"
 "# %s Historia (od najnowszych po najstarsze):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Wiersz poleceñ"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Szukany ci±g"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Wyra¿enie"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Wiersz wprowadzeñ"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar przekracza d³ugo¶æ polecenia"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktywny widok lub bufor skasowany"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: ¶cie¿ka za d³uga by uzupe³niæ"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Niew³a¶ciwy trop: '**[numer]' musi byæ na koñcu tropu lub po nim musi "
+"byæ '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Nie mogê znale¼æ katalogu \"%s\" w cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Nie mogê znale¼æ pliku \"%s\" w tropie"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Katalogu \"%s\" nie ma wiêcej w cdpath"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Pliku \"%s\" nie ma wiêcej w tropie"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autokomendy zmieni³y bufor lub jego nazwê"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Niedopuszczalna nazwa pliku"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "jest katalogiem"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "nie jest plikiem"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "jest urz±dzeniem (wy³±czonym w opcji 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Nowy Plik]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Nowy KATALOG]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Za du¿y plik]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Nie dozwolono]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Autokomendy *ReadPre zrobi³y plik nieodczytywalnym"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Autokomendy *ReadPre nie mog± zmieniaæ bie¿±cego bufora"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Wczytywanie ze stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Wczytywanie ze stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Nie mo¿na otworzyæ pliku utworzonego przez przemianê!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[specjalny znak]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[brak CR]'"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[d³ugie wiersze rozdzielane]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NIE przemienione]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[przemienione]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[zakodowane]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[B£¡D W PRZEMIANIE w linii %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[NIEDOZWOLONY BAJT w wierszu %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[B£ÊDY W ODCZYCIE]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nie mogê znale¼æ pliku tymczasowego w celu przemiany"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Nieudana przemiana z 'charconvert'"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nie mogê odczytaæ wyj¶cia z 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Plik zaszyfrowano w nieznany sposób"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Brak pasuj±cych autokomend dla bufora acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Autokomendy skasowa³y lub wy³adowa³y bufor przeznaczony do zapisu"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autokomenda zmieni³a liczbê wierszy w nieoczekiwany sposób"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans nie pozwala na zapis niezmodyfikowanych buforów"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Czê¶ciowy zapis niemo¿liwy dla buforów NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "nie jest plikiem lub zapisywalnym przyrz±dem"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "zapisywanie do urz±dzenia wy³±czone w opcji 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "jest tylko do odczytu (wymu¶ poprzez !)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Nie mogê zapisaæ do pliku zabezpieczenia (wymu¶ przez !)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: B³±d podczas zamykania pliku zabezpieczenia (wymu¶ przez !)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Nie mogê odczytaæ pliku w celu zabezpieczenia (wymu¶ przez !)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Nie mogê stworzyæ pliku zabezpieczenia (wymu¶ przez !)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Nie mogê zrobiæ pliku zabezpieczenia (wymu¶ przez !)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Rozdzia³ zasobów zostanie utracony (wymu¶ przez !)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nie mogê znale¼æ pliku tymczasowego do zapisania"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nie mogê przemieniæ (u¿yj ! by zapisaæ bez przemiany)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Nie mogê otworzyæ pod³±czonego pliku do zapisu"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Nie mogê otworzyæ pliku do zapisu"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync nie powiód³ siê"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Zamkniêcie siê nie powiod³o"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: B³±d zapisu, przemiana siê nie powiod³a (opró¿nij 'fenc' aby wymusiæ)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: B³±d zapisu, przemiana siê nie powiod³a w wierszu %<PRId64> (opró¿nij 'fenc' "
-"by wymusiæ)"
+"E513: B³±d zapisu, przemiana siê nie powiod³a w wierszu %<PRId64> (opró¿nij "
+"'fenc' by wymusiæ)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: b³±d w zapisie (mo¿e system plików jest przepe³niony?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " B£¡D W PRZEMIANIE"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " w wierszu %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Urz±dzenie]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Nowy]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " do³±czono"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " zapisano"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: nie mogê zapisaæ oryginalnego pliku"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nie mogê stworzyæ pustego oryginalnego pliku"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nie mogê skasowaæ pliku zabezpieczenia"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1808,76 +2259,96 @@ msgstr ""
 "\n"
 "OSTRZE¯ENIE: Oryginalny plik mo¿e zostaæ utracony lub uszkodzony\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "nie wychod¼ edytora, dopóki plik nie zosta³ poprawnie zapisany!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[format dos-a]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[format maca]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[format unixa]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 wiersz, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> wierszy, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znaków"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Niekompletny ostatni wiersz]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "OSTRZE¯ENIE: Plik zmieni³ siê od czasu ostatniego odczytu!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Czy naprawdê chcesz go zapisaæ"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: B³±d zapisywania do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: B³±d w trakcie zamykania \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: B³±d odczytu \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Autokomenda FileChangedShell skasowa³a bufor"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Plik \"%s\" nie jest d³u¿ej dostêpny"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1886,31 +2357,39 @@ msgstr ""
 "W12: OSTRZE¯ENIE: Plik \"%s\" zmieni³ siê od czasu rozpoczêcia edycji, bufor "
 "w Vimie równie¿ zosta³ zmieniony"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Zobacz \":help W12\"  dla dalszych informacji."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: OSTRZE¯ENIE: Plik \"%s\" zmieni³ siê od czasu rozpoczêcia edycji"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Zobacz \":help W11\"  dla dalszych informacji."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: OSTRZE¯ENIE: Tryb pliku \"%s\" zmieni³ siê od czasu rozpoczêcia edycji"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Zobacz \":help W16\"  dla dalszych informacji."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: OSTRZE¯ENIE: Plik \"%s\" zosta³ stworzony po rozpoczêciu edycji"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "OSTRZE¯ENIE"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1918,39 +2397,48 @@ msgstr ""
 "&OK\n"
 "&Za³aduj Plik"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Nie mo¿na przygotowaæ prze³adowania \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Nie mo¿na prze³adowaæ \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Skasowano--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "auto-usuwanie autokomendy: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Nie ma takiej grupy: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Niedopuszczalny znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Nie ma takiego wydarzenia: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Nie ma takiej grupy lub wydarzenia: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1958,538 +2446,761 @@ msgstr ""
 "\n"
 "--- Autokomendy ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: niew³a¶ciwy numer bufora"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Nie mo¿na wykonywaæ autokomend dla wydarzeñ ALL"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Brak pasuj±cych autokomend"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: zbyt g³êbokie zagnie¿d¿enie autokomend"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokomend dla \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Wykonujê %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autokomenda %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Brak {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Brak }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Nie znaleziono zwiniêcia"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Nie mo¿na utworzyæ zwiniêcia przy bie¿±cej 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Nie mo¿na skasowaæ zwiniêcia przy bie¿±cej 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld wierszy zwiniêto "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Dodaj do bufora odczytu"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursywne przyporz±dkowanie"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: istnieje ju¿ globalny skrót dla %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: istnieje ju¿ globalne przyporz±dkowanie dla %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: istnieje ju¿ skrót dla %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: istnieje ju¿ przyporz±dkowanie dla %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Nie znaleziono skrótu"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Nie znaleziono przyporz±dkowania"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Niedopuszczalny tryb"
 
-msgid "<cannot open> "
-msgstr "<nie mogê otworzyæ> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Brak wierszy w buforze--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: nie mogê otrzymaæ czcionki %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Przerwanie komendy"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: nie mogê powróciæ do bie¿±cego katalogu"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: wymagany argument"
 
-msgid "Pathname:"
-msgstr "Trop:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ powinno byæ /, ? lub &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: nie mogê otrzymaæ bie¿±cego katalogu"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Zakoñcz"
-
-msgid "Vim dialog"
-msgstr "VIM - Dialog"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Nie mog³em otrzymaæ rozmiarów rysunku na przycisku."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Nie mogê stworzyæ BalloonEval z powiadomieniem i wywo³aniem"
-
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Nie mog³em stworzyæ nowego procesu dla GUI"
-
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Proces potomny nie móg³ uruchomiæ GUI"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nie mogê odpaliæ GUI"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nie mogê czytaæ z \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Nie mo¿na uruchomiæ GUI, brak prawid³owej czcionki"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Niew³a¶ciwe 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Nieprawid³owa warto¶æ 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Nie mogê zarezerwowaæ koloru %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Brak dopasowania przy kursorze, szukam dalej"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"&Tak\n"
-"&Nie\n"
-"&Zakoñcz"
+"E11: Niedozwolone w oknie wiersza poleceñ; <CR> wykonuje, CTRL-C opuszcza"
 
-msgid "Input _Methods"
-msgstr "Input _Methods"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Szukaj i Zamieñ..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Szukaj..."
-
-msgid "Find what:"
-msgstr "Znajd¼:"
-
-msgid "Replace with:"
-msgstr "Zamieñ na:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Dopasuj tylko ca³e wyrazy"
-
-#. match case button
-msgid "Match case"
-msgstr "Dopasuj wielko¶æ liter"
-
-msgid "Direction"
-msgstr "Kierunek"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "W górê"
-
-msgid "Down"
-msgstr "W dó³"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Znajd¼ nastêpne"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Zamieñ"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Zamieñ wszystkie"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: otrzymano ¿±danie \"die\" od mened¿era sesji\n"
-
-msgid "Close"
-msgstr "Zamknij"
-
-msgid "New tab"
-msgstr "Nowa karta"
-
-msgid "Open Tab..."
-msgstr "Otwórz kartê..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: G³ówne okno nieoczekiwanie zniszczone\n"
-
-msgid "&Filter"
-msgstr "&Filtr"
-
-msgid "&Cancel"
-msgstr "&Anuluj"
-
-msgid "Directories"
-msgstr "Katalogi"
-
-msgid "Filter"
-msgstr "Filtr"
-
-msgid "&Help"
-msgstr "&Pomoc"
-
-msgid "Files"
-msgstr "Pliki"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Wybór"
-
-msgid "Find &Next"
-msgstr "Znajd¼ &nastêpne"
-
-msgid "&Replace"
-msgstr "&Zamieñ"
-
-msgid "Replace &All"
-msgstr "Zamieñ &wszystko"
-
-msgid "&Undo"
-msgstr "&Cofnij"
-
-#, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Nie mogê znale¼æ tytu³u okna \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nie jest wspomagany: \"-%s\"; U¿ywaj wersji OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Nie mo¿na otworzyæ okna wewn±trz aplikacji MDI"
-
-msgid "Close tab"
-msgstr "Zamknij kartê"
-
-msgid "Open tab..."
-msgstr "Otwórz kartê..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Znajd¼ ci±g (u¿yj '\\\\' do szukania '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Szukanie i Zamiana (u¿yj '\\\\' do szukania '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Nie u¿ywany"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Katalog\t*.nic\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"Vim E458: Nie mogê zarezerwowaæ mapy kolorów, pewne kolory mog± byæ "
-"nieprawid³owe"
+"E12: Komenda niedozwolona z exrc/vimrc w bie¿±cym szukaniu katalogu lub "
+"znacznika"
 
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Brak :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Brak :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Brak :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Brak :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile bez :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor bez :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Plik istnieje (wymu¶ poprzez !)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Komenda nie powiod³a siê"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: B³±d wewnêtrzny"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Przerwane"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Niew³a¶ciwy adres"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Niew³a¶ciwy argument"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Niew³a¶ciwy argument: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Niew³a¶ciwe wyra¿enie: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Niew³a¶ciwy zakres"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Niew³a¶ciwa komenda"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" jest katalogiem"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Niew³a¶ciwa wielko¶æ przewiniêcia"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"E250: Brak czcionek dla nastêpuj±cych zestawów znaków w zestawie czcionek %s:"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nazwa zestawu czcionek: %s"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
+#: ../globals.h:1024
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Czcionka '%s' nie posiada znaków jednolitej szeroko¶ci"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Wywo³anie z biblioteki nie powiod³o siê dla \"%s()\""
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Zak³adka ma niew³a¶ciwy numer wiersza"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Zak³adka nienastawiona"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nie mogê wykonaæ zmian, 'modifiable' jest wy³±czone"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Zbyt g³êbokie zagnie¿d¿enie skryptów"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Brak pliku zamiany"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Nie ma takiego skrótu"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Niedozwolone !"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI nie mo¿e byæ u¿yte: Nie w³±czono podczas kompilacji"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Nazwa zestawu czcionek: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Brak takiej nazwy grupy pod¶wietlania: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Nie wprowadzono jeszcze ¿adnego tekstu"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Nie ma poprzedniego wiersza poleceñ"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Nie ma takiego przyporz±dkowania"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Brak dopasowañ"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font0: %s"
-msgstr "Font0: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Brak dopasowañ: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Brak nazwy pliku"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Brak poprzedniego podstawieniowego wyra¿enia regularnego"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Brak poprzedniej komendy"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Brak poprzedniego wyra¿enia regularnego"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Zakres niedozwolony"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Brak miejsca"
+
+#: ../globals.h:1049
 #, c-format
-msgid "Font1: %s"
-msgstr "Font1: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Nie mogê stworzyæ pliku %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Nie mogê pobraæ nazwy pliku tymczasowego"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Szeroko¶æ font%<PRId64> nie jest podwójn± szeroko¶ci± font0"
+msgid "E484: Can't open file %s"
+msgstr "E484: Nie mogê otworzyæ pliku %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Szeroko¶æ font0: %<PRId64>"
+msgid "E485: Can't read file %s"
+msgstr "E485: Nie mogê odczytaæ pliku %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Nie zapisano od ostatniej zmiany (wymu¶ przez !)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Brak zapisu od czasu ostatniej zmiany]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Zerowy argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oczekujê liczby"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Szeroko¶æ font1: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nie mogê otworzyæ pliku b³êdów %s"
 
-msgid "Invalid font specification"
-msgstr "Nieprawid³owy opis czcionki"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Pamiêæ wyczerpana!"
 
-msgid "&Dismiss"
-msgstr "&Anuluj"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Nie znaleziono wzorca"
 
-msgid "no specific match"
-msgstr "brak okre¶lonego dopasowania"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Nie znaleziono wzorca: %s"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - wybór czcionki"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument musi byæ dodatni"
 
-msgid "Name:"
-msgstr "Nazwa:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Nie mo¿na przej¶æ do poprzedniego katalogu"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Poka¿ wielko¶æ w punktach"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Brak B³êdów"
 
-msgid "Encoding:"
-msgstr "Kodowanie:"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Brak listy lokacji"
 
-msgid "Font:"
-msgstr "Czcionka:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Popsuty ci±g wzorca"
 
-msgid "Style:"
-msgstr "Styl:"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Zepsuty program wyra¿eñ regularnych"
 
-msgid "Size:"
-msgstr "Wielko¶æ:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: opcja 'readonly' jest ustawiona (wymu¶ poprzez !)"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: B£¡D w automacie Hangul"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nie mogê zmieniæ zmiennej tylko do odczytu \"%s\""
 
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Nie mogê ustawiæ zmiennej w piaskownicy: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: B³±d w trakcie czytania pliku b³êdów"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Niedozwolone w piaskownicy"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Niedozwolone w tym miejscu"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Ustawianie trybu ekranu niewspomagane"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Niew³a¶ciwa wielko¶æ przewiniêcia"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: opcja 'shell' jest pusta"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Nie mog³em wczytaæ danych znaku!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: B³±d podczas zamykania pliku wymiany"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: stos znaczników jest pusty"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Komenda jest zbyt skomplikowana"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Zbyt d³uga nazwa"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Zbyt wiele ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Zbyt wiele nazw plików"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Nadstêpne znaczki"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Nieznana zak³adka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nie mog± rozwin±æ znaków wieloznacznych"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' nie mo¿e byæ mniejsze ni¿ 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' nie mo¿e byæ mniejsze ni¿ 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: B³±d w trakcie zapisu"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Zerowy licznik"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: U¿ycie <SID> poza kontekstem skryptu"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: B³±d wewnêtrzny: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Wzorzec u¿ywa wiêcej pamiêci ni¿ 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: pusty bufor"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Niew³a¶ciwy wzorzec wyszukiwania lub delimiter"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Plik jest za³adowany w innym buforze"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Nie ustawiono opcji '%s'"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Niew³a¶ciwa nazwa rejestru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "szukanie dobi³o GÓRY; kontynuacja od KOÑCA"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "szukanie dobi³o KOÑCA; kontynuacja od GÓRY"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Brak dwukropka"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Niedozwolona czê¶æ"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: oczekiwa³em na cyfrê"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Strona %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Brak tekstu do drukowania"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Drukujê stronê %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopia %d z %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Wydrukowano: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Drukowanie odwo³ane"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Nie mo¿na zapisaæ do wyj¶ciowego pliku PostScriptu"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Nie mogê otworzyæ pliku \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Nie mo¿na odczytaæ pliku zasobów PostScriptu \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: plik \"%s\" nie jest plikiem zasobów PostScriptu"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: plik \"%s\" nie jest wspieranym plikiem zasobów PostScriptu"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" nieprawid³owa wersja pliku zasobów"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Niekompatybilne kodowanie wielobajtowe i zestaw znaków."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset nie mo¿e byæ pusty przy kodowaniu wielobajtowym."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Nie okre¶lono domy¶lnej czcionki dla drukowania wielobajtowego."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Nie mo¿na otworzyæ pliku PostScript do wyj¶cia"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Nie mogê otworzyæ pliku \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Nie mo¿na znale¼æ pliku zasobów PostScriptu \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Nie mo¿na znale¼æ pliku zasobów PostScriptu \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Nie mo¿na znale¼æ pliku zasobów PostScriptu \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Nie mo¿na przekonwertowaæ by drukowaæ kodowanie \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Przesy³am do drukarki..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Drukowanie pliku PostScript nie powiod³o siê"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Zadanie drukowanie przes³ane."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Dodaj now± bazê danych"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Zapytane o wzorzec"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Poka¿ ten komunikat"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Zabij po³±czenie"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Ponów wszelkie po³±czenia"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Poka¿ po³±czenia"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Zastosowanie: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Ta komenda cscope nie wspomaga podzielenia okna.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Zastosowanie: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: nie znaleziono znacznika"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) b³±d: %d"
 
-msgid "E563: stat error"
-msgstr "E563: b³±d stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s nie jest katalogiem lub poprawn± baz± danych cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Dodano bazê danych cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: b³±d odczytu po³±czenia z cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: nieznany typ szukania cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Nie mog³em stworzyæ potoku do cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Nie mog³em utworzyæ rozwidlenia dla cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "nie powiod³o siê setpgid cs_create_connection"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "wykonanie cs_create_connection nie powiod³o siê"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen dla to_fp nie powiod³o siê"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen dla fr_fp nie powiod³o siê"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Nie mog³em stworzyæ procesu cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: brak po³±czenia z cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: nieprawid³owa flaga cscopequickfix %c dla %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: brak dopasowañ dla zapytania cscope %s o %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "komendy cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (U¿ycie: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2511,32 +3222,31 @@ msgstr ""
 "       s: znajd¼ ten symbol C\n"
 "       t: znajd¼ ten ³añcuch znaków\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: nie mogê otworzyæ bazy danych cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: nie mogê uzyskaæ informacji z bazy danych cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: nie dodano duplikatu bazy danych cscope"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: nie ma po³±czenia %s z cscope"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "po³±czenie %s z cscope zosta³o zamkniête"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: b³±d krytyczny w cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Znacznik cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2544,367 +3254,88 @@ msgstr ""
 "\n"
 "   #   wiersz"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "nazwa pliku  / kontekst / wiersz\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: B³±d cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Wszystkie bazy danych cscope prze³adowano"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "brak po³±czeñ z cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid   nazwa bazy danych               przedsionek tropu\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Nie mo¿na wczytaæ biblioteki Lua."
-
-msgid "cannot save undo information"
-msgstr "nie mogê zachowaæ informacji cofania"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Przykro mi, ta komenda jest wy³±czona, biblioteka MzScheme nie mo¿e "
-"byæ za³adowana."
-
-msgid "invalid expression"
-msgstr "niepoprawne wyra¿enie"
-
-msgid "expressions disabled at compile time"
-msgstr "wyra¿enia wy³±czone podczas kompilacji"
-
-msgid "hidden option"
-msgstr "ukryta opcja"
-
-msgid "unknown option"
-msgstr "nieznana opcja"
-
-msgid "window index is out of range"
-msgstr "indeks okna poza zakresem"
-
-msgid "couldn't open buffer"
-msgstr "nie mogê otworzyæ bufora"
-
-msgid "cannot delete line"
-msgstr "nie mogê skasowaæ wiersza"
-
-msgid "cannot replace line"
-msgstr "nie mogê zamieniæ wiersza"
-
-msgid "cannot insert line"
-msgstr "nie mogê wprowadziæ wiersza"
-
-msgid "string cannot contain newlines"
-msgstr "ci±g nie mo¿e zawieraæ znaków nowego wiersza"
-
-msgid "error converting Scheme values to Vim"
-msgstr "b³±d przy konwersji warto¶ci Scheme do Vima"
-
-msgid "Vim error: ~a"
-msgstr "B³±d vima: ~a"
-
-msgid "Vim error"
-msgstr "B³±d Vima"
-
-msgid "buffer is invalid"
-msgstr "bufor jest niewa¿ny"
-
-msgid "window is invalid"
-msgstr "okno jest niewa¿ne"
-
-msgid "linenr out of range"
-msgstr "numer wiersza poza zakresem"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "Niedozwolone w piaskownicy Vima"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Przykro mi, ta komenda jest wy³±czona, bo nie mo¿na za³adowaæ "
-"biblioteki Pythona"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Nie mo¿na wywo³aæ Pythona rekursywnie"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ musi byæ reprezentacj± £añcucha"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Przykro mi, ta komenda jest wy³±czona, bo nie mo¿na za³adowaæ "
-"biblioteki Ruby."
-
-msgid "E267: unexpected return"
-msgstr "E267: nieoczekiwany return"
-
-msgid "E268: unexpected next"
-msgstr "E268: nieoczekiwany next"
-
-msgid "E269: unexpected break"
-msgstr "E269: nieoczekiwany break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: nieoczekiwane redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: ponowna próba poza klauzul± ratunku"
-
-msgid "E272: unhandled exception"
-msgstr "E272: nieobs³ugiwany wyj±tek"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Nieznany status longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Prze³±cz miêdzy implementacj±/okre¶leniem"
-
-msgid "Show base class of"
-msgstr "Poka¿ bazê klasy"
-
-msgid "Show overridden member function"
-msgstr "Poka¿ przepisan± funkcjê cz³onow±"
-
-msgid "Retrieve from file"
-msgstr "Pobieraj z pliku"
-
-msgid "Retrieve from project"
-msgstr "Pobieraj z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Pobieraj z wszystkich projektów"
-
-msgid "Retrieve"
-msgstr "Pobierz"
-
-msgid "Show source of"
-msgstr "Poka¿ ¼ród³o dla"
-
-msgid "Find symbol"
-msgstr "Znajd¼ symbol"
-
-msgid "Browse class"
-msgstr "Przejrzyj klasê"
-
-msgid "Show class in hierarchy"
-msgstr "Poka¿ klasê w hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Poka¿ klasê w ograniczonej hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odnosi siê do"
-
-msgid "Xref referred by"
-msgstr "Xref ma odniesienia od"
-
-msgid "Xref has a"
-msgstr "Xref ma"
-
-msgid "Xref used by"
-msgstr "Xref u¿yte przez"
-
-msgid "Show docu of"
-msgstr "Poka¿ dokumentacjê dla"
-
-msgid "Generate docu for"
-msgstr "Utwórz dokumentacjê dla"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Nie mogê pod³±czyæ do SNiFF+. Sprawd¼ ¶rodowisko (sniffemacs musi byæ "
-"odnaleziony w $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: B³±d podczas czytania. Roz³±czenie"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ jest obecnie "
-
-msgid "not "
-msgstr "nie "
-
-msgid "connected"
-msgstr "pod³±czony"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Nieznane zapytanie SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: B³±d w trakcie pod³±czania do SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ niepod³±czony"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Nie jest buforem SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: B³±d w trakcie zapisu. Roz³±czony"
-
-msgid "invalid buffer number"
-msgstr "niew³a¶ciwy numer bufora"
-
-msgid "not implemented yet"
-msgstr "obecnie nie zaimplementowano"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nie mogê ustawiæ wiersza(y)"
-
-msgid "invalid mark name"
-msgstr "niepoprawna nazwa zak³adki"
-
-msgid "mark not set"
-msgstr "zak³adka nie ustawiona"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "wiersz %d kolumna %d"
-
-msgid "cannot insert/append line"
-msgstr "nie mogê wprowadziæ/do³±czyæ wiersza"
-
-msgid "line number out of range"
-msgstr "numer wiersza poza zakresem"
-
-msgid "unknown flag: "
-msgstr "nieznana flaga: "
-
-msgid "unknown vimOption"
-msgstr "nieznane vimOption"
-
-msgid "keyboard interrupt"
-msgstr "przerwanie klawiatury"
-
-msgid "vim error"
-msgstr "b³±d vima"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nie mogê stworzyæ bufora/okna komendy: obiekt jest kasowany"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nie mogê zarejestrowaæ wstecznego wywo³ania komendy: bufor/okno ju¿ zosta³a "
-"skasowana"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATALNY B£¡D: reflist zepsuta!? Proszê z³o¿yæ raport o tym na vim-"
-"dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nie mogê zarejestrowaæ wstecznego wywo³ania komendy: brak odniesienia do "
-"bufora/okna"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Przykro mi, ta komenda jest wy³±czona, bo nie mo¿na za³adowaæ "
-"biblioteki Tcl."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: kod wyj¶cia %d"
-
-msgid "cannot get line"
-msgstr "nie mogê dostaæ wiersza"
-
-msgid "Unable to register a command server name"
-msgstr "Nie mogê zarejestrowaæ nazwy serwera komend"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Wys³anie komendy do programu docelowego nie powiod³o siê"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: U¿yto niew³a¶ciwego id serwera: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: wcielenia instancji rejestru Vima jest ¼le sformowane.  Skasowano!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Nieznany argument opcji"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Zbyt wiele argumentów"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Brak argumentu po"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "¦miecie po argumencie opcji"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Zbyt wiele argumentów \"+komenda\", \"-c komenda\" lub \"--cmd komenda\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Niew³a¶ciwy argument dla"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d plików do edycji\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans nie s± obs³ugiwane przez to GUI\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Ta wersja Vima nie by³a skompilowanego z opcj± ró¿nic (diff)."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' - nie mo¿e byæ u¿yte: nie w³±czone przy kompilacji\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Próba ponownego otworzenia pliku skryptu: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Nie mogê otworzyæ do odczytu: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Nie mogê otworzyæ dla wyj¶cia skryptu: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: B³±d: Nie mo¿na uruchomiæ gvim z NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: OSTRZE¯ENIE: Wyj¶cie nie jest terminalem\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: OSTRZE¯ENIE: Wej¶cie nie pochodzi z terminala\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "linia poleceñ pre-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nie mogê czytaæ z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2912,18 +3343,23 @@ msgstr ""
 "\n"
 "Dalsze informacje poprzez: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[plik ..]       edytuj zadane pliki"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               czytaj tekst ze stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t znacznik   edytuj plik, w którym dany znacznik jest zdefiniowany"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  edytuj plik, zawieraj±cy pierwszy b³±d"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2933,9 +3369,11 @@ msgstr ""
 "\n"
 "u¿ycie:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumenty]"
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2943,14 +3381,7 @@ msgstr ""
 "\n"
 "   lub:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"gdzie wielko¶æ znaków jest ignorowana dodaj na pocz±tku / by flaga by³a "
-"wielk± liter±"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2960,327 +3391,196 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tTylko nazwy plików po tym"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNie rozwijaj znaków specjalnych"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tZarejestruj tego gvima w OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tWyrejestruj gvima z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tStartuj w GUI (tak jak \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  lub --nofork\tPierwszy plan: Nie wydzielaj przy odpalaniu GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tTryb vi (jak \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tTryb ex (jak \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tUsprawniony tryb Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tCichy tryb (t³a) (tylko dla \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tTryb ró¿nic (jak \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tTryb ³atwy (jak \"evim\", bez trybów)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tTryb wy³±cznie do odczytu (jak \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tTryb ograniczenia (jak \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModyfikacje (zapisywanie plików) niedozwolone"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZakaz modyfikacji tekstu"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tTryb binarny"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tTryb lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tB±d¼ zgodny z Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tB±d¼ niezupe³nie zgodny z Vi: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][nazwap]\t\tGadatliwy [poziom N] [zapisuj wiadomo¶ci do nazwap]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tTryb odpluskwiania"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tZamiast pliku wymiany, u¿ywaj tylko pamiêci"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tWylicz pliki wymiany i zakoñcz"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (z nazw± pliku)\tOdtwórz za³aman± sesjê"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tTo¿same z -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNie stosuj newcli do otwierania okien"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\tU¿ywaj <device> do I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\trozpocznij w trybie arabskim"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\trozpocznij w trybie hebrajskim"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\trozpocznij w trybie farsi"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tUstaw typ terminala na <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tU¿yj <vimrc> zamiast jakiegokolwiek .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tU¿yj <gvimrc> zamiast jakiegokolwiek .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNie ³aduj skryptów wtyczek"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tOtwórz N kart (domy¶lnie: po jednej dla ka¿dego pliku)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtwórz N okien (domy¶lnie: po jednym dla ka¿dego pliku)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\ttak samo jak -o tylko dziel okno pionowo"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tZacznij na koñcu pliku"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tZacznij w wierszu <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr ""
 "-cmd <command>\t\tWykonaj komendê <command> przed za³adowaniem "
 "jakiegokolwiek pliku vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr ""
 "-c <command>\t\tWykonaj komendê <command> po za³adowaniu pierwszego pliku"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <sesja>\t\tWczytaj plik <sesja> po za³adowaniu pierwszego pliku"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\tWczytuj komendy trybu normalnego z pliku <scriptin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr ""
 "-w <scriptout>\tDo³±cz wszystkie wprowadzane komendy do pliku <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr ""
 "-W <scriptout>\tZapisuj wszystkie wprowadzane komendy do pliku <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEdytuj zakodowane pliki"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tPod³±cz vima to danego X-serwera"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNie ³±cz z serwerem X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <pliki>\tEdytuj pliki w serwerze Vima je¶li mo¿liwe"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <pliki> To samo, nie narzekaj je¶li nie ma serwera"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <pliki>\tTak jak --remote, lecz czekaj na pliki przed edycj±"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <pliki>  To samo, nie narzekaj je¶li nie ma serwera"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <pliki>  tak jak --remote ale u¿ywa jednej "
-"karty na plik"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <klawisze>\tWy¶lij <klawisze> do serwera Vima i zakoñcz"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <wyr>\tWykonaj <wyra¿enie> w serwerze i wypisz wynik"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tWymieñ nazwy dostêpnych serwerów Vima i zakoñcz"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nazwa>\t\tOdsy³aj do/stañ siê serwerem Vim <nazwa>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <plik>\n"
 "Zapisz wiadomo¶ci o d³ugo¶ci startu do <plik>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tU¿ywaj <viminfo> zamiast .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  lub  --help\twy¶wietl Pomoc (czyli tê wiadomo¶æ) i zakoñcz"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\twy¶wietl informacjê o wersji i zakoñcz"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tZa³aduj vim na <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tZacznij Vim jako ikonê"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <kolor>\tU¿ywaj <kolor> dla t³a (równie¿: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <kolor>\tU¿ywaj <kolor> dla normalnego tekstu (równie¿: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t\tU¿ywaj <font> dla normalnego tekstu (równie¿: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\tU¿ywaj <font> dla wyt³uszczonego tekstu"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\tU¿ywaj <font> dla pochy³ego"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tU¿ywaj <geom> dla pocz±tkowych rozmiarów (równie¿: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <szer>\tU¿yj ramki o grubo¶ci <szer> (równie¿: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <szer>  U¿ywaj przewijacza o szeroko¶ci <szer> (równie¿: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <height>\tStosuj belkê menu o wysoko¶ci <height> (równie¿: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tStosuj negatyw kolorów (równie¿: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNie stosuj negatywu kolorów (równie¿: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tUstaw okre¶lony zasób"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumenty rozpoznawane przez gvim (wersja GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tZastartuj vim na <display> (równie¿: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\tUstaw unikatow± rolê do identyfikacji g³ównego okna"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtwórz Vim wewn±trz innego widgetu GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "-echo-wid\t\tGvim wypisze Window ID na wyj¶cie standardowe"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <tytu³ rodzica>\tOtwórz Vima wewn±trz rodzicielskiej aplikacji"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tOtwórz Vima wewn±trz innego elementu win32"
-
-msgid "No display"
-msgstr "Brak display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Wys³anie nie powiod³o siê.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Wys³anie nie powiod³o siê. Próbujê wykonaæ na miejscu\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "otworzono %d z %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Brak terminala: Wys³anie wyra¿enia nie powiod³o siê.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Wys³anie wyra¿enia nie powiod³o siê.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Brak zak³adek"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: ¯adna zak³adka nie pasuje do \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3289,6 +3589,7 @@ msgstr ""
 "zak³. wiersz kol plik/tekst"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3297,6 +3598,7 @@ msgstr ""
 " skok wiersz kol plik/tekst"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3304,6 +3606,7 @@ msgstr ""
 "\n"
 "zmieñ wrsz. kol tekst"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3312,6 +3615,7 @@ msgstr ""
 "# Zak³adki w plikach:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3319,6 +3623,7 @@ msgstr ""
 "\n"
 "# Lista odniesieñ (pocz±wszy od najnowszych):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3326,89 +3631,85 @@ msgstr ""
 "\n"
 "# Historia zak³adek w plikach (od najnowszych po najstarsze):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Brak '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: To nie jest wa¿na strona kodowa"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nie mogê nastawiæ warto¶ci IC"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nie mog³em stworzyæ kontekstu wprowadzeñ"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nie mog³em otworzyæ sposobu wprowadzeñ"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: OSTRZE¯ENIE: Nie mog³em zlikwidowaæ wywo³ania dla IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: metoda wprowadzeñ nie wspomaga ¿adnego stylu"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: metoda wprowadzeñ nie wspomaga mojego typu preedit"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nie by³ zablokowany"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: B³±d w trakcie czytania pliku wymiany"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: B³±d odczytu pliku wymiany"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: B³±d szukania w pliku wymiany"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: B³±d zapisu w pliku wymiany"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Plik wymiany ju¿ istnieje (atak symlink?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nie otrzyma³em bloku nr 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nie otrzyma³em bloku nr 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Nie otrzyma³em bloku nr 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: B³±d w czasie uaktualniania szyfrowania pliku wymiany"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ojej, zgubi³em plik wymiany!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nie mog³em zmieniæ nazwy pliku wymiany"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Nie mogê otworzyæ pliku wymiany dla \"%s\"; odtworzenie niemo¿liwe"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block(): Nie otrzyma³em bloku 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Nie znaleziono pliku wymiany dla %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Wprowad¼ numer pliku wymiany, którego u¿yæ (0 by wyj¶æ): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nie mogê otworzyæ %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nie mogê odczytaæ bloku 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3416,22 +3717,28 @@ msgstr ""
 "\n"
 "Mo¿e nie wykonano zmian albo Vim nie zaktualizowa³ pliku wymiany."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nie mo¿e byæ stosowany z t± wersj± Vima.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "U¿yj Vima w wersji 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s nie wygl±da na plik wymiany Vima"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nie mo¿e byæ stosowany na tym komputerze.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Ten plik zosta³ stworzony na "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3439,104 +3746,86 @@ msgstr ""
 ",\n"
 "lub plik zosta³ uszkodzony."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s jest zaszyfrowany a ta wersja Vima nie wspiera szyfrowania"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr ""
 " zosta³ uszkodzony (wielko¶æ strony jest mniejsza ni¿ najmniejsza warto¶æ).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "U¿ywam pliku wymiany \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Oryginalny plik \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: OSTRZE¯ENIE: Oryginalny plik móg³ byæ zmieniony"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Zaszyfrowany plik wymiany: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Je¶li podano nowy klucz szyfruj±cy, ale nie zapisano pliku tekstowego,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"wprowad¼ nowy klucz szyfruj±cy."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Je¶li zapisano plik tekstowy po zmianie klucza szyfruj±cego wci¶nij Enter"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"aby u¿yæ tego samego klucza dla pliku tekstowego i wymiany"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nie mogê odczytaæ bloku 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???BRAKUJE WIELU WIERSZY"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???LICZNIK WIERSZY NIEZGODNY"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PUSTY BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???BRAKUJE WIERSZY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Niew³a¶ciwe ID bloku 1 (mo¿e %s nie jest plikiem .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BRAK BLOKU"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? od tego miejsca po ???KONIEC wiersze mog± byæ pomieszane"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? od tego miejsca po ???KONIEC wiersze mog± byæ w³o¿one/skasowane"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONIEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Przerwanie odtwarzania"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Wykryto b³êdy podczas odtwarzania; od których wierszy zacz±æ ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Zobacz \":help E312\" dla dalszych informacji."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr ""
 "Odtwarzanie zakoñczono. Powiniene¶ sprawdziæ czy wszystko jest w porz±dku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3544,12 +3833,15 @@ msgstr ""
 "\n"
 "(Mo¿esz chcieæ zapisaæ ten plik pod inn± nazw±\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "i wykonaæ diff z oryginalnym plikiem aby sprawdziæ zmiany)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Odzyskiwanie zakoñczone. Zawarto¶æ bufora jest równa zawarto¶ci pliku."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3559,43 +3851,52 @@ msgstr ""
 "Mo¿esz teraz chcieæ usun±æ plik .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "U¿ywam klucza szyfruj±cego z pliku wymiany do pliku tekstowego.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Znalezione pliki wymiany:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   W bie¿±cym katalogu:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   U¿ywam podanej nazwy:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   W katalogu "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "     -- ¿aden --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "   posiadany przez: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   data: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              data: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [po Vimie wersja 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nie wygl±da na plik wymiany Vima]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "       nazwa pliku: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3603,12 +3904,15 @@ msgstr ""
 "\n"
 "         zmieniono: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "TAK"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nie"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3616,9 +3920,11 @@ msgstr ""
 "\n"
 "        u¿ytkownik: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   nazwa hosta: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3626,6 +3932,7 @@ msgstr ""
 "\n"
 "      nazwa hosta: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3633,16 +3940,11 @@ msgstr ""
 "\n"
 "        ID procesu: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (dalej dzia³a)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nie nadaje siê dla tej wersji Vima]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3650,75 +3952,97 @@ msgstr ""
 "\n"
 "     [nie do u¿ytku na tym komputerze]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "        [nieodczytywalny]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "            [nieotwieralny]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nie mogê zabezpieczyæ, bo brak pliku wymiany"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Plik zabezpieczono"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Nieudane zabezpieczenie"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: niew³a¶ciwy lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nie znaleziono wiersza %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: niepoprawne id wska¼nika bloku 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx powinien byæ 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Zaktualizowano zbyt wiele bloków?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: niepoprawne id wska¼nika bloku 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "blok nr 1 skasowany?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nie mogê znale¼æ wiersza %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: niepoprawne id bloku odniesienia"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count wynosi zero"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: numer wiersza poza zakresem: %<PRId64> jest poza koñcem"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: liczba wierszy niepoprawna w bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Wielko¶æ stosu wzrasta"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: niepoprawne id bloku odniesienia 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Pêtla dowi±zañ dla \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: UWAGA"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3726,34 +4050,40 @@ msgstr ""
 "\n"
 "Znalaz³em plik wymiany o nazwie \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Podczas otwierania pliku \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOWSZE od pliku wymiany!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
 "    be careful not to end up with two different instances of the same\n"
-"    file when making changes.\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Pewnie inny program obrabia ten sam plik.\n"
 "    Je¶li tak, b±d¼ ostro¿ny, aby nie skoñczyæ z dwoma\n"
 "    ró¿nymi wersjami tego samego pliku po zmianach.\n"
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Zakoñcz lub ostro¿nie kontynuuj.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Sesja edycji dla pliku za³ama³a siê.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Je¶li tak, to u¿yj \":recover\" lub \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3761,9 +4091,11 @@ msgstr ""
 "\"\n"
 "    aby odzyskaæ zmiany (zobacz \":help recovery)\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Je¶li ju¿ to zrobi³e¶, usuñ plik wymiany \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3771,18 +4103,23 @@ msgstr ""
 "\"\n"
 "    aby unikn±æ tej wiadomo¶ci.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Plik wymiany \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ju¿ istnieje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - UWAGA"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Plik wymiany ju¿ istnieje!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3796,6 +4133,7 @@ msgstr ""
 "&Zakoñcz\n"
 "&Porzuæ"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3811,34 +4149,56 @@ msgstr ""
 "&Zakoñcz\n"
 "&Porzuæ"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Znaleziono zbyt wiele plików wymiany"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Brak pamiêci!  (rezerwacja %<PRIu64> bajtów)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Czê¶æ tropu punktu menu nie okre¶la podmenu"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menu istnieje tylko w innym trybie"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Nie ma menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Pusta nazwa menu"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Trop menu nie mo¿e prowadziæ do podmenu"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Nie wolno dodawaæ punktów menu wprost do paska menu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Separator nie mo¿e byæ czê¶ci± tropu menu"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3846,60 +4206,73 @@ msgstr ""
 "\n"
 "--- Menu ---"
 
-msgid "Tear off this menu"
-msgstr "Oderwij to menu"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Trop menu musi prowadziæ do punktu menu"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Nie znaleziono menu: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menu nie jest zdefiniowane dla trybu %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Trop menu musi prowadziæ do podmenu"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Nie znaleziono menu - sprawd¼ nazwy menu"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Wykryto b³±d podczas przetwarzania %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "wiersz %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Niew³a¶ciwa nazwa rejestru: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Opiekun komunikatów: Miko³aj Machowski <mikmach@wp.pl>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Przerwanie: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Naci¶nij ENTER lub wprowad¼ komendê aby kontynuowaæ"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s wiersz %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Wiêcej --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: ekran/strona/wiersz w dó³, b/u/k: do góry, q: zakoñcz"
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Pytanie"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3907,6 +4280,17 @@ msgstr ""
 "&Tak\n"
 "&Nie"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Tak\n"
+"&Nie\n"
+"&Zakoñcz"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3920,271 +4304,174 @@ msgstr ""
 "&Odrzuæ wszystkie\n"
 "&Zakoñcz"
 
-msgid "Select Directory dialog"
-msgstr "Dialog wyboru katalogu"
-
-msgid "Save File dialog"
-msgstr "Dialog zapisywania pliku"
-
-msgid "Open File dialog"
-msgstr "Dialog otwierania pliku"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Przykro mi, nie ma przegl±darki plików w trybie konsoli"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Za ma³o argumentów dla printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Spodziewany argument Zmiennoprzecinkowy w printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Za du¿o argumentów dla printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: OSTRZE¯ENIE: Zmiany w pliku tylko do odczytu"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Wpisz numer i <Enter> lub wybierz mysz± (pusta warto¶æ anuluje): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Wpisz numer i <Enter> (puste anuluje): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 wiersz wiêcej"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 wiersz mniej"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "dodano %<PRId64> wierszy"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "usuniêto %<PRId64> wierszy"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Przerwane)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Biiip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachowujê plik...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Zakoñczono.\n"
-
-msgid "ERROR: "
-msgstr "B£¡D: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w u¿ytku %<PRIu64>, maksymalne "
-"u¿ycie %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[wywo³ania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Wiersz staje siê zbyt d³ugi"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Wewnêtrzny b³±d: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Brak pamiêci!  (rezerwacja %<PRIu64> bajtów)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Wywo³ujê pow³okê do wykonania: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Brak dwukropka"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Niedozwolony tryb"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Niedozwolony obrys myszki"
-
-msgid "E548: digit expected"
-msgstr "E548: oczekiwa³em na cyfrê"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Niedozwolony procent"
-
-msgid "Enter encryption key: "
-msgstr "Wprowad¼ klucz do odkodowania: "
-
-msgid "Enter same key again: "
-msgstr "Wprowad¼ ponownie ten sam klucz: "
-
-msgid "Keys don't match!"
-msgstr "Klucze nie pasuj± do siebie!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: ¶cie¿ka za d³uga by uzupe³niæ"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Niew³a¶ciwy trop: '**[numer]' musi byæ na koñcu tropu lub po nim musi "
-"byæ '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Nie mogê znale¼æ katalogu \"%s\" w cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Nie mogê znale¼æ pliku \"%s\" w tropie"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Katalogu \"%s\" nie ma wiêcej w cdpath"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Pliku \"%s\" nie ma wiêcej w tropie"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Nie mo¿na po³±czyæ z Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Nie mo¿na po³±czyæ z Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: B³êdny tryb dostêpu pliku info po³±czenia NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "odczyt z gniazda Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Bufor %<PRId64> utraci³ po³±czenie z NetBeans"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans nie s± obs³ugiwane przez to GUI"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans ju¿ pod³±czone"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s jest tylko do odczytu (dodaj ! aby wymusiæ)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Brak identyfikatora pod kursorem"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' jest pusta"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Funkcjonalno¶æ eval nie jest dostêpna"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "OSTRZE¯ENIE: terminal nie wykonuje pod¶wietlania"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Brak ci±gu pod kursorem"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Nie mogê skasowaæ zwiniêcia z bie¿±c± 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: lista zmian (changelist) jest pusta"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Na pocz±tku listy zmian"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "wprowad¼  :quit<Enter>    zakoñczenie programu"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 wiersz %sed 1 raz"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 wiersz %sed %d razy"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> wierszy %sed 1 raz"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> wierszy %sed %d razy"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> wierszy do wciêcia... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 wiersz wciêty "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> wierszy wciêtych "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Brak poprzednio u¿ytego rejestru"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nie mogê skopiowaæ, mimo to kasujê"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 wiersz zmieniono"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> wierszy zmieniono"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "zwalniam %<PRId64> wierszy"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "skopiowano blok 1 wiersza"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 wiersz skopiowano"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "%<PRId64> wierszy skopiowanych"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> wierszy skopiowanych"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Pusty rejestr %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4192,9 +4479,11 @@ msgstr ""
 "\n"
 "--- Rejestry ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Niedozwolona nazwa rejestru"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4202,162 +4491,181 @@ msgstr ""
 "\n"
 "# Rejestry:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Nieznany typ rejestru %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Kolumn; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Bajtów"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> "
-"Bajtów"
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; "
+"%<PRId64> z %<PRId64> Bajtów"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z "
-"%<PRId64>"
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; "
+"%<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> Bajtów"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Bajt "
+"%<PRId64> z %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Znak "
+"%<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> dla BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strona %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Dziêki za lot Vimem"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Nieznana opcja"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opcja nie jest wspomagana"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Niedozwolone w modeline"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Kod klucza nie jest ustawiony"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Po = wymagany jest numer"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nie znaleziono w termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Niedozwolony znak <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Nie mogê ustawiæ 'term' na pusty ci±g"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Nie mogê zmieniæ term w GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: U¿yj \":gui\" do odpalenia GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' i 'patchmode' s± to¿same"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Konflikty warto¶ci 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Konflikty warto¶ci 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Nie mogê zmieniæ w GTK+2 GUI"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Brak dwukropka"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Ci±g o zerowej d³ugo¶ci"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Brak numeru po <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Brak przecinka"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Musi okre¶laæ warto¶æ '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: zawiera niewy¶wietlalny lub szeroki znak"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Niedozwolona czcionka/ki"
-
-msgid "E597: can't select fontset"
-msgstr "E597: nie mogê wybraæ zestawu czcionek"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Niedozwolony zestaw czcionek"
-
-msgid "E533: can't select wide font"
-msgstr "E533: nie mogê wybraæ szerokiej czcionki"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Niedozwolona szeroka czcionka"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Niedozwolony znak po <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: wymagany przecinek"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' musi byæ pusty lub zawieraæ %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Brak wspomagania myszki"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Niedomkniêty ci±g wyra¿eñ"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: zbyt wiele elementów"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: niezbalansowane grupy"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: okno podgl±du ju¿ istnieje"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabski wymaga UTF-8, zrób ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Potrzebujê przynajmniej %d wierszy"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Potrzebujê przynajmniej %d kolumn"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Nieznana opcja: %s"
@@ -4365,10 +4673,12 @@ msgstr "E355: Nieznana opcja: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Wymagana Liczba: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4376,6 +4686,7 @@ msgstr ""
 "\n"
 "--- Kody terminala ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4383,6 +4694,7 @@ msgstr ""
 "\n"
 "--- Globalne warto¶ci opcji ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4390,6 +4702,7 @@ msgstr ""
 "\n"
 "--- Lokalne warto¶ci opcji ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4397,141 +4710,21 @@ msgstr ""
 "\n"
 "--- Opcje ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: B£¡D get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Brak pasuj±cego znaku dla %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Dodatkowe znaki po ¶redniku: %s"
 
-msgid "cannot open "
-msgstr "nie mogê otworzyæ "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nie mogê otworzyæ okna!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Potrzebujê Amigados w wersji 2.04 lub pó¼niejsz±\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Potrzebujê %s w wersji %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nie mogê otworzyæ NIL:\n"
-
-msgid "Cannot create "
-msgstr "Nie mogê stworzyæ "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim koñczy pracê z %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "nie mogê zmieniæ trybu konsoli ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: nie jest konsol±??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nie mogê wykonaæ pow³oki z opcj± -f"
-
-msgid "Cannot execute "
-msgstr "Nie mogê wykonaæ "
-
-msgid "shell "
-msgstr "pow³oka "
-
-msgid " returned\n"
-msgstr " zwróci³\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE zbyt niskie."
-
-msgid "I/O ERROR"
-msgstr "B£¡D I/O"
-
-msgid "Message"
-msgstr "Wiadomo¶æ"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' nie wynosi 80, nie mogê wykonaæ zewnêtrznych komend"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Wybór drukarki nie powiód³ siê"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "do %s z %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Nieznana czcionka drukarki: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: B³±d drukarki: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Wydrukowano '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr ""
-"E244: Niedozwolona nazwa zestawu znaków \"%s\" w nazwie czcionki \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Niedozwolony znak '%c' w nazwie czcionki \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Podwójny sygna³, wychodzê\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Za³apa³ ¶miertelny sygna³ %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Za³apa³ ¶miertelny sygna³\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Otwieranie ekranu X trwa³o %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Dosta³ b³±d X\n"
-
-msgid "Testing the X display failed"
-msgstr "Test ekranu X nie powiód³ siê"
-
-msgid "Opening the X display timed out"
-msgstr "Próba otwarcia ekranu X trwa³a zbyt d³ugo"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Nie mogê uzyskaæ kontekstu bezpieczeñstwa dla"
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Nie mo¿na uzyskaæ kontekstu bezpieczeñstwa dla"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4539,13 +4732,7 @@ msgstr ""
 "\n"
 "Nie mogê wykonaæ pow³oki "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nie mogê wykonaæ pow³oki sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4553,437 +4740,476 @@ msgstr ""
 "\n"
 "pow³oka zwróci³a "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Nie mogê stworzyæ potoków\n"
+"Nie mogê uzyskaæ kontekstu bezpieczeñstwa dla"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Nie mogê rozdzieliæ siê\n"
+"Nie mo¿na uzyskaæ kontekstu bezpieczeñstwa dla"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Komenda zakoñczona\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP straci³ po³±czenie ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Otwarcie ekranu X nie powiod³o siê"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP obs³uguje ¿±danie samozapisu"
-
-msgid "XSMP opening connection"
-msgstr "XSMP otwiera po³±czenie"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Obserwacja po³±czenia XSMP ICE nie powiod³a siê"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection nie powiod³o siê: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Nie mogê znale¼æ pliku \"%s\" w tropie"
 
-msgid "At line"
-msgstr "W wierszu"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nie mogê za³adowaæ vim32.dll!"
-
-msgid "VIM Error"
-msgstr "B³±d VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nie zdo³a³em poprawiæ wska¼ników funkcji w DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "pow³oka zwróci³a %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Za³apa³ wydarzenie %s\n"
-
-msgid "close"
-msgstr "zamknij"
-
-msgid "logoff"
-msgstr "wyloguj"
-
-msgid "shutdown"
-msgstr "zakoñcz"
-
-msgid "E371: Command not found"
-msgstr "E371: Nie znaleziono komendy"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE nie znaleziono w twoim $PATH.\n"
-"Zewnêtrzne komendy nie bêd± wstrzymane po wykonaniu.\n"
-"Zobacz  :help wim32-vimrun  aby otrzymaæ wiêcej informacji."
-
-msgid "Vim Warning"
-msgstr "Vim Ostrze¿enie"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Zbyt wiele %%%c w ci±gu formatuj±cym"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Nieoczekiwane %%%c w ci±gu formatuj±cym"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Brak ] w ci±gu formatuj±cym"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Niewspomagane %%%c w ci±gu formatuj±cym"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Niepoprawne %%%c w prefiksie ci±gu formatuj±cego"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Niepoprawne %%%c w ci±gu formatuj±cym"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' nie zawiera wzorca"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Pusta nazwa katalogu lub jej brak"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Nie ma wiêcej elementów"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d z %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (wiersz skasowany)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Na dole stosu quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Na górze stosu quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "lista b³êdów %d z %d; %d b³êdów"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nie mogê zapisaæ, opcja 'buftype' jest ustawiona"
 
-msgid "Error file"
-msgstr "Plik b³êdu"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Brak nazwy pliku lub niew³a¶ciwa ¶cie¿ka"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Nie mogê otworzyæ pliku \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Bufor nie jest za³adowany"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Oczekiwa³em na ³añcuch lub listê"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Niew³a¶ciwy element w %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Brak ] po %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Niesparowany %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Niesparowany %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Niesparowany %s)"
 
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( jest niedozwolone w tym miejscu"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 i podobne s± niedozwolone w tym miejscu"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Brak ] po %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: Pusty %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Zbyt d³ugi wzorzec"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Zbyt wiele \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Zbyt wiele %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Niesparowany \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: niedozwolony znak po %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Zbyt wiele z³o¿onych %s{...}"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Zagnie¿d¿one %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Zagnie¿d¿one %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Niedozwolone u¿ycie \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c po niczym"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Niew³a¶ciwe odwo³anie wsteczne"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: niedopuszczalny znak po \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Niedozwolony znak po %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Niedozwolony znak po %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: B³±d sk³adni w %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Zewnêtrzne poddopasowania:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
-msgstr "E:864: \\%#= mo¿e byæ tylko przed 0, 1 lub 2. Zostanie u¿yty silnik automatyczny"
+msgstr ""
+"E:864: \\%#= mo¿e byæ tylko przed 0, 1 lub 2. Zostanie u¿yty silnik "
+"automatyczny"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) przedwczesny koniec wyra¿enia regularnego"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (wyra¿enie regularne NFA) Niepoprawnie umieszczone %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) przedwczesny koniec wyra¿enia regularnego"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Nieznany operator '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) Nieznany operator '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: B³±d przy budowwaniu NFA z klas± ekwiwalencji"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Nieznany operator '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
-msgstr "E870: (wyra¿enie regularne NFA) B³±d przy odczytywaniu limitów powtórzeñ"
+msgstr ""
+"E870: (wyra¿enie regularne NFA) B³±d przy odczytywaniu limitów powtórzeñ"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
-msgstr "E871: (wyra¿enie regularne NFA) wielokrotne nie mo¿e byæ po wielokrotnym!"
+msgstr ""
+"E871: (wyra¿enie regularne NFA) wielokrotne nie mo¿e byæ po wielokrotnym!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (wyra¿enie regularne NFA) Zbyt du¿o '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (wyra¿enie regularne NFA) Za du¿o \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (wyra¿enie regularne NFA) b³±d poprawnego zakoñczenia"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Nie mo¿na zdj±æ elementu ze stosu!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
-msgstr "E875: (wyra¿enie regularne NFA) (w trakcie konwersji postfix do NFA), za wiele stanów na stosie"
+msgstr ""
+"E875: (wyra¿enie regularne NFA) (w trakcie konwersji postfix do NFA), za "
+"wiele stanów na stosie"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (wyra¿enie regularne NFA) Nie ma miejsca na ca³e NFA "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Nie mo¿na przydzieliæ pamiêci do przej¶cia przez ga³êzie!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
-msgstr "Nie mo¿na otworzyæ do zapisu tymczasowego pliku, pokazujê na stderr... "
+msgstr ""
+"Nie mo¿na otworzyæ do zapisu tymczasowego pliku, pokazujê na stderr... "
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) NIE MO¯NA OTWORZYÆ %s !"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Nie mo¿na otworzyæ do zapisu tymczasowego pliku logowania"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-ZAMIANA"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ZAMIANA"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " NEGATYW"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " WPROWADZANIE"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (wprowadzanie)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (zamiana)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-zamiana)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrajski"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabski"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (jêzyk)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (wklejanie)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " WIZUALNY"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " WIZUALNY LINIOWY"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " WIZUALNY BLOKOWY"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ZAZNACZANIE"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ZAZNACZANIE LINIOWE"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ZAZNACZANIE BLOKOWE"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "zapis"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Niew³a¶ciwy ci±g do szukania: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: szukanie dobi³o GÓRY bez znalezienia: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: szukanie dobi³o KOÑCA bez znalezienia : %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Oczekujê '?' lub '/' po ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (zawiera poprzednio wymienione dopasowanie)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Zawarte pliki "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "nie znaleziono"
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "w tropie ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Ju¿ wymienione)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NIE ZNALEZIONO"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Przegl±d w³±czonego pliku: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Przeszukiwanie w³±czonego pliku %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Wzorzec pasuje w bie¿±cym wierszu"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Wszelkie w³±czane pliki odnaleziono"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Brak w³±czanych plików"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nie znalaz³em definicji"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nie znalaz³em wzorca"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Podstawienie "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4994,86 +5220,98 @@ msgstr ""
 "# Ostatni %sWyszukiwany wzorzec:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Nieprawid³owy format pliku sprawdzania pisowni"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Obciêty plik sprawdzania pisowni"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Zbêdny tekst w %s wiersz %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Za d³uga nazwa afiksu w %s wiersz %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: B³±d formatu w pliku afiksów FOL, LOW lub UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Znak w FOL, LOW lub UPP jest poza zasiêgiem"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Kompresja drzewa s³ów..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Sprawdzanie pisowni nie jest w³±czone"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Ostrze¿enie: Nie mogê znale¼æ listy s³ów \"%s_%s.spl\" lub \"%s_ascii.spl\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Ostrze¿enie: Nie mogê znale¼æ listy s³ów \"%s.%s.spl\" lub \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Odczytujê plik sprawdzania pisowni \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: To nie wygl±da na plik sprawdzania pisowni"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Stary plik sprawdzania pisowni, wymagane uaktualnienie"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Plik sprawdzania pisowni dla nowszej wersji Vima"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Niewspierana sekcja w pliku sprawdzania pisowni"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Ostrze¿enie: region %s nie jest wspierany"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Czytam plik afiksów %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konwersja nie powiod³a siê dla wyrazu w %s wierszu %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konwersja w %s nie jest wspierana: od %s do %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konwersja w %s nie jest wspierana"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Nieprawid³owa warto¶æ FLAG w %s wierz %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG po u¿yciu flag w %s wiersz %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5082,6 +5320,7 @@ msgstr ""
 "Definiowanie COMPOUNDFORBIDFLAG po PFX mo¿e skutkowaæ z³ym wynikiem w %s "
 "wiersz %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5090,34 +5329,42 @@ msgstr ""
 "Definiowanie COMPOUNDPERMITFLAG po PFX mo¿e skutkowaæ z³ym wynikiem w %s "
 "wiersz %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Z³a warto¶æ COMPOUNDRULES w %s wiersz %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Z³a warto¶æ COMPOUNDWORDMAX w %s wiersz %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Z³a warto¶æ COMPOUNDMIM w %s wiersz %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Z³a warto¶æ COMPOUNDSYLMAX w %s wiersz %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Z³a warto¶æ CHECKCOMPOUNDPATTERN w %s wiersz %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "Ró¿ne flagi z³o¿eñ w kontynuowanym bloku afiksu w %s wiersz %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Powtórzony afiks w %s wiersz %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5126,273 +5373,337 @@ msgstr ""
 "Afiks u¿yty tak¿e dla BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST w "
 "%s wiersz %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Oczekiwano Y lub N w %s wierszu %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "B³êdny warunek w %s wiersz %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Oczekiwano ilo¶ci REP(SAL) w %s wierszu %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Oczekiwano ilo¶ci MAP w %s wierszu %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Powtórzony znak w MAP w %s wierszu %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Nieznany lub powtórzony element w %s wierszu %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Brak wiersza FOL/LOW/UPP w %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX u¿yty bez SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Zbyt wiele opó¼nionych prefiksów"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Zbyt wiele flag z³o¿eñ"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Zbyt wiele opó¼nionych prefiksów i/lub flag z³o¿eñ"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Brak wiersza SOFO%s wiersz w %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Wiersze SAL i SOFO w %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flaga nie jest liczb± w %s wiersz %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Nieprawid³owa flaga w %s wiersz %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Warto¶æ %s ró¿ni siê od tej u¿ytej w innym pliku .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Czytam plik s³ownika %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Brak ilo¶ci s³ów w %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "wiersz %6d, s³owo %6d - %s"
 
 # c-format
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Powtórzony wyraz w %s wierszu %d: %s"
 
 # c-format
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Pierwszy powtórzony wyraz w %s wiersz %d: %s"
 
 # c-format
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d powtórzony(ch) wyraz(ów) w %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Zignorowa³em %d s³ów ze znakami nie ASCII w %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Odczytujê plik wyrazów %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Zignorowano powtórzony wiersz /encoding= w %s wierszu %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Zignorowano wiersz /encoding= po wyrazie w %s wierszu %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Powtórzony wiersz /regions= zignorowano w %s wierszu %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Za du¿o regionów w %s wiersz %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "wiersz / zignorowano w %s wierszu %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Nieprawid³owy numer regionu w %s wierszu %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nieznane flagi w %s wiersz %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Zignorowa³em %d s³ów ze znakami nie ASCII"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Nie wystarczaj±ca ilo¶æ pamiêci, lista s³ów bêdzie niekompletna"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Skompresowano %d z %d wêz³ów; pozostaje %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Odczytujê plik sprawdzania pisowni..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Wykonujê kompresjê d¼wiêkow±..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Liczba s³ów po kompresji d¼wiêkowej: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Ca³kowita liczba s³ów: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Zapisujê plik sugestii %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Oczekiwane zu¿ycie pamiêci: %d bajtów"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Nazwa pliku wynikowego nie mo¿e byæ nazw± regionu"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Wspieram tylko 8 regionów"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Nieprawid³owy region w %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Ostrze¿enie: okre¶lono zarówno z³o¿enia jak i NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Zapisujê plik sprawdzania pisowni %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Zrobione!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' nie posiada wpisów %<PRId64>"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Usuniêto s³owo z %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Dodano s³owo do %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaki wyrazów ró¿ni± siê miêdzy plikami sprawdzania pisowni"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Przykro mi, brak podpowiedzi"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Przykro mi, tylko %<PRId64> podpowiedzi"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Zmieñ \"%.*s\" na:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Brak poprzednich podmian sprawdzania pisowni"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Nie znaleziono: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Ten plik nie wygl±da na plik .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Stary plik .sug, konieczne jest uaktualnienie: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Plik .sug dla nowszej wersji Vima: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Plik .sug nie pasuje do pliku .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: B³±d w czasie odczytu pliku .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Podwojony znak we wpisie MAP"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Brak elementów sk³adni okre¶lonych dla tego bufora"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Niedozwolony argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Nie ma takiego klastra sk³adni: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizacja komentarzy w stylu C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "brak synchronizacji"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "pocz±tek synchronizacji"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " wierszy przed górn± lini±"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5400,6 +5711,7 @@ msgstr ""
 "\n"
 "--- Elementy synchronizacji sk³adni ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5407,6 +5719,7 @@ msgstr ""
 "\n"
 "synchronizujê na elementach"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5414,212 +5727,272 @@ msgstr ""
 "\n"
 "--- Elementy sk³adni ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Nie ma takiego klastra sk³adni: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimalnie "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maksymalnie "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; pasuje "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr "znaków nowego wiersza"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: argument contains niedozwolony w tym miejscu"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Niew³a¶ciwa warto¶æ cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here niedozwolone w tym miejscu"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Nie znalaz³em elementów regionu dla %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Wymagana nazwa pliku"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Za du¿o w³±czonych sk³adni"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Brak ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Brak '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Za ma³o argumentów: syntax region %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Za du¿o klastrów sk³adni"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Brak specyfikacji klastra"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Brak ogranicznika wzorca: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: ¦mieci po wzorcu: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: wielokrotnie podane wzorce kontynuacji wiersza"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Niedozwolone argumenty: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Brak znaku równo¶ci: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Pusty argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s jest niedozwolone w tym miejscu"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musi byæ pierwsze w li¶cie contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nieznana nazwa grupy: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Niew³a¶ciwa podkomenda :syntax : %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  WSZYTKO    ILO¦Æ  PASUJE  NAJWOLN.    ¦REDNIO   NAZWA              WZORZEC"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursywna pêtla wczytuj±ca syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: nie znaleziono grupy pod¶wietlania: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Zbyt ma³o argumentów: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Zbyt wiele argumentów: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: grupa ma ustawienia; zignorowane pod³±czenie pod¶wietlania"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: nieoczekiwany znak równo¶ci: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: brak znaku równo¶ci: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: brak argumentu: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Niedozwolona warto¶æ: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Kolor FG nieznany"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Kolor BG nieznany"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nazwa lub liczba koloru nierozpoznana: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: za d³ugi kod terminala: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Niedozwolony argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Zbyt wiele ró¿nych atrybutów podkre¶lania w u¿yciu"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Niedrukowalny znak w nazwie grupy"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: nieprawid³owy znak w nazwie grupy"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Za du¿o grup pod¶wietlania i sk³adni"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: na dole stosu znaczników"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: na górze stosu znaczników"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Nie mo¿na przej¶æ przed pierwszy pasuj±cy znacznik"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: nie znaleziono znacznika: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri rodzaj znacznik"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "plik\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Pasuje tylko jeden znacznik"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Nie mo¿na przej¶æ za ostatni pasuj±cy znacznik"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Plik \"%s\" nie istnieje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "znacznik %d z %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " lub wiêcej"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  U¿ywam znacznika o odmiennej wielko¶ci liter!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Plik \"%s\" nie istnieje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5627,66 +6000,79 @@ msgstr ""
 "\n"
 "  # DO znacznik  OD wiersza      w pliku/tek¶cie"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Szukam w pliku znaczników %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Trop szukania pliku znaczników obciêty dla %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ignorujê d³ugie wiersze w pliku znaczników"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: B³±d formatu w pliku znaczników \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Przed bajtem %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Plik znaczników nieuporz±dkowany: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Brak pliku znaczników"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nie mogê znale¼æ wzorca znacznika"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Nie znalaz³em znacznika - tylko zgadujê!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Powtórzona nazwa pola: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' nieznany. Mo¿liwe typy wbudowanych terminali:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "domy¶lnie jest '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Nie mogê otworzyæ pliku termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Nie ma opisu takiego terminala w terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Nie ma opisu takiego terminala w termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Brak opisu \"%s\" w termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: wymagana zdolno¶æ \"cm\" terminala"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5694,244 +6080,169 @@ msgstr ""
 "\n"
 "--- Klawisze terminala ---"
 
-msgid "new shell started\n"
-msgstr "uruchomiono now± pow³okê\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: B³±d podczas wczytywania wej¶cia, koñczê...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "U¿ywam CUT_BUFFER0 zamiast pustego wyboru"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Niespodziewana zmiana ilo¶ci linii"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Cofniêcie niemo¿liwe; mimo to kontynuujê"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Nie mogê otworzyæ do zapisu pliku undo: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Uszkodzony plik undo (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Nie mo¿na zapisaæ pliku undo w ¿adnym katalogu z 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Nie nadpiszê plikiem undo, nie mogê odczytaæ: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Nie nadpiszê, to nie jest plik undo: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Pomijam zapis pliku undo, nic do cofniêcia"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Zapisujê plik undo: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: B³±d zapisu w pliku undo: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Nie wczytujê pliku undo, inny w³a¶ciciel: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Wczytujê plik undo: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Nie mogê otworzyæ pliku undo do odczytu: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: To nie jest plik undo: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Nie zaszyfrowany plik ma zaszyfrowany plik undo: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Nie powiod³o siê odszyfrowywanie pliku undo: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Plik undo jest zaszyfrowany: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Niekompatybilny plik undo: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Zawarto¶æ pliku siê zmieni³a, nie mogê u¿yæ pliku undo"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Skoñczono wczytywanie pliku undo %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Ju¿ w miejscu ostatniej zmiany"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Ju¿ w miejscu najnowszej zmiany"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Nie znaleziono numeru cofniêcia %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: niew³a¶ciwe numery wierszy"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "1 wiersz wiêcej"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "wiêcej wierszy"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "1 wiersz mniej"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "mniej wierszy"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "1 zmiana"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "zmiany"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "przed"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "za"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nie ma zmian do cofniêcia"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "liczba zmiany   kiedy              zapisano"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekund temu"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin nie jest dozwolone po undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: uszkodzona lista cofania"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: brak wiersza cofania"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32-bit wersja GUI dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"64 bitowa wersja GUI dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitowa wersja GUI dla MS-Windows"
-
-msgid " in Win32s mode"
-msgstr " w trybie Win32s"
-
-msgid " with OLE support"
-msgstr " ze wspomaganiem OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"32 bitowa wersja na konsolê dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitowa wersja na konsolê dla MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitowa wersja dla MS-Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitowa wersja dla MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitowa wersja dla MS-DOS"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"wersja dla MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"wersja dla MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"wersja dla MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"wersja dla OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5939,6 +6250,7 @@ msgstr ""
 "\n"
 "Zadane ³aty: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5946,9 +6258,11 @@ msgstr ""
 "\n"
 "Ekstra ³aty: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Zmieniony przez "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5956,9 +6270,11 @@ msgstr ""
 "\n"
 "Skompilowany "
 
+#: ../version.c:649
 msgid "by "
 msgstr "przez "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5966,854 +6282,1902 @@ msgstr ""
 "\n"
 "Olbrzymia wersja "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Du¿a wersja "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normalna wersja "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Ma³a wersja "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Malutka wersja "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "z GTK2-GNOME GUI."
-
-msgid "with GTK2 GUI."
-msgstr "z GTK2 GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "z X11-Motif GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "z X11-neXtaw GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "z X11-Athena GUI."
-
-msgid "with Photon GUI."
-msgstr "z Photon GUI."
-
-msgid "with GUI."
-msgstr "z GUI."
-
-msgid "with Carbon GUI."
-msgstr "z Carbon GUI."
-
-msgid "with Cocoa GUI."
-msgstr "z Cocoa GUI."
-
-msgid "with (classic) GUI."
-msgstr "z (klasycznym) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Opcje w³±czone (+) lub nie (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "       vimrc systemu: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "   vimrc u¿ytkownika: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2-gi plik vimrc u¿ytkownika: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3-ci plik vimrc u¿ytkownika: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "    exrc u¿ytkownika: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2-gi plik exrc u¿ytkownika: \""
 
-msgid "  system gvimrc file: \""
-msgstr "     gvimrc systemu: \""
-
-msgid "    user gvimrc file: \""
-msgstr "  gvimrc u¿ytkownika: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2-gi plik gvimrc u¿ytkownika: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3-ci plik gvimrc u¿ytkownika: \""
-
-msgid "    system menu file: \""
-msgstr " systemowy plik menu: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "   odwet dla $VIM-a: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "f-b dla $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilacja: "
 
-msgid "Compiler: "
-msgstr "Kompilator: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Konsolidacja: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  KOMPILACJA DEBUG"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi rozbudowany"
 
+#: ../version.c:769
 msgid "version "
 msgstr "wersja "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Autor: Bram Moolenaar i Inni."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim jest open source i rozprowadzany darmowo"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomó¿ biednym dzieciom w Ugandzie!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "wprowad¼ :help iccf<Enter>        dla informacji o tym  "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "wprowad¼ :q<Enter>                zakoñczenie programu   "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "wprowad¼ :help<Enter>  lub  <F1>  pomoc na bie¿±co       "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "wprowad¼ :help version7<Enter>    dla informacji o wersji"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Dzia³am w trybie zgodno¶ci z Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "wprowad¼ :set nocp<Enter>         warto¶ci domy¶lne Vim-a"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "wprowad¼ :help cp-default<Enter>  dla informacji to tym  "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "menu Pomoc->Sieroty        dla informacji to tym  "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Uruchomiony bez trybów, wpisany tekst jest wprowadzany"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "menu  Edytuj->Ustawienia globalne->Tryb wstawiania"
-
-msgid "                              for two modes      "
-msgstr "                  dla dwóch trybów           "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "menu Edytuj->Ustawienia globalne->Kompatybilno¶æ z Vi"
-
-msgid "                              for Vim defaults   "
-msgstr "     dla domy¶lnych ustawieñ Vima   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Sponsoruj rozwój Vima!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Zostañ zarejestrowanym u¿ytkownikiem Vima!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "wprowad¼ :help sponsor<Enter>        dla informacji"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "wprowad¼ :help register<Enter>        dla informacji"
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu Pomoc->Sponsoruj/Zarejestruj siê dla informacji"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "OSTRZE¯ENIE: wykryto Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "wprowad¼ :help windows95<Enter>   dla informacji to tym  "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Ju¿ jest tylko jeden widok"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Nie ma okna podgl±du"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Nie mogê rozdzieliæ lewo-górnego i prawo-dolnego jednocze¶nie"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Nie mogê przekrêciæ, gdy inne okno jest rozdzielone"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Nie mogê zamkn±æ ostatniego okna"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Nie mo¿na zamkn±æ okna autocmd"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Nie mo¿na zamkn±æ okna, zosta³oby tylko okno autocmd"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Inne okno zawiera zmiany"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Brak nazwy pliku pod kursorem"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Nie mogê znale¼æ pliku \"%s\" w tropie"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() wywo³any z pustym has³em"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Nie mog³em za³adowaæ biblioteki %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Przykro mi, ta komenda jest wy³±czona: nie mog³em za³adowaæ biblioteki Perla."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Blowfish u¿ywa b³êdnej kolejno¶ci bajtów"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: wyliczenie Perla zabronione w piaskownicy bez modu³u Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: test sha256 nie powiód³ siê"
 
-msgid "Edit with &multiple Vims"
-msgstr "Edytuj w &wielu Vimach"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: test Blowfisha nie powiód³ siê"
 
-msgid "Edit with single &Vim"
-msgstr "Edytuj w pojedynczym &Vimie"
+#~ msgid "Patch file"
+#~ msgstr "Plik ³ata"
 
-msgid "Diff with Vim"
-msgstr "Diff z Vimem"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zakoñcz"
 
-msgid "Edit with &Vim"
-msgstr "Edytuj w &Vimie"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Brak po³±czenia z serwerem Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Edytuj z istniej±cym Vimem - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nie mogê wys³aæ do %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Edytuj wybrane pliki w Vimie"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nie mogê czytaæ odpowiedzi serwera"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "B³±d tworzenia procesu: Sprawd¼ czy gvim jest w twojej ¶cie¿ce!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Nie mogê wys³aæ do klienta"
 
-msgid "gvimext.dll error"
-msgstr "b³±d gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Zapisz jako"
 
-msgid "Path length too long!"
-msgstr "Za d³uga ¶cie¿ka!"
+#~ msgid "Source Vim script"
+#~ msgstr "Wczytaj skrypt Vima"
 
-msgid "--No lines in buffer--"
-msgstr "--Brak wierszy w buforze--"
+#~ msgid "Edit File"
+#~ msgstr "Edytuj Plik"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Przerwanie komendy"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NIE ZNALEZIONO)"
 
-msgid "E471: Argument required"
-msgstr "E471: wymagany argument"
+#~ msgid "unknown"
+#~ msgstr "nieznany"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ powinno byæ /, ? lub &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Edytuj plik w nowym oknie"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Niedozwolone w oknie wiersza poleceñ; <CR> wykonuje, CTRL-C opuszcza"
+#~ msgid "Append File"
+#~ msgstr "Do³±cz plik"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Komenda niedozwolona z exrc/vimrc w bie¿±cym szukaniu katalogu lub "
-"znacznika"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Pozycja okna: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Brak :endif"
+#~ msgid "Save Redirection"
+#~ msgstr "Zapisz przekierowanie"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Brak :endtry"
+#~ msgid "Save View"
+#~ msgstr "Zapisz widok"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Brak :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Zapisz sesjê"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Brak :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Zapisz ustawienia"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile bez :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< nie jest dostêpne bez w³a¶ciwo¶ci +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor bez :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Brak dwugrafów w tej wersji"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Plik istnieje (wymu¶ poprzez !)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "jest urz±dzeniem (wy³±czonym w opcji 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Komenda nie powiod³a siê"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Wczytywanie ze stdin..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Nieznany zestaw czcionek: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Nieznana czcionka: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[zakodowane]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Czcionka \"%s\" nie ma sta³ej szeroko¶ci znaków"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Plik zaszyfrowano w nieznany sposób"
 
-msgid "E473: Internal error"
-msgstr "E473: B³±d wewnêtrzny"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans nie pozwala na zapis niezmodyfikowanych buforów"
 
-msgid "Interrupted"
-msgstr "Przerwane"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Czê¶ciowy zapis niemo¿liwy dla buforów NetBeans"
 
-msgid "E14: Invalid address"
-msgstr "E14: Niew³a¶ciwy adres"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "zapisywanie do urz±dzenia wy³±czone w opcji 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Niew³a¶ciwy argument"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Rozdzia³ zasobów zostanie utracony (wymu¶ przez !)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Niew³a¶ciwy argument: %s"
+#~ msgid "<cannot open> "
+#~ msgstr "<nie mogê otworzyæ> "
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Niew³a¶ciwe wyra¿enie: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: nie mogê otrzymaæ czcionki %s"
 
-msgid "E16: Invalid range"
-msgstr "E16: Niew³a¶ciwy zakres"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: nie mogê powróciæ do bie¿±cego katalogu"
 
-msgid "E476: Invalid command"
-msgstr "E476: Niew³a¶ciwa komenda"
+#~ msgid "Pathname:"
+#~ msgstr "Trop:"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" jest katalogiem"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: nie mogê otrzymaæ bie¿±cego katalogu"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Wywo³anie z biblioteki nie powiod³o siê dla \"%s()\""
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Nie mo¿na za³adowaæ funkcji biblioteki %s"
+#~ msgid "Cancel"
+#~ msgstr "Zakoñcz"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Zak³adka ma niew³a¶ciwy numer wiersza"
+#~ msgid "Vim dialog"
+#~ msgstr "VIM - Dialog"
 
-msgid "E20: Mark not set"
-msgstr "E20: Zak³adka nienastawiona"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Scrollbar Widget: Nie mog³em otrzymaæ rozmiarów rysunku na przycisku."
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nie mogê wykonaæ zmian, 'modifiable' jest wy³±czone"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Nie mogê stworzyæ BalloonEval z powiadomieniem i wywo³aniem"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Zbyt g³êbokie zagnie¿d¿enie skryptów"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Nie mog³em stworzyæ nowego procesu dla GUI"
 
-msgid "E23: No alternate file"
-msgstr "E23: Brak pliku zamiany"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Proces potomny nie móg³ uruchomiæ GUI"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Nie ma takiego skrótu"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nie mogê odpaliæ GUI"
 
-msgid "E477: No ! allowed"
-msgstr "E477: Niedozwolone !"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nie mogê czytaæ z \"%s\""
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI nie mo¿e byæ u¿yte: Nie w³±czono podczas kompilacji"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Nie mo¿na uruchomiæ GUI, brak prawid³owej czcionki"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebrajski nie mo¿e byæ u¿yty: Nie w³±czono podczas kompilacji\n"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Niew³a¶ciwe 'guifontwide'"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi nie mo¿e byæ u¿yty: Nie w³±czono podczas kompilacji\n"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Nieprawid³owa warto¶æ 'imactivatekey'"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabski nie mo¿e byæ u¿yty: Nie w³±czono podczas kompilacji\n"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Nie mogê zarezerwowaæ koloru %s"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Brak takiej nazwy grupy pod¶wietlania: %s"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Brak dopasowania przy kursorze, szukam dalej"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Nie wprowadzono jeszcze ¿adnego tekstu"
+#~ msgid "Input _Methods"
+#~ msgstr "Input _Methods"
 
-msgid "E30: No previous command line"
-msgstr "E30: Nie ma poprzedniego wiersza poleceñ"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Szukaj i Zamieñ..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Nie ma takiego przyporz±dkowania"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Szukaj..."
 
-msgid "E479: No match"
-msgstr "E479: Brak dopasowañ"
+#~ msgid "Find what:"
+#~ msgstr "Znajd¼:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Brak dopasowañ: %s"
+#~ msgid "Replace with:"
+#~ msgstr "Zamieñ na:"
 
-msgid "E32: No file name"
-msgstr "E32: Brak nazwy pliku"
+#~ msgid "Match whole word only"
+#~ msgstr "Dopasuj tylko ca³e wyrazy"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Brak poprzedniego podstawieniowego wyra¿enia regularnego"
+#~ msgid "Match case"
+#~ msgstr "Dopasuj wielko¶æ liter"
 
-msgid "E34: No previous command"
-msgstr "E34: Brak poprzedniej komendy"
+#~ msgid "Direction"
+#~ msgstr "Kierunek"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Brak poprzedniego wyra¿enia regularnego"
+#~ msgid "Up"
+#~ msgstr "W górê"
 
-msgid "E481: No range allowed"
-msgstr "E481: Zakres niedozwolony"
+#~ msgid "Down"
+#~ msgstr "W dó³"
 
-msgid "E36: Not enough room"
-msgstr "E36: Brak miejsca"
+#~ msgid "Find Next"
+#~ msgstr "Znajd¼ nastêpne"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: brak zarejestrowanego serwera o nazwie \"%s\""
+#~ msgid "Replace"
+#~ msgstr "Zamieñ"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Nie mogê stworzyæ pliku %s"
+#~ msgid "Replace All"
+#~ msgstr "Zamieñ wszystkie"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Nie mogê pobraæ nazwy pliku tymczasowego"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: otrzymano ¿±danie \"die\" od mened¿era sesji\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Nie mogê otworzyæ pliku %s"
+#~ msgid "Close"
+#~ msgstr "Zamknij"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Nie mogê odczytaæ pliku %s"
+#~ msgid "New tab"
+#~ msgstr "Nowa karta"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Nie zapisano od ostatniej zmiany (wymu¶ przez !)"
+#~ msgid "Open Tab..."
+#~ msgstr "Otwórz kartê..."
 
-msgid "E38: Null argument"
-msgstr "E38: Zerowy argument"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: G³ówne okno nieoczekiwanie zniszczone\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Oczekujê liczby"
+#~ msgid "&Filter"
+#~ msgstr "&Filtr"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nie mogê otworzyæ pliku b³êdów %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Anuluj"
 
-msgid "E233: cannot open display"
-msgstr "E233: nie mogê otworzyæ ekranu"
+#~ msgid "Directories"
+#~ msgstr "Katalogi"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Pamiêæ wyczerpana!"
+#~ msgid "Filter"
+#~ msgstr "Filtr"
 
-msgid "Pattern not found"
-msgstr "Nie znaleziono wzorca"
+#~ msgid "&Help"
+#~ msgstr "&Pomoc"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Nie znaleziono wzorca: %s"
+#~ msgid "Files"
+#~ msgstr "Pliki"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument musi byæ dodatni"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Nie mo¿na przej¶æ do poprzedniego katalogu"
+#~ msgid "Selection"
+#~ msgstr "Wybór"
 
-msgid "E42: No Errors"
-msgstr "E42: Brak B³êdów"
+#~ msgid "Find &Next"
+#~ msgstr "Znajd¼ &nastêpne"
 
-msgid "E776: No location list"
-msgstr "E776: Brak listy lokacji"
+#~ msgid "&Replace"
+#~ msgstr "&Zamieñ"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Popsuty ci±g wzorca"
+#~ msgid "Replace &All"
+#~ msgstr "Zamieñ &wszystko"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Zepsuty program wyra¿eñ regularnych"
+#~ msgid "&Undo"
+#~ msgstr "&Cofnij"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: opcja 'readonly' jest ustawiona (wymu¶ poprzez !)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Nie mogê znale¼æ tytu³u okna \"%s\""
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Nie mogê zmieniæ zmiennej tylko do odczytu \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nie jest wspomagany: \"-%s\"; U¿ywaj wersji OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Nie mogê ustawiæ zmiennej w piaskownicy: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Nie mo¿na otworzyæ okna wewn±trz aplikacji MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: B³±d w trakcie czytania pliku b³êdów"
+#~ msgid "Close tab"
+#~ msgstr "Zamknij kartê"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Niedozwolone w piaskownicy"
+#~ msgid "Open tab..."
+#~ msgstr "Otwórz kartê..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Niedozwolone w tym miejscu"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Znajd¼ ci±g (u¿yj '\\\\' do szukania '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Ustawianie trybu ekranu niewspomagane"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Szukanie i Zamiana (u¿yj '\\\\' do szukania '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Niew³a¶ciwa wielko¶æ przewiniêcia"
+#~ msgid "Not Used"
+#~ msgstr "Nie u¿ywany"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: opcja 'shell' jest pusta"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Katalog\t*.nic\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Nie mog³em wczytaæ danych znaku!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Nie mogê zarezerwowaæ mapy kolorów, pewne kolory mog± byæ "
+#~ "nieprawid³owe"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: B³±d podczas zamykania pliku wymiany"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Brak czcionek dla nastêpuj±cych zestawów znaków w zestawie czcionek "
+#~ "%s:"
 
-msgid "E73: tag stack empty"
-msgstr "E73: stos znaczników jest pusty"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nazwa zestawu czcionek: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Komenda jest zbyt skomplikowana"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Czcionka '%s' nie posiada znaków jednolitej szeroko¶ci"
 
-msgid "E75: Name too long"
-msgstr "E75: Zbyt d³uga nazwa"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Nazwa zestawu czcionek: %s"
 
-msgid "E76: Too many ["
-msgstr "E76: Zbyt wiele ["
+#~ msgid "Font0: %s"
+#~ msgstr "Font0: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: Zbyt wiele nazw plików"
+#~ msgid "Font1: %s"
+#~ msgstr "Font1: %s"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Nadstêpne znaczki"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "Szeroko¶æ font%<PRId64> nie jest podwójn± szeroko¶ci± font0"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Nieznana zak³adka"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Szeroko¶æ font0: %<PRId64>"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nie mog± rozwin±æ znaków wieloznacznych"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Szeroko¶æ font1: %<PRId64>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' nie mo¿e byæ mniejsze ni¿ 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Nieprawid³owy opis czcionki"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' nie mo¿e byæ mniejsze ni¿ 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "&Anuluj"
 
-msgid "E80: Error while writing"
-msgstr "E80: B³±d w trakcie zapisu"
+#~ msgid "no specific match"
+#~ msgstr "brak okre¶lonego dopasowania"
 
-msgid "Zero count"
-msgstr "Zerowy licznik"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - wybór czcionki"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: U¿ycie <SID> poza kontekstem skryptu"
+#~ msgid "Name:"
+#~ msgstr "Nazwa:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Odebra³em niew³a¶ciwe wyra¿enie"
+#~ msgid "Show size in Points"
+#~ msgstr "Poka¿ wielko¶æ w punktach"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Region jest chroniony, nie mogê zmieniæ"
+#~ msgid "Encoding:"
+#~ msgstr "Kodowanie:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans nie zezwala na zmiany w plikach tylko do odczytu"
+#~ msgid "Font:"
+#~ msgstr "Czcionka:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: B³±d wewnêtrzny: %s"
+#~ msgid "Style:"
+#~ msgstr "Styl:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Wzorzec u¿ywa wiêcej pamiêci ni¿ 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Wielko¶æ:"
 
-msgid "E749: empty buffer"
-msgstr "E749: pusty bufor"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: B£¡D w automacie Hangul"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Niew³a¶ciwy wzorzec wyszukiwania lub delimiter"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: b³±d stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Plik jest za³adowany w innym buforze"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: nie mogê otworzyæ bazy danych cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Nie ustawiono opcji '%s'"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: nie mogê uzyskaæ informacji z bazy danych cscope"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Niew³a¶ciwa nazwa rejestru"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Nie mo¿na wczytaæ biblioteki Lua."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "szukanie dobi³o GÓRY; kontynuacja od KOÑCA"
+#~ msgid "cannot save undo information"
+#~ msgstr "nie mogê zachowaæ informacji cofania"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "szukanie dobi³o KOÑCA; kontynuacja od GÓRY"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Przykro mi, ta komenda jest wy³±czona, biblioteka MzScheme nie mo¿e "
+#~ "byæ za³adowana."
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Potrzebujê klucza szyfrowania dla \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "niepoprawne wyra¿enie"
 
-msgid "empty keys are not allowed"
-msgstr "puste klucze nie s± dozwolone"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "wyra¿enia wy³±czone podczas kompilacji"
 
-msgid "dictionary is locked"
-msgstr "s³ownik jest zablokowany"
+#~ msgid "hidden option"
+#~ msgstr "ukryta opcja"
 
-msgid "list is locked"
-msgstr "lista jest zablokowana"
+#~ msgid "unknown option"
+#~ msgstr "nieznana opcja"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "nie powiod³o siê dodanie klucza '%s' do s³ownika"
+#~ msgid "window index is out of range"
+#~ msgstr "indeks okna poza zakresem"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "indeks musi byæ liczb± lub wycinkiem, nie %s"
+#~ msgid "couldn't open buffer"
+#~ msgstr "nie mogê otworzyæ bufora"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "czeka³em na str() lub unicode(), a dosta³em %s"
+#~ msgid "cannot delete line"
+#~ msgstr "nie mogê skasowaæ wiersza"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "czeka³em na bytes() lub str(), a dosta³em %s"
+#~ msgid "cannot replace line"
+#~ msgstr "nie mogê zamieniæ wiersza"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr ""
-"czeka³em na int(), long() lub co¶ co mo¿na zmieniæ na long(), ale dosta³em %s"
+#~ msgid "cannot insert line"
+#~ msgstr "nie mogê wprowadziæ wiersza"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "czeka³em na int() lub co¶ co mo¿na zmieniæ na int(), ale dosta³em %s"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "ci±g nie mo¿e zawieraæ znaków nowego wiersza"
 
-msgid "value is too large to fit into C int type"
-msgstr "warto¶æ zbyt du¿a by zmie¶ci³a siê w typie int C"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "b³±d przy konwersji warto¶ci Scheme do Vima"
 
-msgid "value is too small to fit into C int type"
-msgstr "warto¶æ jest zbyt ma³a by zmie¶ci³a siê w typie int C"
+#~ msgid "Vim error: ~a"
+#~ msgstr "B³±d vima: ~a"
 
-msgid "number must be greater then zero"
-msgstr "liczba musi byæ wiêksza ni¿ zero"
+#~ msgid "Vim error"
+#~ msgstr "B³±d Vima"
 
-msgid "number must be greater or equal to zero"
-msgstr "liczba musi byæ wiêksza lub mniejsza ni¿ zero"
+#~ msgid "buffer is invalid"
+#~ msgstr "bufor jest niewa¿ny"
 
-msgid "can't delete OutputObject attributes"
-msgstr "nie mogê skasowaæ atrybutów OutputObject"
+#~ msgid "window is invalid"
+#~ msgstr "okno jest niewa¿ne"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "niepoprawny atrybut: %s"
+#~ msgid "linenr out of range"
+#~ msgstr "numer wiersza poza zakresem"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: B³±d w uruchomieniu obiektów I/O"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "Niedozwolone w piaskownicy Vima"
 
-msgid "failed to change directory"
-msgstr "nie powiod³a siê zmiana katalogu"
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em %s"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Przykro mi, ta komenda jest wy³±czona, bo nie mo¿na za³adowaæ "
+#~ "biblioteki Pythona"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em krotkê o wielko¶ci %d"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Python: nie mo¿na u¿ywaæ :py i :py3 w czasie jednej sesji"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "wewnêtrzny b³±d: imp.find_module zwróci³ krotkê z NULL"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Nie mo¿na wywo³aæ Pythona rekursywnie"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "nie mogê usun±æ atrybutów vim.Dictionary"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ musi byæ reprezentacj± £añcucha"
 
-msgid "cannot modify fixed dictionary"
-msgstr "nie mogê zmieniæ zablokowanego s³ownika"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Przykro mi, ta komenda jest wy³±czona, bo nie mo¿na za³adowaæ "
+#~ "biblioteki Ruby."
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "nie mogê ustawiæ atrybutu %s"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: nieoczekiwany return"
 
-msgid "hashtab changed during iteration"
-msgstr "hashtab zmieni³ siê w czasie iteracji"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: nieoczekiwany next"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "czeka³em na element sekwencyjny od d³ugo¶ci 2, a dosta³em sekwencjê o d³ugo¶ci %d"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: nieoczekiwany break"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "konstruktor listy nie akceptuje s³ów kluczowych jako argumentów"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: nieoczekiwane redo"
 
-msgid "list index out of range"
-msgstr "indeks listy poza zakresem"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: ponowna próba poza klauzul± ratunku"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "b³±d wewnêtrzny: nie powiod³o siê pobranie z listy Vima elementu %d"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: nieobs³ugiwany wyj±tek"
 
-msgid "failed to add item to list"
-msgstr "nie powiod³o siê dodanie elementu do listy"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Nieznany status longjmp %d"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "b³±d wewnêtrzny: w li¶cie Vima brak elementu %d"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Prze³±cz miêdzy implementacj±/okre¶leniem"
 
-msgid "internal error: failed to add item to list"
-msgstr "b³±d wewnêtrzny: nie powiod³o siê dodanie elementu do listy"
+#~ msgid "Show base class of"
+#~ msgstr "Poka¿ bazê klasy"
 
-msgid "cannot delete vim.List attributes"
-msgstr "nie mogê usun±æ atrybutów vim.List"
+#~ msgid "Show overridden member function"
+#~ msgstr "Poka¿ przepisan± funkcjê cz³onow±"
 
-msgid "cannot modify fixed list"
-msgstr "nie mogê zmieniæ zablokowanej listy"
+#~ msgid "Retrieve from file"
+#~ msgstr "Pobieraj z pliku"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "nie nazwana funkcja %s nie istnieje"
+#~ msgid "Retrieve from project"
+#~ msgstr "Pobieraj z projektu"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "funkcja %s nie istnieje"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Pobieraj z wszystkich projektów"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "konstruktor funkcji nie akceptuje s³ów kluczowych jako argumentów"
+#~ msgid "Retrieve"
+#~ msgstr "Pobierz"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "nie mogê uruchomiæ funkcji %s"
+#~ msgid "Show source of"
+#~ msgstr "Poka¿ ¼ród³o dla"
 
-msgid "unable to get option value"
-msgstr "nie mogê pobraæ warto¶ci opcji"
+#~ msgid "Find symbol"
+#~ msgstr "Znajd¼ symbol"
 
-msgid "internal error: unknown option type"
-msgstr "b³±d wewnêtrzny: nieznany typ opcji"
+#~ msgid "Browse class"
+#~ msgstr "Przejrzyj klasê"
 
-msgid "problem while switching windows"
-msgstr "wyst±pi³ problem w czasie zmiany okien"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Poka¿ klasê w hierarchii"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "nie mogê wyzerowaæ opcji globalnej %s"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Poka¿ klasê w ograniczonej hierarchii"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "nie mogê wyzerowaæ opcji %s, która nie ma warto¶ci globalnej"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odnosi siê do"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "próba odniesienia do skasowanej karty"
+#~ msgid "Xref referred by"
+#~ msgstr "Xref ma odniesienia od"
 
-msgid "no such tab page"
-msgstr "nie ma takiej karty"
+#~ msgid "Xref has a"
+#~ msgstr "Xref ma"
 
-msgid "attempt to refer to deleted window"
-msgstr "próba odniesienia do skasowanego okna"
+#~ msgid "Xref used by"
+#~ msgstr "Xref u¿yte przez"
 
-msgid "readonly attribute: buffer"
-msgstr "atrybut tylko do odczytu: bufor"
+#~ msgid "Show docu of"
+#~ msgstr "Poka¿ dokumentacjê dla"
 
-msgid "cursor position outside buffer"
-msgstr "pozycja kursora poza buforem"
+#~ msgid "Generate docu for"
+#~ msgstr "Utwórz dokumentacjê dla"
 
-msgid "no such window"
-msgstr "nie ma takiego okna"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Nie mogê pod³±czyæ do SNiFF+. Sprawd¼ ¶rodowisko (sniffemacs musi byæ "
+#~ "odnaleziony w $PATH).\n"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "próba odniesienia do skasowanego bufora"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: B³±d podczas czytania. Roz³±czenie"
 
-msgid "failed to rename buffer"
-msgstr "nie powiod³a siê zmiana nazwy bufora"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ jest obecnie "
 
-msgid "mark name must be a single character"
-msgstr "nazwa zak³adki musi byæ pojedynczym znakiem"
+#~ msgid "not "
+#~ msgstr "nie "
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "oczekiwa³em na obiekt vim.Buffer, a dosta³em %s"
+#~ msgid "connected"
+#~ msgstr "pod³±czony"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "nie przeszed³em do bufora %d"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Nieznane zapytanie SNiFF+: %s"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "oczekiwa³em na obiekt vim.Window, a dosta³em %s"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: B³±d w trakcie pod³±czania do SNiFF+"
 
-msgid "failed to find window in the current tab page"
-msgstr "nie znaleziono okna na bie¿±cej karcie"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ niepod³±czony"
 
-msgid "did not switch to the specified window"
-msgstr "nie przeszed³em do okre¶lonego okna"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Nie jest buforem SNiFF+"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "oczekiwa³em na obiekt vim.TabPage, a dosta³em %s"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: B³±d w trakcie zapisu. Roz³±czony"
 
-msgid "did not switch to the specified tab page"
-msgstr "nie przeszed³em do okre¶lonej karty"
+#~ msgid "invalid buffer number"
+#~ msgstr "niew³a¶ciwy numer bufora"
 
-msgid "failed to run the code"
-msgstr "uruchomienie kodu siê nie powiod³o"
+#~ msgid "not implemented yet"
+#~ msgstr "obecnie nie zaimplementowano"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: eval nie zwróci³o odpowiedniego obiektu pythona"
+#~ msgid "cannot set line(s)"
+#~ msgstr "nie mogê ustawiæ wiersza(y)"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Nie powiod³a siê konwersja obiektu pythona do warto¶ci Vima"
+#~ msgid "invalid mark name"
+#~ msgstr "niepoprawna nazwa zak³adki"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "nie mo¿na konwertowaæ %s do s³ownika Vima"
+#~ msgid "mark not set"
+#~ msgstr "zak³adka nie ustawiona"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "nie mo¿na konwertowaæ %s do struktury Vima"
+#~ msgid "row %d column %d"
+#~ msgstr "wiersz %d kolumna %d"
 
-msgid "internal error: NULL reference passed"
-msgstr "b³±d wewnêtrzny: przekazano referencjê NULL"
+#~ msgid "cannot insert/append line"
+#~ msgstr "nie mogê wprowadziæ/do³±czyæ wiersza"
 
-msgid "internal error: invalid value type"
-msgstr "b³±d wewnêtrzny: b³êdny typ warto¶ci"
+#~ msgid "line number out of range"
+#~ msgstr "numer wiersza poza zakresem"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Nie mogê ustawiæ haka ¶cie¿ki: sys.path_hooks nie jest list±\n"
-"Powiniene¶ teraz wykonaæ nastêpuj±ce czynno¶ci:\n"
-"- dodaæ vim.path_hook do sys.path_hooks\n"
-"- dodaæ vim.VIM_SPECIAL_PATH do sys.path\n"
+#~ msgid "unknown flag: "
+#~ msgstr "nieznana flaga: "
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Nie mogê ustawiæ ¶cie¿ki: sys.path nie jest list±\n"
-"Powinno siê teraz dodaæ vim.VIM_SPECIAL_PATH do sys.path"
+#~ msgid "unknown vimOption"
+#~ msgstr "nieznane vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "przerwanie klawiatury"
+
+#~ msgid "vim error"
+#~ msgstr "b³±d vima"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nie mogê stworzyæ bufora/okna komendy: obiekt jest kasowany"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nie mogê zarejestrowaæ wstecznego wywo³ania komendy: bufor/okno ju¿ "
+#~ "zosta³a skasowana"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATALNY B£¡D: reflist zepsuta!? Proszê z³o¿yæ raport o tym na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nie mogê zarejestrowaæ wstecznego wywo³ania komendy: brak odniesienia do "
+#~ "bufora/okna"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Przykro mi, ta komenda jest wy³±czona, bo nie mo¿na za³adowaæ "
+#~ "biblioteki Tcl."
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: kod wyj¶cia %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "nie mogê dostaæ wiersza"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Nie mogê zarejestrowaæ nazwy serwera komend"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Wys³anie komendy do programu docelowego nie powiod³o siê"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: U¿yto niew³a¶ciwego id serwera: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: wcielenia instancji rejestru Vima jest ¼le sformowane.  Skasowano!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans nie s± obs³ugiwane przez to GUI\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Ta wersja Vima nie by³a skompilowanego z opcj± ró¿nic (diff)."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' - nie mo¿e byæ u¿yte: nie w³±czone przy kompilacji\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: B³±d: Nie mo¿na uruchomiæ gvim z NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "gdzie wielko¶æ znaków jest ignorowana dodaj na pocz±tku / by flaga by³a "
+#~ "wielk± liter±"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tZarejestruj tego gvima w OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tWyrejestruj gvima z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tStartuj w GUI (tak jak \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  lub --nofork\tPierwszy plan: Nie wydzielaj przy odpalaniu GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNie stosuj newcli do otwierania okien"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\tU¿ywaj <device> do I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tU¿yj <gvimrc> zamiast jakiegokolwiek .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEdytuj zakodowane pliki"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tPod³±cz vima to danego X-serwera"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNie ³±cz z serwerem X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <pliki>\tEdytuj pliki w serwerze Vima je¶li mo¿liwe"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <pliki> To samo, nie narzekaj je¶li nie ma serwera"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <pliki>\tTak jak --remote, lecz czekaj na pliki przed edycj±"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <pliki>  To samo, nie narzekaj je¶li nie ma serwera"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <pliki>  tak jak --remote ale u¿ywa jednej "
+#~ "karty na plik"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <klawisze>\tWy¶lij <klawisze> do serwera Vima i zakoñcz"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <wyr>\tWykonaj <wyra¿enie> w serwerze i wypisz wynik"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tWymieñ nazwy dostêpnych serwerów Vima i zakoñcz"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nazwa>\t\tOdsy³aj do/stañ siê serwerem Vim <nazwa>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tZa³aduj vim na <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tZacznij Vim jako ikonê"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <kolor>\tU¿ywaj <kolor> dla t³a (równie¿: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <kolor>\tU¿ywaj <kolor> dla normalnego tekstu (równie¿: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t\tU¿ywaj <font> dla normalnego tekstu (równie¿: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\tU¿ywaj <font> dla wyt³uszczonego tekstu"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\tU¿ywaj <font> dla pochy³ego"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tU¿ywaj <geom> dla pocz±tkowych rozmiarów (równie¿: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <szer>\tU¿yj ramki o grubo¶ci <szer> (równie¿: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <szer>  U¿ywaj przewijacza o szeroko¶ci <szer> (równie¿: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <height>\tStosuj belkê menu o wysoko¶ci <height> (równie¿: -"
+#~ "mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tStosuj negatyw kolorów (równie¿: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNie stosuj negatywu kolorów (równie¿: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tUstaw okre¶lony zasób"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty rozpoznawane przez gvim (wersja GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tZastartuj vim na <display> (równie¿: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\tUstaw unikatow± rolê do identyfikacji g³ównego okna"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtwórz Vim wewn±trz innego widgetu GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "-echo-wid\t\tGvim wypisze Window ID na wyj¶cie standardowe"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <tytu³ rodzica>\tOtwórz Vima wewn±trz rodzicielskiej aplikacji"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tOtwórz Vima wewn±trz innego elementu win32"
+
+#~ msgid "No display"
+#~ msgstr "Brak display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Wys³anie nie powiod³o siê.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Wys³anie nie powiod³o siê. Próbujê wykonaæ na miejscu\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "otworzono %d z %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Brak terminala: Wys³anie wyra¿enia nie powiod³o siê.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Wys³anie wyra¿enia nie powiod³o siê.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: To nie jest wa¿na strona kodowa"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Nie mogê nastawiæ warto¶ci IC"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nie mog³em stworzyæ kontekstu wprowadzeñ"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nie mog³em otworzyæ sposobu wprowadzeñ"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: OSTRZE¯ENIE: Nie mog³em zlikwidowaæ wywo³ania dla IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: metoda wprowadzeñ nie wspomaga ¿adnego stylu"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: metoda wprowadzeñ nie wspomaga mojego typu preedit"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: B³±d w czasie uaktualniania szyfrowania pliku wymiany"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s jest zaszyfrowany a ta wersja Vima nie wspiera szyfrowania"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Zaszyfrowany plik wymiany: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Je¶li podano nowy klucz szyfruj±cy, ale nie zapisano pliku tekstowego,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "wprowad¼ nowy klucz szyfruj±cy."
+
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Je¶li zapisano plik tekstowy po zmianie klucza szyfruj±cego wci¶nij Enter"
+
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "aby u¿yæ tego samego klucza dla pliku tekstowego i wymiany"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "U¿ywam klucza szyfruj±cego z pliku wymiany do pliku tekstowego.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nie nadaje siê dla tej wersji Vima]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Oderwij to menu"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialog wyboru katalogu"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialog zapisywania pliku"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialog otwierania pliku"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Przykro mi, nie ma przegl±darki plików w trybie konsoli"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachowujê plik...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Zakoñczono.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "B£¡D: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w u¿ytku "
+#~ "%<PRIu64>, maksymalne u¿ycie %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[wywo³ania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów "
+#~ "%<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Wiersz staje siê zbyt d³ugi"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Wewnêtrzny b³±d: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Niedozwolony obrys myszki"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Wprowad¼ klucz do odkodowania: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Wprowad¼ ponownie ten sam klucz: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Klucze nie pasuj± do siebie!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Nie mo¿na po³±czyæ z Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Nie mo¿na po³±czyæ z Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: B³êdny tryb dostêpu pliku info po³±czenia NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "odczyt z gniazda Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Bufor %<PRId64> utraci³ po³±czenie z NetBeans"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans nie s± obs³ugiwane przez to GUI"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans ju¿ pod³±czone"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s jest tylko do odczytu (dodaj ! aby wymusiæ)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Funkcjonalno¶æ eval nie jest dostêpna"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "zwalniam %<PRId64> wierszy"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Nie mogê zmieniæ term w GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: U¿yj \":gui\" do odpalenia GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Nie mogê zmieniæ w GTK+2 GUI"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Niedozwolona czcionka/ki"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: nie mogê wybraæ zestawu czcionek"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Niedozwolony zestaw czcionek"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: nie mogê wybraæ szerokiej czcionki"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Niedozwolona szeroka czcionka"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Brak wspomagania myszki"
+
+#~ msgid "cannot open "
+#~ msgstr "nie mogê otworzyæ "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nie mogê otworzyæ okna!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Potrzebujê Amigados w wersji 2.04 lub pó¼niejsz±\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Potrzebujê %s w wersji %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nie mogê otworzyæ NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Nie mogê stworzyæ "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim koñczy pracê z %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "nie mogê zmieniæ trybu konsoli ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: nie jest konsol±??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Nie mogê wykonaæ pow³oki z opcj± -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nie mogê wykonaæ "
+
+#~ msgid "shell "
+#~ msgstr "pow³oka "
+
+#~ msgid " returned\n"
+#~ msgstr " zwróci³\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE zbyt niskie."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "B£¡D I/O"
+
+#~ msgid "Message"
+#~ msgstr "Wiadomo¶æ"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' nie wynosi 80, nie mogê wykonaæ zewnêtrznych komend"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Wybór drukarki nie powiód³ siê"
+
+#~ msgid "to %s on %s"
+#~ msgstr "do %s z %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Nieznana czcionka drukarki: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: B³±d drukarki: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Wydrukowano '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: Niedozwolona nazwa zestawu znaków \"%s\" w nazwie czcionki \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Niedozwolony znak '%c' w nazwie czcionki \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Podwójny sygna³, wychodzê\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Za³apa³ ¶miertelny sygna³ %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Za³apa³ ¶miertelny sygna³\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Otwieranie ekranu X trwa³o %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Dosta³ b³±d X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Test ekranu X nie powiód³ siê"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Próba otwarcia ekranu X trwa³a zbyt d³ugo"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogê wykonaæ pow³oki sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogê stworzyæ potoków\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nie mogê rozdzieliæ siê\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Komenda zakoñczona\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP straci³ po³±czenie ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otwarcie ekranu X nie powiod³o siê"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP obs³uguje ¿±danie samozapisu"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP otwiera po³±czenie"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Obserwacja po³±czenia XSMP ICE nie powiod³a siê"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection nie powiod³o siê: %s"
+
+#~ msgid "At line"
+#~ msgstr "W wierszu"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nie mogê za³adowaæ vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "B³±d VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nie zdo³a³em poprawiæ wska¼ników funkcji w DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "pow³oka zwróci³a %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Za³apa³ wydarzenie %s\n"
+
+#~ msgid "close"
+#~ msgstr "zamknij"
+
+#~ msgid "logoff"
+#~ msgstr "wyloguj"
+
+#~ msgid "shutdown"
+#~ msgstr "zakoñcz"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Nie znaleziono komendy"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE nie znaleziono w twoim $PATH.\n"
+#~ "Zewnêtrzne komendy nie bêd± wstrzymane po wykonaniu.\n"
+#~ "Zobacz  :help wim32-vimrun  aby otrzymaæ wiêcej informacji."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Ostrze¿enie"
+
+#~ msgid "Error file"
+#~ msgstr "Plik b³êdu"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: B³±d przy budowwaniu NFA z klas± ekwiwalencji"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr ""
+#~ "E878: (NFA) Nie mo¿na przydzieliæ pamiêci do przej¶cia przez ga³êzie!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Ostrze¿enie: Nie mogê znale¼æ listy s³ów \"%s_%s.spl\" lub \"%s_ascii.spl"
+#~ "\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konwersja w %s nie jest wspierana"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr ""
+#~ "E845: Nie wystarczaj±ca ilo¶æ pamiêci, lista s³ów bêdzie niekompletna"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Trop szukania pliku znaczników obciêty dla %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "uruchomiono now± pow³okê\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "U¿ywam CUT_BUFFER0 zamiast pustego wyboru"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Cofniêcie niemo¿liwe; mimo to kontynuujê"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Nie zaszyfrowany plik ma zaszyfrowany plik undo: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Nie powiod³o siê odszyfrowywanie pliku undo: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Plik undo jest zaszyfrowany: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32-bit wersja GUI dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "64 bitowa wersja GUI dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja GUI dla MS-Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " w trybie Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " ze wspomaganiem OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja na konsolê dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja na konsolê dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitowa wersja dla MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitowa wersja dla MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitowa wersja dla MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "wersja dla OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Du¿a wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normalna wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Ma³a wersja "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malutka wersja "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "z GTK2-GNOME GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "z GTK2 GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "z X11-Motif GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "z X11-neXtaw GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "z X11-Athena GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "z Photon GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "z GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "z Carbon GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "z Cocoa GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "z (klasycznym) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "     gvimrc systemu: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "  gvimrc u¿ytkownika: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2-gi plik gvimrc u¿ytkownika: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3-ci plik gvimrc u¿ytkownika: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr " systemowy plik menu: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompilator: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "menu Pomoc->Sieroty        dla informacji to tym  "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Uruchomiony bez trybów, wpisany tekst jest wprowadzany"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "menu  Edytuj->Ustawienia globalne->Tryb wstawiania"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                  dla dwóch trybów           "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "menu Edytuj->Ustawienia globalne->Kompatybilno¶æ z Vi"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "     dla domy¶lnych ustawieñ Vima   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "OSTRZE¯ENIE: wykryto Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "wprowad¼ :help windows95<Enter>   dla informacji to tym  "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Nie mog³em za³adowaæ biblioteki %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Przykro mi, ta komenda jest wy³±czona: nie mog³em za³adowaæ biblioteki "
+#~ "Perla."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: wyliczenie Perla zabronione w piaskownicy bez modu³u Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Edytuj w &wielu Vimach"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Edytuj w pojedynczym &Vimie"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diff z Vimem"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Edytuj w &Vimie"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Edytuj z istniej±cym Vimem - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Edytuj wybrane pliki w Vimie"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "B³±d tworzenia procesu: Sprawd¼ czy gvim jest w twojej ¶cie¿ce!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "b³±d gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Za d³uga ¶cie¿ka!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Nieznany zestaw czcionek: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Nieznana czcionka: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Czcionka \"%s\" nie ma sta³ej szeroko¶ci znaków"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Nie mo¿na za³adowaæ funkcji biblioteki %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Hebrajski nie mo¿e byæ u¿yty: Nie w³±czono podczas kompilacji\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Farsi nie mo¿e byæ u¿yty: Nie w³±czono podczas kompilacji\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabski nie mo¿e byæ u¿yty: Nie w³±czono podczas kompilacji\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: brak zarejestrowanego serwera o nazwie \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nie mogê otworzyæ ekranu"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Odebra³em niew³a¶ciwe wyra¿enie"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Region jest chroniony, nie mogê zmieniæ"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans nie zezwala na zmiany w plikach tylko do odczytu"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Potrzebujê klucza szyfrowania dla \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "puste klucze nie s± dozwolone"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "s³ownik jest zablokowany"
+
+#~ msgid "list is locked"
+#~ msgstr "lista jest zablokowana"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "nie powiod³o siê dodanie klucza '%s' do s³ownika"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "indeks musi byæ liczb± lub wycinkiem, nie %s"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "czeka³em na str() lub unicode(), a dosta³em %s"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "czeka³em na bytes() lub str(), a dosta³em %s"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "czeka³em na int(), long() lub co¶ co mo¿na zmieniæ na long(), ale "
+#~ "dosta³em %s"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr ""
+#~ "czeka³em na int() lub co¶ co mo¿na zmieniæ na int(), ale dosta³em %s"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "warto¶æ zbyt du¿a by zmie¶ci³a siê w typie int C"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "warto¶æ jest zbyt ma³a by zmie¶ci³a siê w typie int C"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "liczba musi byæ wiêksza ni¿ zero"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "liczba musi byæ wiêksza lub mniejsza ni¿ zero"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nie mogê skasowaæ atrybutów OutputObject"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "niepoprawny atrybut: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: B³±d w uruchomieniu obiektów I/O"
+
+#~ msgid "failed to change directory"
+#~ msgstr "nie powiod³a siê zmiana katalogu"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em %s"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr ""
+#~ "czeka³em na 3-krotkê jako wynik imp.find_module(), a dosta³em krotkê o "
+#~ "wielko¶ci %d"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "wewnêtrzny b³±d: imp.find_module zwróci³ krotkê z NULL"
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "nie mogê usun±æ atrybutów vim.Dictionary"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "nie mogê zmieniæ zablokowanego s³ownika"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "nie mogê ustawiæ atrybutu %s"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "hashtab zmieni³ siê w czasie iteracji"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "czeka³em na element sekwencyjny od d³ugo¶ci 2, a dosta³em sekwencjê o "
+#~ "d³ugo¶ci %d"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "konstruktor listy nie akceptuje s³ów kluczowych jako argumentów"
+
+#~ msgid "list index out of range"
+#~ msgstr "indeks listy poza zakresem"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "b³±d wewnêtrzny: nie powiod³o siê pobranie z listy Vima elementu %d"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "nie powiod³o siê dodanie elementu do listy"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "b³±d wewnêtrzny: w li¶cie Vima brak elementu %d"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "b³±d wewnêtrzny: nie powiod³o siê dodanie elementu do listy"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "nie mogê usun±æ atrybutów vim.List"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "nie mogê zmieniæ zablokowanej listy"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "nie nazwana funkcja %s nie istnieje"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "funkcja %s nie istnieje"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "konstruktor funkcji nie akceptuje s³ów kluczowych jako argumentów"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "nie mogê uruchomiæ funkcji %s"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "wyst±pi³ problem w czasie zmiany okien"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "nie mogê wyzerowaæ opcji globalnej %s"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "nie mogê wyzerowaæ opcji %s, która nie ma warto¶ci globalnej"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "próba odniesienia do skasowanej karty"
+
+#~ msgid "no such tab page"
+#~ msgstr "nie ma takiej karty"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "próba odniesienia do skasowanego okna"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "atrybut tylko do odczytu: bufor"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "pozycja kursora poza buforem"
+
+#~ msgid "no such window"
+#~ msgstr "nie ma takiego okna"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "próba odniesienia do skasowanego bufora"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "nie powiod³a siê zmiana nazwy bufora"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "nazwa zak³adki musi byæ pojedynczym znakiem"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "oczekiwa³em na obiekt vim.Buffer, a dosta³em %s"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "nie przeszed³em do bufora %d"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "oczekiwa³em na obiekt vim.Window, a dosta³em %s"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "nie znaleziono okna na bie¿±cej karcie"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "nie przeszed³em do okre¶lonego okna"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "oczekiwa³em na obiekt vim.TabPage, a dosta³em %s"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "nie przeszed³em do okre¶lonej karty"
+
+#~ msgid "failed to run the code"
+#~ msgstr "uruchomienie kodu siê nie powiod³o"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: eval nie zwróci³o odpowiedniego obiektu pythona"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Nie powiod³a siê konwersja obiektu pythona do warto¶ci Vima"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "nie mo¿na konwertowaæ %s do s³ownika Vima"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "nie mo¿na konwertowaæ %s do struktury Vima"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "b³±d wewnêtrzny: przekazano referencjê NULL"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "b³±d wewnêtrzny: b³êdny typ warto¶ci"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Nie mogê ustawiæ haka ¶cie¿ki: sys.path_hooks nie jest list±\n"
+#~ "Powiniene¶ teraz wykonaæ nastêpuj±ce czynno¶ci:\n"
+#~ "- dodaæ vim.path_hook do sys.path_hooks\n"
+#~ "- dodaæ vim.VIM_SPECIAL_PATH do sys.path\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Nie mogê ustawiæ ¶cie¿ki: sys.path nie jest list±\n"
+#~ "Powinno siê teraz dodaæ vim.VIM_SPECIAL_PATH do sys.path"
 
 #~ msgid "softspace must be an integer"
 #~ msgstr "softspace musi byæ liczb± ca³kowit±"

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-08-04 20:05-0300\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-08-04 20:36-0300\n"
 "Last-Translator: Eduardo S. Dobay <edudobay@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt-br@li.org>\n"
@@ -13,138 +13,207 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Lixo após argumento de opção"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Lista de locais]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Lista quickfix]"
+
+#: ../buffer.c:94
+#, fuzzy
+msgid "E855: Autocommands caused command to abort"
+msgstr "E812: Autocomandos alteraram o buffer ou o nome do buffer"
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Não foi possível alocar nenhum buffer, saindo do Vim..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Impossível alocar buffer; tentando usar outro..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Nenhum buffer foi descarregado"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Nenhum buffer foi apagado"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Nenhum buffer foi eliminado"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer descarregado"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffers descarregados"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer apagado"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffers apagados"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer eliminado"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffers eliminados"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Impossível descarregar último buffer"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Não foram encontrados buffers modificados"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Não há buffers listados"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Buffer %<PRId64> não existe"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Não é possível ir além do último buffer"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Não é possível ir para antes do primeiro buffer"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
-msgstr "E89: Alterações no buffer %<PRId64> não foram gravadas (adicione ! para forçar)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr ""
+"E89: Alterações no buffer %<PRId64> não foram gravadas (adicione ! para "
+"forçar)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Impossível descarregar último buffer"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Aviso: Estouro da lista de nomes de arquivos"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Buffer %<PRId64> não encontrado"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Mais de uma correspondência com %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Nenhum buffer coincide com %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "linha %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Já existe um buffer com esse nome"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modificado]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Não editado]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Novo arquivo]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Erros de leitura]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[S/L]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[somente-leitura]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 linha --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> linhas --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "linha %<PRId64> de %<PRId64> --%d%%-- col "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Sem nome]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "ajuda"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Ajuda]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Visualização]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Tudo"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Fim"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Topo"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -152,15 +221,11 @@ msgstr ""
 "\n"
 "# Lista de buffers:\n"
 
-msgid "[Location List]"
-msgstr "[Lista de locais]"
-
-msgid "[Quickfix List]"
-msgstr "[Lista quickfix]"
-
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Rascunho]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -168,137 +233,200 @@ msgstr ""
 "\n"
 "--- Sinais ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Sinais para %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    linha=%<PRId64>  id=%d  nome=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Dois-pontos faltando"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Modo de operação inválido"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: era esperado um algarismo"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Porcentagem inválida"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Não é possível usar diff com mais de %<PRId64> buffers"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Não foi possível ler ou gravar arquivos temporários"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: diff não funcionou"
 
-msgid "Patch file"
-msgstr "Selecionar arquivo de patch"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Não foi possível ler o resultado do patch"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Não foi possível ler o resultado do diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: O buffer atual não está no modo diff"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Não há nenhum outro buffer modificável em modo diff"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Não há nenhum outro buffer no modo diff"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Há mais de dois buffers no modo diff; não sei quais usar"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Buffer \"%s\" não encontrado"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffer \"%s\" não está no modo diff"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Buffer foi alterado inesperadamente"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Caractere escape não é permitido em dígrafos"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Arquivo de mapa de teclado não encontrado"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap usado fora de um script Vim"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Entrada vazia no mapa de teclado"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Completar palavra-chave (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " modo ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Completar linha inteira (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Completar nome de arquivo (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Completar marcador (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Completar padrão de caminho (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Completar definição (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Completar do dicionário (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Completar do dicionário de sinônimos (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Completar da linha de comando (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Completar definido pelo usuário (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Completação inteligente (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Sugestão de ortografia (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Completar palavra-chave local (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Fim do parágrafo atingido"
 
+#: ../edit.c:101
+#, fuzzy
+msgid "E839: Completion function changed window"
+msgstr "E813: Não é possível fechar a janela autocmd"
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "opção 'dictionary' vazia"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "opção 'thesaurus' vazia"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Examinando dicionário: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (inserção) Rolagem (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (substituição) Rolagem (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Examinando: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Examinando tags."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Adicionando"
 
@@ -306,426 +434,585 @@ msgstr " Adicionando"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Procurando..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "De volta ao original"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Palavra de outra linha"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "A única correspondência"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "correspondência %d de %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "correspondência %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caracteres inesperados em :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: índice da lista fora dos limites: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Variável indefinida: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: ']' faltando"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argumento de %s deve ser uma Lista"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argumento de %s deve ser uma Lista ou Dicionário"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Impossível usar chave vazia num Dicionário"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Lista requerida"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Dicionário requerido"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Muitos argumentos para a função: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Chave inexistente no Dicionário: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Função %s já existe, adicione ! para substituí-la"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Entrada do Dicionário já existente"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Referência de função (Funcref) requerida"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Não é possível usar [:] com um Dicionário"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Variável de tipo errado para %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Função desconhecida: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Nome ilegal para variável: %s"
 
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr "E806: Float usado como String"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Há menos destinos que itens na Lista"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Há mais destinos que itens na Lista"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "; duplo na lista de variáveis"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Impossível listar variáveis %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Só Listas ou Dicionários podem ser indexados"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] deve vir por último"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] requer uma Lista"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: a Lista tem mais itens que o destino"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: a Lista não tem itens suficientes"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: \"in\" faltando após :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Parênteses faltando: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Variável inexistente: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variável aninhada demais para ser (des)bloqueada"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: ':' faltando depois de '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Uma Lista só pode ser comparada com outra Lista"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Operação inválida para Listas"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Um Dicionário só pode ser comparado com outro Dicionário"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Operação inválida para um Dicionário"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Funcref só pode ser comparada com outra Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Operação inválida para Funcrefs"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Não é possível usar '%' com Float"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: ')' faltando"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Não é possível indexar uma Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Nome de opção faltando: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Opção desconhecida: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Aspas duplas (\") faltando: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Aspas simples (') faltando: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Falta uma vírgula na Lista: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Lista não finalizada com ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Dois-pontos faltando no Dicionário: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Chave duplicada no Dicionário: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Vírgula faltando no Dicionário: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Dicionário não finalizado com '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variável aninhada demais para ser exibida"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Argumentos demais para a função %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Argumentos inválidos para a função %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Função desconhecida: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Argumentos insuficientes para a função: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> usado fora de um script: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Função dict chamada sem um Dicionário: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Número ou Float requerido"
 
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "argumento -c"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Argumentos demais"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() só pode ser usado no modo de Inserção"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&OK"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Chave já existe: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "argumento --cmd"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "argumento -c"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "argumento -c"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld linhas: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Função desconhecida: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Cancelar"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() foi chamado mais vezes que inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "argumento -c"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Intervalos não são permitidos"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Tipo inválido para len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Incremento nulo"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: O início está depois do fim"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<vazio>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Nenhuma conexão a um servidor do Vim"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "argumento --cmd"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Não foi possível enviar para %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Não foi possível ler a resposta do servidor"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Links simbólicos em excesso (cíclicos?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Não foi possível enviar ao cliente"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "argumento -c"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "argumento -c"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "argumento -c"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: A função de comparação para a classificação falhou"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: A função de comparação para a classificação falhou"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Inválido)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Erro ao gravar o arquivo temporário"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float usado como Número"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref usada como Número"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Lista usada como Número"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Dicionário usado como Número"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref usada como String"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Lista usada como String"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Dicionário usado como String"
 
-msgid "E806: using Float as a String"
-msgstr "E806: Float usado como String"
-
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Nome de variável Funcref deve começar com letra maiúscula: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Nome da variável em conflito com função já existente: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Tipo de variável incoerente para: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Impossível excluir variável %s"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Nome de variável Funcref deve começar com letra maiúscula: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Nome da variável em conflito com função já existente: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Valor bloqueado: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Desconhecido"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Não é possível mudar valor de %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: variável aninhada demais para fazer uma cópia"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Função indefinida: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: '(' faltando: %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Não foi possível definir os valores do contexto de entrada"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Argumento inválido: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "Nome de campo duplicado: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: :endfunction faltando"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Nome da função em conflito com variável: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Não é possível redefinir a função %s: ela está em uso"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Nome da função não coincide com o nome de arquivo do script: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Nome da função requerido"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
-msgstr "E128: Nome da função deve começar com letra maiúscula ou conter dois-pontos: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: Nome da função deve começar com letra maiúscula ou conter dois-pontos: "
+"%s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Nome da função deve começar com letra maiúscula ou conter dois-pontos: "
+"%s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Não é possível excluir a função %s: ela está em uso"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Profundidade de chamadas de função é maior que 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "chamando %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s cancelada"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s devolveu #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s devolveu %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "continuando em %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return fora de uma função"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -733,6 +1020,7 @@ msgstr ""
 "\n"
 "# variáveis globais:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -740,213 +1028,104 @@ msgstr ""
 "\n"
 "\tDefinido pela última vez em "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Não há arquivos antigos"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Entrando modo de depuração.  Digite \"cont\" para continuar."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "linha %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "cmdo: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Ponto de interrupção em \"%s%s\", linha %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Ponto de interrupção não encontrado: %s"
-
-msgid "No breakpoints defined"
-msgstr "Nenhum ponto de interrupção definido"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  linha %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Primeiro digite \":profile start {nome_arquivo}\""
-
-msgid "Save As"
-msgstr "Salvar como"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Salvar as alterações em \"%s\"?"
-
-msgid "Untitled"
-msgstr "(Sem título)"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Alterações no buffer \"%s\" não foram gravadas"
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Aviso: Entrada inesperada em outro buffer (verifique os autocomandos)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Só há um arquivo para editar"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Impossível ir antes do primeiro arquivo"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Impossível ir além do último arquivo"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: compilador não suportado: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Procurando por \"%s\" em \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Procurando por \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "não encontrado em 'runtimepath': \"%s\""
-
-msgid "Source Vim script"
-msgstr "Executar script do Vim"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Impossível executar um diretório: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "não foi possível executar \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "linha %<PRId64>: não foi possível executar \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "executando \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "linha %<PRId64>: executando \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "fim da execução de %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-msgid "--cmd argument"
-msgstr "argumento --cmd"
-
-msgid "-c argument"
-msgstr "argumento -c"
-
-msgid "environment variable"
-msgstr "variável de ambiente"
-
-msgid "error handler"
-msgstr "tratador de erro"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Aviso: Separador de linha incorreto; ^M pode estar faltando"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: :scriptencoding usado fora de um script"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: :finish usado fora de um script"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Idioma atual para %s: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Impossível definir idioma como \"%s\""
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: O destino coincide com a origem"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 linha movida"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> linhas movidas"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> linhas filtradas"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Os autocomandos *Filter* não devem modificar o buffer atual"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Alterações não gravadas]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s na linha: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Há erros demais; abandonando a leitura do arquivo"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Lendo arquivo viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " marcas"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " arquivos antigos"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " FALHOU"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: O arquivo viminfo não pode ser escrito: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Não é possível gravar o arquivo viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Gravando arquivo viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Este arquivo viminfo foi gerado pelo Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -954,38 +1133,47 @@ msgstr ""
 "# Você pode editá-lo se for cuidadoso!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Valor de 'encoding' quando este arquivo foi escrito\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Caractere inicial inválido"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Gravar arquivo parcial?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Use ! para gravar o buffer apenas parcialmente"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Sobrescrever arquivo existente \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "O arquivo de troca \"%s\" existe. Sobrescrevê-lo?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Arquivo de troca existe: %s (:silent! para forçar)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Sem nome de arquivo para o buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Arquivo não gravado: gravação desativada pela opção 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -994,6 +1182,7 @@ msgstr ""
 "\"%s\" está com a opção 'readonly' (somente-leitura) ativada.\n"
 "Você deseja gravar assim mesmo?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1004,65 +1193,84 @@ msgstr ""
 "Ainda pode ser possível gravar no arquivo.\n"
 "Você deseja tentar?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: \"%s\" é somente-leitura (adicione ! para forçar)"
 
-msgid "Edit File"
-msgstr "Editar arquivo"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
-msgstr "E143: Algum autocomando inesperadamente apagou o buffer %s recém-criado"
+msgstr ""
+"E143: Algum autocomando inesperadamente apagou o buffer %s recém-criado"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: argumento não-numérico passado a :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Comandos do shell não são permitidos no rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Expressões regulares não podem ser delimitadas por letras"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "substituir por %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Interrompido) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 correspondência"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 substituição"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> correspondências"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> substituições"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " em 1 linha"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " em %<PRId64> linhas"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global não pode ser executado recursivamente"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Expressão regular faltando no comando :global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Padrão encontrado em toda linha: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Padrão não encontrado"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1072,136 +1280,334 @@ msgstr ""
 "# Última string de substituição:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Não entre em pânico!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Desculpe, nenhuma ajuda para %s em '%s'"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Desculpe, nenhuma ajuda para %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Desculpe, arquivo de ajuda \"%s\" não encontrado"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Não é um diretório: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Não foi possível abrir %s para escrita"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Não foi possível abrir %s para leitura"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Mistura de codificações nos arquivos de ajuda na língua: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Marcador duplicado \"%s\" no arquivo %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Subcomando sign desconhecido: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Nome do sinal faltando"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Muitos sinais definidos"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Texto de sinal inválido: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Sinal desconhecido: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Número do sinal faltando"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Nome de buffer inválido: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: ID de sinal inválido: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NÃO ENCONTRADO)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (não suportado)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Excluído]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Entrando modo de depuração.  Digite \"cont\" para continuar."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "linha %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "cmdo: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Ponto de interrupção em \"%s%s\", linha %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Ponto de interrupção não encontrado: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Nenhum ponto de interrupção definido"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  linha %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Primeiro digite \":profile start {nome_arquivo}\""
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Salvar as alterações em \"%s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "(Sem título)"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Alterações no buffer \"%s\" não foram gravadas"
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "Aviso: Entrada inesperada em outro buffer (verifique os autocomandos)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Só há um arquivo para editar"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Impossível ir antes do primeiro arquivo"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Impossível ir além do último arquivo"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: compilador não suportado: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Procurando por \"%s\" em \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Procurando por \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "não encontrado em 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Impossível executar um diretório: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "não foi possível executar \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "linha %<PRId64>: não foi possível executar \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "executando \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "linha %<PRId64>: executando \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "fim da execução de %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "argumento --cmd"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "argumento -c"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "variável de ambiente"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "tratador de erro"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Aviso: Separador de linha incorreto; ^M pode estar faltando"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: :scriptencoding usado fora de um script"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: :finish usado fora de um script"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Idioma atual para %s: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Impossível definir idioma como \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Entrando no modo Ex.  Digite \"visual\" para ir para o modo Normal."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Fim do arquivo"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Comando recursivo demais"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Exceção não interceptada: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Fim do arquivo executado"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Fim da função"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Uso ambíguo de comando definido pelo usuário"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Não é um comando do editor"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Intervalo com limites invertidos"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "O intervalo dado está com os limites invertidos. OK para reverter"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Use w ou w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Desculpe, esse comando não está disponível nesta versão"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Só é permitido um nome de arquivo"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Ainda há 1 arquivo para editar.  Sair mesmo assim?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Há mais %d arquivos para editar.  Sair mesmo assim?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Mais 1 arquivo para editar"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Mais %<PRId64> arquivos para editar"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Comando já existe; adicione ! para substituí-lo"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1209,283 +1615,344 @@ msgstr ""
 "\n"
 "    Nome        Args Intrv Complet.  Definição"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Nenhum comando definido pelo usuário foi encontrado"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Nenhum atributo foi especificado"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Número inválido de argumentos"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Quantificador não pode ser especificado duas vezes"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Valor padrão inválido para o quantificador"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: argumento necessário para -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Atributo inválido: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Nome de comando inválido"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
-msgstr "E183: Comandos definidos pelo usuário devem começar com letra maiúscula"
+msgstr ""
+"E183: Comandos definidos pelo usuário devem começar com letra maiúscula"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Uso ambíguo de comando definido pelo usuário"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Não existe tal comando definido pelo usuário: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Valor inválido para -complete: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Argumento só é permitido para completação personalizada"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Completação automática requer função como argumento"
 
-msgid "unknown"
-msgstr "desconhecido"
-
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Esquema de cores %s não encontrado"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Saudações, usuário do Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Não é possível fechar a última aba"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Já há apenas uma aba"
 
-msgid "Edit File in new window"
-msgstr "Editar arquivo em nova janela"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Aba %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Sem arquivo de troca"
 
-msgid "Append File"
-msgstr "Adicionar arquivo"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
-msgstr "E747: Impossível mudar de diretório, o buffer foi alterado (adicione ! para forçar)"
+msgstr ""
+"E747: Impossível mudar de diretório, o buffer foi alterado (adicione ! para "
+"forçar)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Não há diretório anterior"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Desconhecido"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize requer dois argumentos numéricos"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Posição da janela: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
-msgstr "E188: A obtenção da posição da janela não foi implementada para esta plataforma"
+msgstr ""
+"E188: A obtenção da posição da janela não foi implementada para esta "
+"plataforma"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos requer dois argumentos numéricos"
 
-msgid "Save Redirection"
-msgstr "Salvar redirecionamento"
-
-msgid "Save View"
-msgstr "Salvar visão atual"
-
-msgid "Save Session"
-msgstr "Salvar sessão"
-
-msgid "Save Setup"
-msgstr "Salvar configurações"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Diretório não pode ser criado: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existe (adicione ! para forçar)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" não pode ser aberto para escrita"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumento deve ser uma letra ou aspa (` ou ')"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Recursão excessiva de :normal"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< não está disponível sem o recurso +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Sem nome de arquivo alternativo para substituir '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
-msgstr "E495: nenhum nome de arquivo de autocomandos para substituir \"<afile>\""
+msgstr ""
+"E495: nenhum nome de arquivo de autocomandos para substituir \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
-msgstr "E496: nenhum número de buffer de autocomandos para substituir \"<abuf>\""
+msgstr ""
+"E496: nenhum número de buffer de autocomandos para substituir \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: nenhum critério de autocomando para substituir \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: nenhum nome de arquivo :source para substituir \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: nenhum nome de arquivo :source para substituir \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Nome de arquivo vazio para '%' ou '#' só funciona com \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Expressão resulta em string vazia"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: O arquivo viminfo não pode ser aberto para leitura"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Sem suporte a dígrafos nesta versão"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Não é possível lançar exceções com o prefixo 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Exceção lançada: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Exceção concluída: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Exceção descartada: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, linha %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Exceção interceptada: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s tornado(s) pendente(s)"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s continuado(s)"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s descartado(s)"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Exceção"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Erro e interrupção"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Erro"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Interrupção"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if aninhado demais"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif sem :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else sem :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif sem :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: mais de um :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif depois de :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for aninhados demais"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue sem :while ou :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break sem :while ou :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :endfor usado com :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :endwhile usado com :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try aninhado demais"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch sem :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch depois de :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally sem :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: mais de um :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry sem :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction fora de uma função"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Não é possível editar outro buffer agora"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Não é permitido mudar as informações do buffer agora"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "marcador"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " tipo arquivo\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "opção 'history' vale zero"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1494,221 +1961,303 @@ msgstr ""
 "\n"
 "# Histórico de %s (mais recente primeiro):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Linha de comando"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Expressões de busca"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Expressão"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Linhas de entrada"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar além do final do comando"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: A janela ou buffer ativo foi apagado"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Caminho inválido: '**[número]' deve estar no final do caminho ou "
+"seguido de '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Diretório \"%s\" não encontrado em 'cdpath'"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Arquivo \"%s\" não encontrado em 'path'"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Mais nenhum diretório \"%s\" encontrado em 'cdpath'"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Mais nenhum arquivo \"%s\" encontrado em 'path'"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autocomandos alteraram o buffer ou o nome do buffer"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Nome de arquivo inválido"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "é um diretório"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "não é um arquivo"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "é um dispositivo (desativado pela opção 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Novo arquivo]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Novo DIRETÓRIO]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Arquivo muito grande]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Permissão negada]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Autocomandos *ReadPre tornaram o arquivo ilegível"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Os autocomandos *ReadPre não devem alterar o buffer atual"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Lendo da entrada padrão...\n"
 
-msgid "Reading from stdin..."
-msgstr "Lendo da entrada padrão..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: A conversão tornou o arquivo ilegível!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[dispositivo de caractere]"
 
-msgid "[RO]"
-msgstr "[S/L]"
-
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR faltando]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[linhas longas divididas]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[NÃO convertido]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[convertido]"
 
-msgid "[crypted]"
-msgstr "[criptografado]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ERRO DE CONVERSÃO na linha %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[BYTE INVÁLIDO na linha %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ERROS DE LEITURA]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Não foi possível encontrar um arquivo temporário para a conversão"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Conversão com 'charconvert' falhou"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "não foi possível ler o resultado de 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Nenhum comando automático correspondente para acwrite buffer"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Os autocomandos apagaram ou descarregaram o buffer a ser gravado"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autocomando alterou número de linhas de maneira inesperada"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans não permite gravação de buffers não modificados"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Gravação parcial não é permitida em buffers do NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "não é um arquivo ou dispositivo com permissão de escrita"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "escrita em dispositivo desativada pela opção 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "é somente-leitura (adicione ! para forçar)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Impossível gravar arquivo de backup (adicione ! para forçar)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Erro de fechamento no arquivo de backup (adicione ! para forçar)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Impossível ler o arquivo para backup (adicione ! para forçar)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Impossível criar arquivo de backup (adicione ! para forçar)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Impossível fazer o backup (adicione ! para forçar)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: O resource fork seria perdido (adicione ! para forçar)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Não foi possível encontrar arquivo temporário para escrita"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Impossível converter (adicione ! para gravar sem converter)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Impossível abrir ligação para escrita"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Impossível abrir arquivo para escrita"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync falhou"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Falha no fechamento do arquivo"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: erro de gravação, conversão falhou (torne 'fenc' vazio para forçar)"
+msgstr ""
+"E513: erro de gravação, conversão falhou (torne 'fenc' vazio para forçar)"
 
+#: ../fileio.c:3441
 #, c-format
-msgid "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to override)"
-msgstr "E513: erro de gravação, conversão falhou na linha %<PRId64> (deixe 'fenc' vazio para forçar)"
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: erro de gravação, conversão falhou na linha %<PRId64> (deixe 'fenc' "
+"vazio para forçar)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: erro de gravação (sistema de arquivos cheio?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ERRO DE CONVERSÃO"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr "na linha %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Dispositivo]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Novo]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " adicionado(s)"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [g]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " gravado(s)"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: impossível salvar o arquivo original"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: impossível criar arquivo original vazio"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Impossível excluir arquivo de backup"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1716,103 +2265,137 @@ msgstr ""
 "\n"
 "AVISO: O arquivo original pode ter sido perdido ou danificado\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "não saia do editor até que o arquivo tenha sido gravado com sucesso!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[formato dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[formato mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[formato unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 linha, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> linhas, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 caractere"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> caracteres"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[sem fim de linha]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Última linha incompleta]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "AVISO: O arquivo foi alterado desde que foi carregado!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Você realmente deseja gravá-lo"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Erro ao gravar \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Erro ao fechar \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Erro ao ler \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: O autocomando FileChangedShell apagou o buffer"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Arquivo \"%s\" não está mais disponível"
 
+#: ../fileio.c:4906
 #, c-format
-msgid "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as well"
-msgstr "W12: Aviso: O arquivo \"%s\" foi alterado e o buffer também foi alterado no Vim!"
+msgid ""
+"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
+"well"
+msgstr ""
+"W12: Aviso: O arquivo \"%s\" foi alterado e o buffer também foi alterado no "
+"Vim!"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Veja \":help W12\" para mais informações."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Aviso: O arquivo \"%s\" foi alterado desde o início da edição!"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Veja \":help W11\" para mais informações."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
-msgstr "W16: Aviso: O modo do arquivo \"%s\" foi alterado desde o início da edição!"
+msgstr ""
+"W16: Aviso: O modo do arquivo \"%s\" foi alterado desde o início da edição!"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Veja \":help W16\" para mais informações."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Aviso: O arquivo \"%s\" foi criado após o início da edição!"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Aviso"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1820,39 +2403,48 @@ msgstr ""
 "&OK\n"
 "&Carregar arquivo"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Não foi possível preparar \"%s\" para ser recarregado"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Não foi possível recarregar \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Excluído--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "removendo automaticamente o autocomando: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Grupo inexistente: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Caractere inválido após *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Evento inexistente: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Grupo ou evento inexistente: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1860,533 +2452,768 @@ msgstr ""
 "\n"
 "--- Autocomandos ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: número inválido de buffer "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Não é possível executar autocomandos para TODOS os eventos"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Nenhum autocomando coincidente"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocomandos aninhados demais"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "Comandos automáticos %s para \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Executando %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocomando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: { faltando."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: } faltando."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Nenhuma dobra encontrada"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Impossível criar dobra com a configuração atual de 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
-msgstr "E351: Impossível excluir dobra com a configuração atual de 'foldmethod'"
+msgstr ""
+"E351: Impossível excluir dobra com a configuração atual de 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld linhas dobradas "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Adição a um buffer já lido"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: associação recursiva"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: já existe uma abreviação global para %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: já existe uma associação global para %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: já existe uma abreviação para %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: já existe uma associação para %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Nenhuma abreviação encontrada"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Nenhuma associação encontrada"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Modo inválido"
 
-msgid "<cannot open> "
-msgstr "<impossível abrir> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Sem linhas no buffer--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: impossível obter fonte %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Comando cancelado"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: impossível voltar ao diretório atual"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argumento requerido"
 
-msgid "Pathname:"
-msgstr "Caminho:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ deve ser seguido de /, ? ou &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: impossível obter diretório atual"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Inválido na janela da linha de comando; <CR> executa, CTRL-C sai"
 
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Cancelar"
-
-msgid "Vim dialog"
-msgstr "Diálogo do Vim"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Widget barra de rolagem: impossível obter geometria do pixmap 'thumb'"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Impossível criar BalloonEval com mensagem E callback"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Não é possível iniciar a interface gráfica"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Impossível ler de \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Impossível iniciar a interface gráfica, nenhuma fonte válida encontrada"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Valor inválido para 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Valor inválido para 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Impossível alocar cor %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Nenhum resultado sob o cursor; procurando próximo"
-
-msgid "Vim dialog..."
-msgstr "Diálogo do Vim..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Sim\n"
-"&Não\n"
-"&Cancelar"
+"E12: Comando não permitido no exrc/vimrc do diretório atual ou num arquivo "
+"de marcadores"
 
-msgid "Input _Methods"
-msgstr "_Métodos de entrada"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: :endif faltando"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Procurar e substituir..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry faltando"
 
-msgid "VIM - Search..."
-msgstr "VIM - Procurar..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile faltando"
 
-msgid "Find what:"
-msgstr "Localizar:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor faltando"
 
-msgid "Replace with:"
-msgstr "Substituir por:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile sem :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Coincidir palavra inteira"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor sem :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Diferenciar maiúsculas/minúsculas"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Arquivo existe (adicione ! para forçar)"
 
-msgid "Direction"
-msgstr "Direção"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Comando falhou"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Acima"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Erro interno"
 
-msgid "Down"
-msgstr "Abaixo"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Interrompido"
 
-msgid "Find Next"
-msgstr "Localizar próxima"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Endereço inválido"
 
-msgid "Replace"
-msgstr "Substituir"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Argumento inválido"
 
-msgid "Replace All"
-msgstr "Substituir todas"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Recebido um pedido \"die\" do gerenciador de sessão\n"
-
-msgid "Close"
-msgstr "Fechar"
-
-msgid "New tab"
-msgstr "Nova aba"
-
-msgid "Open Tab..."
-msgstr "Abrir aba..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Janela principal destruída inesperadamente\n"
-
-msgid "Font Selection"
-msgstr "Selecionar fonte"
-
-msgid "&Filter"
-msgstr "&Filtrar"
-
-msgid "&Cancel"
-msgstr "&Cancelar"
-
-msgid "Directories"
-msgstr "Diretórios"
-
-msgid "Filter"
-msgstr "Filtro"
-
-msgid "&Help"
-msgstr "A&juda"
-
-msgid "Files"
-msgstr "Arquivos"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Seleção"
-
-msgid "Find &Next"
-msgstr "Localizar &próxima"
-
-msgid "&Replace"
-msgstr "&Substituir"
-
-msgid "Replace &All"
-msgstr "Substituir &todas"
-
-msgid "&Undo"
-msgstr "&Desfazer"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Impossível encontrar janela de título \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Argumento inválido: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argumento não suportado: \"-%s\"; Use a versão OLE."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Expressão inválida: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Impossível abrir janela dentro de aplicação MDI"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Intervalo inválido"
 
-msgid "Close tab"
-msgstr "Fechar aba"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Comando inválido"
 
-msgid "Open tab..."
-msgstr "Abrir aba..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Localizar cadeia de caracteres (use '\\\\' para procurar por '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Localizar e Substituir (use '\\\\' para procurar por '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Não usado"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Diretório\t*.nada\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: Impossível alocar entrada do mapa de cores; algumas cores podem estar erradas"
-
+#: ../globals.h:1019
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Faltam fontes para os seguintes conjuntos de caracteres no conjunto de fontes %s:"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" é um diretório"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Nome do conjunto de fontes: %s"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Tamanho de rolagem inválido"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Fonte '%s' não é de largura fixa"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Nome do conjunto de fontes: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Fonte0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Fonte1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "O tamanho da Fonte%<PRId64> não é o dobro do da Fonte0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Tamanho da Fonte0: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Tamanho da Fonte1: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Especificação de fonte inválida"
+#: ../globals.h:1022
+#, c-format
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
-msgid "&Dismiss"
-msgstr "&Dispensar"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Chamada à biblioteca falhou para \"%s()\""
 
-msgid "no specific match"
-msgstr "nenhuma coincidência exata"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Marca tem número de linha inválido"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Seletor de fontes"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Marca não definida"
 
-msgid "Name:"
-msgstr "Nome:"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Impossível fazer mudanças, 'modifiable' está desativado"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Mostrar tamanho em pontos"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Scripts excessivamente aninhados"
 
-msgid "Encoding:"
-msgstr "Codificação:"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Nenhum arquivo alternativo"
 
-msgid "Font:"
-msgstr "Fonte:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Abreviação inexistente"
 
-msgid "Style:"
-msgstr "Estilo:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: '!' não permitido"
 
-msgid "Size:"
-msgstr "Tamanho:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr ""
+"E25: Interface gráfica não pode ser usada, não foi ativada na compilação"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ERRO no autômato Hangul"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Não existe grupo de destaque com tal nome: %s"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Nenhum texto foi inserido ainda"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Nenhuma linha de comando anterior"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Associação inexistente"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Nenhuma correspondência"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Nenhuma correspondência: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Nenhum nome de arquivo"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Nenhuma expressão regular de substituição anterior"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Nenhum comando anterior"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Nenhuma expressão regular anterior"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Intervalos não são permitidos"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Não há espaço suficiente"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Impossível criar arquivo %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Impossível obter nome do arquivo temporário"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Impossível abrir arquivo %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Impossível ler arquivo %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Alterações não foram gravadas (adicione ! para forçar)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Alterações não gravadas]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Argumento nulo"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Número era esperado"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Impossível abrir o arquivo de erros %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Memória esgotada!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Padrão não encontrado"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Padrão não encontrado: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argumento deve ser positivo"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Impossível voltar ao diretório anterior"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Nenhum erro"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Nenhuma lista de locais"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: String de busca danificada"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Autômato de expressão regular corrompido"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: opção 'readonly' está definida (adicione ! para forçar)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Impossível alterar variável somente-leitura \"%s\""
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Não é possível definir a variável na caixa de areia: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Erro ao ler arquivo de erros"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Isso não é permitido na caixa de areia"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Isso não é permitido aqui"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Configuração do modo de tela não é suportada"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Tamanho de rolagem inválido"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Opção 'shell' está vazia"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Não foi possível ler os dados dos símbolos!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Erro ao fechar o arquivo de troca"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: pilha de marcadores vazia"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Comando complexo demais"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Nome longo demais"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Muitos ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Muitos nomes de arquivos"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Caracteres em excesso no final da linha"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Marca desconhecida"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Impossível expandir os caracteres-curinga"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' não pode ser menor que 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' não pode ser menor que 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Erro na escrita"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Quantificador nulo"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> usado fora de um script"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Erro interno: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: padrão usa mais memória que 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: buffer vazio"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Padrão de busca ou delimitador inválido"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: O arquivo está carregado em outro buffer"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Opção '%s' não está definida"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Nome de registrador inválido: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "busca atingiu TOPO; continuando do FIM"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "busca atingiu FIM; continuando do TOPO"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Dois-pontos faltando"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Elemento inválido"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: era esperado um algarismo"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Página %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Sem texto para imprimir"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Imprimindo página %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Cópia %d de %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Impresso: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Impressão cancelada"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Erro ao escrever no arquivo PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Impossível abrir arquivo \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Impossível ler o arquivo de recursos de PostScript \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: arquivo \"%s\" não é um arquivo de recursos de PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
-msgstr "E619: arquivo \"%s\" não é um arquivo de recursos de PostScript suportado"
+msgstr ""
+"E619: arquivo \"%s\" não é um arquivo de recursos de PostScript suportado"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: versão errada do arquivo de recursos \"%s\""
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
-msgstr "E673: Codificação multi-byte incompatível com o conjunto de caracteres."
+msgstr ""
+"E673: Codificação multi-byte incompatível com o conjunto de caracteres."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
-msgstr "E674: 'printmbcharset' não pode estar vazio com codificações multi-byte."
+msgstr ""
+"E674: 'printmbcharset' não pode estar vazio com codificações multi-byte."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Nenhuma fonte padrão especificada para impressão em multi-byte."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Impossível abrir arquivo PostScript para saída"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Impossível abrir arquivo \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Arquivo de recursos de PostScript \"prolog.ps\" não encontrado"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Arquivo de recursos de PostScript \"cidfont.ps\" não encontrado"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Arquivo de recursos de PostScript \"%s.ps\" não encontrado"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Impossível converter para a codificação \"%s\" para impressão"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Enviando à impressora..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Não foi possível imprimir o arquivo PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Trabalho de impressão enviado."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Adicionar novo banco de dados"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Procurar por um padrão"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Mostrar esta mensagem"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Terminar uma conexão"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Reinicializar todas as conexões"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Mostrar conexões"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Forma de uso: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Este comando cscope não suporta a divisão da janela.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Forma de uso: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: marcador não encontrado"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: erro em stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: erro em stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s não é um diretório ou um banco de dados válido do cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Adicionado banco de dados do cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: erro ao ler a conexão %<PRId64> do cscope"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: tipo desconhecido de busca do cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Não foi possível criar os pipes para comunicação com o cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Não foi possível fazer a bifurcação de processo para o cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "a execução do cscope em cs_create_connection falhou"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "a execução do cscope em cs_create_connection falhou"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen para to_fp falhou"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen para fr_fp falhou"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Não foi possível invocar o processo do cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: não há conexões com o cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: marca %c inválida para %c em 'cscopequickfix'"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: nenhum resultado para a busca cscope %s de %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "comandos do cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Forma de uso: %s)"
 
+#: ../if_cscope.c:1155
+#, fuzzy
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2396,7 +3223,7 @@ msgid ""
 "       g: Find this definition\n"
 "       i: Find files #including this file\n"
 "       s: Find this C symbol\n"
-"       t: Find assignments to\n"
+"       t: Find this text string\n"
 msgstr ""
 "\n"
 "       c: Procurar funções que chamam esta função\n"
@@ -2408,32 +3235,31 @@ msgstr ""
 "       s: Procurar este símbolo do C\n"
 "       t: Procurar atribuições para isto\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: impossível abrir banco de dados do cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: impossível obter informações do banco de dados do cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: banco de dados do cscope repetido; não foi adicionado"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: conexão %s com o cscope não encontrada"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "conexão %s com o cscope fechada"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: erro fatal em cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Tag do cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2441,375 +3267,88 @@ msgstr ""
 "\n"
 "   #   linha"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "arquivo / contexto / linha\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Erro do cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Todos os bancos de dados do cscope redefinidos"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "nenhuma conexão ao cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    nome do banco de dados              adicionar caminho\n"
 
-msgid "E815: Sorry, this command is disabled, the MzScheme libraries could not be loaded."
-msgstr "E815: Desculpe, este comando está desativado. As bibliotecas do MzScheme não puderam ser carregadas."
-
-msgid "invalid expression"
-msgstr "expressão inválida"
-
-msgid "expressions disabled at compile time"
-msgstr "expressões desativadas na compilação"
-
-msgid "hidden option"
-msgstr "opção oculta"
-
-msgid "unknown option"
-msgstr "opção desconhecida"
-
-msgid "window index is out of range"
-msgstr "número da janela fora dos limites"
-
-msgid "couldn't open buffer"
-msgstr "impossível abrir buffer"
-
-msgid "cannot save undo information"
-msgstr "impossível salvar informações para desfazer"
-
-msgid "cannot delete line"
-msgstr "impossível excluir linha"
-
-msgid "cannot replace line"
-msgstr "impossível substituir linha"
-
-msgid "cannot insert line"
-msgstr "impossível inserir linha"
-
-msgid "string cannot contain newlines"
-msgstr "a cadeia não pode conter quebras de linha"
-
-msgid "Vim error: ~a"
-msgstr "Erro do Vim: ~a"
-
-msgid "Vim error"
-msgstr "Erro do Vim"
-
-msgid "buffer is invalid"
-msgstr "buffer inválido"
-
-msgid "window is invalid"
-msgstr "janela inválida"
-
-msgid "linenr out of range"
-msgstr "número de linha fora dos limites"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "não permitido na caixa de areia do Vim"
-
-msgid "E263: Sorry, this command is disabled, the Python library could not be loaded."
-msgstr "E263: Desculpe, este comando está desativado. A biblioteca do Python não pôde ser carregada."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Não é possível invocar o Python recursivamente"
-
-msgid "can't delete OutputObject attributes"
-msgstr "impossível excluir os atributos do OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "'softspace' deve ser um inteiro"
-
-msgid "invalid attribute"
-msgstr "atributo inválido"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() requer uma lista de cadeias de caracteres"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Erro ao inicializar objetos de E/S"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "tentativa de referência a buffer apagado"
-
-msgid "line number out of range"
-msgstr "número de linha fora dos limites"
-
-#, c-format
-msgid "<buffer object (deleted) at %p>"
-msgstr "<objeto buffer (apagado) em %p>"
-
-msgid "invalid mark name"
-msgstr "nome de marca inválido"
-
-msgid "no such buffer"
-msgstr "buffer inexistente"
-
-msgid "attempt to refer to deleted window"
-msgstr "tentativa de referência a janela excluída"
-
-msgid "readonly attribute"
-msgstr "atributo somente-leitura"
-
-msgid "cursor position outside buffer"
-msgstr "cursor posicionado fora do buffer"
-
-#, c-format
-msgid "<window object (deleted) at %p>"
-msgstr "<objeto janela (apagado) em %p>"
-
-#, c-format
-msgid "<window object (unknown) at %p>"
-msgstr "<objeto janela (desconhecido) em %p>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<janela %d>"
-
-msgid "no such window"
-msgstr "janela inexistente"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ deve ser uma instância de String"
-
-msgid "E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: Desculpe, este comando está desativado. A biblioteca do Ruby não pôde ser carregada."
-
-msgid "E267: unexpected return"
-msgstr "E267: \"return\" inesperado"
-
-msgid "E268: unexpected next"
-msgstr "E268: \"next\" inesperado"
-
-msgid "E269: unexpected break"
-msgstr "E269: \"break\" inesperado"
-
-msgid "E270: unexpected redo"
-msgstr "E270: \"redo\" inesperado"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: \"retry\" fora de bloco \"rescue\""
-
-msgid "E272: unhandled exception"
-msgstr "E272: exceção não tratada"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: status %d de longjmp desconhecido"
-
-msgid "Toggle implementation/definition"
-msgstr "Alternar implementação/definição"
-
-msgid "Show base class of"
-msgstr "Mostrar classe base de"
-
-msgid "Show overridden member function"
-msgstr "Mostrar função membro sobrescrita"
-
-msgid "Retrieve from file"
-msgstr "Recuperar do arquivo"
-
-msgid "Retrieve from project"
-msgstr "Recuperar do projeto"
-
-msgid "Retrieve from all projects"
-msgstr "Recuperar de todos os projetos"
-
-msgid "Retrieve"
-msgstr "Recuperar"
-
-msgid "Show source of"
-msgstr "Mostrar código de"
-
-msgid "Find symbol"
-msgstr "Procurar símbolo"
-
-msgid "Browse class"
-msgstr "Navegador de classe"
-
-msgid "Show class in hierarchy"
-msgstr "Mostrar classe na hierarquia"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Mostrar classe em hierarquia restrita"
-
-msgid "Xref refers to"
-msgstr "Xref refere-se a"
-
-msgid "Xref referred by"
-msgstr "Xref referido por"
-
-msgid "Xref has a"
-msgstr "Xref tem um"
-
-msgid "Xref used by"
-msgstr "Xref usado por"
-
-msgid "Show docu of"
-msgstr "Mostrar docum. de"
-
-msgid "Generate docu for"
-msgstr "Gerar docum. para"
-
-msgid "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in $PATH).\n"
-msgstr "Não foi possível conectar-se ao SNiFF+. Verifique o ambiente (sniffemacs precisa ser encontrado no $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Erro durante a leitura. Desconectado"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ está atualmente "
-
-msgid "not "
-msgstr "des"
-
-msgid "connected"
-msgstr "conectado"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Pedido do SNiFF+ desconhecido: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Erro ao conectar-se ao SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ desconectado"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Não é um buffer do SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Erro durante a gravação. Desconectado"
-
-msgid "invalid buffer number"
-msgstr "número inválido de buffer"
-
-msgid "not implemented yet"
-msgstr "ainda não implementado"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "não foi possível redefinir a(s) linha(s)"
-
-msgid "mark not set"
-msgstr "marca não definida"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "linha %d coluna %d"
-
-msgid "cannot insert/append line"
-msgstr "impossível inserir/adicionar linha"
-
-msgid "unknown flag: "
-msgstr "opção desconhecida: "
-
-msgid "unknown vimOption"
-msgstr "opção do Vim desconhecida"
-
-msgid "keyboard interrupt"
-msgstr "interrompido pelo teclado"
-
-msgid "vim error"
-msgstr "erro do vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "impossível criar comando de buffer/janela: o objeto está sendo excluído"
-
-msgid "cannot register callback command: buffer/window is already being deleted"
-msgstr "não foi possível registrar o comando de callback: o buffer/janela já está sendo excluído"
-
-#. This should never happen.  Famous last word?
-msgid "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"
-msgstr "E280: ERRO FATAL DO TCL: reflist corrompida!? Por favor relate isso para vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "não foi possível registrar o comando de callback: referência a buffer/janela não encontrada"
-
-msgid "E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: Desculpe, este comando está desativado. A biblioteca do Tcl não pôde ser carregada."
-
-msgid "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: ERRO DO TCL: código de saída não é int!? Por favor relate isso para vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: código de saída %d"
-
-msgid "cannot get line"
-msgstr "não foi possível obter a linha"
-
-msgid "Unable to register a command server name"
-msgstr "Não foi possível registrar um nome para o servidor de comandos"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Falha ao enviar comando ao programa de destino"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Foi usada uma id de servidor inválida: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Propriedade de registro de instância do VIM malformada encontrada e excluída!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Argumento de opção desconhecido"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Argumentos de edição em excesso"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argumento faltando após"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Lixo após argumento de opção"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
-msgstr "Demasiados argumentos \"+comando\", \"-c comando\" ou \"--cmd comando\""
+msgstr ""
+"Demasiados argumentos \"+comando\", \"-c comando\" ou \"--cmd comando\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Argumento inválido para"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d arquivos para editar\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Este Vim não foi compilado com o recurso diff."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "'-nb' não pode ser usado: não foi ativado na compilação\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Tentando abrir novamente arquivo de script: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Impossível abrir para leitura: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Impossível abrir para transcrição do script: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Erro: Não foi possível iniciar o gvim a partir do NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Aviso: Saída não é um terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Aviso: Entrada não é de um terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "linha de comando pré-vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Impossível ler de \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2817,18 +3356,23 @@ msgstr ""
 "\n"
 "Mais informações com: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[arquivo ..]    abrir o(s) arquivo(s) especificado(s)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               ler texto a partir da entrada padrão"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t marcador     editar arquivo onde o marcador é definido"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [arq.erro]   editar arquivo e abrir no primeiro erro"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2838,9 +3382,11 @@ msgstr ""
 "\n"
 "uso:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argumentos] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2848,13 +3394,7 @@ msgstr ""
 "\n"
 "   ou:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Se a caixa é ignorada, insira / antes da opção para torná-la maiúscula"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2864,326 +3404,195 @@ msgstr ""
 "\n"
 "Argumentos:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tApenas nomes de arquivo depois daqui"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNão expandir caracteres-curinga"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistrar o gvim para o OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tDesregistrar o gvim para o OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tExecutar a interface gráfica (como \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  ou  --nofork\tPrimeiro plano: Não separar a interface gráfica do terminal"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tModo Vi (como \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tModo Ex (como \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tModo silencioso ou \"batch\" (apenas para \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tModo diff (como \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tModo fácil (como \"evim\", o Vim não modal)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tmodo somente-leitura (como \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tmodo restrito (como \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tNão permitir alterações (gravação de arquivos)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tNão permitir alterações no texto"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tModo binário"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tModo Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tCompatível com o Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNão totalmente compatível com o Vi: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][arq]\t\tDetalhado [nível N] [gravar mensagens em 'arq']"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tModo de depuração (debug)"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNão usar arquivo de troca, apenas a memória"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tListar arquivos de troca e sair"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (nome de arquivo)\tRecuperar sessão perdida"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tMesmo que -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNão usar newcli para abrir janela"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <dispositivo>\tUsar <dispositivo> para E/S"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tiniciar no modo Árabe"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tIniciar no modo Hebraico"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tIniciar no modo Farsi (persa)"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tDefinir tipo de terminal como <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tUsar <vimrc> em vez de qualquer outro .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tUsar <gvimrc> em vez de qualquer outro .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNão carregar scripts de plugins"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tAbrir N abas (padrão: uma para cada arquivo)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tAbrir N janelas (padrão: uma para cada arquivo)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tComo -o, mas dividindo verticalmente"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tAbrir no final do arquivo"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<núm.l>\t\tComeçar na linha <núm.l>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <comando>\tExecutar <comando> antes de carregar qualquer vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
-msgstr "-c <comando>\t\tExecutar <comando> depois de carregar o primeiro arquivo"
+msgstr ""
+"-c <comando>\t\tExecutar <comando> depois de carregar o primeiro arquivo"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sessão>\t\tExecutar o arquivo <sessão> depois de carregar o\n"
 "\t\t\tprimeiro arquivo"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <script>\t\tLer comandos do modo Normal do arquivo <script>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
-msgstr "-w <script>\t\tAdicionar todos os comandos digitados ao arquivo <script>"
+msgstr ""
+"-w <script>\t\tAdicionar todos os comandos digitados ao arquivo <script>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <script>\t\tGravar todos os comandos digitados no arquivo <script>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tEditar arquivos criptografados"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tConectar o vim a este servidor X específico"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNão conectar ao servidor X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <arquivos>\tEditar <arquivos> num servidor Vim se possível"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <arqs.>  Idem, sem reclamar se não houver servidor"
-
-msgid "--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <arqs.>    Como --remote, mas esperar a edição dos arquivos"
-
-msgid "--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <arqs.>  Idem, sem reclamar se não houver servidor"
-
-msgid "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr "--remote-tab[-wait][-silent] <arqs.>  Como --remote, mas com uma aba por arquivo"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <teclas>   Enviar <teclas> para um servidor Vim e sair"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\tAvaliar <expr> num servidor Vim e exibir o resultado"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tListar servidores Vim disponíveis e sair"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <nome>\tEnviar para/tornar-se o servidor Vim <nome>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
-msgstr "--startuptime <arq.>\tGravar mensagens de cronometragem da inicialização para <arquivo>"
+msgstr ""
+"--startuptime <arq.>\tGravar mensagens de cronometragem da inicialização "
+"para <arquivo>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUsar <viminfo> em vez do .viminfo normal"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  ou  --help\tImprimir a ajuda (esta mensagem) e sair"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tImprimir informações da versão e sair"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumentos reconhecidos pelo gvim (versão Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumentos reconhecidos pelo gvim (versão neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumentos reconhecidos pelo gvim (versão Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tExecutar vim em <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tIniciar vim iconizado"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <nome>\t\tUsar recurso como se o vim fosse <nome>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Não implementado)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <cor>\tUsar <cor> para o fundo (abrev.: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <cor>\tUsar <cor> para texto normal (abrev.: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <fonte>\tUsar <fonte> para texto normal (abrev.: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <fonte>\tUsar <fonte> para texto em negrito"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <fonte>\tUsar <fonte> para texto em itálico"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\tUsar <geom> como geometria inicial (abrev.: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <larg.>\tUsar <larg.> como largura da borda (abrev.: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <larg.>  Usar <larg.> como largura da barra de rolagem (abrev.: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <altura>\tUsar <altura> para a barra de menus (abrev.: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tUsar vídeo reverso (abrev.: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNão usar vídeo reverso (abrev.: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <recurso>\tDefinir o recurso especificado"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argumentos reconhecidos pelo gvim (versão RISC OS):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <número>\tLargura inicial da janela, em colunas"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <número>\tAltura inicial da janela, em linhas"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumentos reconhecidos pelo gvim (versão GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tExecutar vim no <display> (alt.: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <papel>\tDefine um papel único para identificar a janela\n"
-"\t\t\tprincipal"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tAbrir o Vim dentro de outro widget do GTK"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <título pai>\tAbrir o Vim dentro de uma aplicação-pai"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tAbrir o Vim dentro de outro widget win32"
-
-msgid "No display"
-msgstr "Não há display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Envio falhou.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Envio falhou. Tentando executar localmente\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d de %d editados"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Não há display: Envio da expressão falhou.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Envio da expressão falhou.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Nenhuma marca definida"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Nenhuma marca coincide com \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3192,6 +3601,7 @@ msgstr ""
 "marc linha col arquivo/texto"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3200,6 +3610,7 @@ msgstr ""
 "salto linha col arquivo/texto"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3207,7 +3618,7 @@ msgstr ""
 "\n"
 "alter. linha col texto"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3216,7 +3627,7 @@ msgstr ""
 "# Marcas nos arquivos:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3224,7 +3635,7 @@ msgstr ""
 "\n"
 "# Lista de saltos (mais recente primeiro):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3232,118 +3643,116 @@ msgstr ""
 "\n"
 "# Histórico de marcas nos arquivos (mais recente primeiro):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "'>' faltando"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Página de códigos inválida"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Não foi possível definir os valores do contexto de entrada"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Falha ao criar o contexto de entrada"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Falha ao abrir o método de entrada"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Aviso: Não foi possível definir o callback de destruição do ME"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: o método de entrada não suporta nenhum estilo"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: o método de entrada não suporta meu tipo de pré-edição"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: o estilo over-the-spot requer um conjunto de fontes"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Sua versão do GTK+ é anterior à 1.2.3. A área de status foi desativada"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: O Servidor de Método de Entrada não está em execução"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: o bloco não estava travado"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Erro de posicionamento na leitura do arquivo de troca"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Erro de leitura no arquivo de troca"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Erro de posicionamento na escrita do arquivo de troca"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Erro de escrita no arquivo de troca"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Arquivo de troca já existe (ataque de symlink?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Não foi obtido o bloco nº 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Não foi obtido o bloco nº 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Não foi obtido o bloco nº 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Oops, o arquivo de troca foi perdido!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Não foi possível renomear o arquivo de troca"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
-msgstr "E303: Impossível abrir arquivo de troca para \"%s\", recuperação impossível"
+msgstr ""
+"E303: Impossível abrir arquivo de troca para \"%s\", recuperação impossível"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Não foi obtido o bloco 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Nenhum arquivo de troca encontrado para %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Insira o número do arquivo de troca a usar (0 para sair): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Impossível abrir %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Impossível ler o bloco 0 de "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
 msgstr ""
 "\n"
-"Talvez nenhuma mudança tenha sido feita ou o Vim não tenha atualizado o arquivo\n"
+"Talvez nenhuma mudança tenha sido feita ou o Vim não tenha atualizado o "
+"arquivo\n"
 "de troca."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " não pode ser usado com esta versão do Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Use o Vim versão 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s não se parece com um arquivo de troca do Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " não pode ser usado neste computador.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "O arquivo foi criado em "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3351,64 +3760,86 @@ msgstr ""
 ",\n"
 "ou o arquivo foi danificado."
 
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " foi danificado (o tamanho da página é menor que o valor mínimo).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Usando arquivo de troca \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Arquivo original \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Aviso: O arquivo original pode ter sido alterado"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Impossível ler o bloco 1 de %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???MUITAS LINHAS FALTANDO"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???NÚMERO DE LINHAS ERRADO"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???BLOCO VAZIO"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???LINHAS FALTANDO"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID do bloco 1 está errado (%s não é um arquivo .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOCO FALTANDO"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? daqui até ???FIM as linhas podem estar corrompidas"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? daqui até ???FIM linhas podem ter sido inseridas/excluídas"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???FIM"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Recuperação interrompida"
 
-msgid "E312: Errors detected while recovering; look for lines starting with ???"
-msgstr "E312: Erros detectados durante a recuperação; procure por linhas começando com ???"
+#: ../memline.c:1243
+msgid ""
+"E312: Errors detected while recovering; look for lines starting with ???"
+msgstr ""
+"E312: Erros detectados durante a recuperação; procure por linhas começando "
+"com ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Veja \":help E312\" para mais informações."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Recuperação concluída. Você deve verificar se está tudo certo."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3416,50 +3847,72 @@ msgstr ""
 "\n"
 "(Você talvez queira salvar este arquivo com outro nome\n"
 
-msgid "and run diff with the original file to check for changes)\n"
-msgstr "e executar diff com o arquivo original para verificar se houve alterações)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
+msgstr ""
+"e executar diff com o arquivo original para verificar se houve alterações)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Exclua o arquivo .swp em seguida.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Arquivos de troca encontrados:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   No diretório atual:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Usando o nome especificado:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   No diretório "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- nenhum --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "        pertence a: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "com data: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "       com data de: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [do Vim versão 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [não se parece com um arquivo de troca do Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "   nome do arquivo: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3467,12 +3920,15 @@ msgstr ""
 "\n"
 "        modificado: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "SIM"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "não"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3480,9 +3936,11 @@ msgstr ""
 "\n"
 "   nome de usuário: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   nome do host: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3490,6 +3948,7 @@ msgstr ""
 "\n"
 "      nome do host: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3497,16 +3956,11 @@ msgstr ""
 "\n"
 "    ID do processo: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (ainda executando)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [não pode ser usado com esta versão do Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3514,75 +3968,97 @@ msgstr ""
 "\n"
 "         [não pode ser usado neste computador]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [não pode ser lido]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [não pode ser aberto]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Impossível preservar, não há um arquivo de troca"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Arquivo preservado"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Preservação falhou"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: número de linha inválido: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: linha %<PRId64> não encontrada"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: id do bloco de ponteiros incorreto: 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx deveria ser 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Foram atualizados blocos demais?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: id do bloco de ponteiros incorreto: 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "bloco 1 apagado?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Linha %<PRId64> não encontrada"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: id do bloco de ponteiros incorreto"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count é zero"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: número da linha fora dos limites: %<PRId64> além do fim"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: número de linhas incorreto no bloco %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Aumenta o tamanho da pilha"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: id do bloco de ponteiros incorreto: 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Links simbólicos cíclicos para \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ATENÇÃO"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3590,38 +4066,44 @@ msgstr ""
 "\n"
 "Foi encontrado um arquivo de troca de nome \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Ao abrir o arquivo \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      MAIS NOVO que o arquivo de troca!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Outro programa pode estar editando o mesmo arquivo.\n"
 "    Se for esse o caso, cuidado para não acabar com duas\n"
 "    versões do mesmo arquivo ao fazer alterações.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Saia do programa, ou continue com cuidado.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Ocorreu um travamento numa sessão de edição desse arquivo.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Se esse for o caso, use \":recover\" ou \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3629,9 +4111,11 @@ msgstr ""
 "\"\n"
 "    para recuperar as alterações (veja \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Se você já vez isso, exclua o arquivo de troca \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3639,18 +4123,23 @@ msgstr ""
 "\"\n"
 "    para evitar esta mensagem.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "O arquivo de troca \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" já existe!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ATENÇÃO"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "O arquivo de troca já existe!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3664,6 +4153,7 @@ msgstr ""
 "&Sair\n"
 "&Cancelar"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3679,34 +4169,56 @@ msgstr ""
 "&Sair\n"
 "&Cancelar"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Foram encontrados arquivos de troca demais"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Memória esgotada!  (ao alocar %<PRIu64> bytes)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Parte do caminho do item do menu não é um submenu"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menu só existe em outro modo"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Não há o menu \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Menu com nome vazio"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Caminho do menu não deve levar a um submenu"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Itens não devem ser adicionados diretamente à barra de menus"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Um separador não pode ser parte de um caminho de menu"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3714,60 +4226,73 @@ msgstr ""
 "\n"
 "--- Menus ---"
 
-msgid "Tear off this menu"
-msgstr "Destacar este menu"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Caminho de menu deve levar a um item de menu"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Menu não encontrado: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menu não definido para o modo %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: O caminho do menu deve levar a um submenu"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Menu não encontrado - verifique os nomes dos menus"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Erro detectado ao processar %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "linha %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nome de registrador inválido: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Tradutor das mensagens: Eduardo Dobay <edudobay@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Interrupção: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Aperte ENTER ou digite um comando para continuar"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s, linha %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Mais --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " ESPAÇO/d/j: tela/página/linha abaixo, b/u/k: acima, q: sair "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Questão"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3775,6 +4300,17 @@ msgstr ""
 "&Sim\n"
 "&Não"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Sim\n"
+"&Não\n"
+"&Cancelar"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3788,257 +4324,176 @@ msgstr ""
 "&Descartar tudo\n"
 "&Cancelar"
 
-msgid "Select Directory dialog"
-msgstr "Seletor de diretório"
-
-msgid "Save File dialog"
-msgstr "Salvar arquivo"
-
-msgid "Open File dialog"
-msgstr "Abrir arquivo"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Desculpe, não há um seletor de arquivos no modo console"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Argumentos insuficientes para printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Era esperado um argumento Float para printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Argumentos demais para printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Aviso: Modificando um arquivo somente-leitura"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
-msgstr "Digite um número e <Enter> ou clique com o mouse (deixe em branco para cancelar): "
+msgstr ""
+"Digite um número e <Enter> ou clique com o mouse (deixe em branco para "
+"cancelar): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Digite um número e <Enter> (deixe em branco para cancelar): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 linha a mais"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 linha a menos"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> linhas a mais"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> linhas a menos"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Interrompido)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Bip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: preservando arquivos...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Concluído.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "ERRO: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bytes] total alocado-liberado %<PRIu64>-%<PRIu64>, em uso %<PRIu64>, pico %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[total de chamadas] re/malloc() %<PRIu64>, free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: A linha está tornando-se muito longa"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Erro interno: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Memória esgotada!  (ao alocar %<PRIu64> bytes)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Chamando o shell para executar: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Dois-pontos faltando"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Modo de operação inválido"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 'mouseshape' inválido"
-
-msgid "E548: digit expected"
-msgstr "E548: era esperado um algarismo"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Porcentagem inválida"
-
-msgid "Enter encryption key: "
-msgstr "Insira a chave criptográfica: "
-
-msgid "Enter same key again: "
-msgstr "Insira a mesma chave novamente: "
-
-msgid "Keys don't match!"
-msgstr "As chaves não coincidem!"
-
-#, c-format
-msgid "E343: Invalid path: '**[number]' must be at the end of the path or be followed by '%s'."
-msgstr "E343: Caminho inválido: '**[número]' deve estar no final do caminho ou seguido de '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Diretório \"%s\" não encontrado em 'cdpath'"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Arquivo \"%s\" não encontrado em 'path'"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Mais nenhum diretório \"%s\" encontrado em 'cdpath'"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Mais nenhum arquivo \"%s\" encontrado em 'path'"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Não foi possível conectar-se ao Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Não foi possível conectar-se ao Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Modo de acesso errado para o arquivo de informação de conexão do NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "lido do socket do NetBeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Conexão com o NetBeans perdida para o buffer %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Nenhum identificador sob o cursor"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' está vazio"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: O recurso eval não está disponível"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Aviso: o terminal não suporta destaque no modo visual"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Nenhuma cadeia de caracteres sob o cursor"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Impossível eliminar dobras com o 'foldmethod' atual"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: lista de modificações está vazia"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: No início da lista de modificações"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: No final da lista de modificações"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Digite  :quit<Enter>  para sair do Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 linha %sada 1 vez"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 linha %sada %d vezes"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> linhas %sadas 1 vez"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> linhas %sadas %d vezes"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> linhas para indentar... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 linha indentada "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> linhas indentadas "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Nenhum registrador foi anteriormente utilizado"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "impossível copiar; excluir assim mesmo"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 linha alterada"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> linhas alteradas"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "liberando %<PRId64> linhas"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "bloco de uma linha copiado"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 linha copiada"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "bloco de %<PRId64> linhas copiado"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> linhas copiadas"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Não há nada no registrador %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4046,10 +4501,11 @@ msgstr ""
 "\n"
 "--- Registradores ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Nome de registrador inválido"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4057,145 +4513,181 @@ msgstr ""
 "\n"
 "# Registradores:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Registrador de tipo desconhecido %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> colunas; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selecionadas %s%<PRId64> de %<PRId64> linhas; %<PRId64> de %<PRId64> palavras; %<PRId64> de %<PRId64> bytes"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Selecionadas %s%<PRId64> de %<PRId64> linhas; %<PRId64> de %<PRId64> "
+"palavras; %<PRId64> de %<PRId64> bytes"
 
+#: ../ops.c:5105
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
-msgstr "Selecionadas %s%<PRId64> de %<PRId64> linhas; %<PRId64> de %<PRId64> palavras; %<PRId64> de %<PRId64> caracteres; %<PRId64> de %<PRId64> bytes"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Selecionadas %s%<PRId64> de %<PRId64> linhas; %<PRId64> de %<PRId64> "
+"palavras; %<PRId64> de %<PRId64> caracteres; %<PRId64> de %<PRId64> bytes"
 
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Coluna %s de %s; linha %<PRId64> de %<PRId64>; palavra %<PRId64> de %<PRId64>; byte %<PRId64> de %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Coluna %s de %s; linha %<PRId64> de %<PRId64>; palavra %<PRId64> de "
+"%<PRId64>; byte %<PRId64> de %<PRId64>"
 
+#: ../ops.c:5133
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Coluna %s de %s; linha %<PRId64> de %<PRId64>; palavra %<PRId64> de %<PRId64>; caractere %<PRId64> de %<PRId64>; byte %<PRId64> de %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Coluna %s de %s; linha %<PRId64> de %<PRId64>; palavra %<PRId64> de "
+"%<PRId64>; caractere %<PRId64> de %<PRId64>; byte %<PRId64> de %<PRId64>"
 
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> para BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Página %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Obrigado por voar com o Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Opção desconhecida"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Opção não suportada"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Não permitido em modelines"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Número requerido após ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Não encontrado no termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Caractere ilegal <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' não pode ser uma string vazia"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: term não pode ser alterado na interface gráfica"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Use \":gui\" para iniciar a interface gráfica"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' e 'patchmode' são iguais"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Não pode ser modificado na interface GTK+ 2"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Dois-pontos faltando"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Cadeia de comprimento zero"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Número faltando após <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Vírgula faltando"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: É necessário especificar um valor para '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: contém caracteres não-imprimíveis ou largos"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Fonte(s) inválida(s)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: impossível selecionar conjunto de fontes"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Conjunto de fontes inválido"
-
-msgid "E533: can't select wide font"
-msgstr "E533: impossível selecionar fonte de caracteres largos"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Fonte de caracteres largos inválida."
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Caractere inválido após <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: vírgula requerida"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' deve estar vazia ou conter %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Não há suporte a mouse"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Expressão não terminada com '}'"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: itens demais"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: parênteses desequilibrados"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Já existe uma janela de visualização"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Árabe requer UTF-8; digite ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: São necessárias pelo menos %d linhas"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: São necessárias pelo menos %d colunas"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Opção desconhecida: %s"
@@ -4203,10 +4695,12 @@ msgstr "E355: Opção desconhecida: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Número requerido: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4214,6 +4708,7 @@ msgstr ""
 "\n"
 "--- Códigos de terminal ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4221,6 +4716,7 @@ msgstr ""
 "\n"
 "--- Valores de opções globais ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4228,6 +4724,7 @@ msgstr ""
 "\n"
 "--- Valores de opções locais ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4235,140 +4732,21 @@ msgstr ""
 "\n"
 "--- Opções ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ERRO em get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Falta um caractere para corresponder com %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Caracteres a mais após ponto-e-vírgula: %s"
 
-msgid "cannot open "
-msgstr "impossível abrir "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Não foi possível abrir a janela!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Necessário Amigados versão 2.04 ou mais nova\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Necessário %s versão %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Impossível abrir NIL:\n"
-
-msgid "Cannot create "
-msgstr "Impossível criar "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim terminando com %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "impossível alterar o modo de console ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: não é um console??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Impossível executar shell com opção -f"
-
-msgid "Cannot execute "
-msgstr "Não é possível executar "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " devolveu\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE pequeno demais."
-
-msgid "I/O ERROR"
-msgstr "ERRO DE E/S"
-
-msgid "Message"
-msgstr "Mensagem"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' não vale 80; impossível executar comandos externos"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Seleção da impressora falhou"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "para %s em %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Fonte de impressão desconhecida: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Erro de impressão: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Imprimindo '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Conjunto de caracteres \"%s\" inválido no nome da fonte \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Caractere '%c' inválido no nome da fonte \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Sinal duplo, saindo\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Sinal mortal %s interceptado\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Sinal mortal interceptado\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Abertura do display X demorou %<PRId64> ms"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Recebido erro do X\n"
-
-msgid "Testing the X display failed"
-msgstr "Teste do display X falhou"
-
-msgid "Opening the X display timed out"
-msgstr "Abertura do display X excedeu o tempo-limite"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Não foi possível obter o contexto de segurança para "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Não foi possível definir o contexto de segurança para "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4376,13 +4754,7 @@ msgstr ""
 "\n"
 "Não foi possível executar o shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Não foi possível executar o shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4390,369 +4762,476 @@ msgstr ""
 "\n"
 "o shell devolveu "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Impossível criar pipes de comunicação\n"
+"Não foi possível obter o contexto de segurança para "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Impossível realizar bifurcação de processo\n"
+"Não foi possível definir o contexto de segurança para "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Comando interrompido\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP perdeu a conexão ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Abertura do display X falhou"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP tratando pedido de auto-salvamento"
-
-msgid "XSMP opening connection"
-msgstr "XSMP abrindo conexão"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "Falha no vigia de conexões ICE do XSMP"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "Falha em SmcOpenConnection do XSMP: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Arquivo \"%s\" não encontrado nos caminhos de busca"
 
-msgid "At line"
-msgstr "Na linha"
-
-msgid "Could not load vim32.dll!"
-msgstr "Não foi possível carregar vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Erro do VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Não foi possível definir os ponteiros de função para a DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "shell devolveu %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Evento %s interceptado\n"
-
-msgid "close"
-msgstr "de fechamento"
-
-msgid "logoff"
-msgstr "de logoff"
-
-msgid "shutdown"
-msgstr "de desligamento"
-
-msgid "E371: Command not found"
-msgstr "E371: Comando não encontrado"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE não foi encontrado no seu $PATH.\n"
-"Comandos externos não farão uma pausa ao terminar.\n"
-"Veja  :help win32-vimrun  para mais informações."
-
-msgid "Vim Warning"
-msgstr "Alerta do Vim"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Muitos %%%c na especificação do formato"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: %%%c inesperado na especificação do formato"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: ] faltando na especificação do formato"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c não suportado na especificação de formato"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: %%%c inválido no prefixo da especificação de formato"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: %%%c inválido na especificação de formato"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' não contém nenhum padrão"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: O nome do diretório está faltando ou vazio"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Não há mais itens"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d de %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (linha excluída)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: No final da pilha do quickfix"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: No topo da pilha do quickfix"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "lista de erros %d de %d; %d erros"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Impossível gravar, opção 'buftype' foi definida"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Nome de arquivo faltando ou padrão inválido"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Impossível abrir arquivo \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Buffer não está carregado"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Era esperada uma String ou uma Lista"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: item inválido em %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Padrão longo demais"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Muitos \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Muitos %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: \\z( sem correspondente"
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: %s%%( sem correspondente"
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: %s( sem correspondente"
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: %s) sem correspondente"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: caractere inválido após %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Muitos %s{...}s complexos"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: %s* aninhado"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: %s%c aninhado"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: uso inválido de \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c não segue nenhum item"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Retrorreferência inválida"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( não é permitido aqui"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 e cia. não são permitidos aqui"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Caractere inválido após \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: ] faltando após %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: %s%%[] vazio"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Caractere inválido após %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Caractere inválido após %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: ] faltando após %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: %s%%( sem correspondente"
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: %s( sem correspondente"
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: %s) sem correspondente"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( não é permitido aqui"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 e cia. não são permitidos aqui"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: ] faltando após %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: %s%%[] vazio"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Padrão longo demais"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Muitos \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Muitos %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: \\z( sem correspondente"
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: caractere inválido após %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Muitos %s{...}s complexos"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: %s* aninhado"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: %s%c aninhado"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: uso inválido de \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c não segue nenhum item"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Retrorreferência inválida"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Caractere inválido após \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Caractere inválido após %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Caractere inválido após %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Erro de sintaxe em %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Subcoincidências externas:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Muitos \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Não foi possível encontrar arquivo temporário para escrita"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " SUBSTITUIÇÃO VISUAL"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " SUBSTITUIÇÃO"
 
 # ESD - In Portuguese it would sound more natural if the message for
 #       "REVERSE" came *after* the message for "INSERT".
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " (INVERTIDA)"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INSERÇÃO"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (inserção)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (substituição)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (substituição visual)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebraico"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Árabe"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (língua)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (colar)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUAL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUAL/LINHA"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUAL/BLOCO"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " SELEÇÃO"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " SELEÇÃO DE LINHAS"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " SELEÇÃO EM BLOCO"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "gravando"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Texto de busca inválido: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: busca atingiu o TOPO sem encontrar: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: busca atingiu o FIM sem encontrar: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: '?' ou '/' esperado após ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (inclui coincidências listadas anteriormente)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Arquivos incluídos "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "não encontrados "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "no caminho de busca ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Já listado)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  NÃO ENCONTRADO"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Examinando arquivo incluído: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Examinando arquivo incluído %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: A correspondência está na linha atual"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Todos os arquivos incluídos foram encontrados"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Não há arquivos incluídos"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Definição não foi encontrada"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Padrão não foi encontrado"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr " de substituição"
 
 # ESD - The %s is replaced by the argument which is given to the wvsp_one()
 #       function (search.c).  The "Substitute " argument which may be given
 #       to it should be translated as well.
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4763,381 +5242,492 @@ msgstr ""
 "# Último padrão de busca %s:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Erro de formato no arquivo de verificação ortográfica"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Arquivo de verificação ortográfica truncado"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Texto a mais em %s, linha %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Nome do afixo longo demais em %s, linha %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Erro de formato em FOL, LOW ou UPP no arquivo de afixos"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Há um caractere fora dos limites em FOL, LOW ou UPP"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Comprimindo árvore de palavras..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: A verificação ortográfica não está ativada"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr "Aviso: A lista de palavras \"%s.%s.spl\" ou \"%s.ascii.spl\" não foi encontrada"
+msgstr ""
+"Aviso: A lista de palavras \"%s.%s.spl\" ou \"%s.ascii.spl\" não foi "
+"encontrada"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Lendo arquivo de verificação ortográfica \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Este não se parece com um arquivo de verificação ortográfica"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
-msgstr "E771: Arquivo de verificação ortográfica antigo; é necessário atualizá-lo"
+msgstr ""
+"E771: Arquivo de verificação ortográfica antigo; é necessário atualizá-lo"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
-msgstr "E772: Arquivo de verificação ortográfica é para uma versão mais nova do Vim"
+msgstr ""
+"E772: Arquivo de verificação ortográfica é para uma versão mais nova do Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Seção não suportada no arquivo de verificação ortográfica"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Aviso: região %s não é suportada"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Lendo arquivo de afixos %s..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Falha na conversão para palavra em %s, linha %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Conversão em %s não é suportada: de %s para %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Conversão em %s não é suportada"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Valor inválido para FLAG em %s, linha %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG encontrado após outros indicadores em %s, linha %d: %s"
 
+#: ../spell.c:4723
 #, c-format
-msgid "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line %d"
-msgstr "Definir COMPOUNDFORBIDFLAG após um item PFX pode causar resultados errados em %s, linha %d"
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+"Definir COMPOUNDFORBIDFLAG após um item PFX pode causar resultados errados "
+"em %s, linha %d"
 
+#: ../spell.c:4731
 #, c-format
-msgid "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line %d"
-msgstr "Definir COMPOUNDPERMITFLAG após um item PFX pode causar resultados errados em %s, linha %d"
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+"Definir COMPOUNDPERMITFLAG após um item PFX pode causar resultados errados "
+"em %s, linha %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Valor COMPOUNDRULES incorreto em %s, linha %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Valor COMPOUNDWORDMAX incorreto em %s, linha %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Valor COMPOUNDMIN incorreto em %s, linha %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Valor COMPOUNDSYLMAX incorreto em %s, linha %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Valor CHECKCOMPOUNDPATTERN incorreto em %s, linha %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr "Indicadores de combinação diferentes no bloco de afixos continuado em %s linha %d: %s"
+msgstr ""
+"Indicadores de combinação diferentes no bloco de afixos continuado em %s "
+"linha %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Afixo duplicado em %s, linha %d: %s"
 
+#: ../spell.c:4871
 #, c-format
-msgid "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s line %d: %s"
-msgstr "Afixo também usado para BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST em %s, linha %d: %s"
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+"Afixo também usado para BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
+"em %s, linha %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Esperado Y ou N em %s, linha %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Condição defeituosa em %s, linha %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Esperado número de REP(SAL) em %s, linha %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Esperado número de MAP em %s, linha %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Caractere duplicado em MAP em %s, linha %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Item não reconhecido ou duplicado em %s, linha %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Linha FOL/LOW/UPP faltando em %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX usado sem SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Há muitos prefixos postergados"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Há muitos indicadores de composição"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Há muitos prefixos postergados e/ou indicadores de composição"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Linha SOFO%s faltando em %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Linhas SAL e SOFO presentes em %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Indicador não numérico em %s, linha %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Indicador inválido em %s, linha %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "O valor de %s é diferente daquele usado em outro arquivo .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Lendo arquivo-dicionário %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Número de palavras não indicado em %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "linha %6d, palavra %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Palavra duplicada em %s, linha %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Primeira palavra duplicada em %s, linha %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d palavra(s) duplicada(s) em %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Foram ignoradas %d palavra(s) com caracteres não-ASCII em %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Lendo arquivo de palavras %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Linha /encoding= duplicada ignorada em %s, linha %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Linha /encoding= ignorada após uma palavra em %s, linha %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Linha /regions= duplicada ignorada em %s, linha %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Regiões demais em %s, linha %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Linha / ignorada em %s, linha %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Núm. de região inválido em %s, linha %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Indicadores não reconhecidos em %s, linha %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignoradas %d palavras com caracteres não-ASCII"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "%d de %d nós comprimidos; %d (%d%%) restantes"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Relendo o arquivo de verificação ortográfica..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Realizando análise fonética..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Número de palavras após análise fonética: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Número total de palavras: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Gravando arquivo de sugestões %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Consumo estimado de memória: %d bytes"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: O nome do arquivo não deve conter o nome da região"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: São suportadas apenas 8 regiões no máximo"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Região inválida em %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Aviso: tanto composição quanto NOBREAK foram especificados"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Gravando arquivo de verificação ortográfica %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Concluído!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' não contém %<PRId64> elementos"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Palavra removida de %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Palavra adicionada a %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Caracteres das palavras diferem entre os arquivos ortográficos"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Desculpe, não há sugestões"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Desculpe, apenas %<PRId64> sugestões"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Alterar \"%.*s\" para:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Nenhuma substituição ortográfica anterior"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Não encontrado: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Este não parece com um arquivo .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Arquivo .sug antigo, precisa ser atualizado: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Arquivo .sug é para uma versão mais nova do Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: O arquivo .sug não corresponde ao arquivo .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: erro ao ler o arquivo .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: caractere duplicado na entrada MAP"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Nenhum item sintático definido para este buffer"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Argumento inválido: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Não existe o agrupamento sintático: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Nenhum item sintático definido para este buffer"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "sincronização nos comentários no estilo do C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "sem sincronização"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "sincronização começa "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " linhas antes do topo da tela"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5145,6 +5735,7 @@ msgstr ""
 "\n"
 "--- Elementos de sincronização da sintaxe ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5152,6 +5743,7 @@ msgstr ""
 "\n"
 "sincronização sobre elementos"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5159,198 +5751,275 @@ msgstr ""
 "\n"
 "--- Elementos de sintaxe ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Não existe o agrupamento de sintaxe: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "mínimo "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "máximo "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; corresponder com "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " quebras de linha"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: o parâmetro \"contains\" não é aceito aqui"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: o parâmetro \"containedin\" não é aceito aqui"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Argumento inválido"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: o parâmetro \"group[t]here\" não é aceito aqui"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Não foi encontrado um item de região para %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Nome de arquivo requerido"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Muitos nomes de arquivos"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' faltando: %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: '=' faltando: %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Argumentos insuficientes: syntax region %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Não existe o agrupamento sintático: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Nenhum agrupamento especificado"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Delimitador de padrão não encontrado: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Caracteres indevidos após o padrão: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax sync: padrão de continuação de linha informado duas vezes"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Argumentos inválidos: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Sinal de igual faltando: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Argumento vazio: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s não é permitido aqui"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s deve ser o primeiro na lista de \"contains\""
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Nome de grupo desconhecido: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Subcomando inválido para :syntax: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: loop recursivo ao carregar syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: grupo de destaque não encontrado: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Argumentos insuficientes: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Argumentos demais: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: o grupo já tem suas definições; associação de destaque ignorada"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: sinal de igual inesperado: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: sinal de igual faltando: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: argumento faltando: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Valor inválido: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: cor do texto desconhecida"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: cor de fundo desconhecida"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Nome ou número de cor não reconhecido: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: código de terminal longo demais: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Argumento inválido: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
-msgstr "E424: Muitos atributos diferentes de destaque sendo usados simultaneamente"
+msgstr ""
+"E424: Muitos atributos diferentes de destaque sendo usados simultaneamente"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Caractere não-imprimível no nome do grupo"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Caractere inválido no nome do grupo"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: no fim da pilha de marcadores"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: no topo da pilha de marcadores"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Impossível ir para antes do primeiro marcador correspondente"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: marcador não encontrado: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri tipo marcador"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "arquivo\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Só há um marcador coincidente"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Impossível ir além do último marcador coincidente"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Arquivo \"%s\" não existe"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "marcador %d de %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " ou mais"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Usando etiqueta com caixa diferente!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Arquivo \"%s\" não existe"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5358,66 +6027,79 @@ msgstr ""
 "\n"
 "  # PARA marcador  DA linha   no arquivo/texto"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Examinando arquivo de marcadores %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Caminho dos arquivos de marcadores truncado para %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr "Ignorando linha muito longa no arquivo de marcas"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Erro de formato no arquivo de marcadores \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Antes do byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Arquivo de marcadores não ordenado: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Não há arquivo de marcadores"
 
-msgid "Ignoring long line in tags file"
-msgstr "Ignorando linha muito longa no arquivo de marcas"
-
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Padrão do marcador não encontrado"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Marcador não foi encontrado, tentando adivinhar apenas!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Nome de campo duplicado: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' desconhecido. Os terminais incorporados disponíveis são:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "usando por omissão '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Impossível abrir arquivo termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Descrição do terminal não encontrada em terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Descrição do terminal não encontrada em termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Nenhuma entrada \"%s\" em termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: é necessário o recurso de terminal \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5425,177 +6107,169 @@ msgstr ""
 "\n"
 "--- Teclas do terminal ---"
 
-msgid "new shell started\n"
-msgstr "novo shell iniciado\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Erro ao ler a entrada; saindo...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Foi usado CUT_BUFFER0 em vez de uma seleção vazia"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: Buffer foi alterado inesperadamente"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Impossível desfazer; continuando assim mesmo"
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Impossível abrir arquivo para escrita"
 
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Gravando arquivo viminfo \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Erro de escrita no arquivo de troca"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Lendo arquivo de palavras %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: O arquivo viminfo não pode ser aberto para leitura"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Não encontrado: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Impossível abrir arquivo %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "fim da execução de %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Já está na alteração mais antiga"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Já está na alteração mais nova"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "Desfazimento nº %<PRId64> não encontrado"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: números de linha errados"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "linha a mais"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "linhas a mais"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "linha a menos"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "linhas a menos"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "alteração"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "alterações"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "antes de"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "após"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Nada a desfazer"
 
-msgid "number changes  time"
-msgstr "número alteraç. hora"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> segundos atrás"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin não é permitido depois de desfazer"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: lista de desfazimentos corrompida"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: a linha para desfazer está faltando"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Versão gráfica para MS-Windows 16/32 bits"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Versão gráfica para MS-Windows 64 bits"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Versão gráfica para MS-Windows 32 bits"
-
-msgid " in Win32s mode"
-msgstr " no modo Win32s"
-
-msgid " with OLE support"
-msgstr " com suporte a OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Versão console para MS-Windows 64 bits"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Versão console para MS-Windows 32 bits"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Versão para MS-Windows 16 bits"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versão MS-DOS 32 bits"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Versão MS-DOS 16 bits"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Versão MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Versão MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Versão MacOS"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"Versão RISC OS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Versão OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5603,6 +6277,7 @@ msgstr ""
 "\n"
 "Correções incluídas: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -5610,9 +6285,11 @@ msgstr ""
 "\n"
 "Correções extras:"
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modificado por "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5620,9 +6297,11 @@ msgstr ""
 "\n"
 "Compilado "
 
+#: ../version.c:649
 msgid "by "
 msgstr "por "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5630,607 +6309,1679 @@ msgstr ""
 "\n"
 "Versão enorme "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Versão grande "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Versão normal "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Versão pequena "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Versão minúscula "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "sem interface gráfica."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "com interface GTK2-GNOME."
-
-msgid "with GTK-GNOME GUI."
-msgstr "com interface GTK-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "com interface GTK2."
-
-msgid "with GTK GUI."
-msgstr "com interface GTK."
-
-msgid "with X11-Motif GUI."
-msgstr "com interface X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "com interface X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "com interface X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "com interface Photon."
-
-msgid "with GUI."
-msgstr "com interface gráfica."
-
-msgid "with Carbon GUI."
-msgstr "com interface Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "com interface Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "com interface gráfica (clássica)."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Recursos incluídos (+) ou não (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "    arquivo vimrc de sistema: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "    arquivo vimrc do usuário: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 2º arquivo vimrc do usuário: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 3º arquivo vimrc do usuário: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "     arquivo exrc do usuário: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  2º arquivo exrc do usuário: \""
 
-msgid "  system gvimrc file: \""
-msgstr "   arquivo gvimrc de sistema: \""
-
-msgid "    user gvimrc file: \""
-msgstr "   arquivo gvimrc do usuário: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "2º arquivo gvimrc do usuário: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "3º arquivo gvimrc do usuário: \""
-
-msgid "    system menu file: \""
-msgstr "  arquivo de menu do sistema: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "            padrão para $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "     padrão para $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Compilação: "
 
-msgid "Compiler: "
-msgstr "Compilador: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Vinculação: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  VERSÃO DE DEPURAÇÃO"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - VI Melhorado"
 
+#: ../version.c:769
 msgid "version "
 msgstr "versão "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "por Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim tem código aberto e é livremente distribuível"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Ajude crianças pobres em Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "digite  :help iccf<Enter>     para informações   "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "digite  :q<Enter>             para sair          "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "digite  :help<Enter> ou <F1>  para ajuda on-line "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "digite  :help version7<Enter> para info da versão"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Executando no modo compatível com Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "digite  :set nocp<Enter>      para restaurar padrões do Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "digite  :help cp-default<Enter> para informações sobre isso"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "  menu  Ajuda->Órfãos         para informações             "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Execução não modal; todo texto digitado é inserido"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "  menu  Editar->Opções globais->Alternar modo de inserção  "
-
-msgid "                              for two modes      "
-msgstr "                              para voltar à execução modal "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "  menu  Editar->Opções globais->Alternar compatível com Vi "
-
-msgid "                              for Vim defaults   "
-msgstr "                              para restaurar padrões do Vim"
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Patrocine o desenvolvimento do Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Torne-se um usuário registrado do Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "digite  :help sponsor<Enter>  para informações  "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "digite  :help register<Enter> para informações  "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "menu  Ajuda->Doar/Registrar  para informações"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "AVISO: Windows 95/98/ME detectado"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "digite  :help windows95<Enter>  para informações sobre isso"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Já há apenas uma janela"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Não há janela de visualização"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: Impossível dividir nos cantos sup.esquerdo e inf.direito ao mesmo tempo"
+msgstr ""
+"E442: Impossível dividir nos cantos sup.esquerdo e inf.direito ao mesmo tempo"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Impossível rodar quando outra janela está dividida"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Não posso fechar a última janela"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Não é possível fechar a janela autocmd"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Não é possível fechar a janela, só restaria a janela autocmd"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Outra janela contém alterações"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Nenhum nome de arquivo sob o cursor"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Arquivo \"%s\" não encontrado nos caminhos de busca"
+#~ msgid "Patch file"
+#~ msgstr "Selecionar arquivo de patch"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Não foi possível carregar a biblioteca %s"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Cancelar"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Desculpe, este comando está desativado: a biblioteca do Perl não pôde ser carregada."
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Nenhuma conexão a um servidor do Vim"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Avaliação de expressões Perl na caixa de areia proibida sem o módulo Safe"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Não foi possível enviar para %s"
 
-msgid "Edit with &multiple Vims"
-msgstr "Editar em &múltiplos Vims"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Não foi possível ler a resposta do servidor"
 
-msgid "Edit with single &Vim"
-msgstr "Editar com único &Vim"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Não foi possível enviar ao cliente"
 
-msgid "Diff with Vim"
-msgstr "Comparar (diff) com Vim"
+#~ msgid "Save As"
+#~ msgstr "Salvar como"
 
-msgid "Edit with &Vim"
-msgstr "Editar com &Vim"
+#~ msgid "Source Vim script"
+#~ msgstr "Executar script do Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Editar com Vim existente - "
+#~ msgid "Edit File"
+#~ msgstr "Editar arquivo"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Edita o(s) arquivo(s) selecionado(s) com o Vim"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NÃO ENCONTRADO)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Erro ao criar processo: verifique se o gvim está no caminho de busca!"
+#~ msgid "unknown"
+#~ msgstr "desconhecido"
 
-msgid "gvimext.dll error"
-msgstr "erro da gvimext.dll"
+#~ msgid "Edit File in new window"
+#~ msgstr "Editar arquivo em nova janela"
 
-msgid "Path length too long!"
-msgstr "Caminho comprido demais!"
+#~ msgid "Append File"
+#~ msgstr "Adicionar arquivo"
 
-msgid "--No lines in buffer--"
-msgstr "--Sem linhas no buffer--"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Posição da janela: X %d, Y %d"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Comando cancelado"
+#~ msgid "Save Redirection"
+#~ msgstr "Salvar redirecionamento"
 
-msgid "E471: Argument required"
-msgstr "E471: Argumento requerido"
+#~ msgid "Save View"
+#~ msgstr "Salvar visão atual"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ deve ser seguido de /, ? ou &"
+#~ msgid "Save Session"
+#~ msgstr "Salvar sessão"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Inválido na janela da linha de comando; <CR> executa, CTRL-C sai"
+#~ msgid "Save Setup"
+#~ msgstr "Salvar configurações"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: Comando não permitido no exrc/vimrc do diretório atual ou num arquivo de marcadores"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< não está disponível sem o recurso +eval"
 
-msgid "E171: Missing :endif"
-msgstr "E171: :endif faltando"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Sem suporte a dígrafos nesta versão"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: :endtry faltando"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "é um dispositivo (desativado pela opção 'opendevice')"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: :endwhile faltando"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Lendo da entrada padrão..."
 
-msgid "E170: Missing :endfor"
-msgstr "E170: :endfor faltando"
+#~ msgid "[crypted]"
+#~ msgstr "[criptografado]"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile sem :while"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans não permite gravação de buffers não modificados"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor sem :for"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Gravação parcial não é permitida em buffers do NetBeans"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Arquivo existe (adicione ! para forçar)"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "escrita em dispositivo desativada pela opção 'opendevice'"
 
-msgid "E472: Command failed"
-msgstr "E472: Comando falhou"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: O resource fork seria perdido (adicione ! para forçar)"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Conjunto de fontes desconhecido: %s"
+#~ msgid "<cannot open> "
+#~ msgstr "<impossível abrir> "
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Fonte desconhecida: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: impossível obter fonte %s"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Fonte \"%s\" não é de largura fixa"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: impossível voltar ao diretório atual"
 
-msgid "E473: Internal error"
-msgstr "E473: Erro interno"
+#~ msgid "Pathname:"
+#~ msgstr "Caminho:"
 
-msgid "Interrupted"
-msgstr "Interrompido"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: impossível obter diretório atual"
 
-msgid "E14: Invalid address"
-msgstr "E14: Endereço inválido"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Argumento inválido"
+#~ msgid "Cancel"
+#~ msgstr "Cancelar"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Argumento inválido: %s"
+#~ msgid "Vim dialog"
+#~ msgstr "Diálogo do Vim"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Expressão inválida: %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr ""
+#~ "Widget barra de rolagem: impossível obter geometria do pixmap 'thumb'"
 
-msgid "E16: Invalid range"
-msgstr "E16: Intervalo inválido"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Impossível criar BalloonEval com mensagem E callback"
 
-msgid "E476: Invalid command"
-msgstr "E476: Comando inválido"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Não é possível iniciar a interface gráfica"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" é um diretório"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Impossível ler de \"%s\""
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Chamada à biblioteca falhou para \"%s()\""
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Impossível iniciar a interface gráfica, nenhuma fonte válida "
+#~ "encontrada"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Não foi possível carregar a função %s de biblioteca"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Valor inválido para 'guifontwide'"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Marca tem número de linha inválido"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Valor inválido para 'imactivatekey'"
 
-msgid "E20: Mark not set"
-msgstr "E20: Marca não definida"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Impossível alocar cor %s"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Impossível fazer mudanças, 'modifiable' está desativado"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Nenhum resultado sob o cursor; procurando próximo"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Scripts excessivamente aninhados"
+#~ msgid "Vim dialog..."
+#~ msgstr "Diálogo do Vim..."
 
-msgid "E23: No alternate file"
-msgstr "E23: Nenhum arquivo alternativo"
+#~ msgid "Input _Methods"
+#~ msgstr "_Métodos de entrada"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Abreviação inexistente"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Procurar e substituir..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: '!' não permitido"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Procurar..."
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Interface gráfica não pode ser usada, não foi ativada na compilação"
+#~ msgid "Find what:"
+#~ msgstr "Localizar:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebraico não pode ser usado, não foi ativado na compilação\n"
+#~ msgid "Replace with:"
+#~ msgstr "Substituir por:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Farsi (persa) não pode ser usado, não foi ativado na compilação\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Coincidir palavra inteira"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Árabe não pode ser usado, não foi ativado na compilação\n"
+#~ msgid "Match case"
+#~ msgstr "Diferenciar maiúsculas/minúsculas"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Não existe grupo de destaque com tal nome: %s"
+#~ msgid "Direction"
+#~ msgstr "Direção"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Nenhum texto foi inserido ainda"
+#~ msgid "Up"
+#~ msgstr "Acima"
 
-msgid "E30: No previous command line"
-msgstr "E30: Nenhuma linha de comando anterior"
+#~ msgid "Down"
+#~ msgstr "Abaixo"
 
-msgid "E31: No such mapping"
-msgstr "E31: Associação inexistente"
+#~ msgid "Find Next"
+#~ msgstr "Localizar próxima"
 
-msgid "E479: No match"
-msgstr "E479: Nenhuma correspondência"
+#~ msgid "Replace"
+#~ msgstr "Substituir"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Nenhuma correspondência: %s"
+#~ msgid "Replace All"
+#~ msgstr "Substituir todas"
 
-msgid "E32: No file name"
-msgstr "E32: Nenhum nome de arquivo"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Recebido um pedido \"die\" do gerenciador de sessão\n"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Nenhuma expressão regular de substituição anterior"
+#~ msgid "Close"
+#~ msgstr "Fechar"
 
-msgid "E34: No previous command"
-msgstr "E34: Nenhum comando anterior"
+#~ msgid "New tab"
+#~ msgstr "Nova aba"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Nenhuma expressão regular anterior"
+#~ msgid "Open Tab..."
+#~ msgstr "Abrir aba..."
 
-msgid "E481: No range allowed"
-msgstr "E481: Intervalos não são permitidos"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Janela principal destruída inesperadamente\n"
 
-msgid "E36: Not enough room"
-msgstr "E36: Não há espaço suficiente"
+#~ msgid "Font Selection"
+#~ msgstr "Selecionar fonte"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: nenhum servidor registrado com o nome \"%s\""
+#~ msgid "&Filter"
+#~ msgstr "&Filtrar"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Impossível criar arquivo %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Cancelar"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Impossível obter nome do arquivo temporário"
+#~ msgid "Directories"
+#~ msgstr "Diretórios"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Impossível abrir arquivo %s"
+#~ msgid "Filter"
+#~ msgstr "Filtro"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Impossível ler arquivo %s"
+#~ msgid "&Help"
+#~ msgstr "A&juda"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Alterações não foram gravadas (adicione ! para forçar)"
+#~ msgid "Files"
+#~ msgstr "Arquivos"
 
-msgid "E38: Null argument"
-msgstr "E38: Argumento nulo"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E39: Number expected"
-msgstr "E39: Número era esperado"
+#~ msgid "Selection"
+#~ msgstr "Seleção"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Impossível abrir o arquivo de erros %s"
+#~ msgid "Find &Next"
+#~ msgstr "Localizar &próxima"
 
-msgid "E233: cannot open display"
-msgstr "E233: impossível abrir display"
+#~ msgid "&Replace"
+#~ msgstr "&Substituir"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Memória esgotada!"
+#~ msgid "Replace &All"
+#~ msgstr "Substituir &todas"
 
-msgid "Pattern not found"
-msgstr "Padrão não encontrado"
+#~ msgid "&Undo"
+#~ msgstr "&Desfazer"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Padrão não encontrado: %s"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Impossível encontrar janela de título \"%s\""
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argumento deve ser positivo"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argumento não suportado: \"-%s\"; Use a versão OLE."
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Impossível voltar ao diretório anterior"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Impossível abrir janela dentro de aplicação MDI"
 
-msgid "E42: No Errors"
-msgstr "E42: Nenhum erro"
+#~ msgid "Close tab"
+#~ msgstr "Fechar aba"
 
-msgid "E776: No location list"
-msgstr "E776: Nenhuma lista de locais"
+#~ msgid "Open tab..."
+#~ msgstr "Abrir aba..."
 
-msgid "E43: Damaged match string"
-msgstr "E43: String de busca danificada"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Localizar cadeia de caracteres (use '\\\\' para procurar por '\\')"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Autômato de expressão regular corrompido"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Localizar e Substituir (use '\\\\' para procurar por '\\')"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: opção 'readonly' está definida (adicione ! para forçar)"
+#~ msgid "Not Used"
+#~ msgstr "Não usado"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Impossível alterar variável somente-leitura \"%s\""
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Diretório\t*.nada\n"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Não é possível definir a variável na caixa de areia: \"%s\""
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Impossível alocar entrada do mapa de cores; algumas cores podem "
+#~ "estar erradas"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Erro ao ler arquivo de erros"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Faltam fontes para os seguintes conjuntos de caracteres no conjunto "
+#~ "de fontes %s:"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Isso não é permitido na caixa de areia"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Nome do conjunto de fontes: %s"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Isso não é permitido aqui"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Fonte '%s' não é de largura fixa"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Configuração do modo de tela não é suportada"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Nome do conjunto de fontes: %s\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Tamanho de rolagem inválido"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Fonte0: %s\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Opção 'shell' está vazia"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Fonte1: %s\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Não foi possível ler os dados dos símbolos!"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "O tamanho da Fonte%<PRId64> não é o dobro do da Fonte0\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Erro ao fechar o arquivo de troca"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Tamanho da Fonte0: %<PRId64>\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: pilha de marcadores vazia"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Tamanho da Fonte1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: Comando complexo demais"
+#~ msgid "Invalid font specification"
+#~ msgstr "Especificação de fonte inválida"
 
-msgid "E75: Name too long"
-msgstr "E75: Nome longo demais"
+#~ msgid "&Dismiss"
+#~ msgstr "&Dispensar"
 
-msgid "E76: Too many ["
-msgstr "E76: Muitos ["
+#~ msgid "no specific match"
+#~ msgstr "nenhuma coincidência exata"
 
-msgid "E77: Too many file names"
-msgstr "E77: Muitos nomes de arquivos"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Seletor de fontes"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Caracteres em excesso no final da linha"
+#~ msgid "Name:"
+#~ msgstr "Nome:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Marca desconhecida"
+#~ msgid "Show size in Points"
+#~ msgstr "Mostrar tamanho em pontos"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Impossível expandir os caracteres-curinga"
+#~ msgid "Encoding:"
+#~ msgstr "Codificação:"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' não pode ser menor que 'winminheight'"
+#~ msgid "Font:"
+#~ msgstr "Fonte:"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' não pode ser menor que 'winminwidth'"
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
 
-msgid "E80: Error while writing"
-msgstr "E80: Erro na escrita"
+#~ msgid "Size:"
+#~ msgstr "Tamanho:"
 
-msgid "Zero count"
-msgstr "Quantificador nulo"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ERRO no autômato Hangul"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> usado fora de um script"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: erro em stat"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Expressão inválida recebida"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: impossível abrir banco de dados do cscope: %s"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: A região é protegida; impossível modificá-la"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: impossível obter informações do banco de dados do cscope"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: O NetBeans não permite alterações em arquivos somente-leitura"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Desculpe, este comando está desativado. As bibliotecas do MzScheme "
+#~ "não puderam ser carregadas."
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Erro interno: %s"
+#~ msgid "invalid expression"
+#~ msgstr "expressão inválida"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: padrão usa mais memória que 'maxmempattern'"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "expressões desativadas na compilação"
 
-msgid "E749: empty buffer"
-msgstr "E749: buffer vazio"
+#~ msgid "hidden option"
+#~ msgstr "opção oculta"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Padrão de busca ou delimitador inválido"
+#~ msgid "unknown option"
+#~ msgstr "opção desconhecida"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: O arquivo está carregado em outro buffer"
+#~ msgid "window index is out of range"
+#~ msgstr "número da janela fora dos limites"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Opção '%s' não está definida"
+#~ msgid "couldn't open buffer"
+#~ msgstr "impossível abrir buffer"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "busca atingiu TOPO; continuando do FIM"
+#~ msgid "cannot save undo information"
+#~ msgstr "impossível salvar informações para desfazer"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "busca atingiu FIM; continuando do TOPO"
+#~ msgid "cannot delete line"
+#~ msgstr "impossível excluir linha"
 
+#~ msgid "cannot replace line"
+#~ msgstr "impossível substituir linha"
+
+#~ msgid "cannot insert line"
+#~ msgstr "impossível inserir linha"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "a cadeia não pode conter quebras de linha"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Erro do Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Erro do Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer inválido"
+
+#~ msgid "window is invalid"
+#~ msgstr "janela inválida"
+
+#~ msgid "linenr out of range"
+#~ msgstr "número de linha fora dos limites"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "não permitido na caixa de areia do Vim"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Desculpe, este comando está desativado. A biblioteca do Python não "
+#~ "pôde ser carregada."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Não é possível invocar o Python recursivamente"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "impossível excluir os atributos do OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "'softspace' deve ser um inteiro"
+
+#~ msgid "invalid attribute"
+#~ msgstr "atributo inválido"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() requer uma lista de cadeias de caracteres"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Erro ao inicializar objetos de E/S"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "tentativa de referência a buffer apagado"
+
+#~ msgid "line number out of range"
+#~ msgstr "número de linha fora dos limites"
+
+#~ msgid "<buffer object (deleted) at %p>"
+#~ msgstr "<objeto buffer (apagado) em %p>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "nome de marca inválido"
+
+#~ msgid "no such buffer"
+#~ msgstr "buffer inexistente"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "tentativa de referência a janela excluída"
+
+#~ msgid "readonly attribute"
+#~ msgstr "atributo somente-leitura"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "cursor posicionado fora do buffer"
+
+#~ msgid "<window object (deleted) at %p>"
+#~ msgstr "<objeto janela (apagado) em %p>"
+
+#~ msgid "<window object (unknown) at %p>"
+#~ msgstr "<objeto janela (desconhecido) em %p>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<janela %d>"
+
+#~ msgid "no such window"
+#~ msgstr "janela inexistente"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ deve ser uma instância de String"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Desculpe, este comando está desativado. A biblioteca do Ruby não "
+#~ "pôde ser carregada."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: \"return\" inesperado"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: \"next\" inesperado"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: \"break\" inesperado"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: \"redo\" inesperado"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: \"retry\" fora de bloco \"rescue\""
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: exceção não tratada"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: status %d de longjmp desconhecido"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Alternar implementação/definição"
+
+#~ msgid "Show base class of"
+#~ msgstr "Mostrar classe base de"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Mostrar função membro sobrescrita"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Recuperar do arquivo"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Recuperar do projeto"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Recuperar de todos os projetos"
+
+#~ msgid "Retrieve"
+#~ msgstr "Recuperar"
+
+#~ msgid "Show source of"
+#~ msgstr "Mostrar código de"
+
+#~ msgid "Find symbol"
+#~ msgstr "Procurar símbolo"
+
+#~ msgid "Browse class"
+#~ msgstr "Navegador de classe"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Mostrar classe na hierarquia"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Mostrar classe em hierarquia restrita"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref refere-se a"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref referido por"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref tem um"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref usado por"
+
+#~ msgid "Show docu of"
+#~ msgstr "Mostrar docum. de"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Gerar docum. para"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Não foi possível conectar-se ao SNiFF+. Verifique o ambiente (sniffemacs "
+#~ "precisa ser encontrado no $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Erro durante a leitura. Desconectado"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ está atualmente "
+
+#~ msgid "not "
+#~ msgstr "des"
+
+#~ msgid "connected"
+#~ msgstr "conectado"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Pedido do SNiFF+ desconhecido: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Erro ao conectar-se ao SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ desconectado"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Não é um buffer do SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Erro durante a gravação. Desconectado"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "número inválido de buffer"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ainda não implementado"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "não foi possível redefinir a(s) linha(s)"
+
+#~ msgid "mark not set"
+#~ msgstr "marca não definida"
+
+#~ msgid "row %d column %d"
+#~ msgstr "linha %d coluna %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "impossível inserir/adicionar linha"
+
+#~ msgid "unknown flag: "
+#~ msgstr "opção desconhecida: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "opção do Vim desconhecida"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "interrompido pelo teclado"
+
+#~ msgid "vim error"
+#~ msgstr "erro do vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "impossível criar comando de buffer/janela: o objeto está sendo excluído"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "não foi possível registrar o comando de callback: o buffer/janela já está "
+#~ "sendo excluído"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ERRO FATAL DO TCL: reflist corrompida!? Por favor relate isso para "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "não foi possível registrar o comando de callback: referência a buffer/"
+#~ "janela não encontrada"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Desculpe, este comando está desativado. A biblioteca do Tcl não "
+#~ "pôde ser carregada."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: ERRO DO TCL: código de saída não é int!? Por favor relate isso para "
+#~ "vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: código de saída %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "não foi possível obter a linha"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Não foi possível registrar um nome para o servidor de comandos"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Falha ao enviar comando ao programa de destino"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Foi usada uma id de servidor inválida: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Propriedade de registro de instância do VIM malformada encontrada e "
+#~ "excluída!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Este Vim não foi compilado com o recurso diff."
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "'-nb' não pode ser usado: não foi ativado na compilação\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Erro: Não foi possível iniciar o gvim a partir do NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Se a caixa é ignorada, insira / antes da opção para torná-la maiúscula"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistrar o gvim para o OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tDesregistrar o gvim para o OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tExecutar a interface gráfica (como \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  ou  --nofork\tPrimeiro plano: Não separar a interface gráfica do "
+#~ "terminal"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNão usar newcli para abrir janela"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <dispositivo>\tUsar <dispositivo> para E/S"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tUsar <gvimrc> em vez de qualquer outro .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tEditar arquivos criptografados"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tConectar o vim a este servidor X específico"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNão conectar ao servidor X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <arquivos>\tEditar <arquivos> num servidor Vim se possível"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <arqs.>  Idem, sem reclamar se não houver servidor"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <arqs.>    Como --remote, mas esperar a edição dos arquivos"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <arqs.>  Idem, sem reclamar se não houver servidor"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <arqs.>  Como --remote, mas com uma aba por "
+#~ "arquivo"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <teclas>   Enviar <teclas> para um servidor Vim e sair"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <expr>\tAvaliar <expr> num servidor Vim e exibir o resultado"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tListar servidores Vim disponíveis e sair"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <nome>\tEnviar para/tornar-se o servidor Vim <nome>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconhecidos pelo gvim (versão Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconhecidos pelo gvim (versão neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconhecidos pelo gvim (versão Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tExecutar vim em <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tIniciar vim iconizado"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <nome>\t\tUsar recurso como se o vim fosse <nome>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Não implementado)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <cor>\tUsar <cor> para o fundo (abrev.: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <cor>\tUsar <cor> para texto normal (abrev.: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <fonte>\tUsar <fonte> para texto normal (abrev.: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <fonte>\tUsar <fonte> para texto em negrito"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <fonte>\tUsar <fonte> para texto em itálico"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tUsar <geom> como geometria inicial (abrev.: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <larg.>\tUsar <larg.> como largura da borda (abrev.: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <larg.>  Usar <larg.> como largura da barra de rolagem "
+#~ "(abrev.: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <altura>\tUsar <altura> para a barra de menus (abrev.: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tUsar vídeo reverso (abrev.: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNão usar vídeo reverso (abrev.: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <recurso>\tDefinir o recurso especificado"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconhecidos pelo gvim (versão RISC OS):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <número>\tLargura inicial da janela, em colunas"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <número>\tAltura inicial da janela, em linhas"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumentos reconhecidos pelo gvim (versão GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tExecutar vim no <display> (alt.: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <papel>\tDefine um papel único para identificar a janela\n"
+#~ "\t\t\tprincipal"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tAbrir o Vim dentro de outro widget do GTK"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <título pai>\tAbrir o Vim dentro de uma aplicação-pai"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tAbrir o Vim dentro de outro widget win32"
+
+#~ msgid "No display"
+#~ msgstr "Não há display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Envio falhou.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Envio falhou. Tentando executar localmente\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d de %d editados"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Não há display: Envio da expressão falhou.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Envio da expressão falhou.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Página de códigos inválida"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Falha ao criar o contexto de entrada"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Falha ao abrir o método de entrada"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Aviso: Não foi possível definir o callback de destruição do ME"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: o método de entrada não suporta nenhum estilo"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: o método de entrada não suporta meu tipo de pré-edição"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: o estilo over-the-spot requer um conjunto de fontes"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr ""
+#~ "E291: Sua versão do GTK+ é anterior à 1.2.3. A área de status foi "
+#~ "desativada"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: O Servidor de Método de Entrada não está em execução"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [não pode ser usado com esta versão do Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Destacar este menu"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Seletor de diretório"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Salvar arquivo"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Abrir arquivo"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Desculpe, não há um seletor de arquivos no modo console"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: preservando arquivos...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Concluído.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ERRO: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] total alocado-liberado %<PRIu64>-%<PRIu64>, em uso %<PRIu64>, "
+#~ "pico %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[total de chamadas] re/malloc() %<PRIu64>, free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: A linha está tornando-se muito longa"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Erro interno: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 'mouseshape' inválido"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Insira a chave criptográfica: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Insira a mesma chave novamente: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "As chaves não coincidem!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Não foi possível conectar-se ao Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Não foi possível conectar-se ao Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Modo de acesso errado para o arquivo de informação de conexão do "
+#~ "NetBeans: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "lido do socket do NetBeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Conexão com o NetBeans perdida para o buffer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: O recurso eval não está disponível"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "liberando %<PRId64> linhas"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: term não pode ser alterado na interface gráfica"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Use \":gui\" para iniciar a interface gráfica"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Não pode ser modificado na interface GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Fonte(s) inválida(s)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: impossível selecionar conjunto de fontes"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Conjunto de fontes inválido"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: impossível selecionar fonte de caracteres largos"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Fonte de caracteres largos inválida."
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Não há suporte a mouse"
+
+#~ msgid "cannot open "
+#~ msgstr "impossível abrir "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Não foi possível abrir a janela!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Necessário Amigados versão 2.04 ou mais nova\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Necessário %s versão %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Impossível abrir NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Impossível criar "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim terminando com %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "impossível alterar o modo de console ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: não é um console??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Impossível executar shell com opção -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Não é possível executar "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " devolveu\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE pequeno demais."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ERRO DE E/S"
+
+#~ msgid "Message"
+#~ msgstr "Mensagem"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' não vale 80; impossível executar comandos externos"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Seleção da impressora falhou"
+
+#~ msgid "to %s on %s"
+#~ msgstr "para %s em %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Fonte de impressão desconhecida: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Erro de impressão: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Imprimindo '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr ""
+#~ "E244: Conjunto de caracteres \"%s\" inválido no nome da fonte \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Caractere '%c' inválido no nome da fonte \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Sinal duplo, saindo\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Sinal mortal %s interceptado\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Sinal mortal interceptado\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Abertura do display X demorou %<PRId64> ms"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Recebido erro do X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Teste do display X falhou"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Abertura do display X excedeu o tempo-limite"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Não foi possível executar o shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Impossível criar pipes de comunicação\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Impossível realizar bifurcação de processo\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Comando interrompido\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP perdeu a conexão ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Abertura do display X falhou"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP tratando pedido de auto-salvamento"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP abrindo conexão"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "Falha no vigia de conexões ICE do XSMP"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "Falha em SmcOpenConnection do XSMP: %s"
+
+#~ msgid "At line"
+#~ msgstr "Na linha"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Não foi possível carregar vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Erro do VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Não foi possível definir os ponteiros de função para a DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "shell devolveu %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Evento %s interceptado\n"
+
+#~ msgid "close"
+#~ msgstr "de fechamento"
+
+#~ msgid "logoff"
+#~ msgstr "de logoff"
+
+#~ msgid "shutdown"
+#~ msgstr "de desligamento"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Comando não encontrado"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE não foi encontrado no seu $PATH.\n"
+#~ "Comandos externos não farão uma pausa ao terminar.\n"
+#~ "Veja  :help win32-vimrun  para mais informações."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Alerta do Vim"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Conversão em %s não é suportada"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: o parâmetro \"containedin\" não é aceito aqui"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Caminho dos arquivos de marcadores truncado para %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "novo shell iniciado\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Foi usado CUT_BUFFER0 em vez de uma seleção vazia"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Impossível desfazer; continuando assim mesmo"
+
+#~ msgid "number changes  time"
+#~ msgstr "número alteraç. hora"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão gráfica para MS-Windows 16/32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão gráfica para MS-Windows 64 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão gráfica para MS-Windows 32 bits"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " no modo Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " com suporte a OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão console para MS-Windows 64 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão console para MS-Windows 32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão para MS-Windows 16 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão MS-DOS 32 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão MS-DOS 16 bits"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão RISC OS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Versão OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versão grande "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versão normal "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versão pequena "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Versão minúscula "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "com interface GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "com interface GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "com interface GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "com interface GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "com interface X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "com interface X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "com interface X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "com interface Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "com interface gráfica."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "com interface Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "com interface Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "com interface gráfica (clássica)."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "   arquivo gvimrc de sistema: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "   arquivo gvimrc do usuário: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "2º arquivo gvimrc do usuário: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "3º arquivo gvimrc do usuário: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "  arquivo de menu do sistema: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Compilador: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "  menu  Ajuda->Órfãos         para informações             "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Execução não modal; todo texto digitado é inserido"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "  menu  Editar->Opções globais->Alternar modo de inserção  "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              para voltar à execução modal "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "  menu  Editar->Opções globais->Alternar compatível com Vi "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              para restaurar padrões do Vim"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "AVISO: Windows 95/98/ME detectado"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "digite  :help windows95<Enter>  para informações sobre isso"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Não foi possível carregar a biblioteca %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Desculpe, este comando está desativado: a biblioteca do Perl não pôde ser "
+#~ "carregada."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Avaliação de expressões Perl na caixa de areia proibida sem o "
+#~ "módulo Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Editar em &múltiplos Vims"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Editar com único &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Comparar (diff) com Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Editar com &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Editar com Vim existente - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Edita o(s) arquivo(s) selecionado(s) com o Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr ""
+#~ "Erro ao criar processo: verifique se o gvim está no caminho de busca!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "erro da gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Caminho comprido demais!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Conjunto de fontes desconhecido: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Fonte desconhecida: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Fonte \"%s\" não é de largura fixa"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Não foi possível carregar a função %s de biblioteca"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hebraico não pode ser usado, não foi ativado na compilação\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Farsi (persa) não pode ser usado, não foi ativado na compilação\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Árabe não pode ser usado, não foi ativado na compilação\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: nenhum servidor registrado com o nome \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: impossível abrir display"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Expressão inválida recebida"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: A região é protegida; impossível modificá-la"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: O NetBeans não permite alterações em arquivos somente-leitura"

--- a/src/nvim/po/ru.cp1251.po
+++ b/src/nvim/po/ru.cp1251.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim_7.4_ru\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-08-31 16:42+0400\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-08-31 21:11+0400\n"
 "Last-Translator: Sergey Alyoshin <alyoshin.s@gmail.com>\n"
 "Language-Team: \n"
@@ -18,166 +18,206 @@ msgstr ""
 "Content-Type: text/plain; charset=cp1251\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() вызван с пустым паролем"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Невозможно получить значение опции"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "Внутренняя ошибка: неизвестный тип опции"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr ""
-"E817: Неправильное использование обратного/прямого порядка байт в Blowfish"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: Не удалось выполнить тест sha256"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Не удалось выполнить тест Blowfish"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Список расположений]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Список быстрых исправлений]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Автокоманды вызвали прекращение команды"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Невозможно выделить память даже для одного буфера, выход..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Невозможно выделить память для буфера, используем другой буфер..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Ни один буфер не был выгружен из памяти"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Ни один буфер не был удалён"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Ни один буфер не был очищен"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Один буфер выгружен из памяти"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Всего выгружено буферов из памяти: %d"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Один буфер удалён"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Всего удалено буферов: %d"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Один буфер очищен"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Всего очищено буферов: %d"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Невозможно выгрузить из памяти последний буфер"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Изменённых буферов не обнаружено"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Буферы в списке отсутствуют"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Буфер %<PRId64> не существует"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Это последний буфер"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Это первый буфер"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Изменения в буфере %<PRId64> не сохранены (добавьте !, чтобы обойти проверку)"
+"E89: Изменения в буфере %<PRId64> не сохранены (добавьте !, чтобы обойти "
+"проверку)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Невозможно выгрузить из памяти последний буфер"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Предупреждение: переполнение списка имён файлов"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Буфер %<PRId64> не найден"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Несколько соответствий для %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Нет соответствующего %s буфера"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "строка %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер с таким именем уже существует"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Изменён]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Не редактировался]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Новый файл]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Ошибки чтения]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[ТЧ]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[только для чтения]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "Одна строка --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> стр. --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "стр. %<PRId64> из %<PRId64> --%d%%-- кол. "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Нет имени]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "справка"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Справка]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Предпросмотр]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Весь"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Внизу"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Наверху"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -185,9 +225,11 @@ msgstr ""
 "\n"
 "# Список буферов:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Временный]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -195,143 +237,199 @@ msgstr ""
 "\n"
 "--- Значки ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Значки для %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    строка=%<PRId64>  id=%d  имя=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Пропущено двоеточие"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Недопустимый режим"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Требуется ввести цифру"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Недопустимое значение процентов"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Следить за отличиями можно не более чем в %<PRId64> буферах"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Невозможно прочитать или записать временные файлы"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Невозможно создать файлы отличий"
 
-msgid "Patch file"
-msgstr "Файл-заплатка"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Невозможно прочитать вывод patch"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Невозможно прочитать вывод diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Активный буфер не находится в режиме отличий"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Больше нет изменяемых буферов в режиме отличий"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Больше нет буферов в режиме отличий"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: В режиме отличий более двух буферов, не могу выбрать"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Не могу найти буфер \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Буфер \"%s\" не находится в режиме отличий"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Буфер неожиданно изменился"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Экранирующий символ Escape нельзя использовать в диграфе"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Файл с раскладкой клавиатуры не найден"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Команда :loadkeymap применена вне файла сценария"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: пустая запись раскладки клавиатуры"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Автодополнение ключевого слова (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Режим ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Автодополнение целой строки (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Автодополнение имени файла (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Автодополнение метки (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Автодополнение шаблона пути (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Автодополнение определения (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Автодополнение по словарю (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Автодополнение синонимов (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Автодополнение командной строки (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Пользовательское автодополнение (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-дополнение (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Предложение исправления правописания (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Местное автодополнение ключевого слова (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Конец абзаца"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Функция автодополнения изменила окно"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Функция автодополнения удалила текст"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "Не задано значение опции 'dictionary'"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "Не задано значение опции 'thesaurus'"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Просмотр словаря: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (вставка) Прокрутка (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (замена) Прокрутка (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Просмотр: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Выполняется поиск среди меток."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Добавление"
 
@@ -339,471 +437,578 @@ msgstr " Добавление"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Поиск..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Исходное слово"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Слово из другой строки"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Единственное соответствие"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "соответствие %d из %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "соответствие %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неожиданные символы в :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Индекс списка за пределами диапазона: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Неопределённая переменная: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Пропущена ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Параметр %s должен быть списком"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Параметр %s должен быть списком или словарём"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Невозможно использовать пустой ключ для словаря"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Требуется список"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Требуется словарь"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Слишком много параметров для функции %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Нет ключа в словаре: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Функция %s уже существует. Добавьте !, чтобы заменить её."
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Запись уже существует в словаре"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Требуется ссылка на функцию"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Невозможно использовать [:] со словарём"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Неправильный тип переменной для %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Неизвестная функция: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Недопустимое имя переменной: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: Использование числа с плавающей точкой как строки"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Целей меньше чем элементов списка"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Целей больше чем элементов списка"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Двойная ; в списке переменных"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Невозможно отобразить переменные для %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Индексирование возможно только списка или словаря"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] должно быть последним"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] требует значением список"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Элементов списка-значения больше чем в цели"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Список-значение не содержит достаточно элементов"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Пропущено \"in\" после :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Пропущены скобки: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Нет такой переменной: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Слишком глубоко вложенные переменные для (раз)блокировки"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Пропущено ':' после '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Список можно сравнивать только со списком"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Недопустимая операция для списков"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Словарь можно сравнивать только со словарём"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Недопустимая операция для словаря"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Ссылку на функцию можно сравнивать только с ссылкой на функцию"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Недопустимая операция для ссылки на функцию"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Невозможно использовать '%' с числом с плавающей точкой"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Пропущена ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Невозможно индексировать ссылку на функцию"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Не указано имя опции: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Неизвестная опция: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Пропущена кавычка: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Пропущена кавычка: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Пропущена запятая в списке: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Пропущено окончание списка ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Пропущено двоеточие в словаре: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Повтор ключа в словаре: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Пропущена запятая в словаре: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Пропущено окончание словаря '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Слишком глубоко вложенные переменные для отображения"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Слишком много параметров для функции %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Параметры для функции %s заданы неверно"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Неизвестная функция: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Недостаточно параметров для функции %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> используется вне сценария: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Вызов функции dict без словаря: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Требуется целое число или с плавающей точкой"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "параметра add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Слишком много параметров"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() может использоваться только в режиме Вставки"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Ключ уже существует: %s"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "параметра extend()"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "параметра map()"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "параметра filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld строк: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Неизвестная функция: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&C Отмена"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Функция inputrestore() вызывается чаще, чем функция inputsave()"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "параметра insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Диапазон не допускается"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Неправильные тип для len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Нулевой шаг"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Начало после конца"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<пусто>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Нет связи с сервером Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Не могу отправить сообщение для %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Сервер не отвечает"
-
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "параметра remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Слишком много символических ссылок (цикл?)"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "параметра reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Не могу ответить клиенту"
-
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "параметра sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "параметра add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Неудачное завершение функции сравнения при сортировке"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Неудачное завершение функции сравнения при сортировке"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Неправильно)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Ошибка записи во временный файл"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Использование числа с плавающей точкой как целого"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Использование ссылки на функцию как числа"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Использование списка как числа"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Использование словаря как числа"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Использование ссылки на функцию как строки"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Использование списка как строки"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Использование словаря как строки"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Несоответствие типа переменной для: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Невозможно удалить переменную %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr ""
 "E704: Имя переменной ссылки на функцию должно начинаться с заглавной буквы: "
 "%s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Имя переменной конфликтует с существующей функцией: %s"
 
-#. Используется с %s = "параметера p"
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Значение %s заблокировано"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#. Используется с %s = "параметера p()"
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Невозможно изменить значение %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Слишком глубоко вложенные переменные для копирования"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Неопределённая функция: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Пропущена '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Здесь невозможно использовать g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Недопустимый параметр: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Повторяющееся имя параметра: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Пропущена команда :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Имя функции конфликтует с переменной: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Невозможно переопределить функцию %s, она используется"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Имя функции не соответствует имени файла сценария: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Требуется имя функции"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Имя функции должно начинаться с заглавной буквы или содержать "
 "двоеточие: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Имя функции должно начинаться с заглавной буквы или содержать "
+"двоеточие: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Невозможно удалить функцию %s, она используется"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Глубина вызова функции больше, чем значение 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "вызов %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s прервана"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s возвращает #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s возвращает %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "продолжение в %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: команда :return вне функции"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -811,6 +1016,7 @@ msgstr ""
 "\n"
 "# глобальные переменные:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -818,83 +1024,105 @@ msgstr ""
 "\n"
 "\tВ последний раз опция изменена в "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Нет старых файлов"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Строки перемещаются сами на себя"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Перемещена одна строка"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Перемещено строк: %<PRId64>"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Пропущено через фильтр строк: %<PRId64>"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманды *Filter* не должны изменять активный буфер"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Изменения не сохранены]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s в строке: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr ""
 "E136: viminfo: Слишком много ошибок, остальная часть файла будет пропущена"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Чтение файла viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " инфо"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " отметок"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " старых файлов"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " НЕУДАЧНО"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Права на запись файла viminfo отсутствуют: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Невозможно записать файл viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Запись файла viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Этот файл viminfo автоматически создан Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -902,40 +1130,47 @@ msgstr ""
 "# Его можно (осторожно!) редактировать.\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Значение опции 'encoding' в момент записи файла\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Недопустимый начальный символ"
 
-msgid "Save As"
-msgstr "Сохранить как"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Записать файл частично?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Для записи части буфера используйте !"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Перезаписать существующий файл \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Своп-файл \"%s\" существует, перезаписать?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Своп-файл существует: %s (:silent! чтобы обойти проверку)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Буфер %<PRId64> не связан с именем файла"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не сохранён: запись отключена опцией 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -944,6 +1179,7 @@ msgstr ""
 "Для \"%s\" включена опция 'readonly'.\n"
 "Записать?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -954,69 +1190,84 @@ msgstr ""
 "Но, возможно, файл удастся записать.\n"
 "Хотите попробовать?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr ""
 "E505: \"%s\" открыт только для чтения (добавьте !, чтобы обойти проверку)"
 
-msgid "Edit File"
-msgstr "Редактирование файла"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Автокоманды неожиданно убили новый буфер %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Параметр команды :z должен быть числом"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Использование команд оболочки не допускается в rvim."
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регулярные выражения не могут разделяться буквами"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "заменить на %s? (y/n/a/q/l/^E/^Y)"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Прервано)"
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "Одно соответствие"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "Одна замена"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> соответствий"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> замен"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " в одной строке"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " в %<PRId64> стр."
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Команда :global не может быть рекурсивной"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: В команде :global пропущено регулярное выражение"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Соответствие шаблону найдено на каждой строке: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Шаблон не найден: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1026,265 +1277,336 @@ msgstr ""
 "# Последняя строка для замены:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Спокойствие, только спокойствие!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: К сожалению, справка '%s' для %s отсутствует"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: К сожалению справка для %s отсутствует"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Извините, файл справки \"%s\" не найден"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s не является каталогом"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Невозможно открыть %s для записи"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Невозможно открыть %s для чтения"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Файлы справки используют разные кодировки для одного языка: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Повторяющаяся метка \"%s\" в файле %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Неизвестная команда значка %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Пропущено имя значка"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Определено слишком много значков"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Неправильный текст значка: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Неизвестный значок: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Пропущен номер значка"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Неправильное имя буфера: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Неправильный ID значка: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (НЕ НАЙДЕНО)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (не поддерживается)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Удалено]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Включён режим отладки. Для продолжения наберите \"cont\""
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "строка %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "команда: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Точка остановки в \"%s%s\" стр. %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Точка остановки не найдена: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Точки остановки не определены"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s стр. %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Первое использование \":profile start {имя-файла}\""
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Сохранить изменения в \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Без имени"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Несохранённые изменения в буфере \"%s\""
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Предупреждение: Неожиданный переход в другой буфер (проверьте автокоманды)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Для редактирования доступен только один файл"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Это первый файл"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Это последний файл"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Компилятор не поддерживается: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Поиск \"%s\" в \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Поиск \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "не найдено в 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Выполнить сценарий Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Нельзя считать каталог: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "невозможно считать \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "строка %<PRId64>: невозможно считать \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "считывание сценария \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "строка %<PRId64>: считывание \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "считывание сценария %s завершено"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "режимная строка"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd параметр"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c параметр"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "переменная окружения"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "обработчик ошибки"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr ""
 "W15: Предупреждение: неправильный разделитель строки. Возможно пропущено ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: Команда :scriptencoding используется вне файла сценария"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: Команда :finish используется вне файла сценария"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Активный %sязык: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Невозможно сменить язык на \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Переход в режим Ex. Для перехода в Обычный режим наберите \"visual\""
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: В конце файла"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Слишком рекурсивная команда"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Исключительная ситуация не обработана: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Конец считанного файла"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Конец функции"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Неоднозначное использование команды пользователя"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Это не команда редактора"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Задан обратный диапазон"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Задан обратный диапазон, меняем границы местами"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Используйте w или w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Извините, эта команда недоступна в данной версии"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Разрешено использовать только одно имя файла"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 файл ожидает редактирования. Выйти?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Есть неотредактированные файлы (%d). Выйти?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 файл ожидает редактирования."
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Есть неотредактированные файлы (%<PRId64>)."
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда уже существует. Добавьте ! для замены."
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1292,294 +1614,340 @@ msgstr ""
 "\n"
 "    Имя      Парам. Диап. Дополн.    Определение"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Команды, определённые пользователем, не обнаружены."
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Параметр не задан"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Неправильное количество параметров"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Число-приставку нельзя указывать дважды"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Неправильное значение числа-приставки по умолчанию"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: Для -complete требуется указать параметр"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Неправильный атрибут: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Неправильное имя команды"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Команда пользователя должна начинаться с заглавной буквы"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr ""
 "E841: Зарезервированное имя не может использоваться для команд пользователя"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Нет такой команды пользователя: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Неправильное значение дополнения: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Параметр автодополнения можно использовать только с особым дополнением"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Особое дополнение требует указания параметра функции"
 
-msgid "unknown"
-msgstr "неизвестно"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Невозможно найти цветовую схему '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Приветствуем вас, пользователь Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Нельзя закрыть последнюю вкладку"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "На экране всего одна вкладка"
 
-msgid "Edit File in new window"
-msgstr "Редактировать файл в новом окне"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Вкладка %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Без своп-файла"
 
-msgid "Append File"
-msgstr "Добавить файл"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Смена каталога невозможна, буфер изменён (добавьте !, чтобы обойти "
 "проверку)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Нет предыдущего каталога"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Неизвестно"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: Команда :winsize требует указания двух числовых параметров"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Положение окна: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: В данной системе определение положения окна не работает"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: Команда :winpos требует указания двух числовых параметров"
 
-msgid "Save Redirection"
-msgstr "Перенаправление записи"
-
-msgid "Save View"
-msgstr "Сохранение вида"
-
-msgid "Save Session"
-msgstr "Сохранение сеанса"
-
-msgid "Save Setup"
-msgstr "Сохранение настроек"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Невозможно создать каталог: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" существует (добавьте !, чтобы обойти проверку)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Невозможно открыть для записи \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Параметр должен быть прямой/обратной кавычкой или буквой"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Слишком глубокая рекурсия при использовании команды :normal"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< не доступно без особенности +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Нет соседнего имени файла для замены '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Нет автокомандного имени файла для замены \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Нет автокомандного номера буфера для замены \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Нет автокомандного имени соответствия для замены \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: Нет имени файла :source для замены \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: Нет номера строки для использования \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Пустое имя файла для '%' или '#', возможно только c \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Результатом выражения является пустая строка"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Невозможно открыть файл viminfo для чтения"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: В этой версии диграфы не работают"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr ""
 "E608: Невозможно выполнить команду :throw для исключений с приставкой 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Исключительная ситуация: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Завершена обработка исключительной ситуации: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Исключительная ситуация проигнорирована: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, строка %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Обработка исключительной ситуации: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s выполняет ожидание"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s возобновлено"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s пропущено"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Исключительная ситуация"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Ошибка и прерывание"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Ошибка"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Прерывание"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Слишком глубоко вложенный :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif без :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else без :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif без :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Обнаружено несколько :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif после :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Слишком глубокое вложение :while или :for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue без :while или :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break без :while или :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Использование :endfor с :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Использование :endwhile с :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Слишком глубоко вложенный :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch без :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch без :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally без :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Обнаружено несколько :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry без :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: Команда :endfunction может использоваться только внутри функции"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Сейчас не допускается редактирование другого буфера"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Сейчас не допускается изменение информации о буфере"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "имя метки"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " тип файла\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "значение опции 'history' равно нулю"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1588,192 +1956,253 @@ msgstr ""
 "\n"
 "# %s, история (начиная от свежего к старому):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Командная строка"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Строка поиска"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Выражение"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Строка ввода"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar больше длины команды"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Удалено активное окно или буфер"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: слишком большой путь для автодополнения"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Неправильно задан путь: '**[число]' должно быть либо в конце пути, "
+"либо за ним должно следовать '%s'"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Каталог \"%s\" не найден в пути для смены каталога"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Файл \"%s\" в известных каталогах не найден"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: В пути смены каталога больше нет каталогов \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: В известных каталогах больше нет файлов \"%s\""
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Автокоманды изменили буфер или имя буфера"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Недопустимое имя файла"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "является каталогом"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "не является файлом"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "является устройством (отключено при опции 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Новый файл]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Новый КАТАЛОГ]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Файл слишком большой]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Доступ запрещён]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: В результате выполнения автокоманд *ReadPre файл стал нечитаемым"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Автокоманды *ReadPre не должны изменять активный буфер"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Чтение из стандартного потока ввода stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Чтение из стандартного потока ввода stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: В результате преобразования файл стал нечитаемым!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/гнездо]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[гнездо]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[специальный символьный]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[пропущены символы CR]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[длинные строки разбиты]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[БЕЗ преобразований]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[перекодировано]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[зашифровано]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ОШИБКА ПРЕОБРАЗОВАНИЯ в строке %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[НЕДОПУСТИМЫЙ БАЙТ в строке %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ОШИБКИ ЧТЕНИЯ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Временный файл для перекодирования не найден"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Преобразование с помощью 'charconvert' не выполнено"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "невозможно прочитать вывод 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Файл зашифрован неизвестным методом"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Нет подходящих автокоманд для буфера acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Буфер, который требовалось записать, удалён или выгружен автокомандой"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Количество строк изменено автокомандой неожиданным образом"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans не позволяет выполнять запись неизменённых буферов"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Частичная запись буферов NetBeans не допускается"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "не является файлом или устройством, доступным для записи"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "запись в устройство отключена при опции 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "открыт только для чтения (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Запись в резервный файл невозможна (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: Ошибка закрытия резервного файла (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Невозможно прочитать резервный файл (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Невозможно создать резервный файл (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Невозможно создать резервный файл (добавьте !, чтобы обойти проверку)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Ветвь ресурса будет потеряна (добавьте !, чтобы обойти проверку)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Временный файл для записи не найден"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Перекодировка невозможна (добавьте ! для записи без перекодировки)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Невозможно открыть связанный файл для записи"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Невозможно открыть файл для записи"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Не удалось выполнить функцию fsync()"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Операция закрытия не удалась"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Ошибка записи, преобразование не удалось (очистите 'fenc', чтобы "
 "обойти)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
@@ -1782,44 +2211,57 @@ msgstr ""
 "E513: Ошибка записи, преобразование не удалось на строке %<PRId64> (очистите "
 "'fenc', чтобы обойти)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Ошибка записи (нет свободного места?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ОШИБКА ПРЕОБРАЗОВАНИЯ"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " на строке %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Устройство]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Новый]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [д]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " добавлено"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [з]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " записано"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Режим заплатки: невозможно сохранение исходного файла"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr ""
 "E206: Режим заплатки: невозможно сменить параметры пустого исходного файла"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Невозможно удалить резервный файл"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1827,80 +2269,96 @@ msgstr ""
 "\n"
 "ПРЕДУПРЕЖДЕНИЕ: Исходный файл может быть утрачен или повреждён\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "не выходите из редактора, пока файл не будет успешно записан!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[формат dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[формат mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[формат unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 строка, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "строк: %<PRId64>, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 символ"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "символов: %<PRId64>"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "символов: %<PRId64>"
-
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Незавершённая последняя строка]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Файл изменён с момента чтения!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Серьёзно хотите записать в этот файл"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Ошибка записи в \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Ошибка закрытия \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Ошибка чтения \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Буфер удалён при выполнении автокоманды FileChangedShell"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Файл \"%s\" больше не доступен"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1909,34 +2367,42 @@ msgstr ""
 "W12: Предупреждение: файл \"%s\" и буфер Vim были изменены независимо друг "
 "от друга"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "См. \":help W12\" для дополнительной информации."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
 "W11: Предупреждение: файл \"%s\" был изменён после начала редактирования"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "См. \":help W11\" для дополнительной информации."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Предупреждение: режим доступа к файлу \"%s\" был изменён после начала "
 "редактирования"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "См. \":help W16\" для дополнительной информации."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Предупреждение: файл \"%s\" был создан после начала редактирования"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Предупреждение"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1944,39 +2410,48 @@ msgstr ""
 "&OK\n"
 "&L Загрузить файл"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Невозможно подготовиться к перезагрузке \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Невозможно выполнить перезагрузку \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Удалено--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "авто-удаление автокоманды: %s <буффер=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Группа \"%s\" не существует"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Недопустимые символы после *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Несуществующее событие: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Несуществующая группа или событие: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1984,542 +2459,766 @@ msgstr ""
 "\n"
 "--- Автокоманды ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: неправильный номер буфера "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Невозможно выполнить автокоманды для ВСЕХ событий"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Нет подходящих автокоманд"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: слишком глубоко вложенные автокоманды"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Автокоманды для \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Выполнение %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "автокоманда %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Пропущена {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Пропущена }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Складок не обнаружено"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr ""
 "E350: Складка не может быть создана с текущим значением опции 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr ""
 "E351: Складка не может быть удалена с текущим значением опции 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld строк в складке"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Добавление в буфер чтения"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Рекурсивная привязка"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Уже есть глобальное сокращение для %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Уже есть глобальная привязка для %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Уже есть сокращение для %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Уже есть привязка для %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Сокращения не найдены"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Привязки не найдены"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: недопустимый режим"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Невозможно создать новый процесс для граф. интерфейса"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "-- Нет строк в буфере --"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Процессу-потомку не удалось запустить граф. интерфейс"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Выполнение команды прервано"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Невозможно перейти в режим графического интерфейса"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Требуется указать параметр"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Невозможно выполнить чтение \"%s\""
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: После \\ должен идти символ /, ? или &"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E665: Невозможно перейти в режим граф. интерфейса, неправильно заданы шрифты"
+"E11: Недопустимо в окне командной строки; <CR> выполнение, CTRL-C выход"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Неправильное значение опции 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Неправильное значение опции 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Невозможно назначить цвет %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Нет совпадения под курсором, поиск следующего"
-
-msgid "<cannot open> "
-msgstr "<нельзя открыть> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: шрифт %s не найден"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: возврат в текущий каталог невозможен"
-
-msgid "Pathname:"
-msgstr "Путь к файлу:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: не могу найти текущий каталог"
-
-msgid "OK"
-msgstr "Да"
-
-msgid "Cancel"
-msgstr "Отмена"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Полоса прокрутки: не могу определить геометрию ползунка"
-
-msgid "Vim dialog"
-msgstr "Диалоговое окно Vim"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E232: \"Пузырь\" для вычислений, включающий и сообщение, и обратный вызов, "
-"не может быть создан"
+"E12: Команда не допускается в exrc/vimrc в текущем каталоге или поиске меток"
 
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Отсутствует команда :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Отсутствует команда :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Отсутствует команда :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Отсутствует команда :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: Команда :endwhile без парной команды :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor без :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Файл существует (добавьте !, чтобы перезаписать)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Не удалось выполнить команду"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Внутренняя ошибка"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Прервано"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Недопустимый адрес"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Недопустимый параметр"
+
+#: ../globals.h:1015
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Недопустимый параметр: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Недопустимое выражение: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Недопустимый диапазон"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Недопустимая команда"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" является каталогом"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Недопустимый размер прокрутки"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Да\n"
-"&Нет\n"
-"О&тмена"
 
-msgid "Input _Methods"
-msgstr "Методы Ввода"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM — Поиск и замена..."
-
-msgid "VIM - Search..."
-msgstr "VIM — Поиск..."
-
-msgid "Find what:"
-msgstr "Что ищем:"
-
-msgid "Replace with:"
-msgstr "На что заменяем:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Только точные соответствия"
-
-#. match case button
-msgid "Match case"
-msgstr "Регистрозависимые соответствия"
-
-msgid "Direction"
-msgstr "Направление"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Вверх"
-
-msgid "Down"
-msgstr "Вниз"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Найти следующее"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Замена"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Заменить все"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Получен запрос на прекращение работы от диспетчера сеансов\n"
-
-msgid "Close"
-msgstr "Закрыть"
-
-msgid "New tab"
-msgstr "Новая вкладка"
-
-msgid "Open Tab..."
-msgstr "Открыть вкладку..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Основное окно было неожиданно закрыто\n"
-
-msgid "&Filter"
-msgstr "&Фильтр"
-
-msgid "&Cancel"
-msgstr "О&тмена"
-
-msgid "Directories"
-msgstr "Каталоги"
-
-msgid "Filter"
-msgstr "Фильтр"
-
-msgid "&Help"
-msgstr "&Справка"
-
-msgid "Files"
-msgstr "Файлы"
-
-msgid "&OK"
-msgstr "&Да"
-
-msgid "Selection"
-msgstr "Выделение"
-
-msgid "Find &Next"
-msgstr "Найти &следующее"
-
-msgid "&Replace"
-msgstr "За&мена"
-
-msgid "Replace &All"
-msgstr "Заменить &все"
-
-msgid "&Undo"
-msgstr "О&тмена"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Окно с заголовком \"%s\" не обнаружено"
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Параметр не поддерживается: \"-%s\"; используйте версию OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Невозможно открыть окно внутри приложения MDI"
-
-msgid "Close tab"
-msgstr "Закрыть вкладку"
-
-msgid "Open tab..."
-msgstr "Открыть вкладку..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Поиск строки (используйте '\\\\' для поиска '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Поиск и замена (используйте '\\\\' для поиска '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Не используется"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Каталог\t*.ничего\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Vim E458: Невозможно выделить запись в таблице цвета, некоторые цвета могут "
-"отображаться неправильно"
 
+#: ../globals.h:1024
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: В наборе шрифтов %s отсутствуют шрифты для следующих кодировок:"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Неудачный вызов функции \"%s()\" из библиотеки"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Отметка указывает на неправильный номер строки"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Отметка не определена"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Изменения невозможны, так как отключена опция 'modifiable'"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Слишком глубоко вложенные сценарии"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Соседний файл не существует"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Нет такого сокращения"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! не допускается"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr ""
+"E25: Возможность использования графического интерфейса выключена при "
+"компиляции"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Набор шрифтов: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Группа подсветки синтаксиса %s не существует"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Пока нет вставленного текста"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Предыдущей командной строки нет"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Такой привязки не существует"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Нет соответствия"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Шрифт '%s' не является моноширинным"
+msgid "E480: No match: %s"
+msgstr "E480: Нет соответствия: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Нет имени файла"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Нет предыдущего регулярного выражения для замены"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Нет предыдущей команды"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Нет предыдущего регулярного выражения"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Использование диапазона не допускается"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Недостаточно места"
+
+#: ../globals.h:1049
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Набор шрифтов: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Невозможно создать файл %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Невозможно получить имя временного файла"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font0: %s"
-msgstr "Font0: %s"
+msgid "E484: Can't open file %s"
+msgstr "E484: Невозможно открыть файл %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font1: %s"
-msgstr "Font1: %s"
+msgid "E485: Can't read file %s"
+msgstr "E485: Невозможно прочитать файл %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Изменения не сохранены (добавьте !, чтобы обойти проверку)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Изменения не сохранены]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Нулевой параметр"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Требуется число"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Ширина шрифта font%<PRId64> должна быть вдвое больше ширины шрифта font0"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Не удалось открыть файл ошибок %s"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Не хватает памяти!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Шаблон не найден"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Ширина шрифта font0: %<PRId64>"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Шаблон не найден: %s"
 
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Параметр должен быть положительным числом"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Возврат в предыдущий каталог невозможен"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Нет ошибок"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Нет списка расположений"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Повреждена строка соответствия"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Программа обработки регулярных выражений повреждена"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Включена опция 'readonly' (добавьте !, чтобы обойти проверку)"
+
+#: ../globals.h:1073
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Ширина шрифта font1: %<PRId64>"
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Невозможно изменить переменную только для чтения \"%s\""
 
-msgid "Invalid font specification"
-msgstr "Неправильное определение шрифта"
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Невозможно изменить переменную в песочнице: \"%s\""
 
-msgid "&Dismiss"
-msgstr "О&тклонить"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Ошибка при чтении файла ошибок"
 
-msgid "no specific match"
-msgstr "нет специального совпадения"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Не допускается в песочнице"
 
-msgid "Vim - Font Selector"
-msgstr "Vim — Выбор шрифта"
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Здесь не разрешено"
 
-msgid "Name:"
-msgstr "Название:"
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Данный режим экрана не поддерживается"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Показывать размер в пунктах"
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Недопустимый размер прокрутки"
 
-msgid "Encoding:"
-msgstr "Кодировка:"
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Значением опции 'shell' является пустая строка"
 
-msgid "Font:"
-msgstr "Шрифт:"
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Невозможно прочитать данные о значках!"
 
-msgid "Style:"
-msgstr "Стиль:"
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Ошибка закрытия своп-файла"
 
-msgid "Size:"
-msgstr "Размер:"
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: Стек меток пустой"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ОШИБКА автоматики Хангыл"
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Слишком сложная команда"
 
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Слишком длинное имя"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Слишком много символов ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Слишком много имён файлов"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Лишние символы на хвосте"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Неизвестная отметка"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Невозможно выполнить подстановку по маске"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+"E591: Значение опции 'winheight' не может быть меньше значения 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+"E592: Значение опции 'winwidth' не может быть меньше значения 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Ошибка при записи"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Нулевое значение счётчика"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Использование <SID> вне контекста сценария"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Внутренняя ошибка: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Шаблон использует больше памяти чем 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Пустой буфер"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Неправильная строка поиска или разделитель"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Файл загружен в другом буфере"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Опция '%s' не установлена"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Недопустимое имя регистра"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Поиск будет продолжен с КОНЦА документа"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Поиск будет продолжен с НАЧАЛА документа"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Пропущено двоеточие"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Недопустимый компонент"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: Требуется указать цифру"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Страница %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Печатать нечего"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Печать стр. %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Копия %d из %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Напечатано: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Печать прекращена"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Ошибка записи в файл PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Невозможно открыть файл \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Невозможно прочитать файл ресурсов PostScript \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Файл \"%s\" не является файлом ресурсов PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Файл \"%s\" не является допустимым файлом ресурсов PostScript"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Файл ресурсов \"%s\" неизвестной версии"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Несовместимые многобайтовая кодировка и набор символов."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset не может быть пустым при многобайтовой кодировке."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Нет определения шрифта по умолчанию для многобайтовой печати."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Невозможно открыть файл PostScript"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Невозможно открыть файл \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Файл ресурсов PostScript \"prolog.ps\" не найден"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Файл ресурсов PostScript \"cidfont.ps\" не найден"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Файл ресурсов PostScript \"%s.ps\" не найден"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Невозможно преобразовать в кодировку печать \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Отправка на печать..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Не удалось выполнить печать файла PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Задание на печать отправлено."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Добавить новую базу данных"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Запрос по шаблону"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Показать это сообщение"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Убить соединение"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Заново инициализировать все соединения"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Показать соединения"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Использование: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Эта команда cscope не поддерживает разделение окна.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Использование: cstag <имя>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: метка не найдена"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: Ошибка stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: Ошибка stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s не является каталогом или именем базы cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Добавлена база данных cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Ошибка получения информации от соединения cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Неизвестный тип поиска cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Невозможно создать трубу для cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Невозможно выполнить fork() для cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection: не удалось выполнить setpgid"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection: не удалось выполнить exec"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: не удалось выполнить fdopen для to_fp"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: не удалось выполнить fdopen для fr_fp"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Не удалось запустить процесс cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: Соединений с cscope не создано"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Неправильный флаг cscopequickfix %c для %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: Не найдено соответствий по запросу cscope %s для %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "Команды cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (использование: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2541,32 +3240,31 @@ msgstr ""
 "       s: Найти этот C-символ\n"
 "       t: Найти эту текстовую строку\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Невозможно открыть базу данных cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Информация о базе данных cscope не доступна"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Данная база данных cscope уже подсоединена"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: Соединение с cscope %s не обнаружено"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "соединение с cscope %s закрыто"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Критическая ошибка в cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Метка cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2574,369 +3272,88 @@ msgstr ""
 "\n"
 "   #   строка"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "имя файла / контекст / строка\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Ошибка cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Перезагрузка всех баз данных cscope"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "соединения с cscope отсутствуют\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    база данных                         начальный путь\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Библиотека Lua не может быть загружена."
-
-msgid "cannot save undo information"
-msgstr "невозможно сохранить информацию об отмене операции"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"MzScheme"
-
-msgid "invalid expression"
-msgstr "неправильное выражение"
-
-msgid "expressions disabled at compile time"
-msgstr "выражения отключены при компиляции"
-
-msgid "hidden option"
-msgstr "скрытая опция"
-
-msgid "unknown option"
-msgstr "неизвестная опция"
-
-msgid "window index is out of range"
-msgstr "индекс окна за пределами диапазона"
-
-msgid "couldn't open buffer"
-msgstr "невозможно открыть буфер"
-
-msgid "cannot delete line"
-msgstr "невозможно удалить строку"
-
-msgid "cannot replace line"
-msgstr "невозможно заменить строку"
-
-msgid "cannot insert line"
-msgstr "невозможно вставить строку"
-
-msgid "string cannot contain newlines"
-msgstr "строка не может содержать символ новой строки"
-
-msgid "error converting Scheme values to Vim"
-msgstr "невозможно преобразовать значения Scheme в Vim"
-
-msgid "Vim error: ~a"
-msgstr "ошибка Vim: ~a"
-
-msgid "Vim error"
-msgstr "ошибка Vim"
-
-msgid "buffer is invalid"
-msgstr "неправильный буфер"
-
-msgid "window is invalid"
-msgstr "неправильное окно"
-
-msgid "linenr out of range"
-msgstr "номер строки за пределами диапазона"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "не допускается в песочнице Vim"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Данный Vim не может выполнить :python после использования :py3"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"Python"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Невозможно выполнить рекурсивный вызов Python"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Данный Vim не может выполнить :py3 после использования :python"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ должен быть экземпляром или строкой"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"Ruby"
-
-msgid "E267: unexpected return"
-msgstr "E267: Неожиданный return"
-
-msgid "E268: unexpected next"
-msgstr "E268: Неожиданный next"
-
-msgid "E269: unexpected break"
-msgstr "E269: Неожиданный break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: Неожиданный redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry вне оператора rescue"
-
-msgid "E272: unhandled exception"
-msgstr "E272: Необработанное исключение"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Неизвестное состояние longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Переключение между реализацией/определением"
-
-msgid "Show base class of"
-msgstr "Показать основной класс"
-
-msgid "Show overridden member function"
-msgstr "Показать перегруженные функции"
-
-msgid "Retrieve from file"
-msgstr "Получить из файла"
-
-msgid "Retrieve from project"
-msgstr "Получить из проекта"
-
-msgid "Retrieve from all projects"
-msgstr "Получить из всех проектов"
-
-msgid "Retrieve"
-msgstr "Получить"
-
-msgid "Show source of"
-msgstr "Показать исходный код"
-
-msgid "Find symbol"
-msgstr "Найти символ"
-
-msgid "Browse class"
-msgstr "Просмотр класса"
-
-msgid "Show class in hierarchy"
-msgstr "Показать класс в иерархии"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Показать класс в ограниченной иерархии"
-
-msgid "Xref refers to"
-msgstr "Xref ссылается на"
-
-msgid "Xref referred by"
-msgstr "Ссылка на xref из"
-
-msgid "Xref has a"
-msgstr "Xref имеет"
-
-msgid "Xref used by"
-msgstr "Xref используется"
-
-msgid "Show docu of"
-msgstr "Показать docu"
-
-msgid "Generate docu for"
-msgstr "Создать docu"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Невозможно подсоединиться к SNiFF+. Проверьте настройки окружения."
-"(sniffemacs должны быть указаны в переменной $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Ошибка во время чтения. Отсоединение"
-
-msgid "SNiFF+ is currently "
-msgstr "В настоящий момент SNiFF+ "
-
-msgid "not "
-msgstr "не "
-
-msgid "connected"
-msgstr "подсоединён"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Неизвестный запрос SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Ошибка соединения со SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ не подсоединён"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Это не буфер SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Ошибка во время записи. Отсоединение"
-
-msgid "invalid buffer number"
-msgstr "неправильный номер буфера"
-
-msgid "not implemented yet"
-msgstr "пока не реализовано"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "невозможно назначить строку или строки"
-
-msgid "invalid mark name"
-msgstr "неправильное имя отметки"
-
-msgid "mark not set"
-msgstr "отметка не установлена"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "ряд %d колонка %d"
-
-msgid "cannot insert/append line"
-msgstr "невозможно вставить или добавить строку"
-
-msgid "line number out of range"
-msgstr "номер строки за пределами диапазона"
-
-msgid "unknown flag: "
-msgstr "неизвестный флаг: "
-
-msgid "unknown vimOption"
-msgstr "неизвестная vimOption"
-
-msgid "keyboard interrupt"
-msgstr "клавиатурное прерывание"
-
-msgid "vim error"
-msgstr "ошибка VIM"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "невозможно создать команду буфера или окна: объект в процессе удаления"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"невозможно зарегистрировать команду с обратным вызовом: буфер или окно в "
-"процессе удаления"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: КРИТИЧЕСКАЯ ОШИБКА TCL: повреждён список ссылок?! Сообщите об этом по "
-"адресу vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"невозможно зарегистрировать команду с обратным вызовом: ссылка на буфер или "
-"окно не обнаружена"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"Tcl"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Код выхода %d"
-
-msgid "cannot get line"
-msgstr "невозможно получить строку"
-
-msgid "Unable to register a command server name"
-msgstr "Невозможно зарегистрировать имя сервера команд"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Не удалась отправка команды в другую программу"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Используется неправильный id сервера: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: Неправильно сформировано значение данного процесса VIM в реестре. "
-"Удалено!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Неизвестный необязательный параметр"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Слишком много параметров редактирования"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Пропущен параметр после"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Мусор после необязательного параметра"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Слишком много параметров \"+команда\", \"-c команда\" или \"--cmd команда\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Недопустимый параметр для"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "Файлов для редактирования: %d\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "NetBeans не поддерживается с этим графическим интерфейсом\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr ""
-"Данный Vim был скомпилирован с выключенной особенностью просмотра отличий"
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "Невозможно использовать '-nb': не включено при компиляции\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Попытка повторного открытия файла сценария: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Невозможно открыть для чтения: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Невозможно открыть для вывода сценария: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Ошибка: Не удалось запустить gvim из NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Предупреждение: Вывод осуществляется не на терминал\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Предупреждение: Ввод происходит не с терминала\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "командная строка перед выполнением vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Невозможно выполнить чтение из \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2944,21 +3361,26 @@ msgstr ""
 "\n"
 "Дополнительная информация: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[файл ..] редактирование указанных файлов"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-           чтение текста из потока ввода stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t метка    редактирование файла с указанной меткой"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr ""
 "-q [файл-ошибок]\n"
 "\t\t\t\t    редактирование файла с первой ошибкой"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2968,9 +3390,11 @@ msgstr ""
 "\n"
 "Использование:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [параметры] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2978,13 +3402,7 @@ msgstr ""
 "\n"
 "   или:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Если регистр игнорируется, добавьте перед флагом / для верхнего регистра"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2994,337 +3412,204 @@ msgstr ""
 "\n"
 "Параметры:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tДалее указываются только имена файлов"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tНе выполнять подстановку по маске"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tЗарегистрировать этот gvim для OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tОтключить регистрацию данного gvim для OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tЗапустить с графическим интерфейсом (как \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  или --nofork\tВ активной задаче: Не выполнять fork при запуске GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tРежим Vi (как \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tРежим Ex (как \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tУлучшенный режим Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tТихий (пакетный) режим (только для \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tРежим отличий (как \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tПростой режим (как \"evim\", безрежимный)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tТолько для чтения (как \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tОграниченный режим (как \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tБез возможности сохранения изменений (записи файлов)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tБез возможности внесения изменений в текст"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tДвоичный режим"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tРежим Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tРежим совместимости с Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tРежим неполной совместимости с Vi: 'nocompatible'"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 "-V[N][файл]\t\tВыводить дополнительные сообщения\n"
 "\t\t\t\t[уровень N] [записывать в файл]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tРежим отладки"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tБез своп-файла, используется только память"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tВывести список своп-файлов и завершить работу"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (с именем файла)\tВосстановить аварийно завершённый сеанс"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tТо же, что и -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tНе использовать newcli для открытия окна"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <устройство>\t\tИспользовать для I/O указанное <устройство>"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tЗапуск в Арабском режиме"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tЗапуск в режиме \"Иврит\""
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tЗапуск в режиме \"Фарси\""
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <терминал>\tНазначить указанный тип <терминала>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tИспользовать <vimrc> вместо любых файлов .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tИспользовать <gvimrc> вместо любых файлов .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tНе загружать сценарии модулей"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr ""
 "-p[N]\t\tОткрыть N вкладок (по умолчанию: по одной\n"
 "\t\t\t\tна каждый файл)"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr ""
 "-o[N]\t\tОткрыть N окон (по умолчанию: по одному\n"
 "\t\t\t\tна каждый файл)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tТо же, что и -o, но с вертикальным разделением окон"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tНачать редактирование в конце файла"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tНачать редактирование в строке с номером <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <команда>\tВыполнить <команду> перед загрузкой файла vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <команда>\t\tВыполнить <команду> после загрузки первого файла"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <сеанс>\t\tПрочитать сценарий <сеанса> после загрузки\n"
 "\t\t\t\tпервого файла"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr ""
 "-s <сценарий>\tПрочитать команды Обычного режима из\n"
 "\t\t\t\tфайла <сценария>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <сценарий>\tДобавлять все введённые команды в файл <сценария>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <сценарий>\tЗаписать все введённые команды в файл <сценария>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tРедактирование зашифрованных файлов"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <экран>\tПодсоединить VIM к указанному X-серверу"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tНе выполнять соединение с сервером X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <файлы>\tПо возможности редактировать <файлы> на сервере Vim"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <файлы>  То же, но без жалоб на отсутствие сервера"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <файлы>  То же, что и --remote, но с ожиданием завершения"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <файлы>  То же, но без жалоб на отсутствие сервера"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <файлы>  То же, что и --remote, но с вкладками"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <кнопки>\tОтправить <кнопки> на сервер Vim и выйти"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <выраж>\tВычислить <выраж> на сервере Vim и напечатать"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tПоказать список имён серверов Vim и завершить работу"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr ""
-"--servername <имя>\tОтправить на/стать сервером Vim с указанным <именем>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <файл>\tЗаписать временную метку о запуске в <файл>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tИспользовать вместо .viminfo файл <viminfo>"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h или --help\tВывести справку (это сообщение) и завершить работу"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tВывести информацию о версии Vim и завершить работу"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <дисплей>\tЗапустить VIM на указанном <дисплее>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tЗапустить VIM в свёрнутом виде"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr ""
-"-background <цвет>\tИспользовать указанный <цвет> для фона (также: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <цвет>\tИспользовать <цвет> для обычного текста (также: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <шрифт>\t\tИспользовать <шрифт> для обычного текста (также: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <шрифт>\tИспользовать <шрифт> для жирного текста"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <шрифт>\tИспользовать <шрифт> для наклонного текста"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <геометрия>\tИспользовать начальную <геометрию> (также: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <ширина>\tИспользовать <ширину> бордюра (также: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <ширина> Использовать ширину полосы прокрутки (также: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <высота>\tИспользовать <высоту> меню (также: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tИспользовать инверсный видеорежим (также: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tНе использовать инверсный видеорежим (также: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ресурс>\tУстановить указанный <ресурс>"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr ""
-"-display <дисплей>\tЗапустить VIM на указанном <дисплее> (также: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <роль>\tУстановить уникальную <роль> для идентификации главного окна"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tОткрыть Vim внутри другого компонента GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tВывести Window ID для gvim на стандартный поток вывода"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <заголовок родителя>\tОткрыть Vim в родительском приложении"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tОткрыть Vim внутри другого компонента win32"
-
-msgid "No display"
-msgstr "Нет дисплея"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Отправка не удалась.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Отправка не удалась. Попытка местного выполнения\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "отредактировано %d из %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Нет дисплея: отправка выражения не удалась.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Отправка выражения не удалась.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Нет установленных отметок"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Нет отметок, совпадающих с \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3333,6 +3618,7 @@ msgstr ""
 "отмет стр  кол файл/текст"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3341,6 +3627,7 @@ msgstr ""
 "прыжок стр  кол файл/текст"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3348,6 +3635,7 @@ msgstr ""
 "\n"
 "измен.  стр  кол текст"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3356,6 +3644,7 @@ msgstr ""
 "# Глобальные отметки:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3363,6 +3652,7 @@ msgstr ""
 "\n"
 "# Список прыжков (сначала более свежие):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3370,94 +3660,87 @@ msgstr ""
 "\n"
 "# История местных отметок (от более свежих к старым):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Пропущена '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Недопустимое имя кодировки"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Невозможно назначить значения контекста ввода"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Невозможно создать контекст ввода"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Неудачная попытка открыть метод ввода"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Предупреждение: невозможно назначить обр. вызов уничтожения метода "
-"ввода"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Метод ввода не поддерживает стили"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr ""
-"E289: Метод ввода не поддерживает мой тип предварительного редактирования"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Блок не заблокирован"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Ошибка поиска при чтении своп-файла"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Ошибка чтения своп-файла"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Ошибка поиска при записи своп-файла"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Ошибка при записи своп-файла"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr ""
 "E300: Своп-файл уже существует (атака с использованием символьной ссылки?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Не получен блок номер 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Не получен блок номер 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Не получен блок номер 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Ошибка при обновлении шифрования своп-файла"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ой, потерялся своп-файл!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Невозможно переименовать своп-файл"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Не удалось открыть своп-файл для \"%s\", восстановление невозможно"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Не получен блок 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Своп-файл для %s не найден"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Введите номер своп-файла, который следует использовать (0 для выхода): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Не могу открыть %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Невозможно прочитать блок 0 из "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3465,22 +3748,28 @@ msgstr ""
 "\n"
 "Нет изменений, или Vim не смог обновить своп-файл"
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " нельзя использовать в данной версии Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Используйте Vim версии 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s не является своп-файлом Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " нельзя использовать на этом компьютере.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Файл был создан "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3488,106 +3777,86 @@ msgstr ""
 ",\n"
 "либо файл был повреждён."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s зашифрован, а эта версия Vim не поддерживает шифрование"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " был повреждён (размер страницы меньше минимального значения).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Используется своп-файл \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Исходный файл \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Предупреждение: исходный файл мог быть изменён"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Своп-файл зашифрован: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Если вы ввели новый пароль для шифрования, но не записали текстовый файл,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"то введите новый пароль для шифрования."
-
-# Перевод сообщения разделён на две части, часть первая
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Если вы записали текстовый файл после изменения пароля шифрования, то нажмите"
-
-# Перевод сообщения разделён на две части, часть вторая
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"Enter для использования одного ключа для текстового файла и своп-файла"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Невозможно прочитать блок 1 из %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???ОТСУТСТВУЕТ МНОГО СТРОК"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???НЕПРАВИЛЬНОЕ ЗНАЧЕНИЕ СЧЁТЧИКА СТРОК"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???ПУСТОЙ БЛОК"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???ОТСУТСТВУЮТ СТРОКИ"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Неправильный блок 1 ID (%s не является файлом .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???ПРОПУЩЕН БЛОК"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "???строки могут быть испорчены отсюда до ???КОНЦА"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "???строки могли быть вставлены или удалены отсюда до ???КОНЦА"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???КОНЕЦ"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Восстановление прервано"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Во время восстановления обнаружены ошибки; см. строки, начинающиеся "
 "с ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "См. \":help E312\" для дополнительной информации."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Восстановление завершено. Проверьте, всё ли в порядке."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3595,12 +3864,15 @@ msgstr ""
 "\n"
 "(Можете записать файл под другим именем и сравнить его с исходным\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "файлом при помощи программы diff)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Восстановление завершено. Содержимое буферов и файлов эквивалентно."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3610,43 +3882,52 @@ msgstr ""
 "Вероятно, сейчас вы захотите удалить файл .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Использование ключа шифрования из своп-файла для текстового файла.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Обнаружены своп-файлы:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   В текущем каталоге:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   С указанным именем:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   В каталоге   "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- нет --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          владелец: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    дата: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              дата: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [от Vim версии 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [не является своп-файлом Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         имя файла: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3654,12 +3935,15 @@ msgstr ""
 "\n"
 "           изменён: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ДА"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "нет"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3667,9 +3951,11 @@ msgstr ""
 "\n"
 "      пользователь: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "  компьютер: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3677,6 +3963,7 @@ msgstr ""
 "\n"
 "         компьютер: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3684,16 +3971,11 @@ msgstr ""
 "\n"
 "           процесс: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (ещё выполняется)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [не пригоден для использования с данной версией Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3701,75 +3983,97 @@ msgstr ""
 "\n"
 "         [не пригоден для использования на этом компьютере]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [не читается]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [не открывается]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Невозможно обновить своп-файл, поскольку он не обнаружен"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Своп-файл обновлён"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Неудачная попытка обновления своп-файла"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: неправильное значение lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: невозможно найти строку %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Неправильное значение указателя блока 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "значение stack_idx должно быть равно 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Обновлено слишком много блоков?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Неправильное значение указателя блока 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "удалён блок 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Строка %<PRId64> не обнаружена"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Неправильное значение указателя блока"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "значение pe_line_count равно нулю"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Номер строки за пределами диапазона: %<PRId64>"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Неправильное значение счётчика строк в блоке %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Размер стека увеличен"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Неправильное значение указателя блока 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Петля символьных ссылок для \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ВНИМАНИЕ"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3778,14 +4082,15 @@ msgstr ""
 "Обнаружен своп-файл с именем \""
 
 # С маленькой буквы, чтобы соответствовало по стилю соседним сообщениям.
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "при открытии файла: \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "                    Более СВЕЖИЙ, чем своп-файл!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3798,17 +4103,21 @@ msgstr ""
 "    у вас не появилось два разных варианта одного и того же файла."
 
 # Сообщение разделено, " \n" добавлено т.к. строка не помещается.
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr ""
 " \n"
 "    Завершите работу или продолжайте с осторожностью.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сеанс редактирования этого файла завершён аварийно.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    В этом случае, используйте команду \":recover\" или \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3816,9 +4125,11 @@ msgstr ""
 "\"\n"
 "    для восстановления изменений (см. \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Если вы уже выполняли эту операцию, удалите своп-файл \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3826,18 +4137,23 @@ msgstr ""
 "\"\n"
 "    чтобы избежать появления этого сообщения в будущем.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Своп-файл \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" уже существует!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM — ВНИМАНИЕ"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Своп-файл уже существует!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3851,6 +4167,7 @@ msgstr ""
 "&Q Выход\n"
 "&A Прервать"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3866,34 +4183,56 @@ msgstr ""
 "&Q Выход\n"
 "&A Прервать"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Обнаружено слишком много своп-файлов"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Не хватает памяти! (выделяется %<PRIu64> байт)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Компонент пути к элементу меню не является подменю"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Меню в этом режиме не существует"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Нет меню %s"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Пустое имя меню"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Путь к меню не должен вести к подменю"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Элементы меню нельзя добавлять непосредственно в полоску меню"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Разделители не могут быть компонентом пути к меню"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3901,62 +4240,75 @@ msgstr ""
 "\n"
 "--- Меню ---"
 
-msgid "Tear off this menu"
-msgstr "Оторвать это меню"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Путь к меню должен вести к элементу меню"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Меню не найдено: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Меню не определено для режима %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Путь к меню должен вести к подменю"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Меню не найдено — проверьте имена меню"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Обнаружена ошибка при обработке %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "строка %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Недопустимое имя регистра: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "Перевод сообщений на русский язык: Василий Рагозин <vrr@users.sourceforge."
 "net>, Сергей Алёшин <alyoshin.s@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Прерывание: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Нажмите ENTER или введите команду для продолжения"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s строка %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Продолжение следует --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: экран/страница/строка вниз, b/u/k: вверх, q: выход "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Вопрос"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3964,6 +4316,17 @@ msgstr ""
 "&Y Да\n"
 "&N Нет"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Да\n"
+"&Нет\n"
+"О&тмена"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3977,273 +4340,175 @@ msgstr ""
 "&D Потерять все\n"
 "&C Отмена"
 
-msgid "Select Directory dialog"
-msgstr "Выбор каталога"
-
-msgid "Save File dialog"
-msgstr "Сохранение файла"
-
-msgid "Open File dialog"
-msgstr "Открытие файла"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr ""
-"E338: Извините, но в консольном режиме нет проводника по файловой системе"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Недостаточно параметров для printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Ожидался параметр типа с плавающей точкой для printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Слишком много параметров для printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Предупреждение: Изменение файла с правами только для чтения"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Введите номер и <Enter> или щёлкните мышью (пусто для отмены): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Введите номер и <Enter> (пусто для отмены): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "Добавлена одна строка"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "Убрана одна строка"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "Добавлено строк: %<PRId64>"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "Убрано строк: %<PRId64>"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Прервано)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Би-би!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: сохранение файлов...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Готово.\n"
-
-msgid "ERROR: "
-msgstr "ОШИБКА: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[байт] всего выдел.-освоб. %<PRIu64>-%<PRIu64>, использ. %<PRIu64>, макс. использ. %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[вызовы] re/malloc() всего %<PRIu64>, free() всего %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Строка становится слишком длинной"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Не хватает памяти! (выделяется %<PRIu64> байт)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Вызов оболочки для исполнения: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Пропущено двоеточие"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Недопустимый режим"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Недопустимая форма курсора"
-
-msgid "E548: digit expected"
-msgstr "E548: Требуется ввести цифру"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Недопустимое значение процентов"
-
-msgid "Enter encryption key: "
-msgstr "Введите пароль для шифрования: "
-
-msgid "Enter same key again: "
-msgstr "Повторите ввод пароля: "
-
-msgid "Keys don't match!"
-msgstr "Введённые пароли не совпадают!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: слишком большой путь для автодополнения"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Неправильно задан путь: '**[число]' должно быть либо в конце пути, "
-"либо за ним должно следовать '%s'"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Каталог \"%s\" не найден в пути для смены каталога"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Файл \"%s\" в известных каталогах не найден"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: В пути смены каталога больше нет каталогов \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: В известных каталогах больше нет файлов \"%s\""
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Невозможно соединиться с NetBeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Невозможно соединиться с NetBeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Неправильный режим доступа к информации о соединении с NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "чтение из гнезда NetBeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Потеряно соединение с NetBeans для буфера %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: NetBeans не поддерживается с этим графическим интерфейсом"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: уже соединён с NetBeans"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s открыт только для чтения (добавьте !, чтобы обойти проверку)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Нет имени в позиции курсора"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: Значением опции 'operatorfunc' является пустая строка"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: eval не доступна"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Предупреждение: терминал не может выполнять подсветку"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Нет строки в позиции курсора"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr ""
 "E352: Невозможно стереть складки с текущим значением опции 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Список изменений пустой"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: В начале списка изменений"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Введите :quit<Enter>  для выхода из Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "Изменены отступы в 1 строке (%s 1 раз)"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Изменены отступы в 1 строке (%s %d раз)"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "Изменены отступы, %<PRId64> строк (%s 1 раз)"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "Изменены отступы, %<PRId64> строк (%s %d раз)"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "Изменяются отступы строках (%<PRId64>)..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "Изменён отступ в одной строке "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "Изменены отступы в строках (%<PRId64>) "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Нет предыдущего использованного регистра"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "скопировать не удалось, удаление выполнено"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "изменена 1 строка"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "изменено строк: %<PRId64>"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "очищено строк: %<PRId64>"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "скопирован блок из одной строки"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "скопирована одна строка"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "скопирован блок из строк: %<PRId64>"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "скопировано строк: %<PRId64>"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: В регистре %s ничего нет"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4251,9 +4516,11 @@ msgstr ""
 "\n"
 "--- Регистры ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Недопустимое имя регистра"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4261,165 +4528,184 @@ msgstr ""
 "\n"
 "# Регистры:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Неизвестный тип регистра %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "Колонок: %<PRId64>; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Выделено %s%<PRId64> из %<PRId64> строк; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> байт"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Выделено %s%<PRId64> из %<PRId64> стр.; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> симв.; %<PRId64> из %<PRId64> "
-"байт"
+"Выделено %s%<PRId64> из %<PRId64> строк; %<PRId64> из %<PRId64> слов; "
+"%<PRId64> из %<PRId64> байт"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; байт %<PRId64> из %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; симв. %<PRId64> из %<PRId64>; байт %<PRId64> "
-"из %<PRId64>"
+"Выделено %s%<PRId64> из %<PRId64> стр.; %<PRId64> из %<PRId64> слов; "
+"%<PRId64> из %<PRId64> симв.; %<PRId64> из %<PRId64> байт"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; байт "
+"%<PRId64> из %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; "
+"симв. %<PRId64> из %<PRId64>; байт %<PRId64> из %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> с учётом BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стр. %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Благодарим за использование Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Неизвестная опция"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Опция не поддерживается"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Не допускается в режимной строке"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Код клавиши не установлен"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: После = требуется указать число"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Не обнаружено в termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Недопустимый символ <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Значение опции 'term' не может быть пустой строкой"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: В графическом интерфейсе изменять терминал невозможно"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Для запуска графического интерфейса используйте \":gui\""
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: Значения опций 'backupext' и 'patchmode' равны"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Конфликтует со значением 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Конфликтует со значением 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Не может быть изменено в графическом интерфейсе GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Пропущено двоеточие"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Строка с нулевой длиной"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Пропущено число после <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Пропущена запятая"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Необходимо указать значение для '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Содержит непечатный символ или символ двойной ширины"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Неправильные шрифты"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Невозможно выбрать шрифтовой набор"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Неправильный шрифтовой набор"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Невозможно выбрать шрифт с символами двойной ширины"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Неправильный шрифт с символами двойной ширины"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Неправильный символ после <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Требуется запятая"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr ""
 "E537: Значение опция 'commentstring' должно быть пустой строкой или "
 "содержать %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Мышь не поддерживается"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Незакрытая последовательность выражения"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Слишком много элементов"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Несбалансированные группы"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Окно предпросмотра уже есть"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: Арабский требует использования UTF-8, введите ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Нужно хотя бы %d строк"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Нужно хотя бы %d колонок"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Неизвестная опция: %s"
@@ -4427,10 +4713,12 @@ msgstr "E355: Неизвестная опция: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Требуется указать число: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4438,6 +4726,7 @@ msgstr ""
 "\n"
 "--- Терминальные коды ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4445,6 +4734,7 @@ msgstr ""
 "\n"
 "--- Глобальные значения опций ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4452,6 +4742,7 @@ msgstr ""
 "\n"
 "--- Местные значения опций ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4459,140 +4750,21 @@ msgstr ""
 "\n"
 "--- Опции ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ОШИБКА get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Нет соответствующего символа для %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Лишние символы после точки с запятой: %s"
 
-msgid "cannot open "
-msgstr "невозможно открыть "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Невозможно открыть окно!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Необходима Amigados версии 2.04 или более поздней\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Необходима %s версии %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Невозможно открыть NIL:\n"
-
-msgid "Cannot create "
-msgstr "Невозможно создать "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Прекращение работы Vim с кодом %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "невозможно сменить режим консоли?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: не в консоли??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Невозможно выполнить оболочку с параметром -f"
-
-msgid "Cannot execute "
-msgstr "Невозможно выполнить "
-
-msgid "shell "
-msgstr "оболочка "
-
-msgid " returned\n"
-msgstr " завершила работу\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "слишком малая величина ANCHOR_BUF_SIZE."
-
-msgid "I/O ERROR"
-msgstr "ОШИБКА ВВОДА/ВЫВОДА"
-
-msgid "Message"
-msgstr "Сообщение"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "Значение опции 'columns' не равно 80, внешние программы не выполняются"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Неудачное завершение выбора принтера"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "в %s на %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Неизвестный шрифт принтера: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Ошибка печати: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Печать '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Недопустимое имя кодировки \"%s\" в имени шрифта \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Недопустимый символ '%c' в имени шрифта \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Двойной сигнал, завершение работы\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Получен убийственный сигнал %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Получен убийственный сигнал\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Открытие дисплея X заняло %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Ошибка X\n"
-
-msgid "Testing the X display failed"
-msgstr "Проверка дисплея X завершена неудачно"
-
-msgid "Opening the X display timed out"
-msgstr "Открытие дисплея X не выполнено в отведённое время"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Невозможно получить контекст безопасности для "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Невозможно установить контекст безопасности для "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4600,13 +4772,7 @@ msgstr ""
 "\n"
 "Невозможно запустить оболочку "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Невозможно запустить оболочку sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4614,254 +4780,235 @@ msgstr ""
 "\n"
 "Оболочка завершила работу "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Невозможно создать трубы\n"
+"Невозможно получить контекст безопасности для "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Невозможно выполнить fork()\n"
+"Невозможно установить контекст безопасности для "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Выполнение команды прервано\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP утеряно соединение ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Неудачное открытие дисплея X"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP обрабатывает запрос самосохранения"
-
-msgid "XSMP opening connection"
-msgstr "XSMP открывает соединение"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP потеряно слежение за соединением ICE"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP неудачно выполнено SmcOpenConnection: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Файл \"%s\" не найден по известным путям"
 
-msgid "At line"
-msgstr "В строке"
-
-msgid "Could not load vim32.dll!"
-msgstr "Невозможно загрузить vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Ошибка VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Невозможно исправить указатели функций для DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "завершение работы оболочки с кодом %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Перехвачено событие %s\n"
-
-msgid "close"
-msgstr "закрытие"
-
-msgid "logoff"
-msgstr "отключение"
-
-msgid "shutdown"
-msgstr "завершение"
-
-msgid "E371: Command not found"
-msgstr "E371: Команда не найдена"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE не найден в пути, заданном в $PATH.\n"
-"Внешние команды не будут останавливаться после выполнения.\n"
-"Дополнительная информация в :help win32-vimrun"
-
-msgid "Vim Warning"
-msgstr "Предупреждение Vim"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: В строке формата слишком много %%%c"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Неожиданный элемент %%%c в строке формата"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: В строке формата пропущена ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c не поддерживается в строке формата"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Недопустимый %%%c в приставке в строке формата"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Недопустимый %%%c в строке формата"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: В значении опции 'errorformat' отсутствует шаблон"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Имя каталога не задано или равно пустой строке"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Больше нет элементов"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d из %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (строка удалена)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Внизу стека быстрых исправлений"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Наверху стека быстрых исправлений"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "список ошибок %d из %d; %d ошибок"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr ""
 "E382: Запись невозможна, значение опции 'buftype' не является пустой строкой"
 
-msgid "Error file"
-msgstr "Файл ошибок"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Нет имени файла или неправильный шаблон"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Невозможно открыть файл \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Буфер не выгружен"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Требуется строка или список"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Недопустимый элемент в %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Пропущена ] после %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Нет пары для %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Нет пары для %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Нет пары для %s)"
 
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( не может быть использовано здесь"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 и т.п. не могут быть использованы здесь"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Пропущена ] после %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: Пустое %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Слишком длинный шаблон"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Слишком много \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Слишком много %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Нет пары для \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: Недопустимый символ после %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Слишком много сложных конструкций %s{...}"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Вложенные %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Вложенные %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Недопустимое использование \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c ни за чем не следует"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Недопустимая обратная ссылка"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Недопустимый символ после \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Недопустимый символ после %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Недопустимый символ после %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Синтаксическая ошибка в %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Внешние подсоответствия:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
@@ -4869,49 +5016,62 @@ msgstr ""
 "E864: после \\%#= может быть только 0, 1 или 2. Будет использоваться "
 "автоматическая машина"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (НКА) неожиданный конец регулярного выражения"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (рег. выражение НКА) неожиданный %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (НКА) неожиданный конец регулярного выражения"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (НКА) неизвестный оператор '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (НКА) неизвестный оператор '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: ошибка при создании НКА с классом эквивалентности!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (НКА) неизвестный оператор '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (рег. выражение НКА) ошибка при чтении границ повторения"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (рег. выражение НКА) множество не может следовать за множеством!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (рег. выражение НКА) слишком много '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (рег. выражение НКА) слишком много \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (рег. выражение НКА) ошибка корректного завершения"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (рег. выражение НКА) невозможно взять из стека!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
@@ -4919,138 +5079,176 @@ msgstr ""
 "E875: (рег. выражение НКА) в стеке осталось слишком много состояний (при "
 "преобразовании из postfix в НКА)"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (рег. выражение НКА) недостаточно места для хранения всего НКА"
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (НКА) невозможно выделить память для прохода ветви!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
 "Невозможно открыть файл временного журнала для записи, вывод на stderr..."
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(НКА) невозможно открыть %s!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Невозможно открыть файл временного журнала для записи"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " ВИРТУАЛЬНАЯ ЗАМЕНА"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ЗАМЕНА"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " ОБРАТНАЯ"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " ВСТАВКА"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (вставка)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (замена)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (виртуальная замена)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Иврит"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Арабский"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (язык)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (вклейка)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ВИЗУАЛЬНЫЙ РЕЖИМ"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ВИЗУАЛЬНАЯ СТРОКА"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ВИЗУАЛЬНЫЙ БЛОК"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ВЫДЕЛЕНИЕ"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ВЫДЕЛЕНИЕ СТРОКИ"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ВЫДЕЛЕНИЕ БЛОКА"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "запись"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Неправильная строка поиска: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Поиск закончен в НАЧАЛЕ документа; %s не найдено"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Поиск закончен в КОНЦЕ документа; %s не найдено"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: После ';' ожидается ввод '?' или '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (включает раннее показанные соответствия)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Включённые файлы "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "не найдено "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "по пути ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Уже показано)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " НЕ НАЙДЕНО"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Просмотр включённых файлов: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Поиск включённого файла %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Соответствие в текущей строке"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Найдены все включённые файлы"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Включённых файлов нет"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Определение не найдено"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Шаблон не найден"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Замена "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5061,88 +5259,99 @@ msgstr ""
 "# Последний %sШаблон поиска:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Ошибка формата в файле правописания"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Файл правописания обрезан"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Лишний текст на хвосте в %s стр. %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Имя аффикса слишком длинное в %s, строка %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Ошибка формата в файле аффиксов FOL, LOW или UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Символы в FOL, LOW или UPP за пределами диапазона"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Сжатие дерева слов..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Проверка правописания выключена"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Предупреждение: Невозможно найти список слов \"%s_%s.spl\" или \"%s_ascii.spl"
-"\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Предупреждение: Невозможно найти список слов \"%s.%s.spl\" или \"%s.ascii.spl"
 "\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Чтение файла правописания \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Это не похоже на файл правописания"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Старый файл правописания, требуется его обновление"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Файл правописания предназначен для более новой версии Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Неподдерживаемый раздел в файле правописания"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Предупреждение: регион %s не поддерживается"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Чтение файла аффиксов %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Не удалось преобразовать слово в %s, строка %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Преобразование в %s не поддерживается: из %s в %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Преобразование в %s не поддерживается"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Неправильное значение FLAG в %s, строка %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG после использования флагов в %s, строка %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5151,6 +5360,7 @@ msgstr ""
 "Определение COMPOUNDFORBIDFLAG после элемента PFX может дать неправильные "
 "результаты в %s, строка %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5159,35 +5369,43 @@ msgstr ""
 "Определение COMPOUNDPERMITFLAG после элемента PFX может дать неправильные "
 "результаты в %s, строка %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDRULES в %s, строка %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDWORDMAX в %s, строка %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDMIN в %s, строка %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDSYLMAX в %s, строка %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Неправильное значение CHECKCOMPOUNDPATTERN в %s, строка %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Другой объединяющий флаг в продолжающем блоке аффикса в %s, строка %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Повторяющийся аффикс в %s, строка %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5196,270 +5414,334 @@ msgstr ""
 "Аффикс также используется для BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
 "NOSUGGEST в %s, строка %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Ожидалось Y или N в %s, строка %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Нарушенное условие в %s, строка %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Ожидался счётчик REP(SAL) в %s, строка %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Ожидался счётчик MAP в %s, строка %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Повторяющийся символ в MAP в %s, строка %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Нераспознанный или повторяющийся элемент в %s, строка %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Пропущена строка FOL/LOW/UPP в %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX используется без SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Слишком много отложенных префиксов"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Слишком много составных флагов"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Слишком много отложенных префиксов и/или составных флагов"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Пропущена строка SOFO%s в %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Обе строки SAL и SOFO в %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Флаг не является числом в %s, строка %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Недопустимый флаг в %s на строке %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s имеет другое значение, чем в файле .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Чтение файла словаря %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Количество слов не указано в %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "строка %6d, слово %6d — %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Повтор слова в %s на строке %d: %s "
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Первый повтор слова в %s на строке %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d повторяющихся слов в %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Пропущено %d слов с не ASCII символами в %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Чтение файла слов %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Проигнорирована повторяющаяся строка /encoding= в %s, строка %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Проигнорирована строка /encoding= после слова в %s, строка %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Пропускается повтор строки /regions= в %s, строка %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Слишком много регионов в %s, строка %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "/ строка пропускается в %s, строка %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Недопустимый номер региона в %s, строка %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Нераспознанные флаги в %s, строка %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Пропущено %d слов с не ASCII символами"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Недостаточно оперативной памяти, список слов будет не полон"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Сжато %d из %d узлов; осталось %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Чтение записанного файла правописания..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Выполнение звуковой свёртки..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Количество слов после звуковой свёртки: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Общее количество слов: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Запись файла предложения исправлений правописания %s"
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Оценка использования памяти при выполнении: %d байт"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Имя выходного файла не должно содержать названия региона"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Поддерживается не более 8-ми регионов"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Недопустимый регион в %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Предупреждение: оба составные и указано NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Запись файла правописания %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Завершено!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' не содержит %<PRId64> элементов"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Слово удалено из %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Слово добавлено в %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Символы слов отличаются в файлах правописания"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Извините, нет предположений"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Извините, только %<PRId64> предположений"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Заменить \"%.*s\" на:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Нет предыдущей замены правописания"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Не найдено: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Это не похоже на файл .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Старый файл .sug, требует обновления: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Файл .sug для более новой версии Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Файл .sug не соответствует файлу .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Ошибка при чтении файла .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Повторяющийся символ в элементе MAP"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Синтаксические элементы для данного буфера не определены"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Недопустимый параметр: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Синтаксический кластер %s не найден"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "Синхронизация по комментариям в стиле языка C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "без синхронизации"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "синхронизация начата "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " строк перед верхней строкой"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5467,6 +5749,7 @@ msgstr ""
 "\n"
 "--- Элементы синхронизации синтаксиса ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5474,6 +5757,7 @@ msgstr ""
 "\n"
 "синхронизация по элементам"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5481,213 +5765,273 @@ msgstr ""
 "\n"
 "--- Синтаксические элементы ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Синтаксический кластер %s не найден"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "минимум "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "максимум "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; соответствие "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " переносов строк"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: Здесь нельзя использовать параметр contains"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Недопустимое значение cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: Здесь нельзя использовать group[t]here"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Элемент области для %s не найден"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Требуется указать имя файла"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Слишком много синтаксических включений"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Пропущено ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Пропущено '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Не хватает параметров: синтаксический регион %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Слишком много синтаксических кластеров"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Кластер не указан"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Не найден разделитель шаблонов: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Мусор после шаблона: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: Синхронизация синтаксиса: шаблон продолжений строки указан дважды"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Недопустимые параметры: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Пропущен знак равенства: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Пустой параметр: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s не допускается в этом месте"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s должно быть первым в списке contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Неизвестная группа: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Неправильная подкоманда :syntax: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  ВСЕГО       КОЛ.  СООТВ. ОТСТАЮЩИЙ    СРЕДНИЙ    ИМЯ                ШАБЛОН"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Рекурсивная петля при загрузке syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Группа подсветки синтаксиса %s не найдена"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Не хватает параметров: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Слишком много параметров: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: У группы есть настройки, пропускается highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Неожиданный знак равенства: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Пропущен знак равенства: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Пропущен параметр: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Недопустимое значение: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Неизвестный цвет текста"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Неизвестный цвет фона"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Имя или номер цвета не известно: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Слишком длинный код терминала: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Недопустимый параметр: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Используется слишком много разных атрибутов подсветки синтаксиса"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Непечатный символ в имени группы"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Недопустимый символ в имени группы"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Слишком много групп подсветки и синтаксиса"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: Внизу стека меток"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: Наверху стека меток"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Невозможно перейти в позицию до первой совпадающей метки"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Метка не найдена: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # при тип  метка"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "файл\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Есть только одна совпадающая метка"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Невозможно перейти в позицию за последней совпадающей меткой"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Файл \"%s\" не существует"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "метка %d из %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " и более"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Используется метка с символами в другом регистре!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Файл \"%s\" не существует"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5695,66 +6039,79 @@ msgstr ""
 "\n"
 "  # К  метке       ОТ   стр.  в файле/тексте"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Поиск в файле меток %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Путь к файлу меток %s обрезан\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Игнорирование длинной строки в файле tags"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Ошибка формата в файле меток \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Перед байтом %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Файл меток не отсортирован: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Файл меток не обнаружен"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Не найден шаблон метки"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Метка не найдена, пытаемся угадать!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Повторяющееся имя поля: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' не известен. Доступны встроенные терминалы:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "по умолчанию '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Невозможно открыть файл termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: В terminfo нет записи об этом терминале"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: В termcap нет записи об этом терминале"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: В termcap нет записи \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Требуется способность терминала \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5762,245 +6119,170 @@ msgstr ""
 "\n"
 "--- Кнопки терминала ---"
 
-msgid "new shell started\n"
-msgstr "запуск новой оболочки\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Ошибка чтения ввода, выход...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Вместо пустого выделения используется CUT_BUFFER0"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Неожиданно изменился счётчик строк"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Отмена невозможна; продолжать выполнение"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Невозможно открыть файл отмен для записи: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Файл отмен повреждён (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Невозможно записать файл отмен в каком-либо каталоге из 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Файл отмен не перезаписан, невозможно прочитать: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Перезапись не выполнена, это не файл отмен: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Пропущена запись файла отмен, нечего отменять"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Запись файла отмен: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Ошибка при записи файла отмен: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Файл отмен не прочитан, другой владелец: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Чтение файла отмен: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Невозможно открыть файл отмен для чтения: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Это не файл отмен: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Не зашифрованный файл имеет зашифрованный файл отмен: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Не удалось дешифровать файл отмен: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Файл отмен зашифрован: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Несовместимый файл отмен: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Изменилось содержимое файла, невозможно использовать информацию отмен"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Завершено чтение файла отмен %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Уже на самом первом изменении"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Уже на самом последнем изменении"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Не найдена отмена номер %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильные номера строк"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "стр. добавлена"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "стр. добавлено"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "стр. удалена"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "стр. удалено"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "изм."
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "изм."
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "перед"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "после"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Нечего отменять"
 
 # Заголовок таблицы :undolist
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr " номер  измен.  когда              сохранено"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> с назад"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: Объединение отмен не допускается после отмены"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: Повреждён список отмены"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Потеряна строка отмены"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Версия с графическим интерфейсом для MS-Windows 16/32 бит"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Версия с графическим интерфейсом для MS-Windows 64 бит"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Версия с графическим интерфейсом для MS-Windows 32 бит"
-
-msgid " in Win32s mode"
-msgstr " в режиме Win32"
-
-msgid " with OLE support"
-msgstr " с поддержкой OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Консольная версия для MS-Windows 64 бит"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Консольная версия для MS-Windows 32 бит"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Версия для MS-Windows 16 бит"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версия для MS-DOS 32 бит"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версия для MS-DOS 16 бит"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Версия для MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Версия для MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Версия для MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Версия для OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -6008,6 +6290,7 @@ msgstr ""
 "\n"
 "Заплатки: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -6015,9 +6298,11 @@ msgstr ""
 "\n"
 "Дополнительные заплатки: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "С изменениями, внесёнными "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -6025,9 +6310,11 @@ msgstr ""
 "\n"
 "Скомпилирован "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6035,859 +6322,1924 @@ msgstr ""
 "\n"
 "Огромная версия "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Большая версия "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Обычная версия "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Малая версия "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Версия \"Кроха\" "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "без графического интерфейса."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "с графическим интерфейсом GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "с графическим интерфейсом GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "с графическим интерфейсом X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "с графическим интерфейсом X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "с графическим интерфейсом X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "с графическим интерфейсом Photon."
-
-msgid "with GUI."
-msgstr "с графическим интерфейсом."
-
-msgid "with Carbon GUI."
-msgstr "с графическим интерфейсом Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "с графическим интерфейсом Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "с классическим графическим интерфейсом."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Включённые (+) и отключённые (-) особенности:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "            общесистемный файл vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "         пользовательский файл vimrc: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  второй пользовательский файл vimrc: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  третий пользовательский файл vimrc: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "          пользовательский файл exrc: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   второй пользовательский файл exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "           общесистемный файл gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "        пользовательский файл gvimrc: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr " второй пользовательский файл gvimrc: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr " третий пользовательский файл gvimrc: \""
-
-msgid "    system menu file: \""
-msgstr "             общесистемный файл меню: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "          значение $VIM по умолчанию: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "   значение $VIMRUNTIME по умолчанию: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Параметры компиляции: "
 
-msgid "Compiler: "
-msgstr "Компилятор: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Сборка: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  ОТЛАДОЧНАЯ СБОРКА"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM — Vi IMproved (улучшенный Vi)"
 
+#: ../version.c:769
 msgid "version "
 msgstr "версия "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Брам Мооленаар и другие"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim это свободно распространяемая программа с открытым кодом"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Бедным детям в Уганде нужна ваша помощь!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "наберите :help iccf<Enter>       для дополнительной информации"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "наберите :q<Enter>               чтобы выйти из программы     "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "наберите :help<Enter> или <F1>   для получения справки        "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "наберите :help version7<Enter>   чтобы узнать об этой версии  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Работа в Vi-совместимом режиме"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "наберите :set nocp<Enter>        для перехода в режим Vim     "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "наберите :help cp-default<Enter> для дополнительной информации"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "меню Справка->Сироты             для получения информации     "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Безрежимная работа, вставка введённого текста"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "меню Правка->Глобальные настройки->Режим Вставки                     "
-
-msgid "                              for two modes      "
-msgstr "                                 для двух режимов               "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "меню Правка->Глобальные настройки->Совместимость с Vi                "
-
-msgid "                              for Vim defaults   "
-msgstr "                                 для перехода в режим Vim       "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Помогите в разработке Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Станьте зарегистрированным пользователем Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "наберите :help sponsor<Enter>    для получения информации     "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "наберите :help register<Enter>   для получения информации     "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "меню Справка->Помощь/Регистрация для получения информации       "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ПРЕДУПРЕЖДЕНИЕ: обнаружена Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "наберите :help windows95<Enter>  для получения информации     "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "На экране всего одно окно"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Окно предпросмотра отсутствует"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Окно не может быть одновременно слева вверху и справа внизу"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Невозможно поменять местами, пока другое окно разделено"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Нельзя закрыть последнее окно"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Нельзя закрыть окно автокоманд"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Нельзя закрыть окно, останется только окно автокоманд"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: В другом окне есть несохранённые изменения"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Нет имени файла в позиции курсора"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Файл \"%s\" не найден по известным путям"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() вызван с пустым паролем"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Невозможно загрузить библиотеку %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Извините, данная команда отключена: невозможно загрузить библиотеку Perl"
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr ""
+#~ "E817: Неправильное использование обратного/прямого порядка байт в Blowfish"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Не допускается вычисление Perl в песочнице без модуля безопасности"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: Не удалось выполнить тест sha256"
 
-msgid "Edit with &multiple Vims"
-msgstr "Редактировать в &разных Vim-ах"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Не удалось выполнить тест Blowfish"
 
-msgid "Edit with single &Vim"
-msgstr "Редактировать в &одном Vim"
+#~ msgid "Patch file"
+#~ msgstr "Файл-заплатка"
 
-msgid "Diff with Vim"
-msgstr "Сравнить с помощью Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&C Отмена"
 
-msgid "Edit with &Vim"
-msgstr "Ре&дактировать с помощью Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Нет связи с сервером Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Редактировать в запущенном Vim — "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Не могу отправить сообщение для %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Редактировать выделенные файлы с помощью Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Сервер не отвечает"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Ошибка создания процесса: проверьте доступность gvim в пути!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Не могу ответить клиенту"
 
-msgid "gvimext.dll error"
-msgstr "ошибка gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Сохранить как"
 
-msgid "Path length too long!"
-msgstr "Слишком длинный путь!"
+#~ msgid "Edit File"
+#~ msgstr "Редактирование файла"
 
-msgid "--No lines in buffer--"
-msgstr "-- Нет строк в буфере --"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (НЕ НАЙДЕНО)"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Выполнение команды прервано"
+#~ msgid "Source Vim script"
+#~ msgstr "Выполнить сценарий Vim"
 
-msgid "E471: Argument required"
-msgstr "E471: Требуется указать параметр"
+#~ msgid "unknown"
+#~ msgstr "неизвестно"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: После \\ должен идти символ /, ? или &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Редактировать файл в новом окне"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Недопустимо в окне командной строки; <CR> выполнение, CTRL-C выход"
+#~ msgid "Append File"
+#~ msgstr "Добавить файл"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Команда не допускается в exrc/vimrc в текущем каталоге или поиске меток"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Положение окна: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Отсутствует команда :endif"
+#~ msgid "Save Redirection"
+#~ msgstr "Перенаправление записи"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Отсутствует команда :endtry"
+#~ msgid "Save View"
+#~ msgstr "Сохранение вида"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Отсутствует команда :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Сохранение сеанса"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Отсутствует команда :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Сохранение настроек"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: Команда :endwhile без парной команды :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< не доступно без особенности +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor без :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: В этой версии диграфы не работают"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Файл существует (добавьте !, чтобы перезаписать)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "является устройством (отключено при опции 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Не удалось выполнить команду"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Чтение из стандартного потока ввода stdin..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Неизвестный шрифтовой набор: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Неизвестный шрифт: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[зашифровано]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Шрифт \"%s\" не является моноширинным"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Файл зашифрован неизвестным методом"
 
-msgid "E473: Internal error"
-msgstr "E473: Внутренняя ошибка"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans не позволяет выполнять запись неизменённых буферов"
 
-msgid "Interrupted"
-msgstr "Прервано"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Частичная запись буферов NetBeans не допускается"
 
-msgid "E14: Invalid address"
-msgstr "E14: Недопустимый адрес"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "запись в устройство отключена при опции 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Недопустимый параметр"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Ветвь ресурса будет потеряна (добавьте !, чтобы обойти проверку)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Недопустимый параметр: %s"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Невозможно создать новый процесс для граф. интерфейса"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Недопустимое выражение: %s"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Процессу-потомку не удалось запустить граф. интерфейс"
 
-msgid "E16: Invalid range"
-msgstr "E16: Недопустимый диапазон"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Невозможно перейти в режим графического интерфейса"
 
-msgid "E476: Invalid command"
-msgstr "E476: Недопустимая команда"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Невозможно выполнить чтение \"%s\""
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" является каталогом"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Невозможно перейти в режим граф. интерфейса, неправильно заданы "
+#~ "шрифты"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Неудачный вызов функции \"%s()\" из библиотеки"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Неправильное значение опции 'guifontwide'"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Не удалось загрузить функцию %s из библиотеки"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Неправильное значение опции 'imactivatekey'"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Отметка указывает на неправильный номер строки"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Невозможно назначить цвет %s"
 
-msgid "E20: Mark not set"
-msgstr "E20: Отметка не определена"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Нет совпадения под курсором, поиск следующего"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Изменения невозможны, так как отключена опция 'modifiable'"
+#~ msgid "<cannot open> "
+#~ msgstr "<нельзя открыть> "
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Слишком глубоко вложенные сценарии"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: шрифт %s не найден"
 
-msgid "E23: No alternate file"
-msgstr "E23: Соседний файл не существует"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: возврат в текущий каталог невозможен"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Нет такого сокращения"
+#~ msgid "Pathname:"
+#~ msgstr "Путь к файлу:"
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! не допускается"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: не могу найти текущий каталог"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr ""
-"E25: Возможность использования графического интерфейса выключена при "
-"компиляции"
+#~ msgid "OK"
+#~ msgstr "Да"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Иврит выключен при компиляции\n"
+#~ msgid "Cancel"
+#~ msgstr "Отмена"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Фарси выключено при компиляции\n"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Полоса прокрутки: не могу определить геометрию ползунка"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Арабский выключен при компиляции\n"
+#~ msgid "Vim dialog"
+#~ msgstr "Диалоговое окно Vim"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Группа подсветки синтаксиса %s не существует"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: \"Пузырь\" для вычислений, включающий и сообщение, и обратный "
+#~ "вызов, не может быть создан"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Пока нет вставленного текста"
+#~ msgid "Input _Methods"
+#~ msgstr "Методы Ввода"
 
-msgid "E30: No previous command line"
-msgstr "E30: Предыдущей командной строки нет"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM — Поиск и замена..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Такой привязки не существует"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM — Поиск..."
 
-msgid "E479: No match"
-msgstr "E479: Нет соответствия"
+#~ msgid "Find what:"
+#~ msgstr "Что ищем:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Нет соответствия: %s"
+#~ msgid "Replace with:"
+#~ msgstr "На что заменяем:"
 
-msgid "E32: No file name"
-msgstr "E32: Нет имени файла"
+#~ msgid "Match whole word only"
+#~ msgstr "Только точные соответствия"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Нет предыдущего регулярного выражения для замены"
+#~ msgid "Match case"
+#~ msgstr "Регистрозависимые соответствия"
 
-msgid "E34: No previous command"
-msgstr "E34: Нет предыдущей команды"
+#~ msgid "Direction"
+#~ msgstr "Направление"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Нет предыдущего регулярного выражения"
+#~ msgid "Up"
+#~ msgstr "Вверх"
 
-msgid "E481: No range allowed"
-msgstr "E481: Использование диапазона не допускается"
+#~ msgid "Down"
+#~ msgstr "Вниз"
 
-msgid "E36: Not enough room"
-msgstr "E36: Недостаточно места"
+#~ msgid "Find Next"
+#~ msgstr "Найти следующее"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Сервер \"%s\" не зарегистрирован"
+#~ msgid "Replace"
+#~ msgstr "Замена"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Невозможно создать файл %s"
+#~ msgid "Replace All"
+#~ msgstr "Заменить все"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Невозможно получить имя временного файла"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Получен запрос на прекращение работы от диспетчера сеансов\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Невозможно открыть файл %s"
+#~ msgid "Close"
+#~ msgstr "Закрыть"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Невозможно прочитать файл %s"
+#~ msgid "New tab"
+#~ msgstr "Новая вкладка"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Изменения не сохранены (добавьте !, чтобы обойти проверку)"
+#~ msgid "Open Tab..."
+#~ msgstr "Открыть вкладку..."
 
-msgid "E38: Null argument"
-msgstr "E38: Нулевой параметр"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Основное окно было неожиданно закрыто\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Требуется число"
+#~ msgid "&Filter"
+#~ msgstr "&Фильтр"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Не удалось открыть файл ошибок %s"
+#~ msgid "&Cancel"
+#~ msgstr "О&тмена"
 
-msgid "E233: cannot open display"
-msgstr "E233: Невозможно открыть дисплей"
+#~ msgid "Directories"
+#~ msgstr "Каталоги"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Не хватает памяти!"
+#~ msgid "Filter"
+#~ msgstr "Фильтр"
 
-msgid "Pattern not found"
-msgstr "Шаблон не найден"
+#~ msgid "&Help"
+#~ msgstr "&Справка"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Шаблон не найден: %s"
+#~ msgid "Files"
+#~ msgstr "Файлы"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Параметр должен быть положительным числом"
+#~ msgid "&OK"
+#~ msgstr "&Да"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Возврат в предыдущий каталог невозможен"
+#~ msgid "Selection"
+#~ msgstr "Выделение"
 
-msgid "E42: No Errors"
-msgstr "E42: Нет ошибок"
+#~ msgid "Find &Next"
+#~ msgstr "Найти &следующее"
 
-msgid "E776: No location list"
-msgstr "E776: Нет списка расположений"
+#~ msgid "&Replace"
+#~ msgstr "За&мена"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Повреждена строка соответствия"
+#~ msgid "Replace &All"
+#~ msgstr "Заменить &все"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Программа обработки регулярных выражений повреждена"
+#~ msgid "&Undo"
+#~ msgstr "О&тмена"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Включена опция 'readonly' (добавьте !, чтобы обойти проверку)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Окно с заголовком \"%s\" не обнаружено"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Невозможно изменить переменную только для чтения \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Параметр не поддерживается: \"-%s\"; используйте версию OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Невозможно изменить переменную в песочнице: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Невозможно открыть окно внутри приложения MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Ошибка при чтении файла ошибок"
+#~ msgid "Close tab"
+#~ msgstr "Закрыть вкладку"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Не допускается в песочнице"
+#~ msgid "Open tab..."
+#~ msgstr "Открыть вкладку..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Здесь не разрешено"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Поиск строки (используйте '\\\\' для поиска '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Данный режим экрана не поддерживается"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Поиск и замена (используйте '\\\\' для поиска '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Недопустимый размер прокрутки"
+#~ msgid "Not Used"
+#~ msgstr "Не используется"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Значением опции 'shell' является пустая строка"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Каталог\t*.ничего\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Невозможно прочитать данные о значках!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Невозможно выделить запись в таблице цвета, некоторые цвета "
+#~ "могут отображаться неправильно"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Ошибка закрытия своп-файла"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: В наборе шрифтов %s отсутствуют шрифты для следующих кодировок:"
 
-msgid "E73: tag stack empty"
-msgstr "E73: Стек меток пустой"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Набор шрифтов: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Слишком сложная команда"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Шрифт '%s' не является моноширинным"
 
-msgid "E75: Name too long"
-msgstr "E75: Слишком длинное имя"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Набор шрифтов: %s"
 
-msgid "E76: Too many ["
-msgstr "E76: Слишком много символов ["
+#~ msgid "Font0: %s"
+#~ msgstr "Font0: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: Слишком много имён файлов"
+#~ msgid "Font1: %s"
+#~ msgstr "Font1: %s"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Лишние символы на хвосте"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr ""
+#~ "Ширина шрифта font%<PRId64> должна быть вдвое больше ширины шрифта font0"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Неизвестная отметка"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Ширина шрифта font0: %<PRId64>"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Невозможно выполнить подстановку по маске"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Ширина шрифта font1: %<PRId64>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr ""
-"E591: Значение опции 'winheight' не может быть меньше значения 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Неправильное определение шрифта"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr ""
-"E592: Значение опции 'winwidth' не может быть меньше значения 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "О&тклонить"
 
-msgid "E80: Error while writing"
-msgstr "E80: Ошибка при записи"
+#~ msgid "no specific match"
+#~ msgstr "нет специального совпадения"
 
-msgid "Zero count"
-msgstr "Нулевое значение счётчика"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim — Выбор шрифта"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Использование <SID> вне контекста сценария"
+#~ msgid "Name:"
+#~ msgstr "Название:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Получено недопустимое выражение"
+#~ msgid "Show size in Points"
+#~ msgstr "Показывать размер в пунктах"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Невозможно изменить охраняемую область"
+#~ msgid "Encoding:"
+#~ msgstr "Кодировка:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans не допускает изменений в файлах только для чтения"
+#~ msgid "Font:"
+#~ msgstr "Шрифт:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Внутренняя ошибка: %s"
+#~ msgid "Style:"
+#~ msgstr "Стиль:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Шаблон использует больше памяти чем 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Размер:"
 
-msgid "E749: empty buffer"
-msgstr "E749: Пустой буфер"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ОШИБКА автоматики Хангыл"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Неправильная строка поиска или разделитель"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: Ошибка stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Файл загружен в другом буфере"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Невозможно открыть базу данных cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Опция '%s' не установлена"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Информация о базе данных cscope не доступна"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Недопустимое имя регистра"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Библиотека Lua не может быть загружена."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Поиск будет продолжен с КОНЦА документа"
+#~ msgid "cannot save undo information"
+#~ msgstr "невозможно сохранить информацию об отмене операции"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Поиск будет продолжен с НАЧАЛА документа"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека MzScheme"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Требуется ключ шифрования для \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "неправильное выражение"
 
-msgid "empty keys are not allowed"
-msgstr "Пустые ключи не допустимы"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "выражения отключены при компиляции"
 
-msgid "dictionary is locked"
-msgstr "Словарь заблокирован"
+#~ msgid "hidden option"
+#~ msgstr "скрытая опция"
 
-msgid "list is locked"
-msgstr "Список заблокирован"
+#~ msgid "unknown option"
+#~ msgstr "неизвестная опция"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "Невозможно добавить ключ '%s' к словарю"
+#~ msgid "window index is out of range"
+#~ msgstr "индекс окна за пределами диапазона"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "Индекс должен быть целым числом или выборкой, а не %s"
+#~ msgid "couldn't open buffer"
+#~ msgstr "невозможно открыть буфер"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "Ожидался экземпляр str() или unicode(), но получен %s"
+#~ msgid "cannot delete line"
+#~ msgstr "невозможно удалить строку"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "Ожидался экземпляр bytes() или str(), но получен %s"
+#~ msgid "cannot replace line"
+#~ msgstr "невозможно заменить строку"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr "Ожидалось int(), long() или что-то приводимое к long(), но получено %s"
+#~ msgid "cannot insert line"
+#~ msgstr "невозможно вставить строку"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "Ожидалось int() или что-то приводимое к int(), но получено %s"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "строка не может содержать символ новой строки"
 
-msgid "value is too large to fit into C int type"
-msgstr "Значение слишком велико для целочисленного типа C"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "невозможно преобразовать значения Scheme в Vim"
 
-msgid "value is too small to fit into C int type"
-msgstr "Значение слишком мало для целочисленного типа C"
+#~ msgid "Vim error: ~a"
+#~ msgstr "ошибка Vim: ~a"
 
-msgid "number must be greater then zero"
-msgstr "Номер должен быть больше нуля"
+#~ msgid "Vim error"
+#~ msgstr "ошибка Vim"
 
-msgid "number must be greater or equal to zero"
-msgstr "Номер должен быть больше или равен нулю"
+#~ msgid "buffer is invalid"
+#~ msgstr "неправильный буфер"
 
-msgid "can't delete OutputObject attributes"
-msgstr "Невозможно удалить атрибуты OutputObject"
+#~ msgid "window is invalid"
+#~ msgstr "неправильное окно"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "Неправильный атрибут: %s"
+#~ msgid "linenr out of range"
+#~ msgstr "номер строки за пределами диапазона"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Ошибка инициализации объектов I/O"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "не допускается в песочнице Vim"
 
-msgid "failed to change directory"
-msgstr "Невозможно сменить каталог"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr ""
+#~ "E836: Данный Vim не может выполнить :python после использования :py3"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "Ожидался 3-кортеж как результат imp.find_module(), но получен %s"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека Python"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr ""
-"Ожидался 3-кортеж как результат imp.find_module(), но получен кортеж с "
-"размером %d"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Невозможно выполнить рекурсивный вызов Python"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "Внутренняя ошибка: imp.find_module возвратил "
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr ""
+#~ "E837: Данный Vim не может выполнить :py3 после использования :python"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "Невозможно удалить атрибуты vim.Dictionary"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ должен быть экземпляром или строкой"
 
-msgid "cannot modify fixed dictionary"
-msgstr "Невозможно изменить фиксированный словарь"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека Ruby"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "Невозможно установить атрибут %s"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: Неожиданный return"
 
-msgid "hashtab changed during iteration"
-msgstr "Хэш-таблица изменилась при итерации"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: Неожиданный next"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr ""
-"Ожидался элемент-последовательность размера 2, а размер полученной "
-"последовательности %d"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: Неожиданный break"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "Конструктор списка не допускает ключевые слова как аргументы"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: Неожиданный redo"
 
-msgid "list index out of range"
-msgstr "Индекс списка за пределами диапазона"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry вне оператора rescue"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "Внутренняя ошибка: не удалось получить элемент VIM-списка %d"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Необработанное исключение"
 
-msgid "failed to add item to list"
-msgstr "Невозможно добавить элемент в список"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Неизвестное состояние longjmp %d"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "Внутренняя ошибка: нет элемента VIM-списка %d"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Переключение между реализацией/определением"
 
-msgid "internal error: failed to add item to list"
-msgstr "Внутренняя ошибка: не удалось добавить элемент в список"
+#~ msgid "Show base class of"
+#~ msgstr "Показать основной класс"
 
-msgid "cannot delete vim.List attributes"
-msgstr "Невозможно удалить атрибуты vim.List"
+#~ msgid "Show overridden member function"
+#~ msgstr "Показать перегруженные функции"
 
-msgid "cannot modify fixed list"
-msgstr "Невозможно изменить фиксированный список"
+#~ msgid "Retrieve from file"
+#~ msgstr "Получить из файла"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "Не существует безымянной функции %s"
+#~ msgid "Retrieve from project"
+#~ msgstr "Получить из проекта"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "Функция %s не существует"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Получить из всех проектов"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "Конструктор функции не допускает ключевые слова как аргументы"
+#~ msgid "Retrieve"
+#~ msgstr "Получить"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "Невозможно выполнить функцию %s"
+#~ msgid "Show source of"
+#~ msgstr "Показать исходный код"
 
-msgid "unable to get option value"
-msgstr "Невозможно получить значение опции"
+#~ msgid "Find symbol"
+#~ msgstr "Найти символ"
 
-msgid "internal error: unknown option type"
-msgstr "Внутренняя ошибка: неизвестный тип опции"
+#~ msgid "Browse class"
+#~ msgstr "Просмотр класса"
 
-msgid "problem while switching windows"
-msgstr "Проблема при переключении окон"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Показать класс в иерархии"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "Невозможно сбросить глобальную опцию %s"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Показать класс в ограниченной иерархии"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "Невозможно сбросить опцию %s без глобального значения"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref ссылается на"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "Попытка сослаться на удалённую вкладку"
+#~ msgid "Xref referred by"
+#~ msgstr "Ссылка на xref из"
 
-msgid "no such tab page"
-msgstr "Нет такой вкладки"
+#~ msgid "Xref has a"
+#~ msgstr "Xref имеет"
 
-msgid "attempt to refer to deleted window"
-msgstr "Попытка сослаться на закрытое окно"
+#~ msgid "Xref used by"
+#~ msgstr "Xref используется"
 
-msgid "readonly attribute: buffer"
-msgstr "Атрибут только для чтения: буфер"
+#~ msgid "Show docu of"
+#~ msgstr "Показать docu"
 
-msgid "cursor position outside buffer"
-msgstr "Позиция курсора находится вне буфера"
+#~ msgid "Generate docu for"
+#~ msgstr "Создать docu"
 
-msgid "no such window"
-msgstr "Нет такого окна"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Невозможно подсоединиться к SNiFF+. Проверьте настройки окружения."
+#~ "(sniffemacs должны быть указаны в переменной $PATH).\n"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "Попытка сослаться на уничтоженный буфер"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Ошибка во время чтения. Отсоединение"
 
-msgid "failed to rename buffer"
-msgstr "Невозможно переименовать буфер"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "В настоящий момент SNiFF+ "
 
-msgid "mark name must be a single character"
-msgstr "Название отметки должно быть одним символом"
+#~ msgid "not "
+#~ msgstr "не "
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "Ожидался объект vim.Buffer, но получен %s"
+#~ msgid "connected"
+#~ msgstr "подсоединён"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "Невозможно переключиться на буфер %d"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Неизвестный запрос SNiFF+: %s"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "Ожидался объект vim.Window, но получен %s"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Ошибка соединения со SNiFF+"
 
-msgid "failed to find window in the current tab page"
-msgstr "Невозможно найти окно в текущей вкладке"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ не подсоединён"
 
-msgid "did not switch to the specified window"
-msgstr "Невозможно переключиться на указанное окно"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Это не буфер SNiFF+"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "Ожидался объект vim.TabPage, но получен %s"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Ошибка во время записи. Отсоединение"
 
-msgid "did not switch to the specified tab page"
-msgstr "Невозможно переключиться на указанную вкладку"
+#~ msgid "invalid buffer number"
+#~ msgstr "неправильный номер буфера"
 
-msgid "failed to run the code"
-msgstr "Невозможно выполнить код"
+#~ msgid "not implemented yet"
+#~ msgstr "пока не реализовано"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval не возвратил допустимого объекта Python"
+#~ msgid "cannot set line(s)"
+#~ msgstr "невозможно назначить строку или строки"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr ""
-"E859: Не удалось преобразовать возвращённый объект Python в значение VIM"
+#~ msgid "invalid mark name"
+#~ msgstr "неправильное имя отметки"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "Невозможно преобразовать %s в словарь VIM"
+#~ msgid "mark not set"
+#~ msgstr "отметка не установлена"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "Невозможно преобразовать %s в структуру VIM"
+#~ msgid "row %d column %d"
+#~ msgstr "ряд %d колонка %d"
 
-msgid "internal error: NULL reference passed"
-msgstr "Внутренняя ошибка: передана ссылка на NULL"
+#~ msgid "cannot insert/append line"
+#~ msgstr "невозможно вставить или добавить строку"
 
-msgid "internal error: invalid value type"
-msgstr "Внутренняя ошибка: неправильный тип значения"
+#~ msgid "line number out of range"
+#~ msgstr "номер строки за пределами диапазона"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Ошибка при установке перехватчика пути: sys.path_hooks не является списком\n"
-"Следует сделать следующее:\n"
-"— Добавить vim.path_hook  в sys.path_hooks\n"
-"— Добавить vim.VIM_SPECIAL_PATH в sys.path\n"
+#~ msgid "unknown flag: "
+#~ msgstr "неизвестный флаг: "
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Ошибка при установке пути: sys.path не является списком\n"
-"Следует добавить vim.VIM_SPECIAL_PATH в sys.path"
+#~ msgid "unknown vimOption"
+#~ msgstr "неизвестная vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "клавиатурное прерывание"
+
+#~ msgid "vim error"
+#~ msgstr "ошибка VIM"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "невозможно создать команду буфера или окна: объект в процессе удаления"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "невозможно зарегистрировать команду с обратным вызовом: буфер или окно в "
+#~ "процессе удаления"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: КРИТИЧЕСКАЯ ОШИБКА TCL: повреждён список ссылок?! Сообщите об этом "
+#~ "по адресу vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "невозможно зарегистрировать команду с обратным вызовом: ссылка на буфер "
+#~ "или окно не обнаружена"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека Tcl"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Код выхода %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "невозможно получить строку"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Невозможно зарегистрировать имя сервера команд"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Не удалась отправка команды в другую программу"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Используется неправильный id сервера: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Неправильно сформировано значение данного процесса VIM в реестре. "
+#~ "Удалено!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "NetBeans не поддерживается с этим графическим интерфейсом\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr ""
+#~ "Данный Vim был скомпилирован с выключенной особенностью просмотра отличий"
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "Невозможно использовать '-nb': не включено при компиляции\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Ошибка: Не удалось запустить gvim из NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Если регистр игнорируется, добавьте перед флагом / для верхнего регистра"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tЗарегистрировать этот gvim для OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tОтключить регистрацию данного gvim для OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tЗапустить с графическим интерфейсом (как \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  или --nofork\tВ активной задаче: Не выполнять fork при запуске GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tНе использовать newcli для открытия окна"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <устройство>\t\tИспользовать для I/O указанное <устройство>"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tИспользовать <gvimrc> вместо любых файлов .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tРедактирование зашифрованных файлов"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <экран>\tПодсоединить VIM к указанному X-серверу"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tНе выполнять соединение с сервером X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <файлы>\tПо возможности редактировать <файлы> на сервере Vim"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <файлы>  То же, но без жалоб на отсутствие сервера"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <файлы>  То же, что и --remote, но с ожиданием завершения"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <файлы>  То же, но без жалоб на отсутствие сервера"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <файлы>  То же, что и --remote, но с "
+#~ "вкладками"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <кнопки>\tОтправить <кнопки> на сервер Vim и выйти"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <выраж>\tВычислить <выраж> на сервере Vim и напечатать"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr ""
+#~ "--serverlist\t\tПоказать список имён серверов Vim и завершить работу"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr ""
+#~ "--servername <имя>\tОтправить на/стать сервером Vim с указанным <именем>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <дисплей>\tЗапустить VIM на указанном <дисплее>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tЗапустить VIM в свёрнутом виде"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr ""
+#~ "-background <цвет>\tИспользовать указанный <цвет> для фона (также: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <цвет>\tИспользовать <цвет> для обычного текста (также: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <шрифт>\t\tИспользовать <шрифт> для обычного текста (также: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <шрифт>\tИспользовать <шрифт> для жирного текста"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <шрифт>\tИспользовать <шрифт> для наклонного текста"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <геометрия>\tИспользовать начальную <геометрию> (также: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <ширина>\tИспользовать <ширину> бордюра (также: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <ширина> Использовать ширину полосы прокрутки (также: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <высота>\tИспользовать <высоту> меню (также: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tИспользовать инверсный видеорежим (также: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tНе использовать инверсный видеорежим (также: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ресурс>\tУстановить указанный <ресурс>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr ""
+#~ "-display <дисплей>\tЗапустить VIM на указанном <дисплее> (также: --"
+#~ "display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <роль>\tУстановить уникальную <роль> для идентификации главного "
+#~ "окна"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tОткрыть Vim внутри другого компонента GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr ""
+#~ "--echo-wid\t\tВывести Window ID для gvim на стандартный поток вывода"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <заголовок родителя>\tОткрыть Vim в родительском приложении"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tОткрыть Vim внутри другого компонента win32"
+
+#~ msgid "No display"
+#~ msgstr "Нет дисплея"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Отправка не удалась.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Отправка не удалась. Попытка местного выполнения\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "отредактировано %d из %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Нет дисплея: отправка выражения не удалась.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Отправка выражения не удалась.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Недопустимое имя кодировки"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Невозможно назначить значения контекста ввода"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Невозможно создать контекст ввода"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Неудачная попытка открыть метод ввода"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Предупреждение: невозможно назначить обр. вызов уничтожения метода "
+#~ "ввода"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Метод ввода не поддерживает стили"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr ""
+#~ "E289: Метод ввода не поддерживает мой тип предварительного редактирования"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Ошибка при обновлении шифрования своп-файла"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s зашифрован, а эта версия Vim не поддерживает шифрование"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Своп-файл зашифрован: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Если вы ввели новый пароль для шифрования, но не записали текстовый файл,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "то введите новый пароль для шифрования."
+
+# Перевод сообщения разделён на две части, часть первая
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Если вы записали текстовый файл после изменения пароля шифрования, то "
+#~ "нажмите"
+
+# Перевод сообщения разделён на две части, часть вторая
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "Enter для использования одного ключа для текстового файла и своп-файла"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr ""
+#~ "Использование ключа шифрования из своп-файла для текстового файла.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [не пригоден для использования с данной версией Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Оторвать это меню"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Выбор каталога"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Сохранение файла"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Открытие файла"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr ""
+#~ "E338: Извините, но в консольном режиме нет проводника по файловой системе"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: сохранение файлов...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Готово.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ОШИБКА: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[байт] всего выдел.-освоб. %<PRIu64>-%<PRIu64>, использ. %<PRIu64>, макс. "
+#~ "использ. %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[вызовы] re/malloc() всего %<PRIu64>, free() всего %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Строка становится слишком длинной"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Недопустимая форма курсора"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Введите пароль для шифрования: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Повторите ввод пароля: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Введённые пароли не совпадают!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Невозможно соединиться с NetBeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Невозможно соединиться с NetBeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Неправильный режим доступа к информации о соединении с NetBeans: "
+#~ "\"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "чтение из гнезда NetBeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Потеряно соединение с NetBeans для буфера %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: NetBeans не поддерживается с этим графическим интерфейсом"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: уже соединён с NetBeans"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr ""
+#~ "E505: %s открыт только для чтения (добавьте !, чтобы обойти проверку)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: eval не доступна"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "очищено строк: %<PRId64>"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: В графическом интерфейсе изменять терминал невозможно"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Для запуска графического интерфейса используйте \":gui\""
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Не может быть изменено в графическом интерфейсе GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Неправильные шрифты"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Невозможно выбрать шрифтовой набор"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Неправильный шрифтовой набор"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Невозможно выбрать шрифт с символами двойной ширины"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Неправильный шрифт с символами двойной ширины"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Мышь не поддерживается"
+
+#~ msgid "cannot open "
+#~ msgstr "невозможно открыть "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Невозможно открыть окно!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Необходима Amigados версии 2.04 или более поздней\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Необходима %s версии %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Невозможно открыть NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Невозможно создать "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Прекращение работы Vim с кодом %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "невозможно сменить режим консоли?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: не в консоли??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Невозможно выполнить оболочку с параметром -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Невозможно выполнить "
+
+#~ msgid "shell "
+#~ msgstr "оболочка "
+
+#~ msgid " returned\n"
+#~ msgstr " завершила работу\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "слишком малая величина ANCHOR_BUF_SIZE."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ОШИБКА ВВОДА/ВЫВОДА"
+
+#~ msgid "Message"
+#~ msgstr "Сообщение"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr ""
+#~ "Значение опции 'columns' не равно 80, внешние программы не выполняются"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Неудачное завершение выбора принтера"
+
+#~ msgid "to %s on %s"
+#~ msgstr "в %s на %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Неизвестный шрифт принтера: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Ошибка печати: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Печать '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Недопустимое имя кодировки \"%s\" в имени шрифта \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Недопустимый символ '%c' в имени шрифта \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Двойной сигнал, завершение работы\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Получен убийственный сигнал %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Получен убийственный сигнал\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Открытие дисплея X заняло %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Ошибка X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Проверка дисплея X завершена неудачно"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Открытие дисплея X не выполнено в отведённое время"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Невозможно запустить оболочку sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Невозможно создать трубы\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Невозможно выполнить fork()\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Выполнение команды прервано\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP утеряно соединение ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Неудачное открытие дисплея X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP обрабатывает запрос самосохранения"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP открывает соединение"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP потеряно слежение за соединением ICE"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP неудачно выполнено SmcOpenConnection: %s"
+
+#~ msgid "At line"
+#~ msgstr "В строке"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Невозможно загрузить vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Ошибка VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Невозможно исправить указатели функций для DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "завершение работы оболочки с кодом %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Перехвачено событие %s\n"
+
+#~ msgid "close"
+#~ msgstr "закрытие"
+
+#~ msgid "logoff"
+#~ msgstr "отключение"
+
+#~ msgid "shutdown"
+#~ msgstr "завершение"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Команда не найдена"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE не найден в пути, заданном в $PATH.\n"
+#~ "Внешние команды не будут останавливаться после выполнения.\n"
+#~ "Дополнительная информация в :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Предупреждение Vim"
+
+#~ msgid "Error file"
+#~ msgstr "Файл ошибок"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: ошибка при создании НКА с классом эквивалентности!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (НКА) невозможно выделить память для прохода ветви!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Предупреждение: Невозможно найти список слов \"%s_%s.spl\" или \"%s_ascii."
+#~ "spl\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Преобразование в %s не поддерживается"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: Недостаточно оперативной памяти, список слов будет не полон"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Путь к файлу меток %s обрезан\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "запуск новой оболочки\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Вместо пустого выделения используется CUT_BUFFER0"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Отмена невозможна; продолжать выполнение"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Не зашифрованный файл имеет зашифрованный файл отмен: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Не удалось дешифровать файл отмен: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Файл отмен зашифрован: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия с графическим интерфейсом для MS-Windows 16/32 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия с графическим интерфейсом для MS-Windows 64 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия с графическим интерфейсом для MS-Windows 32 бит"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " в режиме Win32"
+
+#~ msgid " with OLE support"
+#~ msgstr " с поддержкой OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольная версия для MS-Windows 64 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольная версия для MS-Windows 32 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MS-Windows 16 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MS-DOS 32 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MS-DOS 16 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Большая версия "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Обычная версия "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Малая версия "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Версия \"Кроха\" "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "с графическим интерфейсом GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "с графическим интерфейсом GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "с графическим интерфейсом X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "с графическим интерфейсом X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "с графическим интерфейсом X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "с графическим интерфейсом Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "с графическим интерфейсом."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "с графическим интерфейсом Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "с графическим интерфейсом Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "с классическим графическим интерфейсом."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "           общесистемный файл gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "        пользовательский файл gvimrc: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr " второй пользовательский файл gvimrc: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr " третий пользовательский файл gvimrc: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "             общесистемный файл меню: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Компилятор: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "меню Справка->Сироты             для получения информации     "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Безрежимная работа, вставка введённого текста"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr ""
+#~ "меню Правка->Глобальные настройки->Режим Вставки                     "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                                 для двух режимов               "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr ""
+#~ "меню Правка->Глобальные настройки->Совместимость с Vi                "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                 для перехода в режим Vim       "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ПРЕДУПРЕЖДЕНИЕ: обнаружена Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "наберите :help windows95<Enter>  для получения информации     "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Невозможно загрузить библиотеку %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Извините, данная команда отключена: невозможно загрузить библиотеку Perl"
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Не допускается вычисление Perl в песочнице без модуля безопасности"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Редактировать в &разных Vim-ах"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Редактировать в &одном Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Сравнить с помощью Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Ре&дактировать с помощью Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Редактировать в запущенном Vim — "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Редактировать выделенные файлы с помощью Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Ошибка создания процесса: проверьте доступность gvim в пути!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "ошибка gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Слишком длинный путь!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Неизвестный шрифтовой набор: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Неизвестный шрифт: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Шрифт \"%s\" не является моноширинным"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Не удалось загрузить функцию %s из библиотеки"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Иврит выключен при компиляции\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Фарси выключено при компиляции\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Арабский выключен при компиляции\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Сервер \"%s\" не зарегистрирован"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Невозможно открыть дисплей"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Получено недопустимое выражение"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Невозможно изменить охраняемую область"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans не допускает изменений в файлах только для чтения"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Требуется ключ шифрования для \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "Пустые ключи не допустимы"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "Словарь заблокирован"
+
+#~ msgid "list is locked"
+#~ msgstr "Список заблокирован"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "Невозможно добавить ключ '%s' к словарю"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "Индекс должен быть целым числом или выборкой, а не %s"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "Ожидался экземпляр str() или unicode(), но получен %s"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "Ожидался экземпляр bytes() или str(), но получен %s"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "Ожидалось int(), long() или что-то приводимое к long(), но получено %s"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr "Ожидалось int() или что-то приводимое к int(), но получено %s"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "Значение слишком велико для целочисленного типа C"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "Значение слишком мало для целочисленного типа C"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "Номер должен быть больше нуля"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "Номер должен быть больше или равен нулю"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "Невозможно удалить атрибуты OutputObject"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "Неправильный атрибут: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Ошибка инициализации объектов I/O"
+
+#~ msgid "failed to change directory"
+#~ msgstr "Невозможно сменить каталог"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "Ожидался 3-кортеж как результат imp.find_module(), но получен %s"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr ""
+#~ "Ожидался 3-кортеж как результат imp.find_module(), но получен кортеж с "
+#~ "размером %d"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "Внутренняя ошибка: imp.find_module возвратил "
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "Невозможно удалить атрибуты vim.Dictionary"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "Невозможно изменить фиксированный словарь"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "Невозможно установить атрибут %s"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "Хэш-таблица изменилась при итерации"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "Ожидался элемент-последовательность размера 2, а размер полученной "
+#~ "последовательности %d"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "Конструктор списка не допускает ключевые слова как аргументы"
+
+#~ msgid "list index out of range"
+#~ msgstr "Индекс списка за пределами диапазона"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "Внутренняя ошибка: не удалось получить элемент VIM-списка %d"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "Невозможно добавить элемент в список"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "Внутренняя ошибка: нет элемента VIM-списка %d"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "Внутренняя ошибка: не удалось добавить элемент в список"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "Невозможно удалить атрибуты vim.List"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "Невозможно изменить фиксированный список"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "Не существует безымянной функции %s"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "Функция %s не существует"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "Конструктор функции не допускает ключевые слова как аргументы"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "Невозможно выполнить функцию %s"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "Проблема при переключении окон"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "Невозможно сбросить глобальную опцию %s"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "Невозможно сбросить опцию %s без глобального значения"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "Попытка сослаться на удалённую вкладку"
+
+#~ msgid "no such tab page"
+#~ msgstr "Нет такой вкладки"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "Попытка сослаться на закрытое окно"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "Атрибут только для чтения: буфер"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "Позиция курсора находится вне буфера"
+
+#~ msgid "no such window"
+#~ msgstr "Нет такого окна"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "Попытка сослаться на уничтоженный буфер"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "Невозможно переименовать буфер"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "Название отметки должно быть одним символом"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "Ожидался объект vim.Buffer, но получен %s"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "Невозможно переключиться на буфер %d"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "Ожидался объект vim.Window, но получен %s"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "Невозможно найти окно в текущей вкладке"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "Невозможно переключиться на указанное окно"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "Ожидался объект vim.TabPage, но получен %s"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "Невозможно переключиться на указанную вкладку"
+
+#~ msgid "failed to run the code"
+#~ msgstr "Невозможно выполнить код"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval не возвратил допустимого объекта Python"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr ""
+#~ "E859: Не удалось преобразовать возвращённый объект Python в значение VIM"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "Невозможно преобразовать %s в словарь VIM"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "Невозможно преобразовать %s в структуру VIM"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "Внутренняя ошибка: передана ссылка на NULL"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "Внутренняя ошибка: неправильный тип значения"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Ошибка при установке перехватчика пути: sys.path_hooks не является "
+#~ "списком\n"
+#~ "Следует сделать следующее:\n"
+#~ "— Добавить vim.path_hook  в sys.path_hooks\n"
+#~ "— Добавить vim.VIM_SPECIAL_PATH в sys.path\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Ошибка при установке пути: sys.path не является списком\n"
+#~ "Следует добавить vim.VIM_SPECIAL_PATH в sys.path"

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim_7.4_ru\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-08-31 16:42+0400\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2013-08-31 21:11+0400\n"
 "Last-Translator: Sergey Alyoshin <alyoshin.s@gmail.com>\n"
 "Language-Team: \n"
@@ -18,166 +18,206 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: bf_key_init() вызван с пустым паролем"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Невозможно получить значение опции"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "Внутренняя ошибка: неизвестный тип опции"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr ""
-"E817: Неправильное использование обратного/прямого порядка байт в Blowfish"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: Не удалось выполнить тест sha256"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Не удалось выполнить тест Blowfish"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Список расположений]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Список быстрых исправлений]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Автокоманды вызвали прекращение команды"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Невозможно выделить память даже для одного буфера, выход..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Невозможно выделить память для буфера, используем другой буфер..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Ни один буфер не был выгружен из памяти"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Ни один буфер не был удалён"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Ни один буфер не был очищен"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Один буфер выгружен из памяти"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Всего выгружено буферов из памяти: %d"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Один буфер удалён"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Всего удалено буферов: %d"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Один буфер очищен"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Всего очищено буферов: %d"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Невозможно выгрузить из памяти последний буфер"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Изменённых буферов не обнаружено"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Буферы в списке отсутствуют"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Буфер %<PRId64> не существует"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Это последний буфер"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Это первый буфер"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Изменения в буфере %<PRId64> не сохранены (добавьте !, чтобы обойти проверку)"
+"E89: Изменения в буфере %<PRId64> не сохранены (добавьте !, чтобы обойти "
+"проверку)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Невозможно выгрузить из памяти последний буфер"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Предупреждение: переполнение списка имён файлов"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Буфер %<PRId64> не найден"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Несколько соответствий для %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Нет соответствующего %s буфера"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "строка %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер с таким именем уже существует"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Изменён]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Не редактировался]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Новый файл]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Ошибки чтения]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[ТЧ]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[только для чтения]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "Одна строка --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> стр. --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "стр. %<PRId64> из %<PRId64> --%d%%-- кол. "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Нет имени]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "справка"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Справка]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Предпросмотр]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Весь"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Внизу"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Наверху"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -185,9 +225,11 @@ msgstr ""
 "\n"
 "# Список буферов:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[Временный]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -195,143 +237,199 @@ msgstr ""
 "\n"
 "--- Значки ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Значки для %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    строка=%<PRId64>  id=%d  имя=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Пропущено двоеточие"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Недопустимый режим"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Требуется ввести цифру"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Недопустимое значение процентов"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Следить за отличиями можно не более чем в %<PRId64> буферах"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Невозможно прочитать или записать временные файлы"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Невозможно создать файлы отличий"
 
-msgid "Patch file"
-msgstr "Файл-заплатка"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Невозможно прочитать вывод patch"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Невозможно прочитать вывод diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Активный буфер не находится в режиме отличий"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Больше нет изменяемых буферов в режиме отличий"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Больше нет буферов в режиме отличий"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: В режиме отличий более двух буферов, не могу выбрать"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Не могу найти буфер \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Буфер \"%s\" не находится в режиме отличий"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Буфер неожиданно изменился"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Экранирующий символ Escape нельзя использовать в диграфе"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Файл с раскладкой клавиатуры не найден"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Команда :loadkeymap применена вне файла сценария"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: пустая запись раскладки клавиатуры"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Автодополнение ключевого слова (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Режим ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Автодополнение целой строки (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Автодополнение имени файла (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Автодополнение метки (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Автодополнение шаблона пути (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Автодополнение определения (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Автодополнение по словарю (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Автодополнение синонимов (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Автодополнение командной строки (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Пользовательское автодополнение (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-дополнение (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Предложение исправления правописания (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Местное автодополнение ключевого слова (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Конец абзаца"
 
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Функция автодополнения изменила окно"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Функция автодополнения удалила текст"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "Не задано значение опции 'dictionary'"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "Не задано значение опции 'thesaurus'"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Просмотр словаря: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (вставка) Прокрутка (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (замена) Прокрутка (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Просмотр: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Выполняется поиск среди меток."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Добавление"
 
@@ -339,471 +437,578 @@ msgstr " Добавление"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Поиск..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Исходное слово"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Слово из другой строки"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Единственное соответствие"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "соответствие %d из %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "соответствие %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неожиданные символы в :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Индекс списка за пределами диапазона: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Неопределённая переменная: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Пропущена ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Параметр %s должен быть списком"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Параметр %s должен быть списком или словарём"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Невозможно использовать пустой ключ для словаря"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Требуется список"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Требуется словарь"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Слишком много параметров для функции %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Нет ключа в словаре: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Функция %s уже существует. Добавьте !, чтобы заменить её."
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Запись уже существует в словаре"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Требуется ссылка на функцию"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Невозможно использовать [:] со словарём"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Неправильный тип переменной для %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Неизвестная функция: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Недопустимое имя переменной: %s"
 
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: Использование числа с плавающей точкой как строки"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Целей меньше чем элементов списка"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Целей больше чем элементов списка"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Двойная ; в списке переменных"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Невозможно отобразить переменные для %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Индексирование возможно только списка или словаря"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] должно быть последним"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] требует значением список"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Элементов списка-значения больше чем в цели"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Список-значение не содержит достаточно элементов"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Пропущено \"in\" после :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Пропущены скобки: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Нет такой переменной: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Слишком глубоко вложенные переменные для (раз)блокировки"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Пропущено ':' после '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Список можно сравнивать только со списком"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Недопустимая операция для списков"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Словарь можно сравнивать только со словарём"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Недопустимая операция для словаря"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Ссылку на функцию можно сравнивать только с ссылкой на функцию"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Недопустимая операция для ссылки на функцию"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Невозможно использовать '%' с числом с плавающей точкой"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Пропущена ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Невозможно индексировать ссылку на функцию"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Не указано имя опции: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Неизвестная опция: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Пропущена кавычка: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Пропущена кавычка: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Пропущена запятая в списке: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Пропущено окончание списка ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Пропущено двоеточие в словаре: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Повтор ключа в словаре: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Пропущена запятая в словаре: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Пропущено окончание словаря '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Слишком глубоко вложенные переменные для отображения"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Слишком много параметров для функции %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Параметры для функции %s заданы неверно"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Неизвестная функция: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Недостаточно параметров для функции %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> используется вне сценария: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Вызов функции dict без словаря: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Требуется целое число или с плавающей точкой"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "параметра add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Слишком много параметров"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() может использоваться только в режиме Вставки"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Ключ уже существует: %s"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "параметра extend()"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "параметра map()"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "параметра filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld строк: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Неизвестная функция: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&C Отмена"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Функция inputrestore() вызывается чаще, чем функция inputsave()"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "параметра insert()"
 
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Диапазон не допускается"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Неправильные тип для len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Нулевой шаг"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Начало после конца"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<пусто>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Нет связи с сервером Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Не могу отправить сообщение для %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Сервер не отвечает"
-
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "параметра remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Слишком много символических ссылок (цикл?)"
 
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "параметра reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Не могу ответить клиенту"
-
-#. Используется для получения "значение параметра p()" в E741 и E742
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "параметра sort()"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "параметра add()"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Неудачное завершение функции сравнения при сортировке"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Неудачное завершение функции сравнения при сортировке"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Неправильно)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Ошибка записи во временный файл"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Использование числа с плавающей точкой как целого"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Использование ссылки на функцию как числа"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Использование списка как числа"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Использование словаря как числа"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Использование ссылки на функцию как строки"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Использование списка как строки"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Использование словаря как строки"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Несоответствие типа переменной для: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Невозможно удалить переменную %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr ""
 "E704: Имя переменной ссылки на функцию должно начинаться с заглавной буквы: "
 "%s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Имя переменной конфликтует с существующей функцией: %s"
 
-#. Используется с %s = "параметера p"
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Значение %s заблокировано"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#. Используется с %s = "параметера p()"
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Невозможно изменить значение %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Слишком глубоко вложенные переменные для копирования"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Неопределённая функция: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Пропущена '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Здесь невозможно использовать g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Недопустимый параметр: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Повторяющееся имя параметра: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Пропущена команда :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Имя функции конфликтует с переменной: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Невозможно переопределить функцию %s, она используется"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Имя функции не соответствует имени файла сценария: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Требуется имя функции"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Имя функции должно начинаться с заглавной буквы или содержать "
 "двоеточие: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Имя функции должно начинаться с заглавной буквы или содержать "
+"двоеточие: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Невозможно удалить функцию %s, она используется"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Глубина вызова функции больше, чем значение 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "вызов %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s прервана"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s возвращает #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s возвращает %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "продолжение в %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: команда :return вне функции"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -811,6 +1016,7 @@ msgstr ""
 "\n"
 "# глобальные переменные:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -818,83 +1024,105 @@ msgstr ""
 "\n"
 "\tВ последний раз опция изменена в "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Нет старых файлов"
 
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Строки перемещаются сами на себя"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Перемещена одна строка"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Перемещено строк: %<PRId64>"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Пропущено через фильтр строк: %<PRId64>"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманды *Filter* не должны изменять активный буфер"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Изменения не сохранены]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s в строке: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr ""
 "E136: viminfo: Слишком много ошибок, остальная часть файла будет пропущена"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Чтение файла viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " инфо"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " отметок"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " старых файлов"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " НЕУДАЧНО"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Права на запись файла viminfo отсутствуют: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Невозможно записать файл viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Запись файла viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Этот файл viminfo автоматически создан Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -902,40 +1130,47 @@ msgstr ""
 "# Его можно (осторожно!) редактировать.\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Значение опции 'encoding' в момент записи файла\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Недопустимый начальный символ"
 
-msgid "Save As"
-msgstr "Сохранить как"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Записать файл частично?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Для записи части буфера используйте !"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Перезаписать существующий файл \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Своп-файл \"%s\" существует, перезаписать?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Своп-файл существует: %s (:silent! чтобы обойти проверку)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Буфер %<PRId64> не связан с именем файла"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не сохранён: запись отключена опцией 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -944,6 +1179,7 @@ msgstr ""
 "Для \"%s\" включена опция 'readonly'.\n"
 "Записать?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -954,69 +1190,84 @@ msgstr ""
 "Но, возможно, файл удастся записать.\n"
 "Хотите попробовать?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr ""
 "E505: \"%s\" открыт только для чтения (добавьте !, чтобы обойти проверку)"
 
-msgid "Edit File"
-msgstr "Редактирование файла"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Автокоманды неожиданно убили новый буфер %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Параметр команды :z должен быть числом"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Использование команд оболочки не допускается в rvim."
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регулярные выражения не могут разделяться буквами"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "заменить на %s? (y/n/a/q/l/^E/^Y)"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Прервано)"
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "Одно соответствие"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "Одна замена"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> соответствий"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> замен"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " в одной строке"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " в %<PRId64> стр."
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Команда :global не может быть рекурсивной"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: В команде :global пропущено регулярное выражение"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Соответствие шаблону найдено на каждой строке: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Шаблон не найден: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1026,265 +1277,336 @@ msgstr ""
 "# Последняя строка для замены:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Спокойствие, только спокойствие!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: К сожалению, справка '%s' для %s отсутствует"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: К сожалению справка для %s отсутствует"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Извините, файл справки \"%s\" не найден"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s не является каталогом"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Невозможно открыть %s для записи"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Невозможно открыть %s для чтения"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Файлы справки используют разные кодировки для одного языка: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Повторяющаяся метка \"%s\" в файле %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Неизвестная команда значка %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Пропущено имя значка"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Определено слишком много значков"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Неправильный текст значка: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Неизвестный значок: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Пропущен номер значка"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Неправильное имя буфера: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Неправильный ID значка: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (НЕ НАЙДЕНО)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (не поддерживается)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Удалено]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Включён режим отладки. Для продолжения наберите \"cont\""
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "строка %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "команда: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Точка остановки в \"%s%s\" стр. %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Точка остановки не найдена: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Точки остановки не определены"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s стр. %<PRId64>"
 
+#: ../ex_cmds2.c:942
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Первое использование \":profile start {имя-файла}\""
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Сохранить изменения в \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Без имени"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Несохранённые изменения в буфере \"%s\""
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Предупреждение: Неожиданный переход в другой буфер (проверьте автокоманды)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Для редактирования доступен только один файл"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Это первый файл"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Это последний файл"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Компилятор не поддерживается: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Поиск \"%s\" в \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Поиск \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "не найдено в 'runtimepath': \"%s\""
 
-msgid "Source Vim script"
-msgstr "Выполнить сценарий Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Нельзя считать каталог: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "невозможно считать \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "строка %<PRId64>: невозможно считать \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "считывание сценария \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "строка %<PRId64>: считывание \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "считывание сценария %s завершено"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "режимная строка"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd параметр"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c параметр"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "переменная окружения"
 
+#: ../ex_cmds2.c:2773
 msgid "error handler"
 msgstr "обработчик ошибки"
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr ""
 "W15: Предупреждение: неправильный разделитель строки. Возможно пропущено ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: Команда :scriptencoding используется вне файла сценария"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: Команда :finish используется вне файла сценария"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Активный %sязык: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Невозможно сменить язык на \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Переход в режим Ex. Для перехода в Обычный режим наберите \"visual\""
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: В конце файла"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Слишком рекурсивная команда"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Исключительная ситуация не обработана: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Конец считанного файла"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Конец функции"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Неоднозначное использование команды пользователя"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Это не команда редактора"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Задан обратный диапазон"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Задан обратный диапазон, меняем границы местами"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Используйте w или w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Извините, эта команда недоступна в данной версии"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Разрешено использовать только одно имя файла"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 файл ожидает редактирования. Выйти?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Есть неотредактированные файлы (%d). Выйти?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 файл ожидает редактирования."
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Есть неотредактированные файлы (%<PRId64>)."
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда уже существует. Добавьте ! для замены."
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1292,294 +1614,340 @@ msgstr ""
 "\n"
 "    Имя      Парам. Диап. Дополн.    Определение"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Команды, определённые пользователем, не обнаружены."
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Параметр не задан"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Неправильное количество параметров"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Число-приставку нельзя указывать дважды"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Неправильное значение числа-приставки по умолчанию"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: Для -complete требуется указать параметр"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Неправильный атрибут: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Неправильное имя команды"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Команда пользователя должна начинаться с заглавной буквы"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr ""
 "E841: Зарезервированное имя не может использоваться для команд пользователя"
 
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Нет такой команды пользователя: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Неправильное значение дополнения: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Параметр автодополнения можно использовать только с особым дополнением"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Особое дополнение требует указания параметра функции"
 
-msgid "unknown"
-msgstr "неизвестно"
-
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Невозможно найти цветовую схему '%s'"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Приветствуем вас, пользователь Vim!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Нельзя закрыть последнюю вкладку"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "На экране всего одна вкладка"
 
-msgid "Edit File in new window"
-msgstr "Редактировать файл в новом окне"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Вкладка %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Без своп-файла"
 
-msgid "Append File"
-msgstr "Добавить файл"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Смена каталога невозможна, буфер изменён (добавьте !, чтобы обойти "
 "проверку)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Нет предыдущего каталога"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Неизвестно"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: Команда :winsize требует указания двух числовых параметров"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Положение окна: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: В данной системе определение положения окна не работает"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: Команда :winpos требует указания двух числовых параметров"
 
-msgid "Save Redirection"
-msgstr "Перенаправление записи"
-
-msgid "Save View"
-msgstr "Сохранение вида"
-
-msgid "Save Session"
-msgstr "Сохранение сеанса"
-
-msgid "Save Setup"
-msgstr "Сохранение настроек"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Невозможно создать каталог: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" существует (добавьте !, чтобы обойти проверку)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Невозможно открыть для записи \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Параметр должен быть прямой/обратной кавычкой или буквой"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Слишком глубокая рекурсия при использовании команды :normal"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< не доступно без особенности +eval"
-
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Нет соседнего имени файла для замены '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Нет автокомандного имени файла для замены \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Нет автокомандного номера буфера для замены \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Нет автокомандного имени соответствия для замены \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: Нет имени файла :source для замены \"<sfile>\""
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: Нет номера строки для использования \"<slnum>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Пустое имя файла для '%' или '#', возможно только c \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Результатом выражения является пустая строка"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Невозможно открыть файл viminfo для чтения"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: В этой версии диграфы не работают"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr ""
 "E608: Невозможно выполнить команду :throw для исключений с приставкой 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Исключительная ситуация: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Завершена обработка исключительной ситуации: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Исключительная ситуация проигнорирована: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, строка %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Обработка исключительной ситуации: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s выполняет ожидание"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s возобновлено"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s пропущено"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Исключительная ситуация"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Ошибка и прерывание"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Ошибка"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Прерывание"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Слишком глубоко вложенный :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif без :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else без :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif без :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Обнаружено несколько :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif после :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Слишком глубокое вложение :while или :for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue без :while или :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break без :while или :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Использование :endfor с :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Использование :endwhile с :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Слишком глубоко вложенный :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch без :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch без :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally без :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Обнаружено несколько :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry без :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: Команда :endfunction может использоваться только внутри функции"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Сейчас не допускается редактирование другого буфера"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Сейчас не допускается изменение информации о буфере"
 
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "имя метки"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " тип файла\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "значение опции 'history' равно нулю"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1588,192 +1956,253 @@ msgstr ""
 "\n"
 "# %s, история (начиная от свежего к старому):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Командная строка"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Строка поиска"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Выражение"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Строка ввода"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar больше длины команды"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Удалено активное окно или буфер"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: слишком большой путь для автодополнения"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Неправильно задан путь: '**[число]' должно быть либо в конце пути, "
+"либо за ним должно следовать '%s'"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Каталог \"%s\" не найден в пути для смены каталога"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Файл \"%s\" в известных каталогах не найден"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: В пути смены каталога больше нет каталогов \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: В известных каталогах больше нет файлов \"%s\""
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Автокоманды изменили буфер или имя буфера"
 
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Недопустимое имя файла"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "является каталогом"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "не является файлом"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "является устройством (отключено при опции 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Новый файл]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Новый КАТАЛОГ]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Файл слишком большой]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Доступ запрещён]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: В результате выполнения автокоманд *ReadPre файл стал нечитаемым"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Автокоманды *ReadPre не должны изменять активный буфер"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Чтение из стандартного потока ввода stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Чтение из стандартного потока ввода stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: В результате преобразования файл стал нечитаемым!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/гнездо]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[гнездо]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[специальный символьный]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[пропущены символы CR]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[длинные строки разбиты]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[БЕЗ преобразований]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[перекодировано]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[зашифровано]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ОШИБКА ПРЕОБРАЗОВАНИЯ в строке %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[НЕДОПУСТИМЫЙ БАЙТ в строке %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ОШИБКИ ЧТЕНИЯ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Временный файл для перекодирования не найден"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Преобразование с помощью 'charconvert' не выполнено"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "невозможно прочитать вывод 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Файл зашифрован неизвестным методом"
-
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Нет подходящих автокоманд для буфера acwrite"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Буфер, который требовалось записать, удалён или выгружен автокомандой"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Количество строк изменено автокомандой неожиданным образом"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans не позволяет выполнять запись неизменённых буферов"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Частичная запись буферов NetBeans не допускается"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "не является файлом или устройством, доступным для записи"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "запись в устройство отключена при опции 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "открыт только для чтения (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Запись в резервный файл невозможна (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr ""
 "E507: Ошибка закрытия резервного файла (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Невозможно прочитать резервный файл (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Невозможно создать резервный файл (добавьте !, чтобы обойти проверку)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Невозможно создать резервный файл (добавьте !, чтобы обойти проверку)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Ветвь ресурса будет потеряна (добавьте !, чтобы обойти проверку)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Временный файл для записи не найден"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Перекодировка невозможна (добавьте ! для записи без перекодировки)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Невозможно открыть связанный файл для записи"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Невозможно открыть файл для записи"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Не удалось выполнить функцию fsync()"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Операция закрытия не удалась"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Ошибка записи, преобразование не удалось (очистите 'fenc', чтобы "
 "обойти)"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
@@ -1782,44 +2211,57 @@ msgstr ""
 "E513: Ошибка записи, преобразование не удалось на строке %<PRId64> (очистите "
 "'fenc', чтобы обойти)"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Ошибка записи (нет свободного места?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ОШИБКА ПРЕОБРАЗОВАНИЯ"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " на строке %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Устройство]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Новый]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [д]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " добавлено"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [з]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " записано"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Режим заплатки: невозможно сохранение исходного файла"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr ""
 "E206: Режим заплатки: невозможно сменить параметры пустого исходного файла"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Невозможно удалить резервный файл"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1827,76 +2269,96 @@ msgstr ""
 "\n"
 "ПРЕДУПРЕЖДЕНИЕ: Исходный файл может быть утрачен или повреждён\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "не выходите из редактора, пока файл не будет успешно записан!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[формат dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[формат mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[формат unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 строка, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "строк: %<PRId64>, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 символ"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "символов: %<PRId64>"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Незавершённая последняя строка]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Файл изменён с момента чтения!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Серьёзно хотите записать в этот файл"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Ошибка записи в \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Ошибка закрытия \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Ошибка чтения \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Буфер удалён при выполнении автокоманды FileChangedShell"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Файл \"%s\" больше не доступен"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1905,34 +2367,42 @@ msgstr ""
 "W12: Предупреждение: файл \"%s\" и буфер Vim были изменены независимо друг "
 "от друга"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "См. \":help W12\" для дополнительной информации."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
 "W11: Предупреждение: файл \"%s\" был изменён после начала редактирования"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "См. \":help W11\" для дополнительной информации."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Предупреждение: режим доступа к файлу \"%s\" был изменён после начала "
 "редактирования"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "См. \":help W16\" для дополнительной информации."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Предупреждение: файл \"%s\" был создан после начала редактирования"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Предупреждение"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1940,39 +2410,48 @@ msgstr ""
 "&OK\n"
 "&L Загрузить файл"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Невозможно подготовиться к перезагрузке \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Невозможно выполнить перезагрузку \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Удалено--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "авто-удаление автокоманды: %s <буффер=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Группа \"%s\" не существует"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Недопустимые символы после *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Несуществующее событие: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Несуществующая группа или событие: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1980,542 +2459,766 @@ msgstr ""
 "\n"
 "--- Автокоманды ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: неправильный номер буфера "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Невозможно выполнить автокоманды для ВСЕХ событий"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Нет подходящих автокоманд"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: слишком глубоко вложенные автокоманды"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Автокоманды для \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Выполнение %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "автокоманда %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Пропущена {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Пропущена }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Складок не обнаружено"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr ""
 "E350: Складка не может быть создана с текущим значением опции 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr ""
 "E351: Складка не может быть удалена с текущим значением опции 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld строк в складке"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Добавление в буфер чтения"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Рекурсивная привязка"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Уже есть глобальное сокращение для %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Уже есть глобальная привязка для %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Уже есть сокращение для %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Уже есть привязка для %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Сокращения не найдены"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Привязки не найдены"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: недопустимый режим"
 
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Невозможно создать новый процесс для граф. интерфейса"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "-- Нет строк в буфере --"
 
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Процессу-потомку не удалось запустить граф. интерфейс"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Выполнение команды прервано"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Невозможно перейти в режим графического интерфейса"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Требуется указать параметр"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Невозможно выполнить чтение \"%s\""
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: После \\ должен идти символ /, ? или &"
 
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E665: Невозможно перейти в режим граф. интерфейса, неправильно заданы шрифты"
+"E11: Недопустимо в окне командной строки; <CR> выполнение, CTRL-C выход"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Неправильное значение опции 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Неправильное значение опции 'imactivatekey'"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Невозможно назначить цвет %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Нет совпадения под курсором, поиск следующего"
-
-msgid "<cannot open> "
-msgstr "<нельзя открыть> "
-
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: шрифт %s не найден"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: возврат в текущий каталог невозможен"
-
-msgid "Pathname:"
-msgstr "Путь к файлу:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: не могу найти текущий каталог"
-
-msgid "OK"
-msgstr "Да"
-
-msgid "Cancel"
-msgstr "Отмена"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Полоса прокрутки: не могу определить геометрию ползунка"
-
-msgid "Vim dialog"
-msgstr "Диалоговое окно Vim"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E232: \"Пузырь\" для вычислений, включающий и сообщение, и обратный вызов, "
-"не может быть создан"
+"E12: Команда не допускается в exrc/vimrc в текущем каталоге или поиске меток"
 
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Отсутствует команда :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Отсутствует команда :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Отсутствует команда :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Отсутствует команда :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: Команда :endwhile без парной команды :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor без :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Файл существует (добавьте !, чтобы перезаписать)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Не удалось выполнить команду"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Внутренняя ошибка"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Прервано"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Недопустимый адрес"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Недопустимый параметр"
+
+#: ../globals.h:1015
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Недопустимый параметр: %s"
+
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Недопустимое выражение: %s"
+
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Недопустимый диапазон"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Недопустимая команда"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" является каталогом"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Недопустимый размер прокрутки"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Да\n"
-"&Нет\n"
-"О&тмена"
 
-msgid "Input _Methods"
-msgstr "Методы Ввода"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM — Поиск и замена..."
-
-msgid "VIM - Search..."
-msgstr "VIM — Поиск..."
-
-msgid "Find what:"
-msgstr "Что ищем:"
-
-msgid "Replace with:"
-msgstr "На что заменяем:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Только точные соответствия"
-
-#. match case button
-msgid "Match case"
-msgstr "Регистрозависимые соответствия"
-
-msgid "Direction"
-msgstr "Направление"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Вверх"
-
-msgid "Down"
-msgstr "Вниз"
-
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Найти следующее"
-
-#. 'Replace' button
-msgid "Replace"
-msgstr "Замена"
-
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Заменить все"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Получен запрос на прекращение работы от диспетчера сеансов\n"
-
-msgid "Close"
-msgstr "Закрыть"
-
-msgid "New tab"
-msgstr "Новая вкладка"
-
-msgid "Open Tab..."
-msgstr "Открыть вкладку..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Основное окно было неожиданно закрыто\n"
-
-msgid "&Filter"
-msgstr "&Фильтр"
-
-msgid "&Cancel"
-msgstr "О&тмена"
-
-msgid "Directories"
-msgstr "Каталоги"
-
-msgid "Filter"
-msgstr "Фильтр"
-
-msgid "&Help"
-msgstr "&Справка"
-
-msgid "Files"
-msgstr "Файлы"
-
-msgid "&OK"
-msgstr "&Да"
-
-msgid "Selection"
-msgstr "Выделение"
-
-msgid "Find &Next"
-msgstr "Найти &следующее"
-
-msgid "&Replace"
-msgstr "За&мена"
-
-msgid "Replace &All"
-msgstr "Заменить &все"
-
-msgid "&Undo"
-msgstr "О&тмена"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Окно с заголовком \"%s\" не обнаружено"
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Параметр не поддерживается: \"-%s\"; используйте версию OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Невозможно открыть окно внутри приложения MDI"
-
-msgid "Close tab"
-msgstr "Закрыть вкладку"
-
-msgid "Open tab..."
-msgstr "Открыть вкладку..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Поиск строки (используйте '\\\\' для поиска '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Поиск и замена (используйте '\\\\' для поиска '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Не используется"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Каталог\t*.ничего\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Vim E458: Невозможно выделить запись в таблице цвета, некоторые цвета могут "
-"отображаться неправильно"
 
+#: ../globals.h:1024
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: В наборе шрифтов %s отсутствуют шрифты для следующих кодировок:"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Неудачный вызов функции \"%s()\" из библиотеки"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Отметка указывает на неправильный номер строки"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Отметка не определена"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Изменения невозможны, так как отключена опция 'modifiable'"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Слишком глубоко вложенные сценарии"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Соседний файл не существует"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Нет такого сокращения"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! не допускается"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr ""
+"E25: Возможность использования графического интерфейса выключена при "
+"компиляции"
+
+#: ../globals.h:1036
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Набор шрифтов: %s"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Группа подсветки синтаксиса %s не существует"
 
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Пока нет вставленного текста"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Предыдущей командной строки нет"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Такой привязки не существует"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Нет соответствия"
+
+#: ../globals.h:1041
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Шрифт '%s' не является моноширинным"
+msgid "E480: No match: %s"
+msgstr "E480: Нет соответствия: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Нет имени файла"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Нет предыдущего регулярного выражения для замены"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Нет предыдущей команды"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Нет предыдущего регулярного выражения"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Использование диапазона не допускается"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Недостаточно места"
+
+#: ../globals.h:1049
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Набор шрифтов: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Невозможно создать файл %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Невозможно получить имя временного файла"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font0: %s"
-msgstr "Font0: %s"
+msgid "E484: Can't open file %s"
+msgstr "E484: Невозможно открыть файл %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font1: %s"
-msgstr "Font1: %s"
+msgid "E485: Can't read file %s"
+msgstr "E485: Невозможно прочитать файл %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Изменения не сохранены (добавьте !, чтобы обойти проверку)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Изменения не сохранены]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Нулевой параметр"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Требуется число"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Ширина шрифта font%<PRId64> должна быть вдвое больше ширины шрифта font0"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Не удалось открыть файл ошибок %s"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Не хватает памяти!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Шаблон не найден"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Ширина шрифта font0: %<PRId64>"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Шаблон не найден: %s"
 
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Параметр должен быть положительным числом"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Возврат в предыдущий каталог невозможен"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Нет ошибок"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Нет списка расположений"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Повреждена строка соответствия"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Программа обработки регулярных выражений повреждена"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Включена опция 'readonly' (добавьте !, чтобы обойти проверку)"
+
+#: ../globals.h:1073
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Ширина шрифта font1: %<PRId64>"
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Невозможно изменить переменную только для чтения \"%s\""
 
-msgid "Invalid font specification"
-msgstr "Неправильное определение шрифта"
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Невозможно изменить переменную в песочнице: \"%s\""
 
-msgid "&Dismiss"
-msgstr "О&тклонить"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Ошибка при чтении файла ошибок"
 
-msgid "no specific match"
-msgstr "нет специального совпадения"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Не допускается в песочнице"
 
-msgid "Vim - Font Selector"
-msgstr "Vim — Выбор шрифта"
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Здесь не разрешено"
 
-msgid "Name:"
-msgstr "Название:"
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Данный режим экрана не поддерживается"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Показывать размер в пунктах"
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Недопустимый размер прокрутки"
 
-msgid "Encoding:"
-msgstr "Кодировка:"
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Значением опции 'shell' является пустая строка"
 
-msgid "Font:"
-msgstr "Шрифт:"
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Невозможно прочитать данные о значках!"
 
-msgid "Style:"
-msgstr "Стиль:"
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Ошибка закрытия своп-файла"
 
-msgid "Size:"
-msgstr "Размер:"
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: Стек меток пустой"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: ОШИБКА автоматики Хангыл"
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Слишком сложная команда"
 
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Слишком длинное имя"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Слишком много символов ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Слишком много имён файлов"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Лишние символы на хвосте"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Неизвестная отметка"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Невозможно выполнить подстановку по маске"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+"E591: Значение опции 'winheight' не может быть меньше значения 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+"E592: Значение опции 'winwidth' не может быть меньше значения 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Ошибка при записи"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Нулевое значение счётчика"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Использование <SID> вне контекста сценария"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Внутренняя ошибка: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Шаблон использует больше памяти чем 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Пустой буфер"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Неправильная строка поиска или разделитель"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Файл загружен в другом буфере"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Опция '%s' не установлена"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Недопустимое имя регистра"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Поиск будет продолжен с КОНЦА документа"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Поиск будет продолжен с НАЧАЛА документа"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Пропущено двоеточие"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Недопустимый компонент"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: Требуется указать цифру"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Страница %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Печатать нечего"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Печать стр. %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Копия %d из %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Напечатано: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Печать прекращена"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Ошибка записи в файл PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Невозможно открыть файл \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Невозможно прочитать файл ресурсов PostScript \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Файл \"%s\" не является файлом ресурсов PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Файл \"%s\" не является допустимым файлом ресурсов PostScript"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Файл ресурсов \"%s\" неизвестной версии"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Несовместимые многобайтовая кодировка и набор символов."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset не может быть пустым при многобайтовой кодировке."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Нет определения шрифта по умолчанию для многобайтовой печати."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Невозможно открыть файл PostScript"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Невозможно открыть файл \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Файл ресурсов PostScript \"prolog.ps\" не найден"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Файл ресурсов PostScript \"cidfont.ps\" не найден"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Файл ресурсов PostScript \"%s.ps\" не найден"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Невозможно преобразовать в кодировку печать \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Отправка на печать..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Не удалось выполнить печать файла PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Задание на печать отправлено."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Добавить новую базу данных"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Запрос по шаблону"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Показать это сообщение"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Убить соединение"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Заново инициализировать все соединения"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Показать соединения"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Использование: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Эта команда cscope не поддерживает разделение окна.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Использование: cstag <имя>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: метка не найдена"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: Ошибка stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: Ошибка stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s не является каталогом или именем базы cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Добавлена база данных cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Ошибка получения информации от соединения cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Неизвестный тип поиска cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Невозможно создать трубу для cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Невозможно выполнить fork() для cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection: не удалось выполнить setpgid"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection: не удалось выполнить exec"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: не удалось выполнить fdopen для to_fp"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: не удалось выполнить fdopen для fr_fp"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Не удалось запустить процесс cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: Соединений с cscope не создано"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Неправильный флаг cscopequickfix %c для %c"
 
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: Не найдено соответствий по запросу cscope %s для %s"
 
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "Команды cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (использование: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2537,32 +3240,31 @@ msgstr ""
 "       s: Найти этот C-символ\n"
 "       t: Найти эту текстовую строку\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Невозможно открыть базу данных cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Информация о базе данных cscope не доступна"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Данная база данных cscope уже подсоединена"
 
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: Соединение с cscope %s не обнаружено"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "соединение с cscope %s закрыто"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Критическая ошибка в cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Метка cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2570,369 +3272,88 @@ msgstr ""
 "\n"
 "   #   строка"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "имя файла / контекст / строка\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Ошибка cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Перезагрузка всех баз данных cscope"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "соединения с cscope отсутствуют\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    база данных                         начальный путь\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Библиотека Lua не может быть загружена."
-
-msgid "cannot save undo information"
-msgstr "невозможно сохранить информацию об отмене операции"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"MzScheme"
-
-msgid "invalid expression"
-msgstr "неправильное выражение"
-
-msgid "expressions disabled at compile time"
-msgstr "выражения отключены при компиляции"
-
-msgid "hidden option"
-msgstr "скрытая опция"
-
-msgid "unknown option"
-msgstr "неизвестная опция"
-
-msgid "window index is out of range"
-msgstr "индекс окна за пределами диапазона"
-
-msgid "couldn't open buffer"
-msgstr "невозможно открыть буфер"
-
-msgid "cannot delete line"
-msgstr "невозможно удалить строку"
-
-msgid "cannot replace line"
-msgstr "невозможно заменить строку"
-
-msgid "cannot insert line"
-msgstr "невозможно вставить строку"
-
-msgid "string cannot contain newlines"
-msgstr "строка не может содержать символ новой строки"
-
-msgid "error converting Scheme values to Vim"
-msgstr "невозможно преобразовать значения Scheme в Vim"
-
-msgid "Vim error: ~a"
-msgstr "ошибка Vim: ~a"
-
-msgid "Vim error"
-msgstr "ошибка Vim"
-
-msgid "buffer is invalid"
-msgstr "неправильный буфер"
-
-msgid "window is invalid"
-msgstr "неправильное окно"
-
-msgid "linenr out of range"
-msgstr "номер строки за пределами диапазона"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "не допускается в песочнице Vim"
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Данный Vim не может выполнить :python после использования :py3"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"Python"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Невозможно выполнить рекурсивный вызов Python"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Данный Vim не может выполнить :py3 после использования :python"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ должен быть экземпляром или строкой"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"Ruby"
-
-msgid "E267: unexpected return"
-msgstr "E267: Неожиданный return"
-
-msgid "E268: unexpected next"
-msgstr "E268: Неожиданный next"
-
-msgid "E269: unexpected break"
-msgstr "E269: Неожиданный break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: Неожиданный redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry вне оператора rescue"
-
-msgid "E272: unhandled exception"
-msgstr "E272: Необработанное исключение"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Неизвестное состояние longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Переключение между реализацией/определением"
-
-msgid "Show base class of"
-msgstr "Показать основной класс"
-
-msgid "Show overridden member function"
-msgstr "Показать перегруженные функции"
-
-msgid "Retrieve from file"
-msgstr "Получить из файла"
-
-msgid "Retrieve from project"
-msgstr "Получить из проекта"
-
-msgid "Retrieve from all projects"
-msgstr "Получить из всех проектов"
-
-msgid "Retrieve"
-msgstr "Получить"
-
-msgid "Show source of"
-msgstr "Показать исходный код"
-
-msgid "Find symbol"
-msgstr "Найти символ"
-
-msgid "Browse class"
-msgstr "Просмотр класса"
-
-msgid "Show class in hierarchy"
-msgstr "Показать класс в иерархии"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Показать класс в ограниченной иерархии"
-
-msgid "Xref refers to"
-msgstr "Xref ссылается на"
-
-msgid "Xref referred by"
-msgstr "Ссылка на xref из"
-
-msgid "Xref has a"
-msgstr "Xref имеет"
-
-msgid "Xref used by"
-msgstr "Xref используется"
-
-msgid "Show docu of"
-msgstr "Показать docu"
-
-msgid "Generate docu for"
-msgstr "Создать docu"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Невозможно подсоединиться к SNiFF+. Проверьте настройки окружения."
-"(sniffemacs должны быть указаны в переменной $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Ошибка во время чтения. Отсоединение"
-
-msgid "SNiFF+ is currently "
-msgstr "В настоящий момент SNiFF+ "
-
-msgid "not "
-msgstr "не "
-
-msgid "connected"
-msgstr "подсоединён"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Неизвестный запрос SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Ошибка соединения со SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ не подсоединён"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Это не буфер SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Ошибка во время записи. Отсоединение"
-
-msgid "invalid buffer number"
-msgstr "неправильный номер буфера"
-
-msgid "not implemented yet"
-msgstr "пока не реализовано"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "невозможно назначить строку или строки"
-
-msgid "invalid mark name"
-msgstr "неправильное имя отметки"
-
-msgid "mark not set"
-msgstr "отметка не установлена"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "ряд %d колонка %d"
-
-msgid "cannot insert/append line"
-msgstr "невозможно вставить или добавить строку"
-
-msgid "line number out of range"
-msgstr "номер строки за пределами диапазона"
-
-msgid "unknown flag: "
-msgstr "неизвестный флаг: "
-
-msgid "unknown vimOption"
-msgstr "неизвестная vimOption"
-
-msgid "keyboard interrupt"
-msgstr "клавиатурное прерывание"
-
-msgid "vim error"
-msgstr "ошибка VIM"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "невозможно создать команду буфера или окна: объект в процессе удаления"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"невозможно зарегистрировать команду с обратным вызовом: буфер или окно в "
-"процессе удаления"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: КРИТИЧЕСКАЯ ОШИБКА TCL: повреждён список ссылок?! Сообщите об этом по "
-"адресу vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"невозможно зарегистрировать команду с обратным вызовом: ссылка на буфер или "
-"окно не обнаружена"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: К сожалению эта команда не работает, поскольку не загружена библиотека "
-"Tcl"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Код выхода %d"
-
-msgid "cannot get line"
-msgstr "невозможно получить строку"
-
-msgid "Unable to register a command server name"
-msgstr "Невозможно зарегистрировать имя сервера команд"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Не удалась отправка команды в другую программу"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Используется неправильный id сервера: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr ""
-"E251: Неправильно сформировано значение данного процесса VIM в реестре. "
-"Удалено!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Неизвестный необязательный параметр"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Слишком много параметров редактирования"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Пропущен параметр после"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Мусор после необязательного параметра"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Слишком много параметров \"+команда\", \"-c команда\" или \"--cmd команда\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Недопустимый параметр для"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "Файлов для редактирования: %d\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "NetBeans не поддерживается с этим графическим интерфейсом\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr ""
-"Данный Vim был скомпилирован с выключенной особенностью просмотра отличий"
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "Невозможно использовать '-nb': не включено при компиляции\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Попытка повторного открытия файла сценария: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Невозможно открыть для чтения: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Невозможно открыть для вывода сценария: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Ошибка: Не удалось запустить gvim из NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Предупреждение: Вывод осуществляется не на терминал\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Предупреждение: Ввод происходит не с терминала\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "командная строка перед выполнением vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Невозможно выполнить чтение из \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2940,21 +3361,26 @@ msgstr ""
 "\n"
 "Дополнительная информация: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[файл ..] редактирование указанных файлов"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-           чтение текста из потока ввода stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t метка    редактирование файла с указанной меткой"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr ""
 "-q [файл-ошибок]\n"
 "\t\t\t\t    редактирование файла с первой ошибкой"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2964,9 +3390,11 @@ msgstr ""
 "\n"
 "Использование:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [параметры] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2974,13 +3402,7 @@ msgstr ""
 "\n"
 "   или:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Если регистр игнорируется, добавьте перед флагом / для верхнего регистра"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2990,337 +3412,204 @@ msgstr ""
 "\n"
 "Параметры:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tДалее указываются только имена файлов"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tНе выполнять подстановку по маске"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tЗарегистрировать этот gvim для OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tОтключить регистрацию данного gvim для OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tЗапустить с графическим интерфейсом (как \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  или --nofork\tВ активной задаче: Не выполнять fork при запуске GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tРежим Vi (как \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tРежим Ex (как \"ex\")"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tУлучшенный режим Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tТихий (пакетный) режим (только для \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tРежим отличий (как \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tПростой режим (как \"evim\", безрежимный)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tТолько для чтения (как \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tОграниченный режим (как \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tБез возможности сохранения изменений (записи файлов)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tБез возможности внесения изменений в текст"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tДвоичный режим"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tРежим Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tРежим совместимости с Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tРежим неполной совместимости с Vi: 'nocompatible'"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 "-V[N][файл]\t\tВыводить дополнительные сообщения\n"
 "\t\t\t\t[уровень N] [записывать в файл]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tРежим отладки"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tБез своп-файла, используется только память"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tВывести список своп-файлов и завершить работу"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (с именем файла)\tВосстановить аварийно завершённый сеанс"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tТо же, что и -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tНе использовать newcli для открытия окна"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <устройство>\t\tИспользовать для I/O указанное <устройство>"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tЗапуск в Арабском режиме"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tЗапуск в режиме \"Иврит\""
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tЗапуск в режиме \"Фарси\""
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <терминал>\tНазначить указанный тип <терминала>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tИспользовать <vimrc> вместо любых файлов .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tИспользовать <gvimrc> вместо любых файлов .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tНе загружать сценарии модулей"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr ""
 "-p[N]\t\tОткрыть N вкладок (по умолчанию: по одной\n"
 "\t\t\t\tна каждый файл)"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr ""
 "-o[N]\t\tОткрыть N окон (по умолчанию: по одному\n"
 "\t\t\t\tна каждый файл)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tТо же, что и -o, но с вертикальным разделением окон"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tНачать редактирование в конце файла"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tНачать редактирование в строке с номером <lnum>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <команда>\tВыполнить <команду> перед загрузкой файла vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <команда>\t\tВыполнить <команду> после загрузки первого файла"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <сеанс>\t\tПрочитать сценарий <сеанса> после загрузки\n"
 "\t\t\t\tпервого файла"
 
 # \n\t\t.. для умещения в 80 столбцов
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr ""
 "-s <сценарий>\tПрочитать команды Обычного режима из\n"
 "\t\t\t\tфайла <сценария>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <сценарий>\tДобавлять все введённые команды в файл <сценария>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <сценарий>\tЗаписать все введённые команды в файл <сценария>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tРедактирование зашифрованных файлов"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <экран>\tПодсоединить VIM к указанному X-серверу"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tНе выполнять соединение с сервером X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <файлы>\tПо возможности редактировать <файлы> на сервере Vim"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <файлы>  То же, но без жалоб на отсутствие сервера"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <файлы>  То же, что и --remote, но с ожиданием завершения"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <файлы>  То же, но без жалоб на отсутствие сервера"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <файлы>  То же, что и --remote, но с вкладками"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <кнопки>\tОтправить <кнопки> на сервер Vim и выйти"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <выраж>\tВычислить <выраж> на сервере Vim и напечатать"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tПоказать список имён серверов Vim и завершить работу"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr ""
-"--servername <имя>\tОтправить на/стать сервером Vim с указанным <именем>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <файл>\tЗаписать временную метку о запуске в <файл>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tИспользовать вместо .viminfo файл <viminfo>"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h или --help\tВывести справку (это сообщение) и завершить работу"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tВывести информацию о версии Vim и завершить работу"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <дисплей>\tЗапустить VIM на указанном <дисплее>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tЗапустить VIM в свёрнутом виде"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr ""
-"-background <цвет>\tИспользовать указанный <цвет> для фона (также: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <цвет>\tИспользовать <цвет> для обычного текста (также: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <шрифт>\t\tИспользовать <шрифт> для обычного текста (также: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <шрифт>\tИспользовать <шрифт> для жирного текста"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <шрифт>\tИспользовать <шрифт> для наклонного текста"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <геометрия>\tИспользовать начальную <геометрию> (также: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <ширина>\tИспользовать <ширину> бордюра (также: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <ширина> Использовать ширину полосы прокрутки (также: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <высота>\tИспользовать <высоту> меню (также: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tИспользовать инверсный видеорежим (также: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tНе использовать инверсный видеорежим (также: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ресурс>\tУстановить указанный <ресурс>"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Параметры для gvim (версия GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr ""
-"-display <дисплей>\tЗапустить VIM на указанном <дисплее> (также: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <роль>\tУстановить уникальную <роль> для идентификации главного окна"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tОткрыть Vim внутри другого компонента GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tВывести Window ID для gvim на стандартный поток вывода"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <заголовок родителя>\tОткрыть Vim в родительском приложении"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tОткрыть Vim внутри другого компонента win32"
-
-msgid "No display"
-msgstr "Нет дисплея"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Отправка не удалась.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Отправка не удалась. Попытка местного выполнения\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "отредактировано %d из %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Нет дисплея: отправка выражения не удалась.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Отправка выражения не удалась.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Нет установленных отметок"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Нет отметок, совпадающих с \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3329,6 +3618,7 @@ msgstr ""
 "отмет стр  кол файл/текст"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3337,6 +3627,7 @@ msgstr ""
 "прыжок стр  кол файл/текст"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3344,6 +3635,7 @@ msgstr ""
 "\n"
 "измен.  стр  кол текст"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3352,6 +3644,7 @@ msgstr ""
 "# Глобальные отметки:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3359,6 +3652,7 @@ msgstr ""
 "\n"
 "# Список прыжков (сначала более свежие):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3366,94 +3660,87 @@ msgstr ""
 "\n"
 "# История местных отметок (от более свежих к старым):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Пропущена '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Недопустимое имя кодировки"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Невозможно назначить значения контекста ввода"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Невозможно создать контекст ввода"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Неудачная попытка открыть метод ввода"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Предупреждение: невозможно назначить обр. вызов уничтожения метода "
-"ввода"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Метод ввода не поддерживает стили"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr ""
-"E289: Метод ввода не поддерживает мой тип предварительного редактирования"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Блок не заблокирован"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Ошибка поиска при чтении своп-файла"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Ошибка чтения своп-файла"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Ошибка поиска при записи своп-файла"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Ошибка при записи своп-файла"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr ""
 "E300: Своп-файл уже существует (атака с использованием символьной ссылки?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Не получен блок номер 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Не получен блок номер 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Не получен блок номер 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Ошибка при обновлении шифрования своп-файла"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ой, потерялся своп-файл!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Невозможно переименовать своп-файл"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Не удалось открыть своп-файл для \"%s\", восстановление невозможно"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Не получен блок 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Своп-файл для %s не найден"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Введите номер своп-файла, который следует использовать (0 для выхода): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Не могу открыть %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Невозможно прочитать блок 0 из "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3461,22 +3748,28 @@ msgstr ""
 "\n"
 "Нет изменений, или Vim не смог обновить своп-файл"
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " нельзя использовать в данной версии Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Используйте Vim версии 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s не является своп-файлом Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " нельзя использовать на этом компьютере.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Файл был создан "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3484,106 +3777,86 @@ msgstr ""
 ",\n"
 "либо файл был повреждён."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s зашифрован, а эта версия Vim не поддерживает шифрование"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " был повреждён (размер страницы меньше минимального значения).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Используется своп-файл \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Исходный файл \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Предупреждение: исходный файл мог быть изменён"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Своп-файл зашифрован: \"%s\""
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Если вы ввели новый пароль для шифрования, но не записали текстовый файл,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"то введите новый пароль для шифрования."
-
-# Перевод сообщения разделён на две части, часть первая
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Если вы записали текстовый файл после изменения пароля шифрования, то нажмите"
-
-# Перевод сообщения разделён на две части, часть вторая
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"Enter для использования одного ключа для текстового файла и своп-файла"
-
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Невозможно прочитать блок 1 из %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???ОТСУТСТВУЕТ МНОГО СТРОК"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???НЕПРАВИЛЬНОЕ ЗНАЧЕНИЕ СЧЁТЧИКА СТРОК"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???ПУСТОЙ БЛОК"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???ОТСУТСТВУЮТ СТРОКИ"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Неправильный блок 1 ID (%s не является файлом .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???ПРОПУЩЕН БЛОК"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "???строки могут быть испорчены отсюда до ???КОНЦА"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "???строки могли быть вставлены или удалены отсюда до ???КОНЦА"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???КОНЕЦ"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Восстановление прервано"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Во время восстановления обнаружены ошибки; см. строки, начинающиеся "
 "с ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "См. \":help E312\" для дополнительной информации."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Восстановление завершено. Проверьте, всё ли в порядке."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3591,12 +3864,15 @@ msgstr ""
 "\n"
 "(Можете записать файл под другим именем и сравнить его с исходным\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "файлом при помощи программы diff)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Восстановление завершено. Содержимое буферов и файлов эквивалентно."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3606,43 +3882,52 @@ msgstr ""
 "Вероятно, сейчас вы захотите удалить файл .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Использование ключа шифрования из своп-файла для текстового файла.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Обнаружены своп-файлы:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   В текущем каталоге:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   С указанным именем:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   В каталоге   "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- нет --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          владелец: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    дата: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              дата: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [от Vim версии 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [не является своп-файлом Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         имя файла: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3650,12 +3935,15 @@ msgstr ""
 "\n"
 "           изменён: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ДА"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "нет"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3663,9 +3951,11 @@ msgstr ""
 "\n"
 "      пользователь: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "  компьютер: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3673,6 +3963,7 @@ msgstr ""
 "\n"
 "         компьютер: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3680,16 +3971,11 @@ msgstr ""
 "\n"
 "           процесс: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (ещё выполняется)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [не пригоден для использования с данной версией Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3697,75 +3983,97 @@ msgstr ""
 "\n"
 "         [не пригоден для использования на этом компьютере]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [не читается]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [не открывается]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Невозможно обновить своп-файл, поскольку он не обнаружен"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Своп-файл обновлён"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Неудачная попытка обновления своп-файла"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: неправильное значение lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: невозможно найти строку %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Неправильное значение указателя блока 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "значение stack_idx должно быть равно 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Обновлено слишком много блоков?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Неправильное значение указателя блока 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "удалён блок 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Строка %<PRId64> не обнаружена"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Неправильное значение указателя блока"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "значение pe_line_count равно нулю"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Номер строки за пределами диапазона: %<PRId64>"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Неправильное значение счётчика строк в блоке %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Размер стека увеличен"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Неправильное значение указателя блока 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Петля символьных ссылок для \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ВНИМАНИЕ"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3774,14 +4082,15 @@ msgstr ""
 "Обнаружен своп-файл с именем \""
 
 # С маленькой буквы, чтобы соответствовало по стилю соседним сообщениям.
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "при открытии файла: \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "                    Более СВЕЖИЙ, чем своп-файл!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3794,17 +4103,21 @@ msgstr ""
 "    у вас не появилось два разных варианта одного и того же файла."
 
 # Сообщение разделено, " \n" добавлено т.к. строка не помещается.
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr ""
 " \n"
 "    Завершите работу или продолжайте с осторожностью.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сеанс редактирования этого файла завершён аварийно.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    В этом случае, используйте команду \":recover\" или \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3812,9 +4125,11 @@ msgstr ""
 "\"\n"
 "    для восстановления изменений (см. \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Если вы уже выполняли эту операцию, удалите своп-файл \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3822,18 +4137,23 @@ msgstr ""
 "\"\n"
 "    чтобы избежать появления этого сообщения в будущем.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Своп-файл \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" уже существует!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM — ВНИМАНИЕ"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Своп-файл уже существует!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3847,6 +4167,7 @@ msgstr ""
 "&Q Выход\n"
 "&A Прервать"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3862,34 +4183,56 @@ msgstr ""
 "&Q Выход\n"
 "&A Прервать"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Обнаружено слишком много своп-файлов"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Не хватает памяти! (выделяется %<PRIu64> байт)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Компонент пути к элементу меню не является подменю"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Меню в этом режиме не существует"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Нет меню %s"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Пустое имя меню"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Путь к меню не должен вести к подменю"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Элементы меню нельзя добавлять непосредственно в полоску меню"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Разделители не могут быть компонентом пути к меню"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3897,62 +4240,75 @@ msgstr ""
 "\n"
 "--- Меню ---"
 
-msgid "Tear off this menu"
-msgstr "Оторвать это меню"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Путь к меню должен вести к элементу меню"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Меню не найдено: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Меню не определено для режима %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Путь к меню должен вести к подменю"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Меню не найдено — проверьте имена меню"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Обнаружена ошибка при обработке %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "строка %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Недопустимое имя регистра: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "Перевод сообщений на русский язык: Василий Рагозин <vrr@users.sourceforge."
 "net>, Сергей Алёшин <alyoshin.s@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Прерывание: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Нажмите ENTER или введите команду для продолжения"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s строка %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Продолжение следует --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " SPACE/d/j: экран/страница/строка вниз, b/u/k: вверх, q: выход "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Вопрос"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3960,6 +4316,17 @@ msgstr ""
 "&Y Да\n"
 "&N Нет"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Да\n"
+"&Нет\n"
+"О&тмена"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3973,273 +4340,175 @@ msgstr ""
 "&D Потерять все\n"
 "&C Отмена"
 
-msgid "Select Directory dialog"
-msgstr "Выбор каталога"
-
-msgid "Save File dialog"
-msgstr "Сохранение файла"
-
-msgid "Open File dialog"
-msgstr "Открытие файла"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr ""
-"E338: Извините, но в консольном режиме нет проводника по файловой системе"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Недостаточно параметров для printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Ожидался параметр типа с плавающей точкой для printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Слишком много параметров для printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Предупреждение: Изменение файла с правами только для чтения"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Введите номер и <Enter> или щёлкните мышью (пусто для отмены): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Введите номер и <Enter> (пусто для отмены): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "Добавлена одна строка"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "Убрана одна строка"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "Добавлено строк: %<PRId64>"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "Убрано строк: %<PRId64>"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Прервано)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Би-би!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: сохранение файлов...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Готово.\n"
-
-msgid "ERROR: "
-msgstr "ОШИБКА: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[байт] всего выдел.-освоб. %<PRIu64>-%<PRIu64>, использ. %<PRIu64>, макс. использ. %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[вызовы] re/malloc() всего %<PRIu64>, free() всего %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Строка становится слишком длинной"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Не хватает памяти! (выделяется %<PRIu64> байт)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Вызов оболочки для исполнения: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Пропущено двоеточие"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Недопустимый режим"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Недопустимая форма курсора"
-
-msgid "E548: digit expected"
-msgstr "E548: Требуется ввести цифру"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Недопустимое значение процентов"
-
-msgid "Enter encryption key: "
-msgstr "Введите пароль для шифрования: "
-
-msgid "Enter same key again: "
-msgstr "Повторите ввод пароля: "
-
-msgid "Keys don't match!"
-msgstr "Введённые пароли не совпадают!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: слишком большой путь для автодополнения"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Неправильно задан путь: '**[число]' должно быть либо в конце пути, "
-"либо за ним должно следовать '%s'"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Каталог \"%s\" не найден в пути для смены каталога"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Файл \"%s\" в известных каталогах не найден"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: В пути смены каталога больше нет каталогов \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: В известных каталогах больше нет файлов \"%s\""
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Невозможно соединиться с NetBeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Невозможно соединиться с NetBeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Неправильный режим доступа к информации о соединении с NetBeans: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "чтение из гнезда NetBeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Потеряно соединение с NetBeans для буфера %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: NetBeans не поддерживается с этим графическим интерфейсом"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: уже соединён с NetBeans"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s открыт только для чтения (добавьте !, чтобы обойти проверку)"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Нет имени в позиции курсора"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: Значением опции 'operatorfunc' является пустая строка"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: eval не доступна"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Предупреждение: терминал не может выполнять подсветку"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Нет строки в позиции курсора"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr ""
 "E352: Невозможно стереть складки с текущим значением опции 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Список изменений пустой"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: В начале списка изменений"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Введите :quit<Enter>  для выхода из Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "Изменены отступы в 1 строке (%s 1 раз)"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Изменены отступы в 1 строке (%s %d раз)"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "Изменены отступы, %<PRId64> строк (%s 1 раз)"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "Изменены отступы, %<PRId64> строк (%s %d раз)"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "Изменяются отступы строках (%<PRId64>)..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "Изменён отступ в одной строке "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "Изменены отступы в строках (%<PRId64>) "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Нет предыдущего использованного регистра"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "скопировать не удалось, удаление выполнено"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "изменена 1 строка"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "изменено строк: %<PRId64>"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "очищено строк: %<PRId64>"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "скопирован блок из одной строки"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "скопирована одна строка"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "скопирован блок из строк: %<PRId64>"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "скопировано строк: %<PRId64>"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: В регистре %s ничего нет"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4247,9 +4516,11 @@ msgstr ""
 "\n"
 "--- Регистры ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Недопустимое имя регистра"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4257,165 +4528,184 @@ msgstr ""
 "\n"
 "# Регистры:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Неизвестный тип регистра %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "Колонок: %<PRId64>; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Выделено %s%<PRId64> из %<PRId64> строк; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> байт"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Выделено %s%<PRId64> из %<PRId64> стр.; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> симв.; %<PRId64> из %<PRId64> "
-"байт"
+"Выделено %s%<PRId64> из %<PRId64> строк; %<PRId64> из %<PRId64> слов; "
+"%<PRId64> из %<PRId64> байт"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; байт %<PRId64> из %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; симв. %<PRId64> из %<PRId64>; байт %<PRId64> "
-"из %<PRId64>"
+"Выделено %s%<PRId64> из %<PRId64> стр.; %<PRId64> из %<PRId64> слов; "
+"%<PRId64> из %<PRId64> симв.; %<PRId64> из %<PRId64> байт"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; байт "
+"%<PRId64> из %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; "
+"симв. %<PRId64> из %<PRId64>; байт %<PRId64> из %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> с учётом BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стр. %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Благодарим за использование Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Неизвестная опция"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Опция не поддерживается"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Не допускается в режимной строке"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Код клавиши не установлен"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: После = требуется указать число"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Не обнаружено в termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Недопустимый символ <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Значение опции 'term' не может быть пустой строкой"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: В графическом интерфейсе изменять терминал невозможно"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Для запуска графического интерфейса используйте \":gui\""
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: Значения опций 'backupext' и 'patchmode' равны"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Конфликтует со значением 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Конфликтует со значением 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Не может быть изменено в графическом интерфейсе GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Пропущено двоеточие"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Строка с нулевой длиной"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Пропущено число после <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Пропущена запятая"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Необходимо указать значение для '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Содержит непечатный символ или символ двойной ширины"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Неправильные шрифты"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Невозможно выбрать шрифтовой набор"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Неправильный шрифтовой набор"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Невозможно выбрать шрифт с символами двойной ширины"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Неправильный шрифт с символами двойной ширины"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Неправильный символ после <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Требуется запятая"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr ""
 "E537: Значение опция 'commentstring' должно быть пустой строкой или "
 "содержать %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Мышь не поддерживается"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Незакрытая последовательность выражения"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Слишком много элементов"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Несбалансированные группы"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Окно предпросмотра уже есть"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: Арабский требует использования UTF-8, введите ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Нужно хотя бы %d строк"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Нужно хотя бы %d колонок"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Неизвестная опция: %s"
@@ -4423,10 +4713,12 @@ msgstr "E355: Неизвестная опция: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Требуется указать число: &%s = '%s'"
 
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4434,6 +4726,7 @@ msgstr ""
 "\n"
 "--- Терминальные коды ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4441,6 +4734,7 @@ msgstr ""
 "\n"
 "--- Глобальные значения опций ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4448,6 +4742,7 @@ msgstr ""
 "\n"
 "--- Местные значения опций ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4455,140 +4750,21 @@ msgstr ""
 "\n"
 "--- Опции ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: ОШИБКА get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Нет соответствующего символа для %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Лишние символы после точки с запятой: %s"
 
-msgid "cannot open "
-msgstr "невозможно открыть "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Невозможно открыть окно!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Необходима Amigados версии 2.04 или более поздней\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Необходима %s версии %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Невозможно открыть NIL:\n"
-
-msgid "Cannot create "
-msgstr "Невозможно создать "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Прекращение работы Vim с кодом %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "невозможно сменить режим консоли?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: не в консоли??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Невозможно выполнить оболочку с параметром -f"
-
-msgid "Cannot execute "
-msgstr "Невозможно выполнить "
-
-msgid "shell "
-msgstr "оболочка "
-
-msgid " returned\n"
-msgstr " завершила работу\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "слишком малая величина ANCHOR_BUF_SIZE."
-
-msgid "I/O ERROR"
-msgstr "ОШИБКА ВВОДА/ВЫВОДА"
-
-msgid "Message"
-msgstr "Сообщение"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "Значение опции 'columns' не равно 80, внешние программы не выполняются"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Неудачное завершение выбора принтера"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "в %s на %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Неизвестный шрифт принтера: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Ошибка печати: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Печать '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Недопустимое имя кодировки \"%s\" в имени шрифта \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Недопустимый символ '%c' в имени шрифта \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Двойной сигнал, завершение работы\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Получен убийственный сигнал %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Получен убийственный сигнал\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Открытие дисплея X заняло %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Ошибка X\n"
-
-msgid "Testing the X display failed"
-msgstr "Проверка дисплея X завершена неудачно"
-
-msgid "Opening the X display timed out"
-msgstr "Открытие дисплея X не выполнено в отведённое время"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Невозможно получить контекст безопасности для "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Невозможно установить контекст безопасности для "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4596,13 +4772,7 @@ msgstr ""
 "\n"
 "Невозможно запустить оболочку "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Невозможно запустить оболочку sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4610,254 +4780,235 @@ msgstr ""
 "\n"
 "Оболочка завершила работу "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Невозможно создать трубы\n"
+"Невозможно получить контекст безопасности для "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Невозможно выполнить fork()\n"
+"Невозможно установить контекст безопасности для "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Выполнение команды прервано\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP утеряно соединение ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Неудачное открытие дисплея X"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP обрабатывает запрос самосохранения"
-
-msgid "XSMP opening connection"
-msgstr "XSMP открывает соединение"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP потеряно слежение за соединением ICE"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP неудачно выполнено SmcOpenConnection: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Файл \"%s\" не найден по известным путям"
 
-msgid "At line"
-msgstr "В строке"
-
-msgid "Could not load vim32.dll!"
-msgstr "Невозможно загрузить vim32.dll!"
-
-msgid "VIM Error"
-msgstr "Ошибка VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Невозможно исправить указатели функций для DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "завершение работы оболочки с кодом %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Перехвачено событие %s\n"
-
-msgid "close"
-msgstr "закрытие"
-
-msgid "logoff"
-msgstr "отключение"
-
-msgid "shutdown"
-msgstr "завершение"
-
-msgid "E371: Command not found"
-msgstr "E371: Команда не найдена"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE не найден в пути, заданном в $PATH.\n"
-"Внешние команды не будут останавливаться после выполнения.\n"
-"Дополнительная информация в :help win32-vimrun"
-
-msgid "Vim Warning"
-msgstr "Предупреждение Vim"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: В строке формата слишком много %%%c"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Неожиданный элемент %%%c в строке формата"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: В строке формата пропущена ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c не поддерживается в строке формата"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Недопустимый %%%c в приставке в строке формата"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Недопустимый %%%c в строке формата"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: В значении опции 'errorformat' отсутствует шаблон"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Имя каталога не задано или равно пустой строке"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Больше нет элементов"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d из %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (строка удалена)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Внизу стека быстрых исправлений"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Наверху стека быстрых исправлений"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "список ошибок %d из %d; %d ошибок"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr ""
 "E382: Запись невозможна, значение опции 'buftype' не является пустой строкой"
 
-msgid "Error file"
-msgstr "Файл ошибок"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Нет имени файла или неправильный шаблон"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Невозможно открыть файл \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Буфер не выгружен"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Требуется строка или список"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Недопустимый элемент в %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Пропущена ] после %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Нет пары для %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Нет пары для %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Нет пары для %s)"
 
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( не может быть использовано здесь"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 и т.п. не могут быть использованы здесь"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Пропущена ] после %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: Пустое %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Слишком длинный шаблон"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Слишком много \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Слишком много %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Нет пары для \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: Недопустимый символ после %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Слишком много сложных конструкций %s{...}"
 
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Вложенные %s*"
 
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Вложенные %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Недопустимое использование \\_"
 
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c ни за чем не следует"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Недопустимая обратная ссылка"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Недопустимый символ после \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Недопустимый символ после %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Недопустимый символ после %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Синтаксическая ошибка в %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Внешние подсоответствия:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
@@ -4865,49 +5016,62 @@ msgstr ""
 "E864: после \\%#= может быть только 0, 1 или 2. Будет использоваться "
 "автоматическая машина"
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (НКА) неожиданный конец регулярного выражения"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (рег. выражение НКА) неожиданный %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (НКА) неожиданный конец регулярного выражения"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (НКА) неизвестный оператор '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (НКА) неизвестный оператор '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: ошибка при создании НКА с классом эквивалентности!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (НКА) неизвестный оператор '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (рег. выражение НКА) ошибка при чтении границ повторения"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (рег. выражение НКА) множество не может следовать за множеством!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (рег. выражение НКА) слишком много '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (рег. выражение НКА) слишком много \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (рег. выражение НКА) ошибка корректного завершения"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (рег. выражение НКА) невозможно взять из стека!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
@@ -4915,138 +5079,176 @@ msgstr ""
 "E875: (рег. выражение НКА) в стеке осталось слишком много состояний (при "
 "преобразовании из postfix в НКА)"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (рег. выражение НКА) недостаточно места для хранения всего НКА"
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (НКА) невозможно выделить память для прохода ветви!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
 "Невозможно открыть файл временного журнала для записи, вывод на stderr..."
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(НКА) невозможно открыть %s!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Невозможно открыть файл временного журнала для записи"
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " ВИРТУАЛЬНАЯ ЗАМЕНА"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ЗАМЕНА"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " ОБРАТНАЯ"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " ВСТАВКА"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (вставка)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (замена)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (виртуальная замена)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Иврит"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Арабский"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (язык)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (вклейка)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ВИЗУАЛЬНЫЙ РЕЖИМ"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ВИЗУАЛЬНАЯ СТРОКА"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ВИЗУАЛЬНЫЙ БЛОК"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ВЫДЕЛЕНИЕ"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ВЫДЕЛЕНИЕ СТРОКИ"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ВЫДЕЛЕНИЕ БЛОКА"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "запись"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Неправильная строка поиска: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Поиск закончен в НАЧАЛЕ документа; %s не найдено"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Поиск закончен в КОНЦЕ документа; %s не найдено"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: После ';' ожидается ввод '?' или '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (включает раннее показанные соответствия)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Включённые файлы "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "не найдено "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "по пути ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Уже показано)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " НЕ НАЙДЕНО"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Просмотр включённых файлов: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Поиск включённого файла %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Соответствие в текущей строке"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Найдены все включённые файлы"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Включённых файлов нет"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Определение не найдено"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Шаблон не найден"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Замена "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5057,88 +5259,99 @@ msgstr ""
 "# Последний %sШаблон поиска:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Ошибка формата в файле правописания"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Файл правописания обрезан"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Лишний текст на хвосте в %s стр. %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Имя аффикса слишком длинное в %s, строка %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Ошибка формата в файле аффиксов FOL, LOW или UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Символы в FOL, LOW или UPP за пределами диапазона"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Сжатие дерева слов..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Проверка правописания выключена"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Предупреждение: Невозможно найти список слов \"%s_%s.spl\" или \"%s_ascii.spl"
-"\""
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Предупреждение: Невозможно найти список слов \"%s.%s.spl\" или \"%s.ascii.spl"
 "\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Чтение файла правописания \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Это не похоже на файл правописания"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Старый файл правописания, требуется его обновление"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Файл правописания предназначен для более новой версии Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Неподдерживаемый раздел в файле правописания"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Предупреждение: регион %s не поддерживается"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Чтение файла аффиксов %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Не удалось преобразовать слово в %s, строка %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Преобразование в %s не поддерживается: из %s в %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Преобразование в %s не поддерживается"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Неправильное значение FLAG в %s, строка %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG после использования флагов в %s, строка %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5147,6 +5360,7 @@ msgstr ""
 "Определение COMPOUNDFORBIDFLAG после элемента PFX может дать неправильные "
 "результаты в %s, строка %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5155,35 +5369,43 @@ msgstr ""
 "Определение COMPOUNDPERMITFLAG после элемента PFX может дать неправильные "
 "результаты в %s, строка %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDRULES в %s, строка %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDWORDMAX в %s, строка %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDMIN в %s, строка %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Неправильное значение COMPOUNDSYLMAX в %s, строка %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Неправильное значение CHECKCOMPOUNDPATTERN в %s, строка %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Другой объединяющий флаг в продолжающем блоке аффикса в %s, строка %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Повторяющийся аффикс в %s, строка %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5192,270 +5414,334 @@ msgstr ""
 "Аффикс также используется для BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
 "NOSUGGEST в %s, строка %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Ожидалось Y или N в %s, строка %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Нарушенное условие в %s, строка %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Ожидался счётчик REP(SAL) в %s, строка %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Ожидался счётчик MAP в %s, строка %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Повторяющийся символ в MAP в %s, строка %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Нераспознанный или повторяющийся элемент в %s, строка %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Пропущена строка FOL/LOW/UPP в %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX используется без SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Слишком много отложенных префиксов"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Слишком много составных флагов"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Слишком много отложенных префиксов и/или составных флагов"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Пропущена строка SOFO%s в %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Обе строки SAL и SOFO в %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Флаг не является числом в %s, строка %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Недопустимый флаг в %s на строке %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s имеет другое значение, чем в файле .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Чтение файла словаря %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Количество слов не указано в %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "строка %6d, слово %6d — %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Повтор слова в %s на строке %d: %s "
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Первый повтор слова в %s на строке %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d повторяющихся слов в %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Пропущено %d слов с не ASCII символами в %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Чтение файла слов %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Проигнорирована повторяющаяся строка /encoding= в %s, строка %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Проигнорирована строка /encoding= после слова в %s, строка %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Пропускается повтор строки /regions= в %s, строка %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Слишком много регионов в %s, строка %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "/ строка пропускается в %s, строка %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Недопустимый номер региона в %s, строка %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Нераспознанные флаги в %s, строка %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Пропущено %d слов с не ASCII символами"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Недостаточно оперативной памяти, список слов будет не полон"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Сжато %d из %d узлов; осталось %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Чтение записанного файла правописания..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Выполнение звуковой свёртки..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Количество слов после звуковой свёртки: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Общее количество слов: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Запись файла предложения исправлений правописания %s"
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Оценка использования памяти при выполнении: %d байт"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Имя выходного файла не должно содержать названия региона"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Поддерживается не более 8-ми регионов"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Недопустимый регион в %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Предупреждение: оба составные и указано NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Запись файла правописания %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Завершено!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' не содержит %<PRId64> элементов"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Слово удалено из %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Слово добавлено в %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Символы слов отличаются в файлах правописания"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Извините, нет предположений"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Извините, только %<PRId64> предположений"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Заменить \"%.*s\" на:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Нет предыдущей замены правописания"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Не найдено: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Это не похоже на файл .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Старый файл .sug, требует обновления: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Файл .sug для более новой версии Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Файл .sug не соответствует файлу .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Ошибка при чтении файла .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Повторяющийся символ в элементе MAP"
 
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Синтаксические элементы для данного буфера не определены"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Недопустимый параметр: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Синтаксический кластер %s не найден"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "Синхронизация по комментариям в стиле языка C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "без синхронизации"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "синхронизация начата "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " строк перед верхней строкой"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5463,6 +5749,7 @@ msgstr ""
 "\n"
 "--- Элементы синхронизации синтаксиса ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5470,6 +5757,7 @@ msgstr ""
 "\n"
 "синхронизация по элементам"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5477,213 +5765,273 @@ msgstr ""
 "\n"
 "--- Синтаксические элементы ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Синтаксический кластер %s не найден"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "минимум "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "максимум "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; соответствие "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " переносов строк"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: Здесь нельзя использовать параметр contains"
 
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Недопустимое значение cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: Здесь нельзя использовать group[t]here"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Элемент области для %s не найден"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Требуется указать имя файла"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Слишком много синтаксических включений"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Пропущено ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Пропущено '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Не хватает параметров: синтаксический регион %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Слишком много синтаксических кластеров"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Кластер не указан"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Не найден разделитель шаблонов: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Мусор после шаблона: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: Синхронизация синтаксиса: шаблон продолжений строки указан дважды"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Недопустимые параметры: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Пропущен знак равенства: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Пустой параметр: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s не допускается в этом месте"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s должно быть первым в списке contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Неизвестная группа: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Неправильная подкоманда :syntax: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  ВСЕГО       КОЛ.  СООТВ. ОТСТАЮЩИЙ    СРЕДНИЙ    ИМЯ                ШАБЛОН"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Рекурсивная петля при загрузке syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Группа подсветки синтаксиса %s не найдена"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Не хватает параметров: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Слишком много параметров: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: У группы есть настройки, пропускается highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Неожиданный знак равенства: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Пропущен знак равенства: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Пропущен параметр: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Недопустимое значение: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Неизвестный цвет текста"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Неизвестный цвет фона"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Имя или номер цвета не известно: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Слишком длинный код терминала: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Недопустимый параметр: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Используется слишком много разных атрибутов подсветки синтаксиса"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Непечатный символ в имени группы"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Недопустимый символ в имени группы"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Слишком много групп подсветки и синтаксиса"
 
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: Внизу стека меток"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: Наверху стека меток"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Невозможно перейти в позицию до первой совпадающей метки"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Метка не найдена: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # при тип  метка"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "файл\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Есть только одна совпадающая метка"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Невозможно перейти в позицию за последней совпадающей меткой"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Файл \"%s\" не существует"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "метка %d из %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " и более"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Используется метка с символами в другом регистре!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Файл \"%s\" не существует"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5691,66 +6039,79 @@ msgstr ""
 "\n"
 "  # К  метке       ОТ   стр.  в файле/тексте"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Поиск в файле меток %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Путь к файлу меток %s обрезан\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Игнорирование длинной строки в файле tags"
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Ошибка формата в файле меток \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Перед байтом %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Файл меток не отсортирован: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Файл меток не обнаружен"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Не найден шаблон метки"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Метка не найдена, пытаемся угадать!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Повторяющееся имя поля: %s"
 
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' не известен. Доступны встроенные терминалы:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "по умолчанию '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Невозможно открыть файл termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: В terminfo нет записи об этом терминале"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: В termcap нет записи об этом терминале"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: В termcap нет записи \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Требуется способность терминала \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5758,245 +6119,170 @@ msgstr ""
 "\n"
 "--- Кнопки терминала ---"
 
-msgid "new shell started\n"
-msgstr "запуск новой оболочки\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Ошибка чтения ввода, выход...\n"
 
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Вместо пустого выделения используется CUT_BUFFER0"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Неожиданно изменился счётчик строк"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Отмена невозможна; продолжать выполнение"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Невозможно открыть файл отмен для записи: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Файл отмен повреждён (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Невозможно записать файл отмен в каком-либо каталоге из 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Файл отмен не перезаписан, невозможно прочитать: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Перезапись не выполнена, это не файл отмен: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Пропущена запись файла отмен, нечего отменять"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Запись файла отмен: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Ошибка при записи файла отмен: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Файл отмен не прочитан, другой владелец: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Чтение файла отмен: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Невозможно открыть файл отмен для чтения: %s"
 
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Это не файл отмен: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Не зашифрованный файл имеет зашифрованный файл отмен: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Не удалось дешифровать файл отмен: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Файл отмен зашифрован: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Несовместимый файл отмен: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Изменилось содержимое файла, невозможно использовать информацию отмен"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Завершено чтение файла отмен %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Уже на самом первом изменении"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Уже на самом последнем изменении"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Не найдена отмена номер %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильные номера строк"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "стр. добавлена"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "стр. добавлено"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "стр. удалена"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "стр. удалено"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "изм."
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "изм."
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "перед"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "после"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Нечего отменять"
 
 # Заголовок таблицы :undolist
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr " номер  измен.  когда              сохранено"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> с назад"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: Объединение отмен не допускается после отмены"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: Повреждён список отмены"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Потеряна строка отмены"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Версия с графическим интерфейсом для MS-Windows 16/32 бит"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Версия с графическим интерфейсом для MS-Windows 64 бит"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Версия с графическим интерфейсом для MS-Windows 32 бит"
-
-msgid " in Win32s mode"
-msgstr " в режиме Win32"
-
-msgid " with OLE support"
-msgstr " с поддержкой OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Консольная версия для MS-Windows 64 бит"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Консольная версия для MS-Windows 32 бит"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Версия для MS-Windows 16 бит"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версия для MS-DOS 32 бит"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версия для MS-DOS 16 бит"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Версия для MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Версия для MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Версия для MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Версия для OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -6004,6 +6290,7 @@ msgstr ""
 "\n"
 "Заплатки: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -6011,9 +6298,11 @@ msgstr ""
 "\n"
 "Дополнительные заплатки: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "С изменениями, внесёнными "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -6021,9 +6310,11 @@ msgstr ""
 "\n"
 "Скомпилирован "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6031,859 +6322,1924 @@ msgstr ""
 "\n"
 "Огромная версия "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Большая версия "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Обычная версия "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Малая версия "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Версия \"Кроха\" "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "без графического интерфейса."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "с графическим интерфейсом GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "с графическим интерфейсом GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "с графическим интерфейсом X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "с графическим интерфейсом X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "с графическим интерфейсом X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "с графическим интерфейсом Photon."
-
-msgid "with GUI."
-msgstr "с графическим интерфейсом."
-
-msgid "with Carbon GUI."
-msgstr "с графическим интерфейсом Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "с графическим интерфейсом Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "с классическим графическим интерфейсом."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Включённые (+) и отключённые (-) особенности:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "            общесистемный файл vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "         пользовательский файл vimrc: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  второй пользовательский файл vimrc: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  третий пользовательский файл vimrc: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "          пользовательский файл exrc: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   второй пользовательский файл exrc: \""
 
-msgid "  system gvimrc file: \""
-msgstr "           общесистемный файл gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "        пользовательский файл gvimrc: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr " второй пользовательский файл gvimrc: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr " третий пользовательский файл gvimrc: \""
-
-msgid "    system menu file: \""
-msgstr "             общесистемный файл меню: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "          значение $VIM по умолчанию: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "   значение $VIMRUNTIME по умолчанию: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Параметры компиляции: "
 
-msgid "Compiler: "
-msgstr "Компилятор: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Сборка: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  ОТЛАДОЧНАЯ СБОРКА"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM — Vi IMproved (улучшенный Vi)"
 
+#: ../version.c:769
 msgid "version "
 msgstr "версия "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Брам Мооленаар и другие"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim это свободно распространяемая программа с открытым кодом"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Бедным детям в Уганде нужна ваша помощь!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "наберите :help iccf<Enter>       для дополнительной информации"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "наберите :q<Enter>               чтобы выйти из программы     "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "наберите :help<Enter> или <F1>   для получения справки        "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "наберите :help version7<Enter>   чтобы узнать об этой версии  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Работа в Vi-совместимом режиме"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "наберите :set nocp<Enter>        для перехода в режим Vim     "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "наберите :help cp-default<Enter> для дополнительной информации"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "меню Справка->Сироты             для получения информации     "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Безрежимная работа, вставка введённого текста"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "меню Правка->Глобальные настройки->Режим Вставки                     "
-
-msgid "                              for two modes      "
-msgstr "                                 для двух режимов               "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "меню Правка->Глобальные настройки->Совместимость с Vi                "
-
-msgid "                              for Vim defaults   "
-msgstr "                                 для перехода в режим Vim       "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Помогите в разработке Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Станьте зарегистрированным пользователем Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "наберите :help sponsor<Enter>    для получения информации     "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "наберите :help register<Enter>   для получения информации     "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "меню Справка->Помощь/Регистрация для получения информации       "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ПРЕДУПРЕЖДЕНИЕ: обнаружена Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "наберите :help windows95<Enter>  для получения информации     "
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "На экране всего одно окно"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Окно предпросмотра отсутствует"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Окно не может быть одновременно слева вверху и справа внизу"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Невозможно поменять местами, пока другое окно разделено"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Нельзя закрыть последнее окно"
 
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Нельзя закрыть окно автокоманд"
 
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Нельзя закрыть окно, останется только окно автокоманд"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: В другом окне есть несохранённые изменения"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Нет имени файла в позиции курсора"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Файл \"%s\" не найден по известным путям"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: bf_key_init() вызван с пустым паролем"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Невозможно загрузить библиотеку %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Извините, данная команда отключена: невозможно загрузить библиотеку Perl"
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr ""
+#~ "E817: Неправильное использование обратного/прямого порядка байт в Blowfish"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Не допускается вычисление Perl в песочнице без модуля безопасности"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: Не удалось выполнить тест sha256"
 
-msgid "Edit with &multiple Vims"
-msgstr "Редактировать в &разных Vim-ах"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Не удалось выполнить тест Blowfish"
 
-msgid "Edit with single &Vim"
-msgstr "Редактировать в &одном Vim"
+#~ msgid "Patch file"
+#~ msgstr "Файл-заплатка"
 
-msgid "Diff with Vim"
-msgstr "Сравнить с помощью Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&C Отмена"
 
-msgid "Edit with &Vim"
-msgstr "Ре&дактировать с помощью Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Нет связи с сервером Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Редактировать в запущенном Vim — "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Не могу отправить сообщение для %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Редактировать выделенные файлы с помощью Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Сервер не отвечает"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Ошибка создания процесса: проверьте доступность gvim в пути!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Не могу ответить клиенту"
 
-msgid "gvimext.dll error"
-msgstr "ошибка gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Сохранить как"
 
-msgid "Path length too long!"
-msgstr "Слишком длинный путь!"
+#~ msgid "Edit File"
+#~ msgstr "Редактирование файла"
 
-msgid "--No lines in buffer--"
-msgstr "-- Нет строк в буфере --"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (НЕ НАЙДЕНО)"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Выполнение команды прервано"
+#~ msgid "Source Vim script"
+#~ msgstr "Выполнить сценарий Vim"
 
-msgid "E471: Argument required"
-msgstr "E471: Требуется указать параметр"
+#~ msgid "unknown"
+#~ msgstr "неизвестно"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: После \\ должен идти символ /, ? или &"
+#~ msgid "Edit File in new window"
+#~ msgstr "Редактировать файл в новом окне"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Недопустимо в окне командной строки; <CR> выполнение, CTRL-C выход"
+#~ msgid "Append File"
+#~ msgstr "Добавить файл"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Команда не допускается в exrc/vimrc в текущем каталоге или поиске меток"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Положение окна: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Отсутствует команда :endif"
+#~ msgid "Save Redirection"
+#~ msgstr "Перенаправление записи"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Отсутствует команда :endtry"
+#~ msgid "Save View"
+#~ msgstr "Сохранение вида"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Отсутствует команда :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Сохранение сеанса"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Отсутствует команда :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Сохранение настроек"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: Команда :endwhile без парной команды :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< не доступно без особенности +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor без :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: В этой версии диграфы не работают"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Файл существует (добавьте !, чтобы перезаписать)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "является устройством (отключено при опции 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Не удалось выполнить команду"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Чтение из стандартного потока ввода stdin..."
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Неизвестный шрифтовой набор: %s"
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Неизвестный шрифт: %s"
+#~ msgid "[crypted]"
+#~ msgstr "[зашифровано]"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Шрифт \"%s\" не является моноширинным"
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Файл зашифрован неизвестным методом"
 
-msgid "E473: Internal error"
-msgstr "E473: Внутренняя ошибка"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans не позволяет выполнять запись неизменённых буферов"
 
-msgid "Interrupted"
-msgstr "Прервано"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Частичная запись буферов NetBeans не допускается"
 
-msgid "E14: Invalid address"
-msgstr "E14: Недопустимый адрес"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "запись в устройство отключена при опции 'opendevice'"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Недопустимый параметр"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Ветвь ресурса будет потеряна (добавьте !, чтобы обойти проверку)"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Недопустимый параметр: %s"
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Невозможно создать новый процесс для граф. интерфейса"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Недопустимое выражение: %s"
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Процессу-потомку не удалось запустить граф. интерфейс"
 
-msgid "E16: Invalid range"
-msgstr "E16: Недопустимый диапазон"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Невозможно перейти в режим графического интерфейса"
 
-msgid "E476: Invalid command"
-msgstr "E476: Недопустимая команда"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Невозможно выполнить чтение \"%s\""
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" является каталогом"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Невозможно перейти в режим граф. интерфейса, неправильно заданы "
+#~ "шрифты"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Неудачный вызов функции \"%s()\" из библиотеки"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Неправильное значение опции 'guifontwide'"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Не удалось загрузить функцию %s из библиотеки"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Неправильное значение опции 'imactivatekey'"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Отметка указывает на неправильный номер строки"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Невозможно назначить цвет %s"
 
-msgid "E20: Mark not set"
-msgstr "E20: Отметка не определена"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Нет совпадения под курсором, поиск следующего"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Изменения невозможны, так как отключена опция 'modifiable'"
+#~ msgid "<cannot open> "
+#~ msgstr "<нельзя открыть> "
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Слишком глубоко вложенные сценарии"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: шрифт %s не найден"
 
-msgid "E23: No alternate file"
-msgstr "E23: Соседний файл не существует"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: возврат в текущий каталог невозможен"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Нет такого сокращения"
+#~ msgid "Pathname:"
+#~ msgstr "Путь к файлу:"
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! не допускается"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: не могу найти текущий каталог"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr ""
-"E25: Возможность использования графического интерфейса выключена при "
-"компиляции"
+#~ msgid "OK"
+#~ msgstr "Да"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Иврит выключен при компиляции\n"
+#~ msgid "Cancel"
+#~ msgstr "Отмена"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Фарси выключено при компиляции\n"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Полоса прокрутки: не могу определить геометрию ползунка"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Арабский выключен при компиляции\n"
+#~ msgid "Vim dialog"
+#~ msgstr "Диалоговое окно Vim"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Группа подсветки синтаксиса %s не существует"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: \"Пузырь\" для вычислений, включающий и сообщение, и обратный "
+#~ "вызов, не может быть создан"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Пока нет вставленного текста"
+#~ msgid "Input _Methods"
+#~ msgstr "Методы Ввода"
 
-msgid "E30: No previous command line"
-msgstr "E30: Предыдущей командной строки нет"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM — Поиск и замена..."
 
-msgid "E31: No such mapping"
-msgstr "E31: Такой привязки не существует"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM — Поиск..."
 
-msgid "E479: No match"
-msgstr "E479: Нет соответствия"
+#~ msgid "Find what:"
+#~ msgstr "Что ищем:"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Нет соответствия: %s"
+#~ msgid "Replace with:"
+#~ msgstr "На что заменяем:"
 
-msgid "E32: No file name"
-msgstr "E32: Нет имени файла"
+#~ msgid "Match whole word only"
+#~ msgstr "Только точные соответствия"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Нет предыдущего регулярного выражения для замены"
+#~ msgid "Match case"
+#~ msgstr "Регистрозависимые соответствия"
 
-msgid "E34: No previous command"
-msgstr "E34: Нет предыдущей команды"
+#~ msgid "Direction"
+#~ msgstr "Направление"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Нет предыдущего регулярного выражения"
+#~ msgid "Up"
+#~ msgstr "Вверх"
 
-msgid "E481: No range allowed"
-msgstr "E481: Использование диапазона не допускается"
+#~ msgid "Down"
+#~ msgstr "Вниз"
 
-msgid "E36: Not enough room"
-msgstr "E36: Недостаточно места"
+#~ msgid "Find Next"
+#~ msgstr "Найти следующее"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Сервер \"%s\" не зарегистрирован"
+#~ msgid "Replace"
+#~ msgstr "Замена"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Невозможно создать файл %s"
+#~ msgid "Replace All"
+#~ msgstr "Заменить все"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Невозможно получить имя временного файла"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Получен запрос на прекращение работы от диспетчера сеансов\n"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Невозможно открыть файл %s"
+#~ msgid "Close"
+#~ msgstr "Закрыть"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Невозможно прочитать файл %s"
+#~ msgid "New tab"
+#~ msgstr "Новая вкладка"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Изменения не сохранены (добавьте !, чтобы обойти проверку)"
+#~ msgid "Open Tab..."
+#~ msgstr "Открыть вкладку..."
 
-msgid "E38: Null argument"
-msgstr "E38: Нулевой параметр"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Основное окно было неожиданно закрыто\n"
 
-msgid "E39: Number expected"
-msgstr "E39: Требуется число"
+#~ msgid "&Filter"
+#~ msgstr "&Фильтр"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Не удалось открыть файл ошибок %s"
+#~ msgid "&Cancel"
+#~ msgstr "О&тмена"
 
-msgid "E233: cannot open display"
-msgstr "E233: Невозможно открыть дисплей"
+#~ msgid "Directories"
+#~ msgstr "Каталоги"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Не хватает памяти!"
+#~ msgid "Filter"
+#~ msgstr "Фильтр"
 
-msgid "Pattern not found"
-msgstr "Шаблон не найден"
+#~ msgid "&Help"
+#~ msgstr "&Справка"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Шаблон не найден: %s"
+#~ msgid "Files"
+#~ msgstr "Файлы"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Параметр должен быть положительным числом"
+#~ msgid "&OK"
+#~ msgstr "&Да"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Возврат в предыдущий каталог невозможен"
+#~ msgid "Selection"
+#~ msgstr "Выделение"
 
-msgid "E42: No Errors"
-msgstr "E42: Нет ошибок"
+#~ msgid "Find &Next"
+#~ msgstr "Найти &следующее"
 
-msgid "E776: No location list"
-msgstr "E776: Нет списка расположений"
+#~ msgid "&Replace"
+#~ msgstr "За&мена"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Повреждена строка соответствия"
+#~ msgid "Replace &All"
+#~ msgstr "Заменить &все"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Программа обработки регулярных выражений повреждена"
+#~ msgid "&Undo"
+#~ msgstr "О&тмена"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Включена опция 'readonly' (добавьте !, чтобы обойти проверку)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Окно с заголовком \"%s\" не обнаружено"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Невозможно изменить переменную только для чтения \"%s\""
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Параметр не поддерживается: \"-%s\"; используйте версию OLE."
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Невозможно изменить переменную в песочнице: \"%s\""
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Невозможно открыть окно внутри приложения MDI"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Ошибка при чтении файла ошибок"
+#~ msgid "Close tab"
+#~ msgstr "Закрыть вкладку"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Не допускается в песочнице"
+#~ msgid "Open tab..."
+#~ msgstr "Открыть вкладку..."
 
-msgid "E523: Not allowed here"
-msgstr "E523: Здесь не разрешено"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Поиск строки (используйте '\\\\' для поиска '\\')"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Данный режим экрана не поддерживается"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Поиск и замена (используйте '\\\\' для поиска '\\')"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Недопустимый размер прокрутки"
+#~ msgid "Not Used"
+#~ msgstr "Не используется"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Значением опции 'shell' является пустая строка"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Каталог\t*.ничего\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Невозможно прочитать данные о значках!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Невозможно выделить запись в таблице цвета, некоторые цвета "
+#~ "могут отображаться неправильно"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Ошибка закрытия своп-файла"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: В наборе шрифтов %s отсутствуют шрифты для следующих кодировок:"
 
-msgid "E73: tag stack empty"
-msgstr "E73: Стек меток пустой"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Набор шрифтов: %s"
 
-msgid "E74: Command too complex"
-msgstr "E74: Слишком сложная команда"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Шрифт '%s' не является моноширинным"
 
-msgid "E75: Name too long"
-msgstr "E75: Слишком длинное имя"
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Набор шрифтов: %s"
 
-msgid "E76: Too many ["
-msgstr "E76: Слишком много символов ["
+#~ msgid "Font0: %s"
+#~ msgstr "Font0: %s"
 
-msgid "E77: Too many file names"
-msgstr "E77: Слишком много имён файлов"
+#~ msgid "Font1: %s"
+#~ msgstr "Font1: %s"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Лишние символы на хвосте"
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr ""
+#~ "Ширина шрифта font%<PRId64> должна быть вдвое больше ширины шрифта font0"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Неизвестная отметка"
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Ширина шрифта font0: %<PRId64>"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Невозможно выполнить подстановку по маске"
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Ширина шрифта font1: %<PRId64>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr ""
-"E591: Значение опции 'winheight' не может быть меньше значения 'winminheight'"
+#~ msgid "Invalid font specification"
+#~ msgstr "Неправильное определение шрифта"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr ""
-"E592: Значение опции 'winwidth' не может быть меньше значения 'winminwidth'"
+#~ msgid "&Dismiss"
+#~ msgstr "О&тклонить"
 
-msgid "E80: Error while writing"
-msgstr "E80: Ошибка при записи"
+#~ msgid "no specific match"
+#~ msgstr "нет специального совпадения"
 
-msgid "Zero count"
-msgstr "Нулевое значение счётчика"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim — Выбор шрифта"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Использование <SID> вне контекста сценария"
+#~ msgid "Name:"
+#~ msgstr "Название:"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Получено недопустимое выражение"
+#~ msgid "Show size in Points"
+#~ msgstr "Показывать размер в пунктах"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Невозможно изменить охраняемую область"
+#~ msgid "Encoding:"
+#~ msgstr "Кодировка:"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans не допускает изменений в файлах только для чтения"
+#~ msgid "Font:"
+#~ msgstr "Шрифт:"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Внутренняя ошибка: %s"
+#~ msgid "Style:"
+#~ msgstr "Стиль:"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Шаблон использует больше памяти чем 'maxmempattern'"
+#~ msgid "Size:"
+#~ msgstr "Размер:"
 
-msgid "E749: empty buffer"
-msgstr "E749: Пустой буфер"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: ОШИБКА автоматики Хангыл"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Неправильная строка поиска или разделитель"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: Ошибка stat"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Файл загружен в другом буфере"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Невозможно открыть базу данных cscope: %s"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Опция '%s' не установлена"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Информация о базе данных cscope не доступна"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Недопустимое имя регистра"
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Библиотека Lua не может быть загружена."
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Поиск будет продолжен с КОНЦА документа"
+#~ msgid "cannot save undo information"
+#~ msgstr "невозможно сохранить информацию об отмене операции"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Поиск будет продолжен с НАЧАЛА документа"
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека MzScheme"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Требуется ключ шифрования для \"%s\""
+#~ msgid "invalid expression"
+#~ msgstr "неправильное выражение"
 
-msgid "empty keys are not allowed"
-msgstr "Пустые ключи не допустимы"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "выражения отключены при компиляции"
 
-msgid "dictionary is locked"
-msgstr "Словарь заблокирован"
+#~ msgid "hidden option"
+#~ msgstr "скрытая опция"
 
-msgid "list is locked"
-msgstr "Список заблокирован"
+#~ msgid "unknown option"
+#~ msgstr "неизвестная опция"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "Невозможно добавить ключ '%s' к словарю"
+#~ msgid "window index is out of range"
+#~ msgstr "индекс окна за пределами диапазона"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "Индекс должен быть целым числом или выборкой, а не %s"
+#~ msgid "couldn't open buffer"
+#~ msgstr "невозможно открыть буфер"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "Ожидался экземпляр str() или unicode(), но получен %s"
+#~ msgid "cannot delete line"
+#~ msgstr "невозможно удалить строку"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "Ожидался экземпляр bytes() или str(), но получен %s"
+#~ msgid "cannot replace line"
+#~ msgstr "невозможно заменить строку"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr "Ожидалось int(), long() или что-то приводимое к long(), но получено %s"
+#~ msgid "cannot insert line"
+#~ msgstr "невозможно вставить строку"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "Ожидалось int() или что-то приводимое к int(), но получено %s"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "строка не может содержать символ новой строки"
 
-msgid "value is too large to fit into C int type"
-msgstr "Значение слишком велико для целочисленного типа C"
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "невозможно преобразовать значения Scheme в Vim"
 
-msgid "value is too small to fit into C int type"
-msgstr "Значение слишком мало для целочисленного типа C"
+#~ msgid "Vim error: ~a"
+#~ msgstr "ошибка Vim: ~a"
 
-msgid "number must be greater then zero"
-msgstr "Номер должен быть больше нуля"
+#~ msgid "Vim error"
+#~ msgstr "ошибка Vim"
 
-msgid "number must be greater or equal to zero"
-msgstr "Номер должен быть больше или равен нулю"
+#~ msgid "buffer is invalid"
+#~ msgstr "неправильный буфер"
 
-msgid "can't delete OutputObject attributes"
-msgstr "Невозможно удалить атрибуты OutputObject"
+#~ msgid "window is invalid"
+#~ msgstr "неправильное окно"
 
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "Неправильный атрибут: %s"
+#~ msgid "linenr out of range"
+#~ msgstr "номер строки за пределами диапазона"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Ошибка инициализации объектов I/O"
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "не допускается в песочнице Vim"
 
-msgid "failed to change directory"
-msgstr "Невозможно сменить каталог"
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr ""
+#~ "E836: Данный Vim не может выполнить :python после использования :py3"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "Ожидался 3-кортеж как результат imp.find_module(), но получен %s"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека Python"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr ""
-"Ожидался 3-кортеж как результат imp.find_module(), но получен кортеж с "
-"размером %d"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Невозможно выполнить рекурсивный вызов Python"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "Внутренняя ошибка: imp.find_module возвратил "
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr ""
+#~ "E837: Данный Vim не может выполнить :py3 после использования :python"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "Невозможно удалить атрибуты vim.Dictionary"
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ должен быть экземпляром или строкой"
 
-msgid "cannot modify fixed dictionary"
-msgstr "Невозможно изменить фиксированный словарь"
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека Ruby"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "Невозможно установить атрибут %s"
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: Неожиданный return"
 
-msgid "hashtab changed during iteration"
-msgstr "Хэш-таблица изменилась при итерации"
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: Неожиданный next"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr ""
-"Ожидался элемент-последовательность размера 2, а размер полученной "
-"последовательности %d"
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: Неожиданный break"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "Конструктор списка не допускает ключевые слова как аргументы"
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: Неожиданный redo"
 
-msgid "list index out of range"
-msgstr "Индекс списка за пределами диапазона"
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry вне оператора rescue"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "Внутренняя ошибка: не удалось получить элемент VIM-списка %d"
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Необработанное исключение"
 
-msgid "failed to add item to list"
-msgstr "Невозможно добавить элемент в список"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Неизвестное состояние longjmp %d"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "Внутренняя ошибка: нет элемента VIM-списка %d"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Переключение между реализацией/определением"
 
-msgid "internal error: failed to add item to list"
-msgstr "Внутренняя ошибка: не удалось добавить элемент в список"
+#~ msgid "Show base class of"
+#~ msgstr "Показать основной класс"
 
-msgid "cannot delete vim.List attributes"
-msgstr "Невозможно удалить атрибуты vim.List"
+#~ msgid "Show overridden member function"
+#~ msgstr "Показать перегруженные функции"
 
-msgid "cannot modify fixed list"
-msgstr "Невозможно изменить фиксированный список"
+#~ msgid "Retrieve from file"
+#~ msgstr "Получить из файла"
 
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "Не существует безымянной функции %s"
+#~ msgid "Retrieve from project"
+#~ msgstr "Получить из проекта"
 
-#, c-format
-msgid "function %s does not exist"
-msgstr "Функция %s не существует"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Получить из всех проектов"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "Конструктор функции не допускает ключевые слова как аргументы"
+#~ msgid "Retrieve"
+#~ msgstr "Получить"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "Невозможно выполнить функцию %s"
+#~ msgid "Show source of"
+#~ msgstr "Показать исходный код"
 
-msgid "unable to get option value"
-msgstr "Невозможно получить значение опции"
+#~ msgid "Find symbol"
+#~ msgstr "Найти символ"
 
-msgid "internal error: unknown option type"
-msgstr "Внутренняя ошибка: неизвестный тип опции"
+#~ msgid "Browse class"
+#~ msgstr "Просмотр класса"
 
-msgid "problem while switching windows"
-msgstr "Проблема при переключении окон"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Показать класс в иерархии"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "Невозможно сбросить глобальную опцию %s"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Показать класс в ограниченной иерархии"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "Невозможно сбросить опцию %s без глобального значения"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref ссылается на"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "Попытка сослаться на удалённую вкладку"
+#~ msgid "Xref referred by"
+#~ msgstr "Ссылка на xref из"
 
-msgid "no such tab page"
-msgstr "Нет такой вкладки"
+#~ msgid "Xref has a"
+#~ msgstr "Xref имеет"
 
-msgid "attempt to refer to deleted window"
-msgstr "Попытка сослаться на закрытое окно"
+#~ msgid "Xref used by"
+#~ msgstr "Xref используется"
 
-msgid "readonly attribute: buffer"
-msgstr "Атрибут только для чтения: буфер"
+#~ msgid "Show docu of"
+#~ msgstr "Показать docu"
 
-msgid "cursor position outside buffer"
-msgstr "Позиция курсора находится вне буфера"
+#~ msgid "Generate docu for"
+#~ msgstr "Создать docu"
 
-msgid "no such window"
-msgstr "Нет такого окна"
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Невозможно подсоединиться к SNiFF+. Проверьте настройки окружения."
+#~ "(sniffemacs должны быть указаны в переменной $PATH).\n"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "Попытка сослаться на уничтоженный буфер"
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Ошибка во время чтения. Отсоединение"
 
-msgid "failed to rename buffer"
-msgstr "Невозможно переименовать буфер"
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "В настоящий момент SNiFF+ "
 
-msgid "mark name must be a single character"
-msgstr "Название отметки должно быть одним символом"
+#~ msgid "not "
+#~ msgstr "не "
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "Ожидался объект vim.Buffer, но получен %s"
+#~ msgid "connected"
+#~ msgstr "подсоединён"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "Невозможно переключиться на буфер %d"
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Неизвестный запрос SNiFF+: %s"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "Ожидался объект vim.Window, но получен %s"
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Ошибка соединения со SNiFF+"
 
-msgid "failed to find window in the current tab page"
-msgstr "Невозможно найти окно в текущей вкладке"
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ не подсоединён"
 
-msgid "did not switch to the specified window"
-msgstr "Невозможно переключиться на указанное окно"
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Это не буфер SNiFF+"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "Ожидался объект vim.TabPage, но получен %s"
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Ошибка во время записи. Отсоединение"
 
-msgid "did not switch to the specified tab page"
-msgstr "Невозможно переключиться на указанную вкладку"
+#~ msgid "invalid buffer number"
+#~ msgstr "неправильный номер буфера"
 
-msgid "failed to run the code"
-msgstr "Невозможно выполнить код"
+#~ msgid "not implemented yet"
+#~ msgstr "пока не реализовано"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval не возвратил допустимого объекта Python"
+#~ msgid "cannot set line(s)"
+#~ msgstr "невозможно назначить строку или строки"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr ""
-"E859: Не удалось преобразовать возвращённый объект Python в значение VIM"
+#~ msgid "invalid mark name"
+#~ msgstr "неправильное имя отметки"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "Невозможно преобразовать %s в словарь VIM"
+#~ msgid "mark not set"
+#~ msgstr "отметка не установлена"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "Невозможно преобразовать %s в структуру VIM"
+#~ msgid "row %d column %d"
+#~ msgstr "ряд %d колонка %d"
 
-msgid "internal error: NULL reference passed"
-msgstr "Внутренняя ошибка: передана ссылка на NULL"
+#~ msgid "cannot insert/append line"
+#~ msgstr "невозможно вставить или добавить строку"
 
-msgid "internal error: invalid value type"
-msgstr "Внутренняя ошибка: неправильный тип значения"
+#~ msgid "line number out of range"
+#~ msgstr "номер строки за пределами диапазона"
 
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Ошибка при установке перехватчика пути: sys.path_hooks не является списком\n"
-"Следует сделать следующее:\n"
-"— Добавить vim.path_hook  в sys.path_hooks\n"
-"— Добавить vim.VIM_SPECIAL_PATH в sys.path\n"
+#~ msgid "unknown flag: "
+#~ msgstr "неизвестный флаг: "
 
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Ошибка при установке пути: sys.path не является списком\n"
-"Следует добавить vim.VIM_SPECIAL_PATH в sys.path"
+#~ msgid "unknown vimOption"
+#~ msgstr "неизвестная vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "клавиатурное прерывание"
+
+#~ msgid "vim error"
+#~ msgstr "ошибка VIM"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "невозможно создать команду буфера или окна: объект в процессе удаления"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "невозможно зарегистрировать команду с обратным вызовом: буфер или окно в "
+#~ "процессе удаления"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: КРИТИЧЕСКАЯ ОШИБКА TCL: повреждён список ссылок?! Сообщите об этом "
+#~ "по адресу vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "невозможно зарегистрировать команду с обратным вызовом: ссылка на буфер "
+#~ "или окно не обнаружена"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: К сожалению эта команда не работает, поскольку не загружена "
+#~ "библиотека Tcl"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Код выхода %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "невозможно получить строку"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Невозможно зарегистрировать имя сервера команд"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Не удалась отправка команды в другую программу"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Используется неправильный id сервера: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Неправильно сформировано значение данного процесса VIM в реестре. "
+#~ "Удалено!"
+
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "NetBeans не поддерживается с этим графическим интерфейсом\n"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr ""
+#~ "Данный Vim был скомпилирован с выключенной особенностью просмотра отличий"
+
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "Невозможно использовать '-nb': не включено при компиляции\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Ошибка: Не удалось запустить gvim из NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Если регистр игнорируется, добавьте перед флагом / для верхнего регистра"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tЗарегистрировать этот gvim для OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tОтключить регистрацию данного gvim для OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tЗапустить с графическим интерфейсом (как \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  или --nofork\tВ активной задаче: Не выполнять fork при запуске GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tНе использовать newcli для открытия окна"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <устройство>\t\tИспользовать для I/O указанное <устройство>"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tИспользовать <gvimrc> вместо любых файлов .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tРедактирование зашифрованных файлов"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <экран>\tПодсоединить VIM к указанному X-серверу"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tНе выполнять соединение с сервером X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <файлы>\tПо возможности редактировать <файлы> на сервере Vim"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <файлы>  То же, но без жалоб на отсутствие сервера"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <файлы>  То же, что и --remote, но с ожиданием завершения"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <файлы>  То же, но без жалоб на отсутствие сервера"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <файлы>  То же, что и --remote, но с "
+#~ "вкладками"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <кнопки>\tОтправить <кнопки> на сервер Vim и выйти"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <выраж>\tВычислить <выраж> на сервере Vim и напечатать"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr ""
+#~ "--serverlist\t\tПоказать список имён серверов Vim и завершить работу"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr ""
+#~ "--servername <имя>\tОтправить на/стать сервером Vim с указанным <именем>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <дисплей>\tЗапустить VIM на указанном <дисплее>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tЗапустить VIM в свёрнутом виде"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr ""
+#~ "-background <цвет>\tИспользовать указанный <цвет> для фона (также: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <цвет>\tИспользовать <цвет> для обычного текста (также: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <шрифт>\t\tИспользовать <шрифт> для обычного текста (также: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <шрифт>\tИспользовать <шрифт> для жирного текста"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <шрифт>\tИспользовать <шрифт> для наклонного текста"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <геометрия>\tИспользовать начальную <геометрию> (также: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <ширина>\tИспользовать <ширину> бордюра (также: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <ширина> Использовать ширину полосы прокрутки (также: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <высота>\tИспользовать <высоту> меню (также: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tИспользовать инверсный видеорежим (также: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tНе использовать инверсный видеорежим (также: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ресурс>\tУстановить указанный <ресурс>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры для gvim (версия GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr ""
+#~ "-display <дисплей>\tЗапустить VIM на указанном <дисплее> (также: --"
+#~ "display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <роль>\tУстановить уникальную <роль> для идентификации главного "
+#~ "окна"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tОткрыть Vim внутри другого компонента GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr ""
+#~ "--echo-wid\t\tВывести Window ID для gvim на стандартный поток вывода"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <заголовок родителя>\tОткрыть Vim в родительском приложении"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tОткрыть Vim внутри другого компонента win32"
+
+#~ msgid "No display"
+#~ msgstr "Нет дисплея"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Отправка не удалась.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Отправка не удалась. Попытка местного выполнения\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "отредактировано %d из %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Нет дисплея: отправка выражения не удалась.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Отправка выражения не удалась.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Недопустимое имя кодировки"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Невозможно назначить значения контекста ввода"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Невозможно создать контекст ввода"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Неудачная попытка открыть метод ввода"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Предупреждение: невозможно назначить обр. вызов уничтожения метода "
+#~ "ввода"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Метод ввода не поддерживает стили"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr ""
+#~ "E289: Метод ввода не поддерживает мой тип предварительного редактирования"
+
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Ошибка при обновлении шифрования своп-файла"
+
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s зашифрован, а эта версия Vim не поддерживает шифрование"
+
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Своп-файл зашифрован: \"%s\""
+
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Если вы ввели новый пароль для шифрования, но не записали текстовый файл,"
+
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "то введите новый пароль для шифрования."
+
+# Перевод сообщения разделён на две части, часть первая
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Если вы записали текстовый файл после изменения пароля шифрования, то "
+#~ "нажмите"
+
+# Перевод сообщения разделён на две части, часть вторая
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "Enter для использования одного ключа для текстового файла и своп-файла"
+
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr ""
+#~ "Использование ключа шифрования из своп-файла для текстового файла.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [не пригоден для использования с данной версией Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Оторвать это меню"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Выбор каталога"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Сохранение файла"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Открытие файла"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr ""
+#~ "E338: Извините, но в консольном режиме нет проводника по файловой системе"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: сохранение файлов...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Готово.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "ОШИБКА: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[байт] всего выдел.-освоб. %<PRIu64>-%<PRIu64>, использ. %<PRIu64>, макс. "
+#~ "использ. %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[вызовы] re/malloc() всего %<PRIu64>, free() всего %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Строка становится слишком длинной"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Недопустимая форма курсора"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Введите пароль для шифрования: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Повторите ввод пароля: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Введённые пароли не совпадают!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Невозможно соединиться с NetBeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Невозможно соединиться с NetBeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Неправильный режим доступа к информации о соединении с NetBeans: "
+#~ "\"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "чтение из гнезда NetBeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Потеряно соединение с NetBeans для буфера %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: NetBeans не поддерживается с этим графическим интерфейсом"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: уже соединён с NetBeans"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr ""
+#~ "E505: %s открыт только для чтения (добавьте !, чтобы обойти проверку)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: eval не доступна"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "очищено строк: %<PRId64>"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: В графическом интерфейсе изменять терминал невозможно"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Для запуска графического интерфейса используйте \":gui\""
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Не может быть изменено в графическом интерфейсе GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Неправильные шрифты"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Невозможно выбрать шрифтовой набор"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Неправильный шрифтовой набор"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Невозможно выбрать шрифт с символами двойной ширины"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Неправильный шрифт с символами двойной ширины"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Мышь не поддерживается"
+
+#~ msgid "cannot open "
+#~ msgstr "невозможно открыть "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Невозможно открыть окно!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Необходима Amigados версии 2.04 или более поздней\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Необходима %s версии %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Невозможно открыть NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Невозможно создать "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Прекращение работы Vim с кодом %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "невозможно сменить режим консоли?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: не в консоли??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Невозможно выполнить оболочку с параметром -f"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Невозможно выполнить "
+
+#~ msgid "shell "
+#~ msgstr "оболочка "
+
+#~ msgid " returned\n"
+#~ msgstr " завершила работу\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "слишком малая величина ANCHOR_BUF_SIZE."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "ОШИБКА ВВОДА/ВЫВОДА"
+
+#~ msgid "Message"
+#~ msgstr "Сообщение"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr ""
+#~ "Значение опции 'columns' не равно 80, внешние программы не выполняются"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Неудачное завершение выбора принтера"
+
+#~ msgid "to %s on %s"
+#~ msgstr "в %s на %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Неизвестный шрифт принтера: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Ошибка печати: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Печать '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Недопустимое имя кодировки \"%s\" в имени шрифта \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Недопустимый символ '%c' в имени шрифта \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Двойной сигнал, завершение работы\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Получен убийственный сигнал %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Получен убийственный сигнал\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Открытие дисплея X заняло %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Ошибка X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Проверка дисплея X завершена неудачно"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Открытие дисплея X не выполнено в отведённое время"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Невозможно запустить оболочку sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Невозможно создать трубы\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Невозможно выполнить fork()\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Выполнение команды прервано\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP утеряно соединение ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Неудачное открытие дисплея X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP обрабатывает запрос самосохранения"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP открывает соединение"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP потеряно слежение за соединением ICE"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP неудачно выполнено SmcOpenConnection: %s"
+
+#~ msgid "At line"
+#~ msgstr "В строке"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Невозможно загрузить vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "Ошибка VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Невозможно исправить указатели функций для DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "завершение работы оболочки с кодом %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Перехвачено событие %s\n"
+
+#~ msgid "close"
+#~ msgstr "закрытие"
+
+#~ msgid "logoff"
+#~ msgstr "отключение"
+
+#~ msgid "shutdown"
+#~ msgstr "завершение"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Команда не найдена"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE не найден в пути, заданном в $PATH.\n"
+#~ "Внешние команды не будут останавливаться после выполнения.\n"
+#~ "Дополнительная информация в :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Предупреждение Vim"
+
+#~ msgid "Error file"
+#~ msgstr "Файл ошибок"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: ошибка при создании НКА с классом эквивалентности!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (НКА) невозможно выделить память для прохода ветви!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Предупреждение: Невозможно найти список слов \"%s_%s.spl\" или \"%s_ascii."
+#~ "spl\""
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Преобразование в %s не поддерживается"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: Недостаточно оперативной памяти, список слов будет не полон"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Путь к файлу меток %s обрезан\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "запуск новой оболочки\n"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Вместо пустого выделения используется CUT_BUFFER0"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Отмена невозможна; продолжать выполнение"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Не зашифрованный файл имеет зашифрованный файл отмен: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Не удалось дешифровать файл отмен: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Файл отмен зашифрован: %s"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия с графическим интерфейсом для MS-Windows 16/32 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия с графическим интерфейсом для MS-Windows 64 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия с графическим интерфейсом для MS-Windows 32 бит"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " в режиме Win32"
+
+#~ msgid " with OLE support"
+#~ msgstr " с поддержкой OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольная версия для MS-Windows 64 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольная версия для MS-Windows 32 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MS-Windows 16 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MS-DOS 32 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MS-DOS 16 бит"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версия для OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Большая версия "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Обычная версия "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Малая версия "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Версия \"Кроха\" "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "с графическим интерфейсом GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "с графическим интерфейсом GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "с графическим интерфейсом X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "с графическим интерфейсом X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "с графическим интерфейсом X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "с графическим интерфейсом Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "с графическим интерфейсом."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "с графическим интерфейсом Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "с графическим интерфейсом Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "с классическим графическим интерфейсом."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "           общесистемный файл gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "        пользовательский файл gvimrc: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr " второй пользовательский файл gvimrc: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr " третий пользовательский файл gvimrc: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "             общесистемный файл меню: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Компилятор: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "меню Справка->Сироты             для получения информации     "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Безрежимная работа, вставка введённого текста"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr ""
+#~ "меню Правка->Глобальные настройки->Режим Вставки                     "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                                 для двух режимов               "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr ""
+#~ "меню Правка->Глобальные настройки->Совместимость с Vi                "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                                 для перехода в режим Vim       "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ПРЕДУПРЕЖДЕНИЕ: обнаружена Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "наберите :help windows95<Enter>  для получения информации     "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Невозможно загрузить библиотеку %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Извините, данная команда отключена: невозможно загрузить библиотеку Perl"
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Не допускается вычисление Perl в песочнице без модуля безопасности"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Редактировать в &разных Vim-ах"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Редактировать в &одном Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Сравнить с помощью Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Ре&дактировать с помощью Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Редактировать в запущенном Vim — "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Редактировать выделенные файлы с помощью Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Ошибка создания процесса: проверьте доступность gvim в пути!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "ошибка gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Слишком длинный путь!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Неизвестный шрифтовой набор: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Неизвестный шрифт: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Шрифт \"%s\" не является моноширинным"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Не удалось загрузить функцию %s из библиотеки"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Иврит выключен при компиляции\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Фарси выключено при компиляции\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Арабский выключен при компиляции\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Сервер \"%s\" не зарегистрирован"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Невозможно открыть дисплей"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Получено недопустимое выражение"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Невозможно изменить охраняемую область"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans не допускает изменений в файлах только для чтения"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Требуется ключ шифрования для \"%s\""
+
+#~ msgid "empty keys are not allowed"
+#~ msgstr "Пустые ключи не допустимы"
+
+#~ msgid "dictionary is locked"
+#~ msgstr "Словарь заблокирован"
+
+#~ msgid "list is locked"
+#~ msgstr "Список заблокирован"
+
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "Невозможно добавить ключ '%s' к словарю"
+
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "Индекс должен быть целым числом или выборкой, а не %s"
+
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "Ожидался экземпляр str() или unicode(), но получен %s"
+
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "Ожидался экземпляр bytes() или str(), но получен %s"
+
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "Ожидалось int(), long() или что-то приводимое к long(), но получено %s"
+
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr "Ожидалось int() или что-то приводимое к int(), но получено %s"
+
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "Значение слишком велико для целочисленного типа C"
+
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "Значение слишком мало для целочисленного типа C"
+
+#~ msgid "number must be greater then zero"
+#~ msgstr "Номер должен быть больше нуля"
+
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "Номер должен быть больше или равен нулю"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "Невозможно удалить атрибуты OutputObject"
+
+#~ msgid "invalid attribute: %s"
+#~ msgstr "Неправильный атрибут: %s"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Ошибка инициализации объектов I/O"
+
+#~ msgid "failed to change directory"
+#~ msgstr "Невозможно сменить каталог"
+
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "Ожидался 3-кортеж как результат imp.find_module(), но получен %s"
+
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr ""
+#~ "Ожидался 3-кортеж как результат imp.find_module(), но получен кортеж с "
+#~ "размером %d"
+
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "Внутренняя ошибка: imp.find_module возвратил "
+
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "Невозможно удалить атрибуты vim.Dictionary"
+
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "Невозможно изменить фиксированный словарь"
+
+#~ msgid "cannot set attribute %s"
+#~ msgstr "Невозможно установить атрибут %s"
+
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "Хэш-таблица изменилась при итерации"
+
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "Ожидался элемент-последовательность размера 2, а размер полученной "
+#~ "последовательности %d"
+
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "Конструктор списка не допускает ключевые слова как аргументы"
+
+#~ msgid "list index out of range"
+#~ msgstr "Индекс списка за пределами диапазона"
+
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "Внутренняя ошибка: не удалось получить элемент VIM-списка %d"
+
+#~ msgid "failed to add item to list"
+#~ msgstr "Невозможно добавить элемент в список"
+
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "Внутренняя ошибка: нет элемента VIM-списка %d"
+
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "Внутренняя ошибка: не удалось добавить элемент в список"
+
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "Невозможно удалить атрибуты vim.List"
+
+#~ msgid "cannot modify fixed list"
+#~ msgstr "Невозможно изменить фиксированный список"
+
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "Не существует безымянной функции %s"
+
+#~ msgid "function %s does not exist"
+#~ msgstr "Функция %s не существует"
+
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "Конструктор функции не допускает ключевые слова как аргументы"
+
+#~ msgid "failed to run function %s"
+#~ msgstr "Невозможно выполнить функцию %s"
+
+#~ msgid "problem while switching windows"
+#~ msgstr "Проблема при переключении окон"
+
+#~ msgid "unable to unset global option %s"
+#~ msgstr "Невозможно сбросить глобальную опцию %s"
+
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "Невозможно сбросить опцию %s без глобального значения"
+
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "Попытка сослаться на удалённую вкладку"
+
+#~ msgid "no such tab page"
+#~ msgstr "Нет такой вкладки"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "Попытка сослаться на закрытое окно"
+
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "Атрибут только для чтения: буфер"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "Позиция курсора находится вне буфера"
+
+#~ msgid "no such window"
+#~ msgstr "Нет такого окна"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "Попытка сослаться на уничтоженный буфер"
+
+#~ msgid "failed to rename buffer"
+#~ msgstr "Невозможно переименовать буфер"
+
+#~ msgid "mark name must be a single character"
+#~ msgstr "Название отметки должно быть одним символом"
+
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "Ожидался объект vim.Buffer, но получен %s"
+
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "Невозможно переключиться на буфер %d"
+
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "Ожидался объект vim.Window, но получен %s"
+
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "Невозможно найти окно в текущей вкладке"
+
+#~ msgid "did not switch to the specified window"
+#~ msgstr "Невозможно переключиться на указанное окно"
+
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "Ожидался объект vim.TabPage, но получен %s"
+
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "Невозможно переключиться на указанную вкладку"
+
+#~ msgid "failed to run the code"
+#~ msgstr "Невозможно выполнить код"
+
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval не возвратил допустимого объекта Python"
+
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr ""
+#~ "E859: Не удалось преобразовать возвращённый объект Python в значение VIM"
+
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "Невозможно преобразовать %s в словарь VIM"
+
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "Невозможно преобразовать %s в структуру VIM"
+
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "Внутренняя ошибка: передана ссылка на NULL"
+
+#~ msgid "internal error: invalid value type"
+#~ msgstr "Внутренняя ошибка: неправильный тип значения"
+
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Ошибка при установке перехватчика пути: sys.path_hooks не является "
+#~ "списком\n"
+#~ "Следует сделать следующее:\n"
+#~ "— Добавить vim.path_hook  в sys.path_hooks\n"
+#~ "— Добавить vim.VIM_SPECIAL_PATH в sys.path\n"
+
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Ошибка при установке пути: sys.path не является списком\n"
+#~ "Следует добавить vim.VIM_SPECIAL_PATH в sys.path"

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -1858,10 +1858,6 @@ msgstr "строк: %<PRId64>, "
 msgid "1 character"
 msgstr "1 символ"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "символов: %<PRId64>"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/sjiscorr.c
+++ b/src/nvim/po/sjiscorr.c
@@ -1,4 +1,11 @@
-__END_DECLS int main(int argc, char **argv)
+// Simplistic program to correct SJIS inside strings.
+// When a trail byte is a backslash it needs to be doubled.
+// Public domain.
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv)
 {
 	char buffer[BUFSIZ];
 	char *p;

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -7,145 +7,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-30 15:58+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2005-09-30 15:58+0200\n"
 "Last-Translator: Lubomir Host <rajo@platon.sk>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=cp1250\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Vim 7.x\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Chyby za parametrom vo¾by"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nedá sa alokova buffer, konèím..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nedá sa alokova buffer, pouijem inı..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: iadny buffer nebol uvo¾nenı"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: iadny buffer nebol vymazanı"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: iadny buffer nebol vymazanı"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer uvo¾nenı"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d bufferov uvo¾nenıch"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer vymazanı"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d bufferov vymazanıch"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer odstránenı"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d bufferov odstránenıch"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Poslednı buffer sa nedá odstráni"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nebol nájdenı iadny zmenenı buffer"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nenašiel som iadny buffer"
 
+#: ../buffer.c:913
+#, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Buffer %<PRId64> neexistuje"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za poslednı buffer sa nedá preskoèi"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pred prvı buffer sa nedá preskoèi"
 
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+#: ../buffer.c:945
+#, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Zmeny v bufferi %<PRId64> neboli uloené (! pre vynútenie)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Poslednı buffer sa nedá odstráni"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varovanie: preteèenie zoznamu s názvami súborov"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: buffer %<PRId64> nenájdenı"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Vzoru %s vyhovuje viac bufferov"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje iadny buffer"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "riadok %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer takéhoto mena u existuje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmenenı]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Neupravovanı]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Novı súbor]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Chyby pri èítaní]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[iba pre èítanie]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 riadok --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> riadkov --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "riadok %<PRId64> z %<PRId64> --%d%%-- ståpec"
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Bez mena]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "pomocník"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[pomocník]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Náh¾ad]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Všetko"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Koniec"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Zaèiatok"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -153,9 +223,11 @@ msgstr ""
 "\n"
 "# Zoznam bufferov:\n"
 
-msgid "[Error List]"
-msgstr "[Zoznam chıb]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -163,124 +235,205 @@ msgstr ""
 "\n"
 "--- Znaky ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaky pre %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    riadok=%<PRId64>  id=%d  meno=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Chıba dvojbodka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Neprípustnı mód"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: oèakávaná èíslica"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Neprípustné percento"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nemôem porovna viac ako %<PRId64> bufferov"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Nedá sa otvori termcap súbor"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nedajú sa vytvori porovnania"
 
-msgid "Patch file"
-msgstr "Záplatovı súbor"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Nedá sa èíta vıstup porovnania"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nedá sa èíta vıstup porovnania"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktuálny buffer nie je v porovnávacom móde"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: V porovnávacom móde sa nenachádza inı buffer"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: V porovnávacom móde sa nenachádza inı buffer"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Viac ako dva buffery v porovnávacom móde; neviem, ktorı poui"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nedá sa nájs buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffer \"%s\" nie je v porovnávacom móde"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
 # TODO: digraph
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: digraph nesmie obsahova znak Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Mapa kláves nenájdená"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Pouitı príkaz :loadkeymap v súbore, ktorı nie je interpretovanı"
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Doplòovanie k¾úèovıch slov (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X reim (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Doplòovanie celıch riadkov (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Doplòovanie názvov súborov (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Doplòovanie tagov (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Doplòovanie vzoru ciest (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Doplòovanie definícií (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Doplòovanie pod¾a slovníka (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Doplòovanie pod¾a lexikonu (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Doplòovanie príkazového riadka (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Doplòovanie celıch riadkov (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Doplòovanie tagov (^O^N^P)"
 
-msgid " Spelling suggestion (^S^N^P)"
+#: ../edit.c:96
+#, fuzzy
+msgid " Spelling suggestion (s^N^P)"
 msgstr " Doplòovanie celıch riadkov (^S^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Miestne doplòovanie k¾úèovıch slov (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Koniec odstavca"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "vo¾ba 'dictionary' (slovník) je prázdna"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "vo¾ba 'thesaurus' (lexikon) je prázdna"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "preh¾adávam slovník %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (insert) Rolovanie (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (replace) Rolovanie (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Preh¾adávam: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Preh¾adávam tagy."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Pridávam"
 
@@ -288,352 +441,591 @@ msgstr " Pridávam"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- H¾adám..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Vıchodzia podoba"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Slovo z iného riadku"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jediná zhoda"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "zhoda %d z %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "zhoda %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Neoèekávané znaky v :let"
 
+#: ../eval.c:138
+#, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: index v zozname je mimo rozsah: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nedefinovaná premenná: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Chıba ']'"
 
+#: ../eval.c:141
+#, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument %s musí by Zoznam (List)"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument %s musí by Zoznam (List) alebo Slovník (Dictionary)"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Nemono poui prázdny k¾úè pre Slovník (Dictionary)"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: vyaduje sa Zoznam (List)"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Vyaduje sa Slovník (Dictionary)"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Príliš mnoho argumentov pre funkciu %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: k¾úè sa v Slovníku (Dictionary) nenachádza: %s"
 
+#: ../eval.c:150
+#, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkcia %s u existuje. Pouite ! pre jej nahradenie."
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Záznam v Slovníku (Dictionary) u existuje"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Je vyadovanı odkaz na Funkciu (Funcref)"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Nemono pouit [:] so Slovníkom (Dictionary)"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Zlı typ premennej pre %s="
 
+#: ../eval.c:155
+#, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Neznáma funkcia: %s"
 
+#: ../eval.c:156
+#, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Neprípustné meno premennej: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: Zoznam (List) pouitı ako Reazec (String)"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Menej cie¾ov ako poloiek Po¾a (List items)"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Viac cie¾ov ako poloiek Po¾a (List items)"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Dvojitá ; v zozname premennıch"
 
+#: ../eval.c:2078
+#, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Nemono vypísa premenné pre %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Indexova mono iba Zoznam (List) alebo Slovník (Dictionary)"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] musí prís ako posledná"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] vyaduje hodnotu Po¾a (List value)"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Hodnota Po¾a (List value) má viac poloiek ako cie¾"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Hodnota Po¾a (List value) nemá dostatok poloiek"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Chıba \"in\" po :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Chıbajú zátvorky: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Premenná \"%s\" neexistuje"
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: premenná je príliš vnorená na (od)blokovanie"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Po '?' chıba ':'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Porovnáva mono iba Zoznam so Zoznamom (List with List)"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Neplatná operácia pre Zoznamy (Lists)"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
-msgstr "E735: Porovnáva mono iba Slovník so Slovníkom (Dictionary with Dictionary)"
+msgstr ""
+"E735: Porovnáva mono iba Slovník so Slovníkom (Dictionary with Dictionary)"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Neplatná operácia pre Slovník"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
-msgstr "E693: Porovnáva mono iba odkaz na Funkciu s odkazom na Funkciu (Funcref with Funcref)"
+msgstr ""
+"E693: Porovnáva mono iba odkaz na Funkciu s odkazom na Funkciu (Funcref "
+"with Funcref)"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Neplatná operácia pre odkazy na Funkcie (Funcrefs)"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Nemono pouit [:] so Slovníkom (Dictionary)"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Chıba ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Nemono indexova odkaz na Funkciu (Funcref)"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Chıba meno vo¾by: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Neznáma vo¾ba: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Chıbajú úvodzovky: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Chıbajú úvodzovky: %s"
 
+#: ../eval.c:5084
+#, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Chıba èiarka v Zozname: %s"
 
+#: ../eval.c:5091
+#, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Chıba koniec Zoznamu (List) ']': %s"
 
+#: ../eval.c:6475
+#, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Chıba dvojbodka v Slovníku (Dictionary): %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Duplikovanı k¾úè v Slovníku (Dictionary): \"%s\""
 
+#: ../eval.c:6517
+#, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Chıba èiarka v Slovníku (Dictionary): %s"
 
+#: ../eval.c:6524
+#, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Chıba koniec Slovníka (Dictionary) '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: premenná je vnorená príliš hlboko pre zobrazenie"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Príliš mnoho argumentov pre funkciu %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: Príliš mnoho argumentov pre funkciu %s"
+
+#: ../eval.c:7377
+#, fuzzy, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E130: Neznáma funkcia: %s"
+
+#: ../eval.c:7383
+#, fuzzy, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E118: Príliš mnoho argumentov pre funkciu %s"
+
+#: ../eval.c:7387
+#, fuzzy, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E81: Pouitie <SID> mimo kontext skriptu"
+
+#: ../eval.c:7391
+#, fuzzy, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E720: Chıba dvojbodka v Slovníku (Dictionary): %s"
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Po = je vyadované èíslo"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "Chybnı argument pre"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Príliš mnoho argumentov"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: Ponuka existuje iba v inom móde"
+
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
+#, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: K¾úè u existuje: %s"
 
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "vim [argumenty] "
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld riadky: "
 
+#: ../eval.c:9291
+#, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Neznáma funkcia: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zruši"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "funkcia inputrestore() volaná èastejšie ako inputsave()"
 
-msgid "E745: Range not allowed"
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "Príliš mnoho upravovacích argumentov"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
 msgstr "E745: Rozsah nie je povolenı"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Neplatnı typ pre len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Krok je nulovı"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Zaèiatok presahuje koniec"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<prázdny>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Neexistuje pripojenie k Vim serveru"
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nemôem posla na %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nemôem èíta odpoveï servra"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Príliš mnoho symbolickıch odkazov (sluèka?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Nemôem posla klientovi"
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
 
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "Chybnı argument pre"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funkcia na utriedenie/porovnanie zlyhala"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funkcia na utriedenie/porovnanie zlyhala"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Chybnı)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Chyba pri zápise doèasného súboru"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Zoznam (List) pouitı ako èíslo"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Pouitı odkaz na Funkciu (Funcref) ako èíslo"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Zoznam (List) pouitı ako èíslo"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Slovník (Dictionary) pouitı ako èíslo"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Odkaz na Funkciu (Funcref) pouitı ako Reazec (String)"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Zoznam (List) pouitı ako Reazec (String)"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Slovník (Dictionary) pouitı ako Reazec (String)"
 
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Premenná typu odkaz na Funkciu (Funcref) musí zaèína s ve¾kım písmenom: %s"
+#: ../eval.c:16619
+#, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E706: Typ premennej sa nezhoduje: %s"
 
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: Nemono vypísa premenné pre %s"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr ""
+"E704: Premenná typu odkaz na Funkciu (Funcref) musí zaèína s ve¾kım "
+"písmenom: %s"
+
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Meno premennej je v konflikte s existujúcou funkciou: %s"
 
-msgid "E706: Variable type mismatch for: %s"
-msgstr "E706: Typ premennej sa nezhoduje: %s"
-
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Hodnota je uzamknutá: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Neznámy"
 
+#: ../eval.c:16768
+#, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Nemono zmeni hodnotu %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: premenná je vnorená príliš hlboko pre skopírovanie"
 
+#: ../eval.c:17249
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Neznáma funkcia: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Chıba '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Nedajú sa nastavi IC hodnoty"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Neprípustnı argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Neprípustnı argument: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Chıba :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: Meno funkcie sa nezhoduje s menom interpretovaného súboru: %s"
+
+#: ../eval.c:17549
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Nedá sa vymaza funkcia %s: je pouívaná"
+
+#: ../eval.c:17604
+#, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Meno funkcie sa nezhoduje s menom interpretovaného súboru: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Je vyadované meno funkcie"
 
-msgid "E128: Function name must start with a capital or contain a colon: %s"
-msgstr "E128: Názov funkcie musí zaèína ve¾kım písmenom alebo obsahova dvojbodku: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: Názov funkcie musí zaèína ve¾kım písmenom alebo obsahova dvojbodku: "
+"%s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Názov funkcie musí zaèína ve¾kım písmenom alebo obsahova dvojbodku: "
+"%s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nedá sa vymaza funkcia %s: je pouívaná"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zanorenie funkcií je hlbšie ne 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "volám %s"
 
+#: ../eval.c:18651
+#, c-format
 msgid "%s aborted"
 msgstr "%s zrušenı"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s vrátilo #%<PRId64>"
 
+#: ../eval.c:18670
+#, c-format
 msgid "%s returning %s"
 msgstr "%s vrátilo %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "pokraèujem v %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return mimo funkciu"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -641,6 +1033,7 @@ msgstr ""
 "\n"
 "# globálne premenné:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -648,73 +1041,106 @@ msgstr ""
 "\n"
 "\tPosledné nastavenie z "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "iadne vloené súbory"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  šestnástkovo %02x,  osmièkovo %03o"
 
+#: ../ex_cmds.c:145
+#, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d,  šestnástkovo %04x,  osmièkovo %o"
 
+#: ../ex_cmds.c:146
+#, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d,  šestnástkovo %08x,  osmièkovo %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Prekrytie riadkov sebou samımi"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 riadok presunutı"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> riadkov presunutıch"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> riadkov filtrovanıch"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické príkazy *Filter* nesmú meni aktuálny buffer"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Neuloené zmeny]\n"
 
+#: ../ex_cmds.c:1424
+#, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s na riadku: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: príliš mnoho chıb, preskakujem zbytok súboru"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Èítam viminfo súbor \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informácie"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " znaèky"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "iadne vloené súbory"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " ZLYHALO"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Do viminfo súboru %s sa nedá zapisova"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nedá sa uloi viminfo súbor %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Ukládám viminfo súboru \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tento viminfo súbor bol vytvorenı editorom Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -722,39 +1148,48 @@ msgstr ""
 "# Pokia¾ budete opatrnı, môete ho upravova.\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Hodnota 'encoding' (kódovania) poèas zápisu tohoto súboru\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Neprípustnı zaèiatoènı znak"
 
-msgid "Save As"
-msgstr "Uloi ako"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Uloi neúplnı súbor?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Pouite ! pre uloenie neúplného bufferu"
 
+#: ../ex_cmds.c:2281
+#, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Prepísa existujúci súbor \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Odkladací súbor \"%s\" existuje, aj tak prepísa?"
 
+#: ../ex_cmds.c:2326
+#, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Odkladací súbor existuje: %s (pouite :silent! pre prepísanie)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: iadny názov súboru pre buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Súbor nebol uloenı: ukladanie je zakázané vo¾bou 'write'"
 
+#: ../ex_cmds.c:2434
+#, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
@@ -762,60 +1197,91 @@ msgstr ""
 "Pre \"%s\" je nastavená vo¾ba 'readonly' (iba na èítanie).\n"
 "Prajete si aj tak uloi?"
 
-msgid "Edit File"
-msgstr "Upravova súbor"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "je iba pre èítanie (pouite ! pre vynútenie)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Automatické príkazy neoèakávane zmazali novı buffer %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselnı argument pre :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim nepovo¾uje pouitie príkazov shellu"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulárne vırazy nesmú by oddelené písmenami"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "nahradi %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(prerušenı) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 zhoda"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 nahradenie"
 
+#: ../ex_cmds.c:4387
+#, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> zhôd"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> nahradení"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " na 1 riadku"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " na %<PRId64> riadkov"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global sa nedá vola rekurzívne"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Pri príkaze global chıba regulárny vıraz"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Vzor nájdenı na kadom riadku: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Vzor nenájdenı"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -825,244 +1291,340 @@ msgstr ""
 "# Poslednı zamieòanı reazec:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: iadnu paniku!"
 
+#: ../ex_cmds.c:4717
+#, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: ¼utujem, iadny '%s' pomocník pre %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: ¼utujem, pre %s nie je iadny pomocník"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "¼utujem, súbor \"%s\" s pomocníkom nebol nájdenı"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s nie je adresárom"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: %s sa nedá sa otvori pre zápis"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: %s as nedá otvori pre èítanie"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Rôzne kódovania pre súbory s pomocníkom pre jazyk: %s"
 
+#: ../ex_cmds.c:5565
+#, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplicitnı tag \"%s\" v súbore %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Neznámu príkaz pre znaèky: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Chıba meno pre znaèku"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Príliš mnoho definovanıch znaèiek"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Chybnı text znaèky: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Neznáma znaèka: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Chıba èislo znaèky"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Chybné meno bufferu: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Chybné ID znaèky: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NENÁJDENÉ)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (nepodporované)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[vymazanı]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Spúšam reim ladenia. Pre ukonèenie napíšte \"cont\"."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "riadok %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "príkaz: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Bod prerušenia v \"%s%s\" na riadku %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Bod prerušenia nenájdenı: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Neboli definovné iadne body prerušenia"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  riadok %<PRId64>"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Najprv pouite príkaz :profile start <meno_suboru>"
 
+#: ../ex_cmds2.c:1269
+#, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Uloi zmeny do \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Bez mena"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Buffer \"%s\" obsahuje neuloené zmeny"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Varovanie: Neèakanı vstup do iného bufferu (skontrolujte automatické príkazy)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Pre úpravu bol zadanı iba jeden súbor"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Nedá sa preskoèi pred prvı súbor"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Nedá sa preskoèi za poslednı súbor"
 
+#: ../ex_cmds2.c:2175
+#, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: prekladaè nie je podporovanı: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "H¾adám \"%s\" v \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "H¾adám \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "súbor \"%s\" nebol nájdenı v 'runtimepath'"
 
-msgid "Source Vim script"
-msgstr "Zdrojovı skript Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Nemono interpretova adresár: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "nedá sa interpretova \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "riadok %<PRId64>: nemôno interpretova \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretujem \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "riadok %<PRId64>: interpretujem \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "dokonèená interpretácia %s"
 
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "1 novı riadok"
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr "vim [argumenty] "
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr "vim [argumenty] "
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+#, fuzzy
+msgid "error handler"
+msgstr "Chyba a prerušené"
+
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Varovanie: chybnı odde¾ovaè riadkov. Mono chıba ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: príkaz :scriptencoding pouitı mimo interpretovanı súbor"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: príkaz :finish pouitı mimo interpretovanı súbor"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Aktuálny %sjazyk: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Nedá sa nastavi jazyk na \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Spúšam Ex reim. Napíšte \"visual\" pre návrat do Normálneho reimu."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Koniec súboru"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Príkaz je príliš rekurzívny"
 
+#: ../ex_docmd.c:1006
+#, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Vınimka nezachytená: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Koniec interpretovaného súboru"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Koniec funkcie"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Nejednoznaèné pouitie pouívate¾om definovaného príkazu"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Nie je príkazom editoru"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Zadanı spätnı rozsah"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Zadanı spätnı rozsah. OK pre zámenu"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Pouite w alebo w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: ¼utujem, ale tento príkaz nie je dostupnı v tejto verzii"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Prípustnı je iba jeden názov súboru"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Ešte zostáva 1 súbor k úprave. Chcete napriek tomu ukonèi editor?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Ešte zostáva %d súborov k úprave. Chcete napriek tomu ukonèi editor?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Ešte zostáva 1 súbor k úprave."
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Ešte zostáva %<PRId64> súborov k úprave."
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Príkaz u existuje: pouite ! pre predefinovanie"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1070,258 +1632,347 @@ msgstr ""
 "\n"
 "    Meno       Args Rozsah Úplnos  Definícia"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Neboli nájdené iadne pouivate¾om definované príkazy"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Neboli zadané iadne vlastnosti"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Chybnı poèet argumentov"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Poèet nemôe by zadanı dvakrát"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Chybná implicitná hodnota pre poèet"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: pre doplnenie (-complete) je potrebnı argument"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Chybná vlastnos: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Chybné meno príkazu"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Pouívate¾om definované príkazy musia zaèína ve¾kım písmenom"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Nejednoznaèné pouitie pouívate¾om definovaného príkazu"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Pouívate¾om definovanı príkaz %s neexistuje"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Chybná hodnota doplnenia: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: Argument doplnenia je povolenı iba pre vlastné dopåòania (completion)"
+msgstr ""
+"E468: Argument doplnenia je povolenı iba pre vlastné dopåòania (completion)"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Vlastné doplnenia vyadujú meno funkcie ako argument"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Schéma farieb %s nenájdená"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Pozdravujem, uívate¾ Vimu!"
 
-msgid "Edit File in new window"
-msgstr "Upravi súbor v novom okne"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Posledné okno sa nedá zatvori"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "Existuje u iba jedno okno"
+
+#: ../ex_docmd.c:6004
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "Strana %d"
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "iadny odkladací súbor"
 
-msgid "Append File"
-msgstr "Pripoji súbor"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
-msgstr "E747: Nemono zmeni adresár, buffer je modifikovanı (pouite ! pre vynútenie)"
+msgstr ""
+"E747: Nemono zmeni adresár, buffer je modifikovanı (pouite ! pre "
+"vynútenie)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: iadny predchádzajúci adresár"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Neznámy"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize (ve¾kos okna) vyaduje dva argumenty"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Pozícia okna: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Na tejto platforme sa nedá zisti umiestnenie okna"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos (pozícia okna) vyaduje dva argumenty"
 
-msgid "Save Redirection"
-msgstr "Uloi presmerovanie"
-
-msgid "Save View"
-msgstr "Uloi poh¾ad"
-
-msgid "Save Session"
-msgstr "Uloi sedenie"
-
-msgid "Save Setup"
-msgstr "Uloi nastavenie"
-
+#: ../ex_docmd.c:7241
+#, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Nemono vytvori adresár: %s"
 
+#: ../ex_docmd.c:7268
+#, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existuje (pouite ! pre vynútenie)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" sa nedá otvori pre zápis"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumentem môe by iba písmeno alebo pravı èi ¾avı apostrof"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekurzívne pouitie príkazu :normal príliš hlboké"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr ""
 "E194: iadny alternatívny názov súboru, ktorım by bolo moné nahradi '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: iadny názov súboru, ktorım by bolo moné nahradi \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: iadne èíslo bufferu, ktorım by bolo moné nahradi \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
-"E497: iadna zhoda automatickıch príkazov, ktorou by bolo moné nahradi \"<amatch>"
-"\""
+"E497: iadna zhoda automatickıch príkazov, ktorou by bolo moné nahradi "
+"\"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: iadny :source súbor, ktorım by bolo moné nahradi \"<sfile>\""
 
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: iadny :source súbor, ktorım by bolo moné nahradi \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Prázdnı názov súboru pre '%' alebo '#', funguje iba s \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Vısledkom vyhodnotenia je prázdny reazec"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Súbor viminfo sa nedá sa otvori na èítanie"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: V tejto verzi nie sú digraphy podporované"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Nemono spracova vınimku :throw s preponou 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Spracovanie vınimky: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Vınimka ukonèená: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Vınimka zahodená: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
+#, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, riadok %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
+#, c-format
 msgid "Exception caught: %s"
 msgstr "Zachytená vınimka: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s prebieha"
 
+#: ../ex_eval.c:679
+#, c-format
 msgid "%s resumed"
 msgstr "%s vrátené"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s zahodené"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Vınimka"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Chyba a prerušené"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Chyba"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Prerušené"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: vnorenie :if je príliš hlboké"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif bez zodpovedajúceho :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else bez zodpovedajúceho :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif bez zodpovedajúceho :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: viacnásobné :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif nasleduje po :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: vnorenie :while/:for je príliš hlboké"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue bez zodpovedajúceho :while alebo :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break bez zodpovedajúceho :while alebo :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Pouité :endfor spolu s :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Pouité :endwhile spolu s :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: vnorenie :try je príliš hlboké"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch bez :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch nasleduje po :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally bez :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: viacnásobné pouité :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry bez :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction mimo funkciu"
 
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: Nie je dovolené v bezpeènostnej schránke"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: Vzoru %s nevyhovuje iadny buffer"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "meno tagu"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " typ súboru\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'vo¾ba 'history' je nastavená na nulu"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1330,200 +1981,308 @@ msgstr ""
 "\n"
 "# História %s (zaèínajúci najnovšou polokou):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Príkazovı riadok"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Vyh¾adávanı reazec"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Vıraz"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Vstupnı riadok"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar prevyšuje dåku príkazu"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktívne okno alebo buffer bol vymazanı"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Chybná cesta: '**[èíslo] musí by buï na konci cesty, alebo musí by\n"
+"nasledované '%s. Viï :help path."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Adresár \"%s\" sa nedá nájs v cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Súbor \"%s\" sa nepodarilo nájs"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: iadny ïalší adresár \"%s\" nebol v cdpath nájdenı"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: iadny ïalší súbor \"%s\" nebol v ceste nájdenı"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: Automatické príkazy *Filter* nesmú meni aktuálny buffer"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Neprípustnı názov súboru"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "je adresárom"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "nie je súborom"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[novı súbor]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[prístup odmietnutı]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: automatické príkazy *ReadPre urobili súbor neèitate¾nım"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: automatické príkazy *ReadPre nesmú meni aktuálny buffer"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: èítam zo štandardného vstupu...\n"
 
-msgid "Reading from stdin..."
-msgstr "Èítam zo štandardného vstupu..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Po konverzii je súbor neèitate¾nı!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[pomenovaná rúra/soket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[pomenovaná rúra]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[soket]"
 
-msgid "[RO]"
-msgstr "[RO]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 znak"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[chıba CR]"
 
-msgid "[NL found]"
-msgstr "[nájdené NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[dlhé riadky zalomené]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[neskonvertovanı]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[skonvertovanı]"
 
-msgid "[crypted]"
-msgstr "[šifrovanı]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[NEPRÍPUSTNİ BAJT na riadku %<PRId64>]"
 
-msgid "[CONVERSION ERROR]"
-msgstr "[CHYBA PREVODU]"
-
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[NEPRÍPUSTNİ BAJT na riadku %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[CHYBY ÈÍTANIA]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nedá sa nájs doèasnı súbor pre konverziu"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konverzia s 'charconvert' sa nepodarila"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nedá sa èíta vıstup 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: iadne vyhovujúce automatické príkazy pre acwrite buffer "
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Automatické príkazy zmazali èi deaktivovali buffer, ktorı mal by "
 "uloenı"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Automatickı príkaz neoèakávanım spôsobom zmenil poèet riadkov"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans rozhranie nedovolilo zapísa nemodifikované buffre"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Èiastoèné zápisy nie sú povolené pre NetBeans buffre"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "nie je súborom ani zapisovatelnım zariadením"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "je iba pre èítanie (pouite ! pre vynútenie)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Nedá sa zapisova do záloného súboru (pouite ! pre vynútenie)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Chyba pri uzatváraní záloného súboru (pouite ! pre vynútenie)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Nedá sa naèíta súbor pre zálohu (pouite ! pre vynútenie)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Nedá sa vytvori zálonı súbor (pouite ! pre vynútenie)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Nedá sa vytvori zálonı súbor (pouite ! pre vynútenie)"
 
-# TODO: resource fork ?! Note: used only in MACOS_X version
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: 'Resource fork' bude stratenı (pouite ! pre vynútenie)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nedá sa nájs doèasnı súbor pre ukladanie"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nedá sa spravi konverzia (pouite ! pre zápis bez konverzie)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Súbor sa nedá otvori pre ukladanie"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Súbor sa nedá otvori pre ukladanie"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync zlyhal"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Zatvorenie zlyhalo"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: chyba pri zápise, konverzia sa nepodarila (nastavte vo¾bu 'fenc' na prázdnu pre vynútenie)"
+msgstr ""
+"E513: chyba pri zápise, konverzia sa nepodarila (nastavte vo¾bu 'fenc' na "
+"prázdnu pre vynútenie)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: chyba pri zápise, konverzia sa nepodarila (nastavte vo¾bu 'fenc' na "
+"prázdnu pre vynútenie)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: chyba pri ukladaní (plnı disk?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " CHYBA PREVODU"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "riadok %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[zariadenie]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[novı]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [p]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " pripojenı"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [u]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " uloenı"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: nedá sa uloi pôvodnı súbor"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nedá sa zapisova do prázdneho pôvodného súboru"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nedá sa vymaza zálonı súbor"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1531,74 +2290,96 @@ msgstr ""
 "\n"
 "VAROVANIE: Obsah pôvodného súboru môe by stratenı alebo poškodenı\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "neukonèujte editor skôr, ne bude súbor úspešne uloenı!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos formát]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac formát]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix formát]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 riadok, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> riadkov, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znakov"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[bez znaku konca riadku]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[neúplnı poslednı riadok]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "VAROVANIE: Súbor bol zmenenı od jeho naèítania!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Chcete ho naozaj uloi"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Chyba pri zápise do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Chyba pri uzatváraní \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Chyba pri èítaní \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: automatickı príkaz FileChangedShell vymazal buffer"
 
+#: ../fileio.c:4894
+#, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Varovanie: súbor \"%s\" u nie je dostupnı"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1607,31 +2388,39 @@ msgstr ""
 "W12: Varovanie: súbor \"%s\" bol po zaèatí úpravy zmenenı a buffer sa tie "
 "zmenil "
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Pozrite \":help W12\" pre viac informácií."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Varovanie: súbor \"%s\" bol po zaèatí úpravy zmenenı"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Pozrite \":help W11\" pre viac informácií."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Varovanie: Prístupové práva k súboru \"%s\" boli po zaèatí úprav zmenené"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Pozrite \":help W16\" pre viac informácií."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Varovanie: Súbor \"%s\" bol vytvorenı po zaèatí úpravy"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Varovanie"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1639,37 +2428,48 @@ msgstr ""
 "&OK\n"
 "&Naèíta súbor"
 
+#: ../fileio.c:5065
+#, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Nemono pripravi na opätovné naèítanie \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: nedá sa obnovi \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Vymazanı--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "samomazací automatickı príkaz: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Skupina \"%s\" neexistuje"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Neprípustnı znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Udalos %s neexistuje"
 
+#: ../fileio.c:5907
+#, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Udalos alebo skupina %s neexistuje"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1677,541 +2477,808 @@ msgstr ""
 "\n"
 "--- Automatické príkazy ---"
 
+#: ../fileio.c:6293
+#, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: chybné èíslo bufferu"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Automatické príkazy sa nedajú spusti pre VŠETKY udalosti"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "iadne vyhovujúce automatické príkazy"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: vnorenia automatického príkazu sú príliš hlboké"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Automatické príkazy pre \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Spúšam %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "automatickı príkaz %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Chıba {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Chıba }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Nebol nájdené iadne vnorenie"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Nedá sa vytvori vnorenie s aktuálnou metódou 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Nedá sa zruši vnorenie s aktuálnou metódou 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld riadkov zahnutıch "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Prida do bufferu pre èítanie"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekurzívne mapovanie"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: pre %s u globálna skratka existuje"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: pre %s u globálne mapovanie existuje"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: pre %s u skratka existuje"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: pre %s u mapovanie existuje"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "iadna skratka nebola nájdená"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "iadne mapovanie nebolo nájdené"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: neprípustnı mód"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nedá sa spusti GUI (grafické rozhranie)"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Buffer neobsahuje iadne riadky--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nedá sa èíta z \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Príkaz prerušenı"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Nemono naštartova grafické rozhranie, nenájdenı iaden pouitelnı font"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Je vyadovanı argument"
 
-msgid "E231: 'guifontwide' invalid"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ by malo nasledova /, ? alebo &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E231: vo¾ba 'guifontwide' (nastavenie širokého písma) je chybne nastavená"
+"E11: Chybnı príkaz v okne príkazového riadku; <Enter> spúša, CTRL-C ukonèuje"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Hodnota 'imactivatekey' je nesprávne nastavená"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Nedá sa alokova farba %s"
-
-msgid "No match at cursor, finding next"
-msgstr "iadna zhoda na pozícii kurzora, h¾adám ïalej"
-
-msgid "<cannot open> "
-msgstr "<nedá sa otvori> "
-
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: písmo %s nie je dostupné"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: nedá sa vráti do aktuálneho adresára"
-
-msgid "Pathname:"
-msgstr "Názov cesty:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: nedá sa zisti aktuálny adresár"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Zruši"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Prípravok posuvnej lišty: nedá sa zisti geometria náh¾adu obrázku."
-
-msgid "Vim dialog"
-msgstr "Vim dialóg"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: BalloonEval nedá sa vytvori správou a zároveò spätnım volaním"
-
-msgid "Vim dialog..."
-msgstr "Vim dialóg.."
-
-# TODO: Translate as "&Ano\n&Nie\n&Zruši" ?
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Ano\n"
-"&Nie\n"
-"&Zruši"
+"E12: Príkaz nie je z exrc/vimrc v aktuálnom adresári alebo pri h¾adaní tagu "
+"povolenı."
 
-msgid "Input _Methods"
-msgstr "Vstupné metódy (_Methods)"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Chıba :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Nájs a nahradi..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Chıba :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Nájs..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Chıba :endwhile"
 
-msgid "Find what:"
-msgstr "Vyh¾ada:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Chıba :endfor"
 
-msgid "Replace with:"
-msgstr "Nahradi s:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile bez zodpovedajúceho :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "H¾ada len celé slová"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor bez zodpovedajúceho :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Zhoda ve¾kosti písmen"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Súbor existuje (pouite ! pre prepísanie)"
 
-msgid "Direction"
-msgstr "Smer"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Príkaz zlyhal"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Hore"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Vnútorná chyba"
 
-msgid "Down"
-msgstr "Dolu"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Prerušené"
 
-msgid "Find Next"
-msgstr "Nájs ïalšie"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Chybná adresa"
 
-msgid "Replace"
-msgstr "Nahradi"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Chybnı argument"
 
-msgid "Replace All"
-msgstr "Nahradi Všetko"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Prijatá poiadavka na ukonèenie (die) od manaéra sedení\n"
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Hlavné okno neoèakávane zrušené\n"
-
-msgid "Font Selection"
-msgstr "Vıber Písma"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Pouitı CUT_BUFFER0 namiesto prázdneho vıberu"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Zruši"
-
-msgid "Directories"
-msgstr "Adresáre"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Pomocník"
-
-msgid "Files"
-msgstr "Súbory"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Vıber"
-
-msgid "Find &Next"
-msgstr "Nájs ïa&lšie"
-
-msgid "&Replace"
-msgstr "&Nahradi"
-
-msgid "Replace &All"
-msgstr "Nahradi &Všetko"
-
-msgid "&Undo"
-msgstr "&Spä"
-
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Nemono nájs okno s titulkom \"%s\""
-
+#: ../globals.h:1015
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nie je podporovanı: \"-%s\"; Pouite OLE verziu."
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Chybnı argument: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Nemono otvori okno vnútri MDI aplikácie"
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Chybnı vıraz: %s"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Nájs reazec (pouite '\\\\' ak chete nájs '\\')"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Chybnı rozsah"
 
-# Following warning can be ignored:
-# msgfmt -v --statistics --check -C --check-accelerators="&" -o sk.mo sk.po
-# sk.po:2497: msgstr lacks the keyboard accelerator mark '&'
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Nájs a Nahradi (pouite '\\\\' ak chcete nájs '\\')"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Chybnı príkaz"
 
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "[neupravovanı]"
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" je adresárom"
 
-msgid "Directory\t*.nothing\n"
-msgstr "Adresár\t*.niè\n"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Chybná hodnota ve¾kosti rolovania"
 
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Nedá sa alokova poloka mapy farieb, niektoré farby môu by "
-"nesprávne"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Chıba písmo pre nasledujúce znakové sady %s:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Názov sady písiem: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Písmo '%s' nemá pevnou šírku"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Názov sady písiem: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Písmo0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Písmo1: %s\n"
-
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Písmo%<PRId64> nie je dvakrát širšie ako písmo0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Šírka písma0: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Šírka písma1: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Chybná špecifikácia písma"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Vyvolanie kniniènej funkcia zlyhalo pre \"%s()\""
 
-msgid "&Dismiss"
-msgstr "&Zruši"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Znaèka má chybné èíslo riadku"
 
-msgid "no specific match"
-msgstr "iadna špecifická zhoda"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Znaèka nie je nastavená"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Vıber písma"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nemono robi zmeny, vo¾ba 'modifiable' je vypnutá"
 
-msgid "Name:"
-msgstr "Meno:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skripty vnorené príliš hlboko"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Ukazuj ve¾kos v bodoch"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: iadny alternatívny súbor"
 
-msgid "Encoding:"
-msgstr "Kódujem:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Taká skratka neexistuje"
 
-msgid "Font:"
-msgstr "Písmo:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! nie je povolenı"
 
-msgid "Style:"
-msgstr "Štıl"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Nedá sa pouí GUI: nebolo zapnuté pri preklade programu"
 
-msgid "Size:"
-msgstr "Ve¾kos:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Skupina zvıraznenia %s neexistuje"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul ERROR - chyba kórejského spôsobu vkladania znakov"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Zatia¾ nie je vloenı iaden text"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: iadny predchádzajúci príkazovı riadok"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Mapovanie nenájdené"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: iadna zhoda"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: iadna zhoda: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: iadny názov súboru"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: iadny predchádzajúci prislúchajúci správny vıraz"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: iadny predchádzajúci príkaz"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: iadny predchádzajúci regulárny vıraz"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Rozsah nie je povolenı"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Nedostatok miesta"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Nedá sa vytvori súbor %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Nedá sa získa názov doèasného súboru"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Nedá sa otvori súbor %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Nedá sa èíta súbor %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Neuloené zmeny (pouite ! pre vynútenie)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Neuloené zmeny]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nulovı argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oèakávané èíslo"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nedá sa otvori chybovı súbor %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Nedostatok pamäti!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Vzor nenájdenı"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Vzor nenájdenı: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument musí by kladnı"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: iadny predchádzajúci adresár"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: iadne chyby"
+
+#: ../globals.h:1067
+#, fuzzy
+msgid "E776: No location list"
+msgstr "E760: Chıajúci poèet slov v %s"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Poškodenı reazac pre vyh¾adávanie"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Poškodenı regexp program"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr ""
+"E45: vo¾ba 'readonly' (iba na èítanie) je nastavená (pouite ! pre "
+"prepísanie)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nedá sa nastavi premenná len na èítanie \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Nedá sa nastavi premenná v bezpeènostnej schránke: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Chyba pri èítaní chybového súboru"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Nie je dovolené v bezpeènostnej schránke"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Nie je na povolené na tomto mieste"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Nastavovanie reimu obrazovky nie je podporované"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Chybná hodnota ve¾kosti rolovania"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: vo¾ba 'shell' je prázdna"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Chyba -- nedájú sa preèíta oznaèovacie dáta!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Chyba pri uzatváraní odkladacieho súboru"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: zoznam tagov je prázdny"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Príkaz je príliš zloitı"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Názov je príliš dlhı"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Príliš mnoho ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Príliš mnoho názvov súborov"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Nadbytoèné znaky na konci"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Neznáma znaèka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nemono expandova olíkové znaky (wildcards)"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+"E591: hodnota vo¾by 'winheight' (vıška okna) nesmie by menšia ne hodnota "
+"vo¾by 'winminheight' (minimálna vıška okna)"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+"E592: hodnota vo¾by 'winwidth' (šírka okna) nesmie by menšia ne hodnota "
+"vol¾y 'winminwidth' (minimálna šírka okna)"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Chyba pri ukladaní"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nulovı poèet"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Pouitie <SID> mimo kontext skriptu"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Vnútorná chyba: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: vzor pouíva viac pamäte ako 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: prázdny buffer"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Neprípustnı h¾adanı reazec alebo odde¾ovaè"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Súbor je naèítanı v inom buffere"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Vo¾ba \"%s\" nie je nastavená"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: '%s' nie je prístupné meno registru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "h¾adanie dosiahlo zaèiatok, pokraèovanie od konca"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "h¾adanie dosiahlo koniec, pokraèovanie od zaèiatku"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Chıba dvojbodka"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Neprípustnı komponent"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: oèakávaná èíslica"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Strana %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "iadny text na tlaè"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Tlaèím stranu %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kópia %d z %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Vytlaèené: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Tlaè bola zrušená"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Nedá sa zapisova do vıstupného PostScriptového súboru"
 
+#: ../hardcopy.c:1747
+#, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Nedá sa otvori súbor \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Nedá sa èíta PostScriptovı súbor \"%s\""
 
+#: ../hardcopy.c:1772
+#, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: súbor \"%s\" nie je vo formáte PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: súbor \"%s\" nie je podporvanı PostScriptovı súbor"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" zdrojovı súbor má zlé èíslo verzie"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: nekompatibilné viacbajtové kódovanie a znaková sada."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
-msgstr "E674: vo¾ba printmbcharset nemôe by prázdna pri viacbajtovom kódovaní."
+msgstr ""
+"E674: vo¾ba printmbcharset nemôe by prázdna pri viacbajtovom kódovaní."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Nie je špecifikované iadne písmo pre viacbajtové tlaèenie."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Nedá sa otvori vıstupnı PostScriptovı súbor"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Nedá sa otvori súbor \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Nemono nájs PostScriptovı zdrojovı súbor \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Nemono nájs PostScriptovı zdrojovı súbor \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Nemono nájs PostScriptovı zdrojovı súbor \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Nemono skonvertova do kódovania na tlaèenie \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Posielam na tlaèiareò..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScriptovı súbor sa nepodarilo vytlaèi"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Tlaèová úloha bola odoslaná."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Prida novú databázu"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "H¾adanie vzoru"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Zobrazi túto správu"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Ukonèi spojenie"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Znovu inicializova všetky spojenia"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Zobrazi spojenia"
 
+#: ../if_cscope.c:101
+#, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Pouitie: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Tento cscope príkaz nepodporuje rozde¾ovanie okna.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Pouitie: cstag <odsadenie>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tag nenájdenı"
 
+#: ../if_cscope.c:461
+#, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) chyba: %d"
 
-msgid "E563: stat error"
-msgstr "E563: chyba stat"
-
+#: ../if_cscope.c:551
+#, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s nie je ani adresárom ani správnou cscope databázou"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Pridaná cscope databáza %s"
 
+#: ../if_cscope.c:616
+#, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: chyba pri èítaní cscope spojenia %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: neznámy typ cscope h¾adania"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Nedajú sa vytvori cscope rúry"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Nemono spusti proces pre cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "spustenie cs_create_connection zlyhalo"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "spustenie cs_create_connection zlyhalo"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Nedajú sa vytvori cscope rúry"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: volanie fdopen pre to_fp zlyhalo"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: volanie fdopen pre fr_fp zlyhalo"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Nedajú sa vytvori cscope rúry"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: iadne cscope spojenia"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: cscope h¾adanie %s vo vzore %s nenašlo iadnu zhodu"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: chybnı cscopequickfix príznak %c pre %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: cscope h¾adanie %s vo vzore %s nenašlo iadnu zhodu"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "príkazy cscope:\n"
 
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Pouitie: %s)"
 
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: nemono otvori cscope databázu: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: nemono získa cscope databázové informácie"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: duplicitná cscope databáza nebola pridaná"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: dosiahnutı maximálny poèet cscope spojení"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope spojenie %s nenájdené"
 
+#: ../if_cscope.c:1364
+#, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope spojenie %s ukonèené"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: vána chyba v cs_manage_matches"
 
+#: ../if_cscope.c:1693
+#, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2219,372 +3286,88 @@ msgstr ""
 "\n"
 "   #   riadok"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "názov súboru/ kontext / riadok\n"
 
+#: ../if_cscope.c:1809
+#, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Chyba cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Všetky cscope databáze resetované"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "iadne cscope spojenia\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    názov databázy                      predpona cesty\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr "???: Prepáète, tento príkaz je vypnutı, MzScheme kninica nemôe by naèítaná."
-
-msgid "invalid expression"
-msgstr "chybnı vıraz"
-
-msgid "expressions disabled at compile time"
-msgstr "podpora vırazov bola vypnutá pri preklade programu"
-
-msgid "hidden option"
-msgstr "skrytá vo¾ba"
-
-msgid "unknown option"
-msgstr "neznáma vo¾ba"
-
-msgid "window index is out of range"
-msgstr "èíslo okna mimo rozsah"
-
-msgid "couldn't open buffer"
-msgstr "nemono otvori buffer"
-
-msgid "cannot save undo information"
-msgstr "nedajú sa uloi zálone (opravné) informácie"
-
-msgid "cannot delete line"
-msgstr "nedá sa vymaza riadok"
-
-msgid "cannot replace line"
-msgstr "nedá sa nahradi riadok"
-
-msgid "cannot insert line"
-msgstr "nedá sa vloi riadok"
-
-msgid "string cannot contain newlines"
-msgstr "reazec nesmie obsahova znaky nového riadku"
-
-msgid "Vim error: ~a"
-msgstr "Chyba Vim: ~a"
-
-msgid "Vim error"
-msgstr "Chyba Vim"
-
-msgid "buffer is invalid"
-msgstr "buffer je neplatnı"
-
-msgid "window is invalid"
-msgstr "okno je neplatné"
-
-msgid "linenr out of range"
-msgstr "èíslo riadka mimo rozsah"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "nie je dovolené v bezpeènostnej schránke"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E262: Prepáète, tento príkaz je vypnutı, Python kninica nemôe by naèítaná."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python nemôe by spustenı rekurzívne"
-
-msgid "can't delete OutputObject attributes"
-msgstr "nedá sa vymaza vlastnos OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "softspace musí by kladné celé èíslo"
-
-msgid "invalid attribute"
-msgstr "chybná vlastnos"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() vyaduje zoznam reazcov"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Chyba pri inicializácii I/O objektov"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "pokus o odkaz na vymazanı buffer"
-
-msgid "line number out of range"
-msgstr "èíslo riadka mimo rozsah"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<objekt bufferu (vymazanı) na %8lX>"
-
-msgid "invalid mark name"
-msgstr "chybné meno znaèky"
-
-msgid "no such buffer"
-msgstr "iadny takı buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "pokus o odkaz na vymazané okno"
-
-msgid "readonly attribute"
-msgstr "vlastnos iba pre èítanie"
-
-msgid "cursor position outside buffer"
-msgstr "umiestnenie kurzoru mimo buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<objekt okna (vymazanı) na %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<objekt okna (neznámy) na %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<okno %d>"
-
-msgid "no such window"
-msgstr "iadne také okno"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Prepáète, tento príkaz je vypnutı, Ruby kninica nemôe by naèítaná."
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Neznámy 'longjmp' stav %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Prepnú implementáciu/definíciu"
-
-msgid "Show base class of"
-msgstr "Ukáza základnú triedu"
-
-msgid "Show overridden member function"
-msgstr "Ukáza preaenú èlenskú funkciu"
-
-msgid "Retrieve from file"
-msgstr "Obnovi zo súboru"
-
-msgid "Retrieve from project"
-msgstr "Obnovi z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Obnovi zo všetkıch projektov"
-
-msgid "Retrieve"
-msgstr "Obnovi"
-
-msgid "Show source of"
-msgstr "Ukáza zdroj"
-
-msgid "Find symbol"
-msgstr "Nájs znak"
-
-msgid "Browse class"
-msgstr "Prezrie triedu"
-
-msgid "Show class in hierarchy"
-msgstr "Ukáza triedu v hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Ukáza triedu v obmedzenej hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odkazuje na"
-
-msgid "Xref referred by"
-msgstr "Xref odkázanı z"
-
-msgid "Xref has a"
-msgstr "Xref má"
-
-msgid "Xref used by"
-msgstr "Xref pouitı"
-
-msgid "Show docu of"
-msgstr "Ukáza dokumentáciu"
-
-msgid "Generate docu for"
-msgstr "Vytvori dokumentáciu pre"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Zlyhalo pripojenie na SNiFF+, Preverte prostredie (sniffemacs sa musí "
-"nachádza v $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Chyba poèas èítania. Odpojené"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ je aktuálne "
-
-msgid "not "
-msgstr "ne"
-
-msgid "connected"
-msgstr "pripojenı"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Neznáma SNiFF+ poiadavka: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Chyba pripojenia na SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ nie je pripojenı"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Nie je SNiFF+ bufferom"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Chyba zápisu. Odpojené"
-
-msgid "invalid buffer number"
-msgstr "chybné èíslo bufferu"
-
-msgid "not implemented yet"
-msgstr "nie je ešte podporované"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nedajú sa nastavi riadky"
-
-msgid "mark not set"
-msgstr "znaèka nie je nastavená"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "riadok %d ståpec %d"
-
-msgid "cannot insert/append line"
-msgstr "nedá sa vloi/pripoji riadok"
-
-msgid "unknown flag: "
-msgstr "neznámy príznak: "
-
-msgid "unknown vimOption"
-msgstr "neznáma vo¾ba (vimOption)"
-
-msgid "keyboard interrupt"
-msgstr "prerušenie z klávesnice"
-
-msgid "vim error"
-msgstr "chyba Vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nedá sa vytvori príkaz bufferu/okna: objekt bude vymazanı"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nedá sa zaregistrova príkaz spätného volania: buffer/okno u bol vymazanı"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATAL ERROR: reflist poškodenı!? Oznámte, prosím, túto chybu na "
-"vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nedá sa zaregistrova príkaz spätného volania: odkaz na buffer/okno nenájdenı"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Prepáète, tento príkaz je vypnutı, Tcl kninica nemôe by naèítaná."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL CHYBA: návratovı kód nie je celé èíslo!? Oznámte, prosím, túto "
-"chybu na vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: návratovı kód %d"
-
-msgid "cannot get line"
-msgstr "nedá sa preèíta riadok"
-
-msgid "Unable to register a command server name"
-msgstr "Nemôem zaregistrova meno príkazového servra"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Chyba poèas prenosu príkazu do cie¾ového programu"
-
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Pouíté chybné èíslo servera: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM registrová vlastnos je zle formátovaná.  Vymazané!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Neznámy parameter vo¾by"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Príliš mnoho upravovacích argumentov"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Chıba argument po"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Chyby za parametrom vo¾by"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
-msgstr "Príliš mnoho \"+príkaz\", \"-c príkaz\" alebo \"--cmd príkaz\" argumentov"
+msgstr ""
+"Príliš mnoho \"+príkaz\", \"-c príkaz\" alebo \"--cmd príkaz\" argumentov"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Chybnı argument pre"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d súborov pre úpravu\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Tento Vim nebol kompilovanı s porovnávacími funkciami."
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Pokus o opätovné otvorenie skriptu: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Nedá sa otvori pre zápis: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Nedá sa otvori pre vıstup skriptu: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Chyba: Chyba spúšania gvim pre NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Varovanie: Vıstup nesmeruje na terminál\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Varovanie: Vstup nepochádza z terminálu\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc príkazovı riadok"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nedá sa èíta z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2592,18 +3375,23 @@ msgstr ""
 "\n"
 "Podrobnejšie informácie získáte pomocou \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[súbor ..] ..       upravi súbor(y)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                   èíta text z štandardného vstupu"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          upravi súbor na mieste definície tagu"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [chybovı súbor]  upravi súbor na mieste vıskytu prvej chyby"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2613,9 +3401,11 @@ msgstr ""
 "\n"
 "pouitie:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr "vim [argumenty] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2623,10 +3413,7 @@ msgstr ""
 "\n"
 "   alebo:"
 
-#. TODO: is translation correct?
-msgid "where case is ignored prepend / to make flag upper case"
-msgstr "v prípade, e je ignorovaná ve¾kos písmen, pouite znak '/' na zaèiatku, aby mal príznak vıznam ve¾kého písmena"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2636,335 +3423,191 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tMôu nasledova iba názvy súborov"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNexpandova olíkové znaky (wildcards)"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tPrihlási gvim na OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-register\t\tOdhlási gvim z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tSpusti v grafickom (GUI) móde (rovnaké ako \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr ""
-"-f  alebo  --nofork\tPopredie: Pri spustení grafického (GUI) módu sa nepresunie do pozadia"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi mód (rovnaké ako \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx mód (rovnaké ako \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tTichı (dávkovı) mód (iba pre \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tPorovnávací mód (rovnaké ako \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tJednoduchı mód (rovnaké ako \"evim\", bezmódovı)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMód iba pre èítanie (ako \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tObmedzenı mód (rovnaké ako \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmeny (ukladanie súborov) zakázané"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZmeny v texte zakázané"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinárny mód"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp mód"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatabilnı s Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tKompatibilita s Vi vypnutá: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tÚroveò vıpisu hlášok"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tLadiaci mód"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNevytvára odkladací súbor, pouíva iba pamä"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tVypíš zoznam odkladacích súborov a skonèi"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (s názvom súboru)\tObnoví prerušené sedenie"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tRovnaké ako -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNebude pouíva newcli pre otvorenie okna"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <zariadenie>\t\tPoui <zariadenie> pre I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tspusti v Arabic móde"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tspusti v hebrejskom móde"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tspusti vo Farsi móde"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminál>\tNastaví typ terminálu na <terminál>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tPouije <vimrc> namiesto akéhoko¾vek .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tPouije <gvimrc> namiesto akéhoko¾vek .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNenahrá zásuvné moduly(plugin skripty)"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tOtvorí N okien (implicitne jedno pre kadı súbor)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtvorí N okien (implicitne jedno pre kadı súbor)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tAko -o ale rozdelí vertikálne"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tNastaví kurzor na koniec súboru"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<riadok>\t\tNastaví kurzor na <riadok>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <príkaz>\t\tVykoná <príkaz> pred nahratím vimrc súboru"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <príkaz>\t\tPo nahratí prvého súboru vykoná <príkaz>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sedenie>\t\tPo nahratí prvého súboru vykoná príkazy v súbore <sedenie>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skript>\t\tNaèíta príkazy normálneho módu zo <skriptu>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <skript>\t\tPripojí všetky napísané príkazy do súboru <skript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <skript>\t\tUloí všetky napísané príkazy do súboru <skript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tÚprava zašifrovanıch súborov"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <displej>\tPripojí vim na príslušnı X-server"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNepripojí sa k X serveru"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <súbory>\tUpravi <súbory> na Vim servri ak je to moné"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <súbory>\tTo isté, ale nesauj si, ak neexistuje server"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <súbory>\tAko --remote ale èaká na súbory pre ukonèenie úprav"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <súbory>\tTo isté, ale nesauj si, ak neexistuje server"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <vo¾by>\tOdošle <vo¾by> na Vim server a skonèí"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <vıraz>\tSpusti <vıraz> na servri a vytlaèí vısledok"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVypíše zoznam mien dostupnıch Vim servrov a skonèí"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <názov>\tOdošle na Vim server <názov>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tPouije <viminfo> namiesto akéhoko¾vek .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  alebo  --help\tVypíše túto nápovedu a skonèí"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tVypíše informácie o verzii a skonèí"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (Motif verzia):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (neXtaw verzia):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (Athena verzia):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <displej>\tSpustí vim na <displej>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tSpustí vim minimalizované"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <názov>\t\tPouije resource ako by vim mal <názov>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (nie je implementované)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <farba>\tNastaví sa <farba> pozadia (tie -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <farba>\tNastaví sa <farba> popredia (tie -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <písmo>\t\tNastaví <písmo> normálneho textu (tie -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <písmo>\tNastaví <písmo> pre zvıraznenı text"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <písmo>\tNastaví <písmo> pre kurzívu"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geometrie>\tNastaví sa <geometria> (tie -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <šírka>\tNastaví <šírku> okrajov (tie -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <šírka>  Nastaví <šírku> posuvnej lišty (tie -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <vıška>\tNastaví <vıšku> ponuky (tie -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tPouije reverzné farby (tie -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNepouije reverzné farby (tie +rv)"
-
-# TODO: howto translate 'resource' in this case?
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tNastaví zadanı <resource>"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (RISC OS verzia):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <poèet>\tPoèiatoèná šírka okna v ståpcoch"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <poèet>\tPoèiatoèná vıška okna v riadkoch"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (GTK+ verzia):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <displej>\tSpustí vim na <displej> (tie --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "-role <rola>\tNastaví unikátnu rolu pre identifikáciu hlavného okna"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtvorí Vim vnútri iného GTK programu."
-
-msgid ""
-"\n"
-"Arguments recognised by kvim (KDE version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre kvim (KDE verzia):\n"
-
-msgid "-black\t\tUse reverse video"
-msgstr "-black\t\tPouije reverzné farby"
-
-msgid "-tip\t\t\tDisplay the tip dialog on startup"
-msgstr "-tip\t\t\tZobraz tip pri štarte"
-
-msgid "-notip\t\tDisable the tip dialog"
-msgstr "-notip\t\tNezobrazuj tip pri štarte"
-
-msgid "--display <display>\tRun vim on <display>"
-msgstr "-display <displej>\tSpustí vim na <displej>"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <titulok rodièa>\tOtvor Vim vnútri materskej aplikácie"
-
-msgid "No display"
-msgstr "Bez grafického rozhrania"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Odoslanie zlyhalo.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Odoslanie zlyhalo. Pokúšam sa spusti lokálne\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d upravenıch súborov z %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "iaden graf. mód: Odoslanie vırazu zlyhalo.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Odoslanie vırazu zlyhalo.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Nie sú nastavené iadne znaèky"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283:\"%s\" nevyhovujú iadne znaèky"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2973,6 +3616,7 @@ msgstr ""
 "znaèka riadok  ståpec súbor/text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2981,6 +3625,7 @@ msgstr ""
 " skok riadok ståpec súbor/text"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -2988,7 +3633,7 @@ msgstr ""
 "\n"
 "znaèka riadok  ståpec text"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2997,7 +3642,7 @@ msgstr ""
 "# Súborové znaèky:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3005,7 +3650,7 @@ msgstr ""
 "\n"
 "# Zoznam skokov (zaèínajúci najnovšou polokou):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3013,95 +3658,85 @@ msgstr ""
 "\n"
 "# História znaèiek v súboroch (zaèínajúci najnovšou polokou):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Chıba '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Chybná kódová stránka"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nedajú sa nastavi IC hodnoty"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nepodarilo sa vytvori vstupnı kontext"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nepodarilo sa otvori vstupnú metódu"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Varovanie: likvidaèné spätné volanie sa nedá nastavi na IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: vstupná metóda nepodporuje iadny štıl"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: vstupná metóda nepodporuje môj 'preedit' typ"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: Nadbodovı štıl vyaduje sadu fontov (fontset)"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Máte GTK+ verziu staršiu ne 1.2.3. Stavová plocha vypnutá."
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Server vstupnıch metód nebeí"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nebol zamknutı"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Chyba posunu pri èítaní odkladacieho súboru"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Chyba pri èítaní odkladacieho súboru"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Chyba posunu pri ukladaní do odkladacieho súboru"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Chyba pri ukladaní do odkladacieho súboru"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Odkladací súbor u existuje (symlink útok?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nedá sa získa blok 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nedá sa získa blok 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Nedá sa získa blok 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ups, odkladací súbor bol stratenı!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nedá sa premenova odkladací súbor"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Nedá sa otvori odkladací súbor pre \"%s\", oprava nemoná"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): nedá sa získa blok 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Odkladací súbor pre %s nebol nájdenı"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Zadajte èíslo odkladacieho súboru, ktorı sa má pouit (0 pre ukonèenie): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nedá sa otvori %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nedá sa èíta blok 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3109,22 +3744,28 @@ msgstr ""
 "\n"
 "Mono nedošlo k iadnym zmenám, alebo Vim neaktualizoval odkladací súbor."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nedá sa poui s touto verziou Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Pouite Vim verziu 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s sa nezdá by odkladacím súborom Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nedá sa pouí na tomto poèítaèi.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Súbor bol vytvorenı "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3132,63 +3773,85 @@ msgstr ""
 ",\n"
 "alebo bol súbor poškodenı."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Pouívam odkladací súbor \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Pôvodnı súbor \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Varovanie: Pôvodnı súbor mohol by zmenenı"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nedá sa èíta blok 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???CHİBA MNOHO RIADKOV"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???CHYBNİ POÈET RIADKOV"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PRÁZDNY BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???CHİBAJÚCE RIADKY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID bloku 1 je chybné (je %s odkladacím súborom?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???CHİBA BLOK"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "od ??? po ???END môu by riadky pomiešané"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "od ??? po ???END môu by riadky vloené/vymazané"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONIEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Obnova prerušená"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: V priebehu obnovy došlo k chybám; skontrolujte riadky zaèínajúce na ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Pozrite \":help E312\" pre ïalšie informácie"
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Obnova dokonèená. Skontrolujte, èi je všetko v poriadku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3196,48 +3859,69 @@ msgstr ""
 "\n"
 "(Zváte uloenie tohoto súboru pod inım menom\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "a pomocou programu diff zistite zmeny oproti pôvodnému súboru)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr "Potom vymate odkladací súbor s príponou .swp.\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Nájdené odkladacie súbory:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   V aktuálnom adresári:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   So zadanım menom:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   V adresári "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- iadne --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            vlastník: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    dátum vytvorenia: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "    dátum vytvorenia: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [od Vim verzie 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nevyzerá ako odkladací súbor Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "        názov súboru: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3245,12 +3929,15 @@ msgstr ""
 "\n"
 "             zmenenı: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ÁNO"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nie"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3258,9 +3945,11 @@ msgstr ""
 "\n"
 "    uívate¾ské meno: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   názov poèítaèa: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3268,6 +3957,7 @@ msgstr ""
 "\n"
 "         názov poèítaèa: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3275,16 +3965,11 @@ msgstr ""
 "\n"
 "         ID procesu : "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (stále beí)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nepouite¾né s touto verziou Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3292,71 +3977,97 @@ msgstr ""
 "\n"
 "         [nepouitelné na tomto poèítaèi]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [nedá sa preèíta]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [nedá sa otvori]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nedá sa zachova - odkladací súbor neexistuje"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Súbor zachovanı"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Uchovanie sa nepodarilo"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: chybné èíslo riadku: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nedá sa nájs riadok %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné èíslo ukazovate¾a na blok 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx by mal ma hodnotu 3"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Aktualizovanıch príliš ve¾a blokov?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: chybné èíslo ukazovate¾a na blok 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "vymazanı blok 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nedá sa nájs riadok %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné èíslo ukazovate¾a na blok"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovú hodnotu"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: èíslo riadku je mimo rozsah: %<PRId64> (za koncom)"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: chybnı poèet riadkov v bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Nárast ve¾kosti zásobníku"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: chybnı èíslo ukazovate¾a na blok 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: POZOR"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3364,38 +4075,44 @@ msgstr ""
 "\n"
 "Nájdenı odkladací súbor s menom \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Pri otváraní súboru \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOVŠÍ ako odkladací súbor!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Súbor môe by upravovanı inım programom.\n"
 "    Ak je tomu tak, potom si dajte pozor, aby ste po uloení zmien\n"
 "    nemali dve rôzne verzie toho istého súboru.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Ukonèite program, alebo opatrne pokraèujte v úpravách.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Úprava tohoto súboru bola prerušená neoèakávanım ukonèením programu.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Ak je tomu tak, potom pouite \":recover\" alebo \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3403,9 +4120,11 @@ msgstr ""
 "\"\n"
 "    pre obnovenie zmien (viï \":help recovery)\".\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Pokia¾ ste tak u urobili, tak vymate odkladací súbor \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3413,18 +4132,23 @@ msgstr ""
 "\"\n"
 "    a táto správa sa u nebude objavova.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Odkladací súbor \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" u existuje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - POZOR"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Odkladací súbor u existuje!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3438,44 +4162,73 @@ msgstr ""
 "&Koniec\n"
 "&Zruši"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Abort\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "&Otvori iba pre èítanie\n"
-"&Pokraèovat v úpravách\n"
+"&Pokraèova v úpravách\n"
 "O&bnovi súbor\n"
 "&Koniec\n"
-"&Zruši\n"
-"Z&maza"
+"&Zruši"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Príliš mnoho odkladacích súborov"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatok pamäte! (alokujem %<PRIu64> bajtov)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Èas cesty k predmetu ponuky nie je podponukou"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Ponuka existuje iba v inom móde"
 
+#: ../menu.c:64
+#, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Ponuka \"%s\" neexistuje"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+#, fuzzy
+msgid "E792: Empty menu name"
+msgstr "E749: prázdny buffer"
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Cesta ponuky nesmie vies do podponuky"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Poloky ponuky sa nejdú pridáva priamo na lištu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Odde¾ovaè nesmie by èasou cesty ponuky"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3483,57 +4236,74 @@ msgstr ""
 "\n"
 "--- Ponuky ---"
 
-msgid "Tear off this menu"
-msgstr "Odtrhnú tuto ponuku"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Cesta ponuky musí vies k poloke ponuky"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Ponuka nenájdená: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: V %s móde nie je ponuka definovaná"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Cesta ponuky musí vies do podponuky"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Ponuka nenájdená - skontrolujte názvy ponúk"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Chyba pri spracovaní %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "riadok %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: '%s' nie je prístupné meno registru"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Správca prekladu: Lubomir Host <rajo@platon.sk>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Prerušenie: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Stlaète ENTER alebo zadajte príkaz pre pokraèovanie"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, riadok %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Pokraèovanie --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " MEDZERA/d/j: obrazovka/stránka/riadok dole, b/u/k: hore, q: koniec "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Otázka"
 
 # TODO: Translate as "&Ano\n&Nie" ?
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3541,7 +4311,19 @@ msgstr ""
 "&Ano\n"
 "&Nie"
 
+# TODO: Translate as "&Ano\n&Nie\n&Zruši" ?
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ano\n"
+"&Nie\n"
+"&Zruši"
+
 # TODO: Translate as "&Ano\n&Nie\n&Uloi všetko\nZahodi &všetko\n&Zruši" ?
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3555,250 +4337,178 @@ msgstr ""
 "Zahodi &všetko\n"
 "&Zruši"
 
-msgid "Select Directory dialog"
-msgstr "Dialóg pre vytvorenie adresára"
-
-msgid "Save File dialog"
-msgstr "Dialóg pre ukladanie súborov"
-
-msgid "Open File dialog"
-msgstr "Dialóg pre otváranie súborov"
-
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: ¼utujem, ale konzolová verzia nepodporuje prehliadaè súborov"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Chybné argumenty pre funkciu printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Chybné argumenty pre funkciu printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Príliš mnoho argumentov pre funkciu printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Varovanie: mením súbor iba pre èítanie"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Zadajte èíslo ale kliknite myšou (<Enter> zruší): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Zvo¾te èíslo (<Enter> zruší): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 novı riadok"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 vymazanı riadok"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> novıch riadkov"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> vymazanıch riadkov"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Prerušené)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Piip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachovávam súbory...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: ukonèenı\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "CHYBA: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bajtov] celkom uvolnené-alokované %<PRIu64>-%<PRIu64>, vyuité %<PRIu64>, maximálne vyuitie %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[volanie] celkom re/malloc(): %<PRIu64>, celkom free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Riadok sa stáva príliš dlhım"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Nedostatok pamäte! (alokujem %<PRIu64> bajtov)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Volám shell na spustenie: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Chıba dvojbodka"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Neprípustnı mód"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Chybnı tvar myši"
-
-msgid "E548: digit expected"
-msgstr "E548: oèakávaná èíslica"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Neprípustné percento"
-
-msgid "Enter encryption key: "
-msgstr "Zadajte šifrovací k¾úè: "
-
-msgid "Enter same key again: "
-msgstr "Vlote ten istı k¾úè znova: "
-
-msgid "Keys don't match!"
-msgstr "K¾úèe sa nezhodujú!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Chybná cesta: '**[èíslo] musí by buï na konci cesty, alebo musí by\n"
-"nasledované '%s. Viï :help path."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Adresár \"%s\" sa nedá nájs v cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Súbor \"%s\" sa nepodarilo nájs"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: iadny ïalší adresár \"%s\" nebol v cdpath nájdenı"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: iadny ïalší súbor \"%s\" nebol v ceste nájdenı"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Nedá sa pripoji na Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Nedá sa pripoji na Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Zlé prístupové práva pre súbor s informáciami pre NetBeans spojenie: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "èítanie z Netbeans soketu"
-
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Stratené NetBeans spojenie pre buffer %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Varovanie: terminál nepodporuje zvırazòovanie"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Pod kurzorom nie je iadny reazec"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Pod kurzorom nie je iadny identifikátor"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E91: vo¾ba 'shell' je prázdna"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Varovanie: terminál nepodporuje zvırazòovanie"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Pod kurzorom nie je iadny reazec"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Pomocou 'foldmethod' sa nedá vymaza vnorenie"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: zoznam zmien je prázdny"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Na zaèiatku zoznamu zmien"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "poèet riadkov upravenıch naraz pomocou %s: 1"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 riadok upravenı pomocou %s %d krát"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> riadkov upravenıch naraz pomocou %s"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> riadkov upravenıch pomocou %s %d krát"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> riadkov pre odsadenie..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 riadok odsadenı "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> riadkov odsadenıch "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: iadny predtım pouívanı register"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nedá sa kopírova; napriek tomu vymazané"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 riadok zmenenı"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> zmenenıch riadkov"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "uvolòujem %<PRId64> riadkov"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "skopírovanı blok 1 riadku"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 riadok skopírovanı"
 
+#: ../ops.c:2525
+#, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "skopírovanı blok %<PRId64> riadkov"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> skopírovanıch riadkov"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Register %s je prázdny"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3806,10 +4516,11 @@ msgstr ""
 "\n"
 "--- Registre ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Neprípustnı názov registra"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3817,151 +4528,197 @@ msgstr ""
 "\n"
 "# Registre:\n"
 
+#: ../ops.c:4575
+#, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Neznámy typ registra %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Ståpcov; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Vybranıch %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Bajtov"
-
-msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "Vybranıch %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Znakov; %<PRId64> z %<PRId64> Bajtov"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
-msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybranıch %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; "
+"%<PRId64> z %<PRId64> Bajtov"
 
+#: ../ops.c:5105
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybranıch %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; "
+"%<PRId64> z %<PRId64> Znakov; %<PRId64> z %<PRId64> Bajtov"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> pre BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strana %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Ïakujeme za pouitie Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Neznáma vo¾ba"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Vo¾ba nie je podporovaná"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Nie je v modeline povolené"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Po = je vyadované èíslo"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nenájdenı v termcape"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Neprípustnı znak <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Vo¾ba 'term' nemôe by prázdna"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: V grafickom móde (GUI) sa nedá meni typ terminálu"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Pouite \"gui\" pre spustenie GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: vo¾by 'backupext' a 'patchmode' majú rovnakú hodnotu"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Nedá sa zmeni v grafickom rozhraní GTK+ 2"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Chıba dvojbodka"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Reazec s nulovou dåkou"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Po <%s> chıba èíslo"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Chıba èiarka"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Je nutné zada hodnotu '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: obsahuje netlaèite¾né znaky"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Chybné písma"
-
-msgid "E597: can't select fontset"
-msgstr "E597: nedá sa vybra sada písiem"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Chybná sada písiem"
-
-msgid "E533: can't select wide font"
-msgstr "E533: nedá sa vybra širokı font"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Chybné široké písmo"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Neprípustnı znak po <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: je nutná èiarka"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
-msgstr "E537: 'commentstring' (komentár) musí by prázdny alebo musí obsahova %s"
+msgstr ""
+"E537: 'commentstring' (komentár) musí by prázdny alebo musí obsahova %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Bez podpory myši"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Neuzatvorené zoskupenie vırazov"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: príliš mnoho poloiek"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: nevyváené skupiny"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Okno náh¾adu u existuje"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
-msgstr "W17: Mód Arabic vyaduje kódovanie UTF-8, nastavte to príkazom ':set encoding=utf-8'"
+msgstr ""
+"W17: Mód Arabic vyaduje kódovanie UTF-8, nastavte to príkazom ':set "
+"encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Minimálny potrebnı poèet riadkov je %d"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Minimálne potrebnı poèet ståpcov je %d"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Neznáma vo¾ba: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Po = je vyadované èíslo"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3969,6 +4726,7 @@ msgstr ""
 "\n"
 "--- Kódy terminálu ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3976,6 +4734,7 @@ msgstr ""
 "\n"
 "--- Nastavenie globálnych volieb ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3983,6 +4742,7 @@ msgstr ""
 "\n"
 "--- Nastavenie lokálnych volieb ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3990,134 +4750,21 @@ msgstr ""
 "\n"
 "--- Monosti ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp CHYBA"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': pre %s chıba vyhovujúci znak"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': nadbytoèné znaky po bodkoèiarke: %s"
 
-msgid "cannot open "
-msgstr "nedá sa otvori "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nedá sa otvori okno!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Je potrebná Amigados verzia 2.04 alebo novšia\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Potrebná %s verzia %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nedá sa otvori NIL:\n"
-
-msgid "Cannot create "
-msgstr "Nedá sa vytvori "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim ukonèenı s %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "nemôem zmeni konzolovı mód ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: nie je konzolou??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nedá sa spusti shell s -f vo¾bou"
-
-msgid "Cannot execute "
-msgstr "Nedá sa spusti "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " vrátené\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE príliš malá."
-
-msgid "I/O ERROR"
-msgstr "I/O CHYBA"
-
-msgid "...(truncated)"
-msgstr "...(skrátené)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'ståpce' nie je 80, nemôem spusti externı príkaz"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Zlyhal vıber tlaèiarne"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "%s na %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Neznámy font tlaèiarne: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Chyba tlaèe: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Tlaèím '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Chybnı názov znakovej sady \"%s\" v názve písma \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Chybnı znak '%c' v názve písma \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: dvojitı signál, konèím\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Zachytenı smrtiaci signál %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Zachytenı smrtiaci signál\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Otvorenie X displej zabralo %<PRId64> msec"
-
-#. KDE sometimes produces X error that we want to ignore
-msgid ""
-"\n"
-"Vim: Got X error but we continue...\n"
-msgstr ""
-"\n"
-"Vim: Chyba X ale pokraèujem ...\n"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Chyba X\n"
-
-msgid "Testing the X display failed"
-msgstr "Testovanie X displeja zlyhalo"
-
-msgid "Opening the X display timed out"
-msgstr "Uplynul èas otvorenia X displeja"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4125,13 +4772,7 @@ msgstr ""
 "\n"
 "Nedá sa spusti shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nedá sa spusti sh shell\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4139,668 +4780,958 @@ msgstr ""
 "\n"
 " návratová hodnota shellu "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Nedjú sa vytvori rúry\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Vyvolanie fork zlyhalo\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Príkaz ukonèenı\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP stratilo ICE spojenie"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Otvorenie X displeja zlyhalo"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP spracuváva poiadavku na samouloenie"
-
-msgid "XSMP opening connection"
-msgstr "XSMP otvára spojenie"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP kontrola spojenia ICE zlyhala"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection zlyhalo: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Súbor \"%s\" sa nedá nájs v ceste"
 
-msgid "At line"
-msgstr "Na riadku"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nemôem nahra vim32.dll!"
-
-msgid "VIM Error"
-msgstr "VIM Chyba"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nemôem opravi odkazy funkcií na DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "návratová hodnota shellu %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Zachytená udalos %s\n"
-
-msgid "close"
-msgstr "zavrie"
-
-msgid "logoff"
-msgstr "odhlási"
-
-msgid "shutdown"
-msgstr "vypnú"
-
-msgid "E371: Command not found"
-msgstr "E371: Príkaz nenájdenı"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE nenájdenı v $PATH.\n"
-"Po dokonèení externıch príkazov nebude vıstup pozastavenı.\n"
-"Pozrite  :help win32-vimrun  pre viac informácií."
-
-msgid "Vim Warning"
-msgstr "Vim Varovanie"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Príliš mnoho %%%c vo formátovacom reazci"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Neoèakávanı vıskyt %%%c vo formátovacom reazci"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Vo formátovacom reazci chıba ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr ""
 "E375: Nepodporovaná formátová špecifikácia %%%c vo formátovacom reazci"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Neprístupné %%%c v prefixe formátovacieho reazca"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Neprístupné %%%c vo formátovacom reazci"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' neobsahuje iadny vzor"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Chıbajúci alebo prázdny názov adresára"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: iadne ïalšie poloky"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d z %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (riadok vymazanı)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Koniec quickfix zoznamu"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Zaèiatok quickfix zoznamu"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "zoznam chıb %d z %d; %d chıb"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nedá sa uloi, je nastavená vo¾ba 'buftype'"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Chıba meno súboru alebo chybnı vzor"
 
+#: ../quickfix.c:2911
+#, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Nedá sa otvori súbor \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Buffer nie je naèítanı"
 
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E552: oèakávaná èíslica"
+
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: chybná poloka v %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Vzor je príliš dlhı"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Príliš mnoho \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Príliš mnoho %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Nespárované \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Nespárované %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Nespárované %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Nespárované %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Neprípustnı znak po %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Príliš komplexné %s{...}"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Vnorenı %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Vnorenı %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: Chybne pouité \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c niè nenasleduje"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Chybná spätná referencia"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( tu nie je povolené"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 a spol. tu nie je povolené"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Neprípustnı znak po \\z"
-
-#,  c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Chıbajúca ] po %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Prázdny %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Neprípustnı znak po %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Neprípustnı znak po %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Chıbajúca ] po %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Nespárované %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Nespárované %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Nespárované %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( tu nie je povolené"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 a spol. tu nie je povolené"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Chıbajúca ] po %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Prázdny %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Vzor je príliš dlhı"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Príliš mnoho \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Príliš mnoho %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Nespárované \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: Neprípustnı znak po %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Príliš komplexné %s{...}"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Vnorenı %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Vnorenı %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Chybne pouité \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c niè nenasleduje"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Chybná spätná referencia"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Neprípustnı znak po \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Neprípustnı znak po %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Neprípustnı znak po %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Chyba syntaxe v %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Vnútorné podradené zhody:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Príliš mnoho \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Nedá sa nájs doèasnı súbor pre ukladanie"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " NAHRADI VERTIKÁLNE"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " NAHRADI"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " OBRÁTI"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " VLOI"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (vloi)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (nahradi)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (nahradi vertikálne)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrejskı"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabskı"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (jazyk)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (vloi)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VIZUÁLNE"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VIZUÁLNY RIADOK"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VIZUÁLNY BLOK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ZHODY"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " OZNAÈ RIADOK"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " OZNAÈ BLOK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "nahrávam"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Neprípustnı h¾adanı reazec: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: h¾adanie dosiahlo zaèiatok bez nájdenia %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: h¾adanie dosiahlo koniec bez nájdenia %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Po ';' oèakávam '?' alebo '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (vrátane u vypísanıch zhôd)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Vloené súbory"
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "nenájdené "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "v ceste ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (U vypísané)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " NENÁJDENÉ"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Preh¾adávam vloené súbory: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "Preh¾adávam vloené súbory: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Zhoda je na aktuálnom riadku"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Všetky vloené súbory boli nájdené"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "iadne vloené súbory"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nedá sa nájs definícia"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nedá sa nájs vzor"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 nahradenie"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Chyba formátovania v spell súbore (kontrola pravopisu)"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Odseknutı spell súbor (kontrola pravopisu)"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Prebytoènı text v %s na riadku %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Prípona príliœ dlhá v %s riadok %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
-msgstr "E761: Chyba formátovania v súbore prípon FOL, LOW alebo UPP (NASLEDUJE, MALÉ alebo VE¼KÉ)"
+msgstr ""
+"E761: Chyba formátovania v súbore prípon FOL, LOW alebo UPP (NASLEDUJE, MALÉ "
+"alebo VE¼KÉ)"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
-msgstr "E762: Znak v FOL, LOW alebo UPP (NASLEDUJE, MALÉ alebo VE¼KÉ) je mimo rozsah"
+msgstr ""
+"E762: Znak v FOL, LOW alebo UPP (NASLEDUJE, MALÉ alebo VE¼KÉ) je mimo rozsah"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Robím kompresiu stromu slov..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Kontrola pravopisu nie je zapnutá"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr "Varovanie: Nemono nájs zoznam slov \"%s.%s.spl\" alebo \"%s.ascii.spl\""
+msgstr ""
+"Varovanie: Nemono nájs zoznam slov \"%s.%s.spl\" alebo \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Èítam slovníkovı súbor \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Toto sa nezdá by slovníkovım súborom"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Starı slovníkovı súbor, potrebuje by zaktualizovanı"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Slovníkovı súbor je pre novšiu verziu Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Nepodporovaná sekcia v slovníkovom súbore"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Varovanie: región %s nie je podporovanı"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Naèítavam súbor s príponami %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konverzia slova zlyhala v %s riadok %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konverzia v %s nie je podporovaná: z %s do %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konverzia v %s nie je podporovaná"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Neplatná hodnota pre príznak (FLAG) v %s riadok %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "Príznak (FLAG) po pouití príznakov v %s riadok %d: %s"
 
+#: ../spell.c:4723
 #, c-format
-msgid "Character used for SLASH must be ASCII; in %s line %d: %s"
-msgstr "Znak pouitı pre SLASH musí by ASCII; v %s riadok %d: %s"
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-msgid "Wrong COMPOUNDMAX value in %s line %d: %s"
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Zlá hodnota COMPOUNDMAX v %s riadok %d: %s"
 
+#: ../spell.c:4771
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr "Zlá hodnota COMPOUNDMAX v %s riadok %d: %s"
+
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Zlá hodnota COMPOUNDMIN v %s riadok %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Zlá hodnota COMPOUNDSYLMAX v %s riadok %d: %s"
 
+#: ../spell.c:4795
+#, fuzzy, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr "Zlá hodnota COMPOUNDMIN v %s riadok %d: %s"
+
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr "Rozdielna kombinácia príznakov v nasledujúcom bloku prípon v %s riadok %d: %s"
+msgstr ""
+"Rozdielna kombinácia príznakov v nasledujúcom bloku prípon v %s riadok %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Duplicitná prípona v %s riadok %d: %s"
 
-#, c-format
+#: ../spell.c:4871
+#, fuzzy, c-format
 msgid ""
-"Affix also used for BAD/RAR/KEP/NEEDAFFIX/NEEDCOMPOUND in %s line %d: %s"
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
 msgstr ""
 "Prípona pouitá aj pre BAD/RAR/KEP/NEEDAFFIX/NEEDCOMPOUND in %s line %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Oèakávane Y alebo N v %s riadok %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Narušená podmienka v %s riadok %d: %s"
 
-#, c-format
-msgid "Expected REP count in %s line %d"
+#: ../spell.c:5091
+#, fuzzy, c-format
+msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Oèakávam poèet REP v %s riadok %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Oèakávam poèet MAP v %s riadok %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Opakovanı znak v MAP v %s riadok %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Nerozpoznaná alebo opakujúca sa poloka v %s riadok %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Chıbajúci riadok FOL/LOW/UPP v %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX pouitı bez SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Príliš mnoho odloenıch prípon"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Príliš mnoho upravovacích príznakov"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Príliš mnoho odloenıch prípon a/alebo upravovacích príznakov"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Chıba SOFO%s riadok v %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "SAL a SOFO riadky zároveò v %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Príznak nie je èíslo v %s na riadku %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Neprípustnı príznak v %s riadok %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Hodnota %s sa odlišuje od hodnoty pouitej v inom .aff súbore"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Naèítavam slovník %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Chıajúci poèet slov v %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "riadok %6d, slovo %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Opakujúce sa slovo v %s riadok %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Prvé duplicitné slovo v %s riadok %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d duplicitné slovo(á) v %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ignorovanıch %d slov s nepísmennımi znakmi v %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Naèítavam súbor so slovami %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Duplicitnı riadok /encoding= v %s riadok %d ignorovanı: %s "
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "/encoding= riadok nasledujúci po slove v %s riadok %d ignorovanı: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Duplicitnı riadok /regions= v %s riadok %d ignorovanı: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Príliš mnoho regiónov v %s riadok %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Riadok / v %s riadok %d ignorovanı: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Pouíté chybné èíslo regiónu v %s riadok %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nerozpoznanı príznak v %s riadok %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignorovanıch %d slov s nepísmennımi znakmi"
 
-#, c-format
-msgid "Compressed %d of %d nodes; %d%% remaining"
+#: ../spell.c:6656
+#, fuzzy, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Skomprimovanıch %d z %d uzlov; %d%% zostáva"
 
-msgid "E751: Output file name must not have region name"
-msgstr "E751: Vıstupné meno súboru nesmie ma názov regiónu"
+#: ../spell.c:7340
+#, fuzzy
+msgid "Reading back spell file..."
+msgstr "Èítam slovníkovı súbor \"%s\""
 
-msgid "E754: Only up to 8 regions supported"
-msgstr "E754: Podporovanıch max. 8 regiónov"
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
 
+#: ../spell.c:7368
 #, c-format
-msgid "E755: Invalid region in %s"
-msgstr "E755: Chybnı región v %s"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
 
-msgid "Warning: both compounding and NOBREAK specified"
-msgstr "Varovanie: špecifikované spájanie a nezalamovanie"
-
+#: ../spell.c:7476
 #, c-format
-msgid "Writing spell file %s ..."
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
 msgstr "Ukládám slovníkovı súbor %s ..."
 
-msgid "Done!"
-msgstr "Hotovo!"
-
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Ve¾kos pouívanej pamäte: %d bajtov"
 
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr "E751: Vıstupné meno súboru nesmie ma názov regiónu"
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr "E754: Podporovanıch max. 8 regiónov"
+
+#: ../spell.c:7846
+#, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E755: Chybnı región v %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr "Varovanie: špecifikované spájanie a nezalamovanie"
+
+#: ../spell.c:7920
+#, c-format
+msgid "Writing spell file %s ..."
+msgstr "Ukládám slovníkovı súbor %s ..."
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr "Hotovo!"
+
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' nemá %<PRId64> poloiek"
 
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaky slov sa odlišujú medzi slovníkovımi súbormi"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Prepáète, iadne návrhy"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Prepáète, iba %<PRId64> návrhov"
 
+#. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Zmeni \"%.*s\" na:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: iadny predchádzajúce nahradenie pod¾a slovníka"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Nenájdené: %s"
 
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E757: Toto sa nezdá by slovníkovım súborom"
+
+#: ../spell.c:9282
+#, fuzzy, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr "E771: Starı slovníkovı súbor, potrebuje by zaktualizovanı"
+
+#: ../spell.c:9286
+#, fuzzy, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr "E772: Slovníkovı súbor je pre novšiu verziu Vim"
+
+#: ../spell.c:9295
+#, fuzzy, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr "E746: Meno funkcie sa nezhoduje s menom interpretovaného súboru: %s"
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Chyba pri èítaní chybového súboru"
+
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: duplicitnı znak v MAP poloke"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Pre tento buffer nie sú definované iadne poloky syntaxe"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Neprípustnı argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaktická zostava %s neexistuje"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Pre tento buffer nie sú definované iadne poloky syntaxe"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizujem pod¾a komentárov jazyka C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "iadne synchronizácie"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synchronizácia zaèína "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " riadkov pred zaèiatkom"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -4808,6 +5739,7 @@ msgstr ""
 "\n"
 "--- Poloky synchronizácie syntaxe ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -4815,6 +5747,7 @@ msgstr ""
 "\n"
 "synchronizujem poloky"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -4822,198 +5755,274 @@ msgstr ""
 "\n"
 "--- Poloky syntaxe ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Syntaktická zostava %s neexistuje"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimálne "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximálne "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; zhoda "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " zalomení riadkov"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: obsahuje argumenty, ktoré tu nie sú povolené"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: obsahuje argumenty, ktoré tu nie sú povolené"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Chybnı argument"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here nesmie by na tomto mieste"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Pre %s chıba poloka regiónu"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Vyadovanı názov súboru"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Príliš mnoho názvov súborov"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Chıba ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Chıba '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Príliš málo argumentov: oblas syntaxe %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaktická zostava %s neexistuje"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Nebola zadaná iadna zostava"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Odde¾ovaè vzoru %s nenájdenı"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Chyba za vzorom: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: synchronizácia syntaxe: vzor pokraèovania riadkov zadanı dvakrát"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Chybné argumenty: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Chıba znamienko rovná sa: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Prázdny argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s tu nie je povolené"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musí by prvı v 'contains' zozname"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Neznámy názov skupiny: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Chybnı podradenı príkaz :syntax : %s "
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekurzívna sluèka pri naèítavaní syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: skupina zvıraznenia %s nebola nájdená"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Príliš málo argumentov: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Príliš mnoho argumentov: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: skupina je nastavená, odkaz na zvırazòovaciu skupinu ignorovanı"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: neoèakávané znamienko rovná sa: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: chıba znamienko rovná sa: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: chıba argument: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Neprípustná hodnota: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: farba popredia nie je známa"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: farba pozadia nie je známa"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Názov alebo èíslo farby nebolo rozpoznané: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminálovı kód je príliš dlhı: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Neprípustnı argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Pouívanıch príliš ve¾a odlišnıch zvırazòovacích vlastností"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Netlaèitelnı znak v mene skupiny"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Chybnı znak v mene skupiny"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: na konci zoznamu tagov"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: na zaèiatku zoznamu tagov"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Nedá sa skoèi pred prvı vyhovujúci tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tag %s nenájdenı"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri typ tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "súbor\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Vyhovuje iba jeden tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Za poslednı vyhovujúci tag sa nedá preskoèi"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Súbor \"%s\" neexistuje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d z %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " alebo viac"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Pouívam tag s písmom inej ve¾kosti!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Súbor \"%s\" neexistuje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5021,59 +6030,79 @@ msgstr ""
 "\n"
 "  # CIE¼ tag        ŠTART riadok  v súbore/texte"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Preh¾adávam súbor tagov %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Cesta k súboru tagov %s bola orezaná\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátovania v súbore tagov \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Pred bajtom %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Obsah súboru tagov %s nie je zoradenı"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: iadny súbor tagov"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nedá sa nájs vzor tagov"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Tag sa nedá nájs, iba hádam!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Duplicitná prípona v %s riadok %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' nie je známy. Dostupné vstavané terminály:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "nastavujem na '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Nedá sa otvori termcap súbor"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Terminfo neobsahuje poloku pre tento terminál"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Termcap neobsahuje poloku pre tento terminál"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Termcap neobsahuje poloku \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminál musí ma schopnos \"cm\" (schopnos pohybu kurzora)"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5081,109 +6110,176 @@ msgstr ""
 "\n"
 "--- Klávesy terminálu ---"
 
-msgid "new shell started\n"
-msgstr "spustenı novı shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Chyba pri èítaní vstupu, konèím...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Odstránenie zmien nie je moné; chcete napriek tomu pokraèova"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Súbor sa nedá otvori pre ukladanie"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Ukládám viminfo súboru \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Chyba pri ukladaní do odkladacieho súboru"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Naèítavam súbor so slovami %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Súbor viminfo sa nedá sa otvori na èítanie"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Nenájdené: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Nedá sa otvori súbor %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "dokonèená interpretácia %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> nenájdenı"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: èísla riadkov sú chybné"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "1 novı riadok"
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "1 novı riadok"
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "1 vymazanı riadok"
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "%<PRId64> vymazanıch riadkov"
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "1 zmena"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "%<PRId64> zmien"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "1 zmena"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> riadkov upravenıch pomocou %s %d krát"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "iadne mapovanie nebolo nájdené"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> Ståpcov; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s tu nie je povolené"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmenách poškodenı"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: chıba opravnı riadok"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32 bitová GUI verzia pre MS Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitová GUI verzia pre MS Windows"
-
-msgid " in Win32s mode"
-msgstr " vo Win32 reime"
-
-msgid " with OLE support"
-msgstr " s OLE podporou"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitová verzia pre MS Windows konzolu"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitová verzia pre MS Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitová verzia pre MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitová MS-DOS verzia"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) verzia"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X verzia"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS verzia"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS verzia"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5191,9 +6287,18 @@ msgstr ""
 "\n"
 "Pouité záplaty: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Vnútorné podradené zhody:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Zmenil "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5201,9 +6306,11 @@ msgstr ""
 "\n"
 "Preloená "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5211,611 +6318,1646 @@ msgstr ""
 "\n"
 "Maximálna verzia"
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Ve¾ká verzia "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normálna verzia"
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Malá verzia "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Minimálna verzia "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez grafického rozhrania."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "s grafickım rozhraním GTK2-GNOME."
-
-msgid "with GTK-GNOME GUI."
-msgstr "s grafickım rozhraním GTK-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "s grafickım rozhraním GTK2."
-
-msgid "with GTK GUI."
-msgstr "s grafickım rozhraním GTK."
-
-msgid "with X11-Motif GUI."
-msgstr "s grafickım rozhraním X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "s grafickım rozhraním X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "s grafickım rozhraním X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "s grafickım rozhraním Photon."
-
-msgid "with GUI."
-msgstr "s grafickım rozhraním."
-
-msgid "with Carbon GUI."
-msgstr "s grafickım rozhraním Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "s grafickım rozhraním Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "s klasickım grafickım rozhraním."
-
-msgid "with KDE GUI."
-msgstr "s grafickım rozhraním KDE."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Vlastnosti zahrnuté (+) a nezahrnuté (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "          systémovı vimrc súbor: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        uívate¾skı vimrc súbor: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  druhı uívate¾skı vimrc súbor: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  tretí uívate¾skı vimrc súbor: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         uívate¾skı exrc súbor: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   druhı uívate¾skı exrc súbor: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  systémovı gvimrc súbor: \""
-
-msgid "    user gvimrc file: \""
-msgstr "      uívate¾skı gvimrc súbor: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "druhı uívate¾skı gvimrc súbor: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "tretí uívate¾skı gvimrc súbor: \""
-
-msgid "    system menu file: \""
-msgstr "     systémovı súbor s ponukou: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       implicitná hodnota $VIM:\""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " f-b pre $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Preklad: "
 
-msgid "Compiler: "
-msgstr "Prekladaè: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Zlinkované: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  PODPORA LADENIA"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "verzia "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "od Brama Moolenaara a ïalších"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim je vo¾ne šírite¾nı program s otvorenım kódom"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomôte chudobnım deom v Ugande!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "zadajte  :help iccf<Enter>          pre informácie         "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "zadajte  :q<Enter>                  pre ukonèenie programu "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "zadajte  :help<Enter>  alebo  <F1>  pre pomocníka          "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "zadajte  :help version7<Enter>      pre informácie o verzii"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Pracujem v reime kompatibility s Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "zadajte  :set nocp<Enter>           pre implicitné nastavenie Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "podrobnejšie informácie získate pomocou :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "blišie informácie v ponuke  Pomocník->Samostatné"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Spúšam v bezmódovom reime, písanı text je vloenı"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "ponuka  Úpravy->Globálne monosti->Prepnú reim vloenia "
-
-msgid "                              for two modes      "
-msgstr "                            pre dva reimy       "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "ponuka  Úpravy->Globálne monostt->Prepnú Vi kompatibilnı reim"
-
-msgid "                              for Vim defaults   "
-msgstr "                 pre predvolené vlastnosti Vim   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Zasponzorujte vıvoj Vimu!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Staòte sa registrovanım uívate¾om Vimu!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "zadajte  :help sponsor<Enter>          pre informácie         "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "zadajte  :help register<Enter>      pre informácie         "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "blišie informácie v ponuke  Pomocník->Sponzor/Registrácia"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "VAROVANIE: detekované Windows 95/98/ME"
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "Existuje u iba jedno okno"
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "zadajte  :help windows95<Enter>  pre podrobnejšie informácie"
-
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Nenájdené iadne okno náh¾adu"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr ""
 "E442: Okno sa nedá rozdeli zároveò v móde 'vrchnı-¾avı' a 'spodnı-"
 "pravı' ('topleft' a 'botright')"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Nedá sa rotova, ak je iné okno rozdelené"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Posledné okno sa nedá zatvori"
 
-msgid "Already only one window"
-msgstr "Existuje u iba jedno okno"
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Posledné okno sa nedá zatvori"
 
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Posledné okno sa nedá zatvori"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Iné okno obsahuje zmeny"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Pod kurzorom sa nenachádza názov súboru"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Súbor \"%s\" sa nedá nájs v ceste"
+#~ msgid "[Error List]"
+#~ msgstr "[Zoznam chıb]"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Nepodarilo sa nahra kninicu %s"
+#~ msgid "Patch file"
+#~ msgstr "Záplatovı súbor"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Prepáète, tento príkaz je vypnutı, Perl kninica nemôe by naèítaná."
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zruši"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Vykonanie kódu v jazyku Perl nie je moné v bezpeènostnej schránke bez bezpeènostného modulu"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Neexistuje pripojenie k Vim serveru"
 
-msgid "Edit with &multiple Vims"
-msgstr "Upravi s viacerı&mi Vimmi"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nemôem posla na %s"
 
-msgid "Edit with single &Vim"
-msgstr "Upravi s jednım &Vimom"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nemôem èíta odpoveï servra"
 
-msgid "Diff with Vim"
-msgstr "Porovna &Vimom"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Nemôem posla klientovi"
 
-msgid "Edit with &Vim"
-msgstr "Upravi s &Vimom"
+#~ msgid "Save As"
+#~ msgstr "Uloi ako"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Upravi s existujúcim Vimom - "
+#~ msgid "Edit File"
+#~ msgstr "Upravova súbor"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Upravi vybrané súbory s Vimom"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NENÁJDENÉ)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Chyba vytvárania procesu: Skontrolujte, èi je gvim vo vašej ceste!"
+#~ msgid "Source Vim script"
+#~ msgstr "Zdrojovı skript Vim"
 
-msgid "gvimext.dll error"
-msgstr "chyba gvimext.dll"
+#~ msgid "Edit File in new window"
+#~ msgstr "Upravi súbor v novom okne"
 
-msgid "Path length too long!"
-msgstr "Príliš dlhá cesta!"
+#~ msgid "Append File"
+#~ msgstr "Pripoji súbor"
 
-msgid "--No lines in buffer--"
-msgstr "--Buffer neobsahuje iadne riadky--"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Pozícia okna: X %d, Y %d"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Príkaz prerušenı"
+#~ msgid "Save Redirection"
+#~ msgstr "Uloi presmerovanie"
 
-msgid "E471: Argument required"
-msgstr "E471: Je vyadovanı argument"
+#~ msgid "Save View"
+#~ msgstr "Uloi poh¾ad"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ by malo nasledova /, ? alebo &"
+#~ msgid "Save Session"
+#~ msgstr "Uloi sedenie"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chybnı príkaz v okne príkazového riadku; <Enter> spúša, CTRL-C ukonèuje"
+#~ msgid "Save Setup"
+#~ msgstr "Uloi nastavenie"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Príkaz nie je z exrc/vimrc v aktuálnom adresári alebo pri h¾adaní tagu "
-"povolenı."
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: V tejto verzi nie sú digraphy podporované"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Chıba :endif"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Èítam zo štandardného vstupu..."
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Chıba :endtry"
+#~ msgid "[NL found]"
+#~ msgstr "[nájdené NL]"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Chıba :endwhile"
+#~ msgid "[crypted]"
+#~ msgstr "[šifrovanı]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Chıba :endfor"
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "[CHYBA PREVODU]"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile bez zodpovedajúceho :while"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans rozhranie nedovolilo zapísa nemodifikované buffre"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor bez zodpovedajúceho :for"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Èiastoèné zápisy nie sú povolené pre NetBeans buffre"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Súbor existuje (pouite ! pre prepísanie)"
+# TODO: resource fork ?! Note: used only in MACOS_X version
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: 'Resource fork' bude stratenı (pouite ! pre vynútenie)"
 
-msgid "E472: Command failed"
-msgstr "E472: Príkaz zlyhal"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nedá sa spusti GUI (grafické rozhranie)"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Neznáma sada písiem: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nedá sa èíta z \"%s\""
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Neznáme písmo: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Nemono naštartova grafické rozhranie, nenájdenı iaden pouitelnı "
+#~ "font"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Písmo \"%s\" nemá pevnú šírku"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr ""
+#~ "E231: vo¾ba 'guifontwide' (nastavenie širokého písma) je chybne nastavená"
 
-msgid "E473: Internal error"
-msgstr "E473: Vnútorná chyba"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Hodnota 'imactivatekey' je nesprávne nastavená"
 
-msgid "Interrupted"
-msgstr "Prerušené"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Nedá sa alokova farba %s"
 
-msgid "E14: Invalid address"
-msgstr "E14: Chybná adresa"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "iadna zhoda na pozícii kurzora, h¾adám ïalej"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Chybnı argument"
+#~ msgid "<cannot open> "
+#~ msgstr "<nedá sa otvori> "
 
-#,  c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Chybnı argument: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: písmo %s nie je dostupné"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Chybnı vıraz: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: nedá sa vráti do aktuálneho adresára"
 
-msgid "E16: Invalid range"
-msgstr "E16: Chybnı rozsah"
+#~ msgid "Pathname:"
+#~ msgstr "Názov cesty:"
 
-msgid "E476: Invalid command"
-msgstr "E476: Chybnı príkaz"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: nedá sa zisti aktuálny adresár"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" je adresárom"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Vyvolanie kniniènej funkcia zlyhalo pre \"%s()\""
+#~ msgid "Cancel"
+#~ msgstr "Zruši"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Nepodarilo sa nahra funkciu kninice %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Prípravok posuvnej lišty: nedá sa zisti geometria náh¾adu obrázku."
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Znaèka má chybné èíslo riadku"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim dialóg"
 
-msgid "E20: Mark not set"
-msgstr "E20: Znaèka nie je nastavená"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: BalloonEval nedá sa vytvori správou a zároveò spätnım volaním"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nemono robi zmeny, vo¾ba 'modifiable' je vypnutá"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialóg.."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skripty vnorené príliš hlboko"
+#~ msgid "Input _Methods"
+#~ msgstr "Vstupné metódy (_Methods)"
 
-msgid "E23: No alternate file"
-msgstr "E23: iadny alternatívny súbor"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Nájs a nahradi..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Taká skratka neexistuje"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Nájs..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! nie je povolenı"
+#~ msgid "Find what:"
+#~ msgstr "Vyh¾ada:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Nedá sa pouí GUI: nebolo zapnuté pri preklade programu"
+#~ msgid "Replace with:"
+#~ msgstr "Nahradi s:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E26: Nedá sa pouí hebrejskı reim: nebol zapnutı pri preklade programu\n"
+#~ msgid "Match whole word only"
+#~ msgstr "H¾ada len celé slová"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Nedá sa pouí farsi reim: nebol zapnutı pri preklade programu\n"
+#~ msgid "Match case"
+#~ msgstr "Zhoda ve¾kosti písmen"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Nedá sa pouí arabic reim: nebol zapnutı pri preklade programu\n"
+#~ msgid "Direction"
+#~ msgstr "Smer"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Skupina zvıraznenia %s neexistuje"
+#~ msgid "Up"
+#~ msgstr "Hore"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Zatia¾ nie je vloenı iaden text"
+#~ msgid "Down"
+#~ msgstr "Dolu"
 
-msgid "E30: No previous command line"
-msgstr "E30: iadny predchádzajúci príkazovı riadok"
+#~ msgid "Find Next"
+#~ msgstr "Nájs ïalšie"
 
-msgid "E31: No such mapping"
-msgstr "E31: Mapovanie nenájdené"
+#~ msgid "Replace"
+#~ msgstr "Nahradi"
 
-msgid "E479: No match"
-msgstr "E479: iadna zhoda"
+#~ msgid "Replace All"
+#~ msgstr "Nahradi Všetko"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: iadna zhoda: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Prijatá poiadavka na ukonèenie (die) od manaéra sedení\n"
 
-msgid "E32: No file name"
-msgstr "E32: iadny názov súboru"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Hlavné okno neoèakávane zrušené\n"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: iadny predchádzajúci prislúchajúci správny vıraz"
+#~ msgid "Font Selection"
+#~ msgstr "Vıber Písma"
 
-msgid "E34: No previous command"
-msgstr "E34: iadny predchádzajúci príkaz"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Pouitı CUT_BUFFER0 namiesto prázdneho vıberu"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: iadny predchádzajúci regulárny vıraz"
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
 
-msgid "E481: No range allowed"
-msgstr "E481: Rozsah nie je povolenı"
+#~ msgid "&Cancel"
+#~ msgstr "&Zruši"
 
-msgid "E36: Not enough room"
-msgstr "E36: Nedostatok miesta"
+#~ msgid "Directories"
+#~ msgstr "Adresáre"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: iaden registrovanı server pomenovanı \"%s\""
+#~ msgid "Filter"
+#~ msgstr "Filter"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Nedá sa vytvori súbor %s"
+#~ msgid "&Help"
+#~ msgstr "&Pomocník"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Nedá sa získa názov doèasného súboru"
+#~ msgid "Files"
+#~ msgstr "Súbory"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Nedá sa otvori súbor %s"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Nedá sa èíta súbor %s"
+#~ msgid "Selection"
+#~ msgstr "Vıber"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Neuloené zmeny (pouite ! pre vynútenie)"
+#~ msgid "Find &Next"
+#~ msgstr "Nájs ïa&lšie"
 
-msgid "E38: Null argument"
-msgstr "E38: Nulovı argument"
+#~ msgid "&Replace"
+#~ msgstr "&Nahradi"
 
-msgid "E39: Number expected"
-msgstr "E39: Oèakávané èíslo"
+#~ msgid "Replace &All"
+#~ msgstr "Nahradi &Všetko"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nedá sa otvori chybovı súbor %s"
+#~ msgid "&Undo"
+#~ msgstr "&Spä"
 
-msgid "E233: cannot open display"
-msgstr "E233: nedá sa otvori displej"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Nemono nájs okno s titulkom \"%s\""
 
-msgid "E41: Out of memory!"
-msgstr "E41: Nedostatok pamäti!"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nie je podporovanı: \"-%s\"; Pouite OLE verziu."
 
-msgid "Pattern not found"
-msgstr "Vzor nenájdenı"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Nemono otvori okno vnútri MDI aplikácie"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Vzor nenájdenı: %s"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Nájs reazec (pouite '\\\\' ak chete nájs '\\')"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument musí by kladnı"
+# Following warning can be ignored:
+# msgfmt -v --statistics --check -C --check-accelerators="&" -o sk.mo sk.po
+# sk.po:2497: msgstr lacks the keyboard accelerator mark '&'
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Nájs a Nahradi (pouite '\\\\' ak chcete nájs '\\')"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: iadny predchádzajúci adresár"
+#~ msgid "Not Used"
+#~ msgstr "[neupravovanı]"
 
-msgid "E42: No Errors"
-msgstr "E42: iadne chyby"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Adresár\t*.niè\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Poškodenı reazac pre vyh¾adávanie"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Nedá sa alokova poloka mapy farieb, niektoré farby môu by "
+#~ "nesprávne"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Poškodenı regexp program"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Chıba písmo pre nasledujúce znakové sady %s:"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr ""
-"E45: vo¾ba 'readonly' (iba na èítanie) je nastavená (pouite ! pre "
-"prepísanie)"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Názov sady písiem: %s"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Nedá sa nastavi premenná len na èítanie \"%s\""
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Písmo '%s' nemá pevnou šírku"
 
-#, c-format
-msgid "E46: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: Nedá sa nastavi premenná v bezpeènostnej schránke: \"%s\""
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Názov sady písiem: %s\n"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Chyba pri èítaní chybového súboru"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Písmo0: %s\n"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Nie je dovolené v bezpeènostnej schránke"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Písmo1: %s\n"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Nie je na povolené na tomto mieste"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Písmo%<PRId64> nie je dvakrát širšie ako písmo0\n"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Nastavovanie reimu obrazovky nie je podporované"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Šírka písma0: %<PRId64>\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Chybná hodnota ve¾kosti rolovania"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Šírka písma1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: vo¾ba 'shell' je prázdna"
+#~ msgid "Invalid font specification"
+#~ msgstr "Chybná špecifikácia písma"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Chyba -- nedájú sa preèíta oznaèovacie dáta!"
+#~ msgid "&Dismiss"
+#~ msgstr "&Zruši"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Chyba pri uzatváraní odkladacieho súboru"
+#~ msgid "no specific match"
+#~ msgstr "iadna špecifická zhoda"
 
-msgid "E73: tag stack empty"
-msgstr "E73: zoznam tagov je prázdny"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Vıber písma"
 
-msgid "E74: Command too complex"
-msgstr "E74: Príkaz je príliš zloitı"
+#~ msgid "Name:"
+#~ msgstr "Meno:"
 
-msgid "E75: Name too long"
-msgstr "E75: Názov je príliš dlhı"
+#~ msgid "Show size in Points"
+#~ msgstr "Ukazuj ve¾kos v bodoch"
 
-msgid "E76: Too many ["
-msgstr "E76: Príliš mnoho ["
+#~ msgid "Encoding:"
+#~ msgstr "Kódujem:"
 
-msgid "E77: Too many file names"
-msgstr "E77: Príliš mnoho názvov súborov"
+#~ msgid "Font:"
+#~ msgstr "Písmo:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Nadbytoèné znaky na konci"
+#~ msgid "Style:"
+#~ msgstr "Štıl"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Neznáma znaèka"
+#~ msgid "Size:"
+#~ msgstr "Ve¾kos:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nemono expandova olíkové znaky (wildcards)"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul ERROR - chyba kórejského spôsobu vkladania znakov"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr ""
-"E591: hodnota vo¾by 'winheight' (vıška okna) nesmie by menšia ne hodnota vo¾by 'winminheight' (minimálna vıška okna)"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: chyba stat"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr ""
-"E592: hodnota vo¾by 'winwidth' (šírka okna) nesmie by menšia ne hodnota vol¾y 'winminwidth' (minimálna šírka okna)"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: nemono otvori cscope databázu: %s"
 
-msgid "E80: Error while writing"
-msgstr "E80: Chyba pri ukladaní"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: nemono získa cscope databázové informácie"
 
-msgid "Zero count"
-msgstr "Nulovı poèet"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: dosiahnutı maximálny poèet cscope spojení"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Pouitie <SID> mimo kontext skriptu"
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Prepáète, tento príkaz je vypnutı, MzScheme kninica nemôe by "
+#~ "naèítaná."
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Bol prijatı chybnı vıraz"
+#~ msgid "invalid expression"
+#~ msgstr "chybnı vıraz"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Región je uzamknutı, nemono modifikova"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "podpora vırazov bola vypnutá pri preklade programu"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans nepovo¾uje zmeny v súboroch len na èítanie"
+#~ msgid "hidden option"
+#~ msgstr "skrytá vo¾ba"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Vnútorná chyba: %s"
+#~ msgid "unknown option"
+#~ msgstr "neznáma vo¾ba"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: vzor pouíva viac pamäte ako 'maxmempattern'"
+#~ msgid "window index is out of range"
+#~ msgstr "èíslo okna mimo rozsah"
 
-msgid "E749: empty buffer"
-msgstr "E749: prázdny buffer"
+#~ msgid "couldn't open buffer"
+#~ msgstr "nemono otvori buffer"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Neprípustnı h¾adanı reazec alebo odde¾ovaè"
+#~ msgid "cannot save undo information"
+#~ msgstr "nedajú sa uloi zálone (opravné) informácie"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Súbor je naèítanı v inom buffere"
+#~ msgid "cannot delete line"
+#~ msgstr "nedá sa vymaza riadok"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Vo¾ba \"%s\" nie je nastavená"
+#~ msgid "cannot replace line"
+#~ msgstr "nedá sa nahradi riadok"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "h¾adanie dosiahlo zaèiatok, pokraèovanie od konca"
+#~ msgid "cannot insert line"
+#~ msgstr "nedá sa vloi riadok"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "h¾adanie dosiahlo koniec, pokraèovanie od zaèiatku"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "reazec nesmie obsahova znaky nového riadku"
 
+#~ msgid "Vim error: ~a"
+#~ msgstr "Chyba Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Chyba Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer je neplatnı"
+
+#~ msgid "window is invalid"
+#~ msgstr "okno je neplatné"
+
+#~ msgid "linenr out of range"
+#~ msgstr "èíslo riadka mimo rozsah"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "nie je dovolené v bezpeènostnej schránke"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E262: Prepáète, tento príkaz je vypnutı, Python kninica nemôe by "
+#~ "naèítaná."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python nemôe by spustenı rekurzívne"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nedá sa vymaza vlastnos OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace musí by kladné celé èíslo"
+
+#~ msgid "invalid attribute"
+#~ msgstr "chybná vlastnos"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() vyaduje zoznam reazcov"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Chyba pri inicializácii I/O objektov"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "pokus o odkaz na vymazanı buffer"
+
+#~ msgid "line number out of range"
+#~ msgstr "èíslo riadka mimo rozsah"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<objekt bufferu (vymazanı) na %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "chybné meno znaèky"
+
+#~ msgid "no such buffer"
+#~ msgstr "iadny takı buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "pokus o odkaz na vymazané okno"
+
+#~ msgid "readonly attribute"
+#~ msgstr "vlastnos iba pre èítanie"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "umiestnenie kurzoru mimo buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<objekt okna (vymazanı) na %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<objekt okna (neznámy) na %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<okno %d>"
+
+#~ msgid "no such window"
+#~ msgstr "iadne také okno"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Prepáète, tento príkaz je vypnutı, Ruby kninica nemôe by "
+#~ "naèítaná."
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Neznámy 'longjmp' stav %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Prepnú implementáciu/definíciu"
+
+#~ msgid "Show base class of"
+#~ msgstr "Ukáza základnú triedu"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Ukáza preaenú èlenskú funkciu"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Obnovi zo súboru"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Obnovi z projektu"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Obnovi zo všetkıch projektov"
+
+#~ msgid "Retrieve"
+#~ msgstr "Obnovi"
+
+#~ msgid "Show source of"
+#~ msgstr "Ukáza zdroj"
+
+#~ msgid "Find symbol"
+#~ msgstr "Nájs znak"
+
+#~ msgid "Browse class"
+#~ msgstr "Prezrie triedu"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Ukáza triedu v hierarchii"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Ukáza triedu v obmedzenej hierarchii"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odkazuje na"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref odkázanı z"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref má"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref pouitı"
+
+#~ msgid "Show docu of"
+#~ msgstr "Ukáza dokumentáciu"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Vytvori dokumentáciu pre"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Zlyhalo pripojenie na SNiFF+, Preverte prostredie (sniffemacs sa musí "
+#~ "nachádza v $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Chyba poèas èítania. Odpojené"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ je aktuálne "
+
+#~ msgid "not "
+#~ msgstr "ne"
+
+#~ msgid "connected"
+#~ msgstr "pripojenı"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Neznáma SNiFF+ poiadavka: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Chyba pripojenia na SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ nie je pripojenı"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Nie je SNiFF+ bufferom"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Chyba zápisu. Odpojené"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "chybné èíslo bufferu"
+
+#~ msgid "not implemented yet"
+#~ msgstr "nie je ešte podporované"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "nedajú sa nastavi riadky"
+
+#~ msgid "mark not set"
+#~ msgstr "znaèka nie je nastavená"
+
+#~ msgid "row %d column %d"
+#~ msgstr "riadok %d ståpec %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "nedá sa vloi/pripoji riadok"
+
+#~ msgid "unknown flag: "
+#~ msgstr "neznámy príznak: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "neznáma vo¾ba (vimOption)"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "prerušenie z klávesnice"
+
+#~ msgid "vim error"
+#~ msgstr "chyba Vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nedá sa vytvori príkaz bufferu/okna: objekt bude vymazanı"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nedá sa zaregistrova príkaz spätného volania: buffer/okno u bol vymazanı"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATAL ERROR: reflist poškodenı!? Oznámte, prosím, túto chybu na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nedá sa zaregistrova príkaz spätného volania: odkaz na buffer/okno "
+#~ "nenájdenı"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Prepáète, tento príkaz je vypnutı, Tcl kninica nemôe by naèítaná."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL CHYBA: návratovı kód nie je celé èíslo!? Oznámte, prosím, túto "
+#~ "chybu na vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: návratovı kód %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "nedá sa preèíta riadok"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Nemôem zaregistrova meno príkazového servra"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Chyba poèas prenosu príkazu do cie¾ového programu"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Pouíté chybné èíslo servera: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM registrová vlastnos je zle formátovaná.  Vymazané!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Tento Vim nebol kompilovanı s porovnávacími funkciami."
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Chyba: Chyba spúšania gvim pre NetBeans\n"
+
+#~ msgid "where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "v prípade, e je ignorovaná ve¾kos písmen, pouite znak '/' na zaèiatku, "
+#~ "aby mal príznak vıznam ve¾kého písmena"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tPrihlási gvim na OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-register\t\tOdhlási gvim z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tSpusti v grafickom (GUI) móde (rovnaké ako \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  alebo  --nofork\tPopredie: Pri spustení grafického (GUI) módu sa "
+#~ "nepresunie do pozadia"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tÚroveò vıpisu hlášok"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNebude pouíva newcli pre otvorenie okna"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <zariadenie>\t\tPoui <zariadenie> pre I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tPouije <gvimrc> namiesto akéhoko¾vek .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tÚprava zašifrovanıch súborov"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <displej>\tPripojí vim na príslušnı X-server"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNepripojí sa k X serveru"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <súbory>\tUpravi <súbory> na Vim servri ak je to moné"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <súbory>\tTo isté, ale nesauj si, ak neexistuje server"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <súbory>\tAko --remote ale èaká na súbory pre ukonèenie "
+#~ "úprav"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <súbory>\tTo isté, ale nesauj si, ak neexistuje "
+#~ "server"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <vo¾by>\tOdošle <vo¾by> na Vim server a skonèí"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <vıraz>\tSpusti <vıraz> na servri a vytlaèí vısledok"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVypíše zoznam mien dostupnıch Vim servrov a skonèí"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <názov>\tOdošle na Vim server <názov>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (Motif verzia):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (neXtaw verzia):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (Athena verzia):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <displej>\tSpustí vim na <displej>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tSpustí vim minimalizované"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <názov>\t\tPouije resource ako by vim mal <názov>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (nie je implementované)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <farba>\tNastaví sa <farba> pozadia (tie -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <farba>\tNastaví sa <farba> popredia (tie -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <písmo>\t\tNastaví <písmo> normálneho textu (tie -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <písmo>\tNastaví <písmo> pre zvıraznenı text"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <písmo>\tNastaví <písmo> pre kurzívu"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geometrie>\tNastaví sa <geometria> (tie -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <šírka>\tNastaví <šírku> okrajov (tie -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <šírka>  Nastaví <šírku> posuvnej lišty (tie -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <vıška>\tNastaví <vıšku> ponuky (tie -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tPouije reverzné farby (tie -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNepouije reverzné farby (tie +rv)"
+
+# TODO: howto translate 'resource' in this case?
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tNastaví zadanı <resource>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (RISC OS verzia):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <poèet>\tPoèiatoèná šírka okna v ståpcoch"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <poèet>\tPoèiatoèná vıška okna v riadkoch"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (GTK+ verzia):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <displej>\tSpustí vim na <displej> (tie --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "-role <rola>\tNastaví unikátnu rolu pre identifikáciu hlavného okna"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtvorí Vim vnútri iného GTK programu."
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by kvim (KDE version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre kvim (KDE verzia):\n"
+
+#~ msgid "-black\t\tUse reverse video"
+#~ msgstr "-black\t\tPouije reverzné farby"
+
+#~ msgid "-tip\t\t\tDisplay the tip dialog on startup"
+#~ msgstr "-tip\t\t\tZobraz tip pri štarte"
+
+#~ msgid "-notip\t\tDisable the tip dialog"
+#~ msgstr "-notip\t\tNezobrazuj tip pri štarte"
+
+#~ msgid "--display <display>\tRun vim on <display>"
+#~ msgstr "-display <displej>\tSpustí vim na <displej>"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <titulok rodièa>\tOtvor Vim vnútri materskej aplikácie"
+
+#~ msgid "No display"
+#~ msgstr "Bez grafického rozhrania"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Odoslanie zlyhalo.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Odoslanie zlyhalo. Pokúšam sa spusti lokálne\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d upravenıch súborov z %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "iaden graf. mód: Odoslanie vırazu zlyhalo.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Odoslanie vırazu zlyhalo.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Chybná kódová stránka"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nepodarilo sa vytvori vstupnı kontext"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nepodarilo sa otvori vstupnú metódu"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Varovanie: likvidaèné spätné volanie sa nedá nastavi na IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: vstupná metóda nepodporuje iadny štıl"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: vstupná metóda nepodporuje môj 'preedit' typ"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: Nadbodovı štıl vyaduje sadu fontov (fontset)"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Máte GTK+ verziu staršiu ne 1.2.3. Stavová plocha vypnutá."
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Server vstupnıch metód nebeí"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nepouite¾né s touto verziou Vim]"
+
+#~ msgid ""
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
+#~ msgstr ""
+#~ "&Otvori iba pre èítanie\n"
+#~ "&Pokraèovat v úpravách\n"
+#~ "O&bnovi súbor\n"
+#~ "&Koniec\n"
+#~ "&Zruši\n"
+#~ "Z&maza"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Odtrhnú tuto ponuku"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialóg pre vytvorenie adresára"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialóg pre ukladanie súborov"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialóg pre otváranie súborov"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: ¼utujem, ale konzolová verzia nepodporuje prehliadaè súborov"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachovávam súbory...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: ukonèenı\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "CHYBA: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtov] celkom uvolnené-alokované %<PRIu64>-%<PRIu64>, vyuité "
+#~ "%<PRIu64>, maximálne vyuitie %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[volanie] celkom re/malloc(): %<PRIu64>, celkom free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Riadok sa stáva príliš dlhım"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Chybnı tvar myši"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Zadajte šifrovací k¾úè: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Vlote ten istı k¾úè znova: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "K¾úèe sa nezhodujú!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Nedá sa pripoji na Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Nedá sa pripoji na Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Zlé prístupové práva pre súbor s informáciami pre NetBeans "
+#~ "spojenie: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "èítanie z Netbeans soketu"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Stratené NetBeans spojenie pre buffer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "uvolòujem %<PRId64> riadkov"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: V grafickom móde (GUI) sa nedá meni typ terminálu"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Pouite \"gui\" pre spustenie GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Nedá sa zmeni v grafickom rozhraní GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Chybné písma"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: nedá sa vybra sada písiem"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Chybná sada písiem"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: nedá sa vybra širokı font"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Chybné široké písmo"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Bez podpory myši"
+
+#~ msgid "cannot open "
+#~ msgstr "nedá sa otvori "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nedá sa otvori okno!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Je potrebná Amigados verzia 2.04 alebo novšia\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Potrebná %s verzia %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nedá sa otvori NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Nedá sa vytvori "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim ukonèenı s %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "nemôem zmeni konzolovı mód ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: nie je konzolou??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Nedá sa spusti shell s -f vo¾bou"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nedá sa spusti "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " vrátené\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE príliš malá."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O CHYBA"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(skrátené)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'ståpce' nie je 80, nemôem spusti externı príkaz"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Zlyhal vıber tlaèiarne"
+
+#~ msgid "to %s on %s"
+#~ msgstr "%s na %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Neznámy font tlaèiarne: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Chyba tlaèe: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Tlaèím '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Chybnı názov znakovej sady \"%s\" v názve písma \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Chybnı znak '%c' v názve písma \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: dvojitı signál, konèím\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Zachytenı smrtiaci signál %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Zachytenı smrtiaci signál\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Otvorenie X displej zabralo %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error but we continue...\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Chyba X ale pokraèujem ...\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Chyba X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Testovanie X displeja zlyhalo"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Uplynul èas otvorenia X displeja"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nedá sa spusti sh shell\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nedjú sa vytvori rúry\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vyvolanie fork zlyhalo\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Príkaz ukonèenı\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP stratilo ICE spojenie"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otvorenie X displeja zlyhalo"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP spracuváva poiadavku na samouloenie"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP otvára spojenie"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP kontrola spojenia ICE zlyhala"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection zlyhalo: %s"
+
+#~ msgid "At line"
+#~ msgstr "Na riadku"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nemôem nahra vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM Chyba"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nemôem opravi odkazy funkcií na DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "návratová hodnota shellu %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Zachytená udalos %s\n"
+
+#~ msgid "close"
+#~ msgstr "zavrie"
+
+#~ msgid "logoff"
+#~ msgstr "odhlási"
+
+#~ msgid "shutdown"
+#~ msgstr "vypnú"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Príkaz nenájdenı"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE nenájdenı v $PATH.\n"
+#~ "Po dokonèení externıch príkazov nebude vıstup pozastavenı.\n"
+#~ "Pozrite  :help win32-vimrun  pre viac informácií."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Varovanie"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konverzia v %s nie je podporovaná"
+
+#~ msgid "Character used for SLASH must be ASCII; in %s line %d: %s"
+#~ msgstr "Znak pouitı pre SLASH musí by ASCII; v %s riadok %d: %s"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: obsahuje argumenty, ktoré tu nie sú povolené"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Cesta k súboru tagov %s bola orezaná\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "spustenı novı shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Odstránenie zmien nie je moné; chcete napriek tomu pokraèova"
+
+#~ msgid "%<PRId64> changes"
+#~ msgstr "%<PRId64> zmien"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32 bitová GUI verzia pre MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová GUI verzia pre MS Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " vo Win32 reime"
+
+#~ msgid " with OLE support"
+#~ msgstr " s OLE podporou"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verzia pre MS Windows konzolu"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová verzia pre MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verzia pre MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová MS-DOS verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Ve¾ká verzia "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normálna verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malá verzia "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Minimálna verzia "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "s grafickım rozhraním GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "s grafickım rozhraním GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "s grafickım rozhraním GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "s grafickım rozhraním GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "s grafickım rozhraním X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "s grafickım rozhraním X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "s grafickım rozhraním X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "s grafickım rozhraním Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "s grafickım rozhraním."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "s grafickım rozhraním Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "s grafickım rozhraním Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "s klasickım grafickım rozhraním."
+
+#~ msgid "with KDE GUI."
+#~ msgstr "s grafickım rozhraním KDE."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  systémovı gvimrc súbor: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "      uívate¾skı gvimrc súbor: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "druhı uívate¾skı gvimrc súbor: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "tretí uívate¾skı gvimrc súbor: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "     systémovı súbor s ponukou: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Prekladaè: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "blišie informácie v ponuke  Pomocník->Samostatné"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Spúšam v bezmódovom reime, písanı text je vloenı"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "ponuka  Úpravy->Globálne monosti->Prepnú reim vloenia "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                            pre dva reimy       "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "ponuka  Úpravy->Globálne monostt->Prepnú Vi kompatibilnı reim"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                 pre predvolené vlastnosti Vim   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "VAROVANIE: detekované Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "zadajte  :help windows95<Enter>  pre podrobnejšie informácie"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Nepodarilo sa nahra kninicu %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Prepáète, tento príkaz je vypnutı, Perl kninica nemôe by naèítaná."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Vykonanie kódu v jazyku Perl nie je moné v bezpeènostnej schránke "
+#~ "bez bezpeènostného modulu"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Upravi s viacerı&mi Vimmi"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Upravi s jednım &Vimom"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Porovna &Vimom"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Upravi s &Vimom"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Upravi s existujúcim Vimom - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Upravi vybrané súbory s Vimom"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Chyba vytvárania procesu: Skontrolujte, èi je gvim vo vašej ceste!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "chyba gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Príliš dlhá cesta!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Neznáma sada písiem: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Neznáme písmo: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Písmo \"%s\" nemá pevnú šírku"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Nepodarilo sa nahra funkciu kninice %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Nedá sa pouí hebrejskı reim: nebol zapnutı pri preklade programu\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Nedá sa pouí farsi reim: nebol zapnutı pri preklade programu\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Nedá sa pouí arabic reim: nebol zapnutı pri preklade programu\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: iaden registrovanı server pomenovanı \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nedá sa otvori displej"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Bol prijatı chybnı vıraz"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Región je uzamknutı, nemono modifikova"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans nepovo¾uje zmeny v súboroch len na èítanie"

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -7,145 +7,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-09-30 15:58+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2005-09-30 15:58+0200\n"
 "Last-Translator: Lubomir Host <rajo@platon.sk>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-2\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Vim 7.x\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Chyby za parametrom voµby"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Nedá sa alokova» buffer, konèím..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Nedá sa alokova» buffer, pou¾ijem iný..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: ®iadny buffer nebol uvoµnený"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: ®iadny buffer nebol vymazaný"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: ®iadny buffer nebol vymazaný"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffer uvoµnený"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d bufferov uvoµnených"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffer vymazaný"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d bufferov vymazaných"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffer odstránený"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d bufferov odstránených"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Posledný buffer sa nedá odstráni»"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Nebol nájdený ¾iadny zmenený buffer"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nena¹iel som ¾iadny buffer"
 
+#: ../buffer.c:913
+#, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Buffer %<PRId64> neexistuje"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za posledný buffer sa nedá preskoèi»"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pred prvý buffer sa nedá preskoèi»"
 
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+#: ../buffer.c:945
+#, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Zmeny v bufferi %<PRId64> neboli ulo¾ené (! pre vynútenie)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Posledný buffer sa nedá odstráni»"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varovanie: preteèenie zoznamu s názvami súborov"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: buffer %<PRId64> nenájdený"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Vzoru %s vyhovuje viac bufferov"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje ¾iadny buffer"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "riadok %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer takéhoto mena u¾ existuje"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Zmenený]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Neupravovaný]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Nový súbor]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Chyby pri èítaní]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[iba pre èítanie]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 riadok --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> riadkov --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "riadok %<PRId64> z %<PRId64> --%d%%-- ståpec"
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Bez mena]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "pomocník"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[pomocník]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Náhµad]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "V¹etko"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Koniec"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Zaèiatok"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -153,9 +223,11 @@ msgstr ""
 "\n"
 "# Zoznam bufferov:\n"
 
-msgid "[Error List]"
-msgstr "[Zoznam chýb]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -163,124 +235,205 @@ msgstr ""
 "\n"
 "--- Znaky ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Znaky pre %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    riadok=%<PRId64>  id=%d  meno=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Chýba dvojbodka"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Neprípustný mód"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: oèakávaná èíslica"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Neprípustné percento"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Nemô¾em porovna» viac ako %<PRId64> bufferov"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Nedá sa otvori» termcap súbor"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nedajú sa vytvori» porovnania"
 
-msgid "Patch file"
-msgstr "Záplatový súbor"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Nedá sa èíta» výstup porovnania"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Nedá sa èíta» výstup porovnania"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktuálny buffer nie je v porovnávacom móde"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: V porovnávacom móde sa nenachádza iný buffer"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: V porovnávacom móde sa nenachádza iný buffer"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Viac ako dva buffery v porovnávacom móde; neviem, ktorý pou¾i»"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Nedá sa nájs» buffer \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffer \"%s\" nie je v porovnávacom móde"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
 # TODO: digraph
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: digraph nesmie obsahova» znak Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Mapa kláves nenájdená"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Pou¾itý príkaz :loadkeymap v súbore, ktorý nie je interpretovaný"
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Doplòovanie kµúèových slov (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X re¾im (^]^D^E^F^I^K^L^N^O^P^S^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Doplòovanie celých riadkov (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Doplòovanie názvov súborov (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Doplòovanie tagov (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Doplòovanie vzoru ciest (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Doplòovanie definícií (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Doplòovanie podµa slovníka (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Doplòovanie podµa lexikonu (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Doplòovanie príkazového riadka (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Doplòovanie celých riadkov (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Doplòovanie tagov (^O^N^P)"
 
-msgid " Spelling suggestion (^S^N^P)"
+#: ../edit.c:96
+#, fuzzy
+msgid " Spelling suggestion (s^N^P)"
 msgstr " Doplòovanie celých riadkov (^S^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Miestne doplòovanie kµúèových slov (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Koniec odstavca"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "voµba 'dictionary' (slovník) je prázdna"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "voµba 'thesaurus' (lexikon) je prázdna"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "prehµadávam slovník %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (insert) Rolovanie (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (replace) Rolovanie (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Prehµadávam: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Prehµadávam tagy."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Pridávam"
 
@@ -288,352 +441,591 @@ msgstr " Pridávam"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Hµadám..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Východzia podoba"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Slovo z iného riadku"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Jediná zhoda"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "zhoda %d z %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "zhoda %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Neoèekávané znaky v :let"
 
+#: ../eval.c:138
+#, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: index v zozname je mimo rozsah: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Nedefinovaná premenná: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Chýba ']'"
 
+#: ../eval.c:141
+#, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument %s musí by» Zoznam (List)"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument %s musí by» Zoznam (List) alebo Slovník (Dictionary)"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Nemo¾no pou¾i» prázdny kµúè pre Slovník (Dictionary)"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: vy¾aduje sa Zoznam (List)"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Vy¾aduje sa Slovník (Dictionary)"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Príli¹ mnoho argumentov pre funkciu %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: kµúè sa v Slovníku (Dictionary) nenachádza: %s"
 
+#: ../eval.c:150
+#, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funkcia %s u¾ existuje. Pou¾ite ! pre jej nahradenie."
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Záznam v Slovníku (Dictionary) u¾ existuje"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Je vy¾adovaný odkaz na Funkciu (Funcref)"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Nemo¾no pou¾it [:] so Slovníkom (Dictionary)"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Zlý typ premennej pre %s="
 
+#: ../eval.c:155
+#, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Neznáma funkcia: %s"
 
+#: ../eval.c:156
+#, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Neprípustné meno premennej: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: Zoznam (List) pou¾itý ako Re»azec (String)"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Menej cieµov ako polo¾iek Poµa (List items)"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Viac cieµov ako polo¾iek Poµa (List items)"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Dvojitá ; v zozname premenných"
 
+#: ../eval.c:2078
+#, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Nemo¾no vypísa» premenné pre %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Indexova» mo¾no iba Zoznam (List) alebo Slovník (Dictionary)"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] musí prís» ako posledná"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] vy¾aduje hodnotu Poµa (List value)"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Hodnota Poµa (List value) má viac polo¾iek ako cieµ"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Hodnota Poµa (List value) nemá dostatok polo¾iek"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Chýba \"in\" po :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Chýbajú zátvorky: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Premenná \"%s\" neexistuje"
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: premenná je príli¹ vnorená na (od)blokovanie"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Po '?' chýba ':'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Porovnáva» mo¾no iba Zoznam so Zoznamom (List with List)"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Neplatná operácia pre Zoznamy (Lists)"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
-msgstr "E735: Porovnáva» mo¾no iba Slovník so Slovníkom (Dictionary with Dictionary)"
+msgstr ""
+"E735: Porovnáva» mo¾no iba Slovník so Slovníkom (Dictionary with Dictionary)"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Neplatná operácia pre Slovník"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
-msgstr "E693: Porovnáva» mo¾no iba odkaz na Funkciu s odkazom na Funkciu (Funcref with Funcref)"
+msgstr ""
+"E693: Porovnáva» mo¾no iba odkaz na Funkciu s odkazom na Funkciu (Funcref "
+"with Funcref)"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Neplatná operácia pre odkazy na Funkcie (Funcrefs)"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Nemo¾no pou¾it [:] so Slovníkom (Dictionary)"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Chýba ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Nemo¾no indexova» odkaz na Funkciu (Funcref)"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Chýba meno voµby: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Neznáma voµba: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Chýbajú úvodzovky: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Chýbajú úvodzovky: %s"
 
+#: ../eval.c:5084
+#, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Chýba èiarka v Zozname: %s"
 
+#: ../eval.c:5091
+#, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Chýba koniec Zoznamu (List) ']': %s"
 
+#: ../eval.c:6475
+#, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Chýba dvojbodka v Slovníku (Dictionary): %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Duplikovaný kµúè v Slovníku (Dictionary): \"%s\""
 
+#: ../eval.c:6517
+#, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Chýba èiarka v Slovníku (Dictionary): %s"
 
+#: ../eval.c:6524
+#, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Chýba koniec Slovníka (Dictionary) '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: premenná je vnorená príli¹ hlboko pre zobrazenie"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Príli¹ mnoho argumentov pre funkciu %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: Príli¹ mnoho argumentov pre funkciu %s"
+
+#: ../eval.c:7377
+#, fuzzy, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E130: Neznáma funkcia: %s"
+
+#: ../eval.c:7383
+#, fuzzy, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E118: Príli¹ mnoho argumentov pre funkciu %s"
+
+#: ../eval.c:7387
+#, fuzzy, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E81: Pou¾itie <SID> mimo kontext skriptu"
+
+#: ../eval.c:7391
+#, fuzzy, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E720: Chýba dvojbodka v Slovníku (Dictionary): %s"
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Po = je vy¾adované èíslo"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "Chybný argument pre"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Príli¹ mnoho argumentov"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: Ponuka existuje iba v inom móde"
+
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
+#, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Kµúè u¾ existuje: %s"
 
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "vim [argumenty] "
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld riadky: "
 
+#: ../eval.c:9291
+#, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Neznáma funkcia: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Zru¹i»"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "funkcia inputrestore() volaná èastej¹ie ako inputsave()"
 
-msgid "E745: Range not allowed"
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "Príli¹ mnoho upravovacích argumentov"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
 msgstr "E745: Rozsah nie je povolený"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Neplatný typ pre len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Krok je nulový"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Zaèiatok presahuje koniec"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<prázdny>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Neexistuje pripojenie k Vim serveru"
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Nemô¾em posla» na %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Nemô¾em èíta» odpoveï servra"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Príli¹ mnoho symbolických odkazov (sluèka?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Nemô¾em posla» klientovi"
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
 
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "Chybný argument pre"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Funkcia na utriedenie/porovnanie zlyhala"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Funkcia na utriedenie/porovnanie zlyhala"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Chybný)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Chyba pri zápise doèasného súboru"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Zoznam (List) pou¾itý ako èíslo"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Pou¾itý odkaz na Funkciu (Funcref) ako èíslo"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Zoznam (List) pou¾itý ako èíslo"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Slovník (Dictionary) pou¾itý ako èíslo"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Odkaz na Funkciu (Funcref) pou¾itý ako Re»azec (String)"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: Zoznam (List) pou¾itý ako Re»azec (String)"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Slovník (Dictionary) pou¾itý ako Re»azec (String)"
 
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Premenná typu odkaz na Funkciu (Funcref) musí zaèína» s veµkým písmenom: %s"
+#: ../eval.c:16619
+#, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E706: Typ premennej sa nezhoduje: %s"
 
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: Nemo¾no vypísa» premenné pre %s"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr ""
+"E704: Premenná typu odkaz na Funkciu (Funcref) musí zaèína» s veµkým "
+"písmenom: %s"
+
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Meno premennej je v konflikte s existujúcou funkciou: %s"
 
-msgid "E706: Variable type mismatch for: %s"
-msgstr "E706: Typ premennej sa nezhoduje: %s"
-
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Hodnota je uzamknutá: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Neznámy"
 
+#: ../eval.c:16768
+#, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Nemo¾no zmeni» hodnotu %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: premenná je vnorená príli¹ hlboko pre skopírovanie"
 
+#: ../eval.c:17249
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Neznáma funkcia: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Chýba '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Nedajú sa nastavi» IC hodnoty"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Neprípustný argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Neprípustný argument: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Chýba :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: Meno funkcie sa nezhoduje s menom interpretovaného súboru: %s"
+
+#: ../eval.c:17549
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Nedá sa vymaza» funkcia %s: je pou¾ívaná"
+
+#: ../eval.c:17604
+#, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Meno funkcie sa nezhoduje s menom interpretovaného súboru: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Je vy¾adované meno funkcie"
 
-msgid "E128: Function name must start with a capital or contain a colon: %s"
-msgstr "E128: Názov funkcie musí zaèína» veµkým písmenom alebo obsahova» dvojbodku: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: Názov funkcie musí zaèína» veµkým písmenom alebo obsahova» dvojbodku: "
+"%s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Názov funkcie musí zaèína» veµkým písmenom alebo obsahova» dvojbodku: "
+"%s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Nedá sa vymaza» funkcia %s: je pou¾ívaná"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Zanorenie funkcií je hlb¹ie ne¾ 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "volám %s"
 
+#: ../eval.c:18651
+#, c-format
 msgid "%s aborted"
 msgstr "%s zru¹ený"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s vrátilo #%<PRId64>"
 
+#: ../eval.c:18670
+#, c-format
 msgid "%s returning %s"
 msgstr "%s vrátilo %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "pokraèujem v %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return mimo funkciu"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -641,6 +1033,7 @@ msgstr ""
 "\n"
 "# globálne premenné:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -648,73 +1041,106 @@ msgstr ""
 "\n"
 "\tPosledné nastavenie z "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "®iadne vlo¾ené súbory"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  ¹estnástkovo %02x,  osmièkovo %03o"
 
+#: ../ex_cmds.c:145
+#, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d,  ¹estnástkovo %04x,  osmièkovo %o"
 
+#: ../ex_cmds.c:146
+#, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d,  ¹estnástkovo %08x,  osmièkovo %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Prekrytie riadkov sebou samými"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 riadok presunutý"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> riadkov presunutých"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> riadkov filtrovaných"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické príkazy *Filter* nesmú meni» aktuálny buffer"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Neulo¾ené zmeny]\n"
 
+#: ../ex_cmds.c:1424
+#, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s na riadku: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: príli¹ mnoho chýb, preskakujem zbytok súboru"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Èítam viminfo súbor \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " informácie"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " znaèky"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "®iadne vlo¾ené súbory"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " ZLYHALO"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Do viminfo súboru %s sa nedá zapisova»"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Nedá sa ulo¾i» viminfo súbor %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Ukládám viminfo súboru \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tento viminfo súbor bol vytvorený editorom Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -722,39 +1148,48 @@ msgstr ""
 "# Pokiaµ budete opatrný, mô¾ete ho upravova».\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Hodnota 'encoding' (kódovania) poèas zápisu tohoto súboru\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Neprípustný zaèiatoèný znak"
 
-msgid "Save As"
-msgstr "Ulo¾i» ako"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Ulo¾i» neúplný súbor?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Pou¾ite ! pre ulo¾enie neúplného bufferu"
 
+#: ../ex_cmds.c:2281
+#, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Prepísa» existujúci súbor \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Odkladací súbor \"%s\" existuje, aj tak prepísa»?"
 
+#: ../ex_cmds.c:2326
+#, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Odkladací súbor existuje: %s (pou¾ite :silent! pre prepísanie)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: ®iadny názov súboru pre buffer %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Súbor nebol ulo¾ený: ukladanie je zakázané voµbou 'write'"
 
+#: ../ex_cmds.c:2434
+#, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
@@ -762,60 +1197,91 @@ msgstr ""
 "Pre \"%s\" je nastavená voµba 'readonly' (iba na èítanie).\n"
 "Prajete si aj tak ulo¾i»?"
 
-msgid "Edit File"
-msgstr "Upravova» súbor"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "je iba pre èítanie (pou¾ite ! pre vynútenie)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Automatické príkazy neoèakávane zmazali nový buffer %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselný argument pre :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim nepovoµuje pou¾itie príkazov shellu"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulárne výrazy nesmú by» oddelené písmenami"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "nahradi» %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(preru¹ený) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 zhoda"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 nahradenie"
 
+#: ../ex_cmds.c:4387
+#, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> zhôd"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> nahradení"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " na 1 riadku"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " na %<PRId64> riadkov"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global sa nedá vola» rekurzívne"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Pri príkaze global chýba regulárny výraz"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Vzor nájdený na ka¾dom riadku: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Vzor nenájdený"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -825,244 +1291,340 @@ msgstr ""
 "# Posledný zamieòaný re»azec:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: ®iadnu paniku!"
 
+#: ../ex_cmds.c:4717
+#, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: ¥utujem, ¾iadny '%s' pomocník pre %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: ¥utujem, pre %s nie je ¾iadny pomocník"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "¥utujem, súbor \"%s\" s pomocníkom nebol nájdený"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s nie je adresárom"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: %s sa nedá sa otvori» pre zápis"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: %s as nedá otvori» pre èítanie"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Rôzne kódovania pre súbory s pomocníkom pre jazyk: %s"
 
+#: ../ex_cmds.c:5565
+#, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplicitný tag \"%s\" v súbore %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Neznámu príkaz pre znaèky: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Chýba meno pre znaèku"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Príli¹ mnoho definovaných znaèiek"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Chybný text znaèky: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Neznáma znaèka: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Chýba èislo znaèky"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Chybné meno bufferu: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Chybné ID znaèky: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (NENÁJDENÉ)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (nepodporované)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[vymazaný]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Spú¹»am re¾im ladenia. Pre ukonèenie napí¹te \"cont\"."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "riadok %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "príkaz: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Bod preru¹enia v \"%s%s\" na riadku %<PRId64>"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Bod preru¹enia nenájdený: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "Neboli definovné ¾iadne body preru¹enia"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  riadok %<PRId64>"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Najprv pou¾ite príkaz :profile start <meno_suboru>"
 
+#: ../ex_cmds2.c:1269
+#, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Ulo¾i» zmeny do \"%s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "Bez mena"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Buffer \"%s\" obsahuje neulo¾ené zmeny"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Varovanie: Neèakaný vstup do iného bufferu (skontrolujte automatické príkazy)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: Pre úpravu bol zadaný iba jeden súbor"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: Nedá sa preskoèi» pred prvý súbor"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Nedá sa preskoèi» za posledný súbor"
 
+#: ../ex_cmds2.c:2175
+#, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: prekladaè nie je podporovaný: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Hµadám \"%s\" v \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Hµadám \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "súbor \"%s\" nebol nájdený v 'runtimepath'"
 
-msgid "Source Vim script"
-msgstr "Zdrojový skript Vim"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Nemo¾no interpretova» adresár: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "nedá sa interpretova» \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "riadok %<PRId64>: nemô¾no interpretova» \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretujem \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "riadok %<PRId64>: interpretujem \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "dokonèená interpretácia %s"
 
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "1 nový riadok"
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr "vim [argumenty] "
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr "vim [argumenty] "
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+#, fuzzy
+msgid "error handler"
+msgstr "Chyba a preru¹ené"
+
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Varovanie: chybný oddeµovaè riadkov. Mo¾no chýba ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: príkaz :scriptencoding pou¾itý mimo interpretovaný súbor"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: príkaz :finish pou¾itý mimo interpretovaný súbor"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Aktuálny %sjazyk: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Nedá sa nastavi» jazyk na \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Spú¹»am Ex re¾im. Napí¹te \"visual\" pre návrat do Normálneho re¾imu."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Koniec súboru"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Príkaz je príli¹ rekurzívny"
 
+#: ../ex_docmd.c:1006
+#, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Výnimka nezachytená: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Koniec interpretovaného súboru"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Koniec funkcie"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Nejednoznaèné pou¾itie pou¾ívateµom definovaného príkazu"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Nie je príkazom editoru"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Zadaný spätný rozsah"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Zadaný spätný rozsah. OK pre zámenu"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Pou¾ite w alebo w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: ¥utujem, ale tento príkaz nie je dostupný v tejto verzii"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Prípustný je iba jeden názov súboru"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "E¹te zostáva 1 súbor k úprave. Chcete napriek tomu ukonèi» editor?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "E¹te zostáva %d súborov k úprave. Chcete napriek tomu ukonèi» editor?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: E¹te zostáva 1 súbor k úprave."
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: E¹te zostáva %<PRId64> súborov k úprave."
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Príkaz u¾ existuje: pou¾ite ! pre predefinovanie"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1070,258 +1632,347 @@ msgstr ""
 "\n"
 "    Meno       Args Rozsah Úplnos»  Definícia"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Neboli nájdené ¾iadne pou¾ivateµom definované príkazy"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Neboli zadané ¾iadne vlastnosti"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Chybný poèet argumentov"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Poèet nemô¾e by» zadaný dvakrát"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Chybná implicitná hodnota pre poèet"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: pre doplnenie (-complete) je potrebný argument"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Chybná vlastnos»: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Chybné meno príkazu"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Pou¾ívateµom definované príkazy musia zaèína» veµkým písmenom"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Nejednoznaèné pou¾itie pou¾ívateµom definovaného príkazu"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Pou¾ívateµom definovaný príkaz %s neexistuje"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Chybná hodnota doplnenia: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: Argument doplnenia je povolený iba pre vlastné dopåòania (completion)"
+msgstr ""
+"E468: Argument doplnenia je povolený iba pre vlastné dopåòania (completion)"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Vlastné doplnenia vy¾adujú meno funkcie ako argument"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Schéma farieb %s nenájdená"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Pozdravujem, u¾ívateµ Vimu!"
 
-msgid "Edit File in new window"
-msgstr "Upravi» súbor v novom okne"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Posledné okno sa nedá zatvori»"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "Existuje u¾ iba jedno okno"
+
+#: ../ex_docmd.c:6004
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "Strana %d"
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "®iadny odkladací súbor"
 
-msgid "Append File"
-msgstr "Pripoji» súbor"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
-msgstr "E747: Nemo¾no zmeni» adresár, buffer je modifikovaný (pou¾ite ! pre vynútenie)"
+msgstr ""
+"E747: Nemo¾no zmeni» adresár, buffer je modifikovaný (pou¾ite ! pre "
+"vynútenie)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: ®iadny predchádzajúci adresár"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Neznámy"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize (veµkos» okna) vy¾aduje dva argumenty"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Pozícia okna: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Na tejto platforme sa nedá zisti» umiestnenie okna"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos (pozícia okna) vy¾aduje dva argumenty"
 
-msgid "Save Redirection"
-msgstr "Ulo¾i» presmerovanie"
-
-msgid "Save View"
-msgstr "Ulo¾i» pohµad"
-
-msgid "Save Session"
-msgstr "Ulo¾i» sedenie"
-
-msgid "Save Setup"
-msgstr "Ulo¾i» nastavenie"
-
+#: ../ex_docmd.c:7241
+#, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Nemo¾no vytvori» adresár: %s"
 
+#: ../ex_docmd.c:7268
+#, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existuje (pou¾ite ! pre vynútenie)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" sa nedá otvori» pre zápis"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Argumentem mô¾e by» iba písmeno alebo pravý èi µavý apostrof"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekurzívne pou¾itie príkazu :normal príli¹ hlboké"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr ""
 "E194: ®iadny alternatívny názov súboru, ktorým by bolo mo¾né nahradi» '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: ¾iadny názov súboru, ktorým by bolo mo¾né nahradi» \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: ¾iadne èíslo bufferu, ktorým by bolo mo¾né nahradi» \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
-"E497: ¾iadna zhoda automatických príkazov, ktorou by bolo mo¾né nahradi» \"<amatch>"
-"\""
+"E497: ¾iadna zhoda automatických príkazov, ktorou by bolo mo¾né nahradi» "
+"\"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: ¾iadny :source súbor, ktorým by bolo mo¾né nahradi» \"<sfile>\""
 
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: ¾iadny :source súbor, ktorým by bolo mo¾né nahradi» \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Prázdný názov súboru pre '%' alebo '#', funguje iba s \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Výsledkom vyhodnotenia je prázdny re»azec"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Súbor viminfo sa nedá sa otvori» na èítanie"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: V tejto verzi nie sú digraphy podporované"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Nemo¾no spracova» výnimku :throw s preponou 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Spracovanie výnimky: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Výnimka ukonèená: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Výnimka zahodená: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
+#, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, riadok %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
+#, c-format
 msgid "Exception caught: %s"
 msgstr "Zachytená výnimka: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s prebieha"
 
+#: ../ex_eval.c:679
+#, c-format
 msgid "%s resumed"
 msgstr "%s vrátené"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s zahodené"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Výnimka"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Chyba a preru¹ené"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Chyba"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Preru¹ené"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: vnorenie :if je príli¹ hlboké"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif bez zodpovedajúceho :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else bez zodpovedajúceho :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif bez zodpovedajúceho :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: viacnásobné :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif nasleduje po :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: vnorenie :while/:for je príli¹ hlboké"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue bez zodpovedajúceho :while alebo :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break bez zodpovedajúceho :while alebo :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Pou¾ité :endfor spolu s :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Pou¾ité :endwhile spolu s :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: vnorenie :try je príli¹ hlboké"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch bez :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch nasleduje po :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally bez :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: viacnásobné pou¾ité :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry bez :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction mimo funkciu"
 
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: Nie je dovolené v bezpeènostnej schránke"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: Vzoru %s nevyhovuje ¾iadny buffer"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "meno tagu"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " typ súboru\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'voµba 'history' je nastavená na nulu"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1330,200 +1981,308 @@ msgstr ""
 "\n"
 "# História %s (zaèínajúci najnov¹ou polo¾kou):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Príkazový riadok"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Vyhµadávaný re»azec"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Výraz"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Vstupný riadok"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar prevy¹uje då¾ku príkazu"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktívne okno alebo buffer bol vymazaný"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Chybná cesta: '**[èíslo] musí by» buï na konci cesty, alebo musí by»\n"
+"nasledované '%s. Viï :help path."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Adresár \"%s\" sa nedá nájs» v cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Súbor \"%s\" sa nepodarilo nájs»"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: ®iadny ïal¹í adresár \"%s\" nebol v cdpath nájdený"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: ®iadny ïal¹í súbor \"%s\" nebol v ceste nájdený"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: Automatické príkazy *Filter* nesmú meni» aktuálny buffer"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Neprípustný názov súboru"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "je adresárom"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "nie je súborom"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[nový súbor]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[prístup odmietnutý]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: automatické príkazy *ReadPre urobili súbor neèitateµným"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: automatické príkazy *ReadPre nesmú meni» aktuálny buffer"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: èítam zo ¹tandardného vstupu...\n"
 
-msgid "Reading from stdin..."
-msgstr "Èítam zo ¹tandardného vstupu..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Po konverzii je súbor neèitateµný!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[pomenovaná rúra/soket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[pomenovaná rúra]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[soket]"
 
-msgid "[RO]"
-msgstr "[RO]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 znak"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[chýba CR]"
 
-msgid "[NL found]"
-msgstr "[nájdené NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[dlhé riadky zalomené]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[neskonvertovaný]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[skonvertovaný]"
 
-msgid "[crypted]"
-msgstr "[¹ifrovaný]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[NEPRÍPUSTNÝ BAJT na riadku %<PRId64>]"
 
-msgid "[CONVERSION ERROR]"
-msgstr "[CHYBA PREVODU]"
-
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[NEPRÍPUSTNÝ BAJT na riadku %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[CHYBY ÈÍTANIA]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Nedá sa nájs» doèasný súbor pre konverziu"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konverzia s 'charconvert' sa nepodarila"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "nedá sa èíta» výstup 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: ®iadne vyhovujúce automatické príkazy pre acwrite buffer "
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Automatické príkazy zmazali èi deaktivovali buffer, ktorý mal by» "
 "ulo¾ený"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Automatický príkaz neoèakávaným spôsobom zmenil poèet riadkov"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans rozhranie nedovolilo zapísa» nemodifikované buffre"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Èiastoèné zápisy nie sú povolené pre NetBeans buffre"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "nie je súborom ani zapisovatelným zariadením"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "je iba pre èítanie (pou¾ite ! pre vynútenie)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Nedá sa zapisova» do zálo¾ného súboru (pou¾ite ! pre vynútenie)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Chyba pri uzatváraní zálo¾ného súboru (pou¾ite ! pre vynútenie)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Nedá sa naèíta» súbor pre zálohu (pou¾ite ! pre vynútenie)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Nedá sa vytvori» zálo¾ný súbor (pou¾ite ! pre vynútenie)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Nedá sa vytvori» zálo¾ný súbor (pou¾ite ! pre vynútenie)"
 
-# TODO: resource fork ?! Note: used only in MACOS_X version
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: 'Resource fork' bude stratený (pou¾ite ! pre vynútenie)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Nedá sa nájs» doèasný súbor pre ukladanie"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Nedá sa spravi» konverzia (pou¾ite ! pre zápis bez konverzie)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Súbor sa nedá otvori» pre ukladanie"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Súbor sa nedá otvori» pre ukladanie"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync zlyhal"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Zatvorenie zlyhalo"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: chyba pri zápise, konverzia sa nepodarila (nastavte voµbu 'fenc' na prázdnu pre vynútenie)"
+msgstr ""
+"E513: chyba pri zápise, konverzia sa nepodarila (nastavte voµbu 'fenc' na "
+"prázdnu pre vynútenie)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: chyba pri zápise, konverzia sa nepodarila (nastavte voµbu 'fenc' na "
+"prázdnu pre vynútenie)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: chyba pri ukladaní (plný disk?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " CHYBA PREVODU"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "riadok %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[zariadenie]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[nový]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [p]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " pripojený"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [u]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " ulo¾ený"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: nedá sa ulo¾i» pôvodný súbor"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: nedá sa zapisova» do prázdneho pôvodného súboru"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Nedá sa vymaza» zálo¾ný súbor"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1531,74 +2290,96 @@ msgstr ""
 "\n"
 "VAROVANIE: Obsah pôvodného súboru mô¾e by» stratený alebo po¹kodený\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "neukonèujte editor skôr, ne¾ bude súbor úspe¹ne ulo¾ený!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos formát]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac formát]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix formát]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 riadok, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> riadkov, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 znak"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> znakov"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[bez znaku konca riadku]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[neúplný posledný riadok]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "VAROVANIE: Súbor bol zmenený od jeho naèítania!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Chcete ho naozaj ulo¾i»"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Chyba pri zápise do \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Chyba pri uzatváraní \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Chyba pri èítaní \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: automatický príkaz FileChangedShell vymazal buffer"
 
+#: ../fileio.c:4894
+#, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Varovanie: súbor \"%s\" u¾ nie je dostupný"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1607,31 +2388,39 @@ msgstr ""
 "W12: Varovanie: súbor \"%s\" bol po zaèatí úpravy zmenený a buffer sa tie¾ "
 "zmenil "
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Pozrite \":help W12\" pre viac informácií."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Varovanie: súbor \"%s\" bol po zaèatí úpravy zmenený"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Pozrite \":help W11\" pre viac informácií."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Varovanie: Prístupové práva k súboru \"%s\" boli po zaèatí úprav zmenené"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Pozrite \":help W16\" pre viac informácií."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Varovanie: Súbor \"%s\" bol vytvorený po zaèatí úpravy"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Varovanie"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1639,37 +2428,48 @@ msgstr ""
 "&OK\n"
 "&Naèíta» súbor"
 
+#: ../fileio.c:5065
+#, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Nemo¾no pripravi» na opätovné naèítanie \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: nedá sa obnovi» \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Vymazaný--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "samomazací automatický príkaz: %s <buffer=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Skupina \"%s\" neexistuje"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Neprípustný znak po *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Udalos» %s neexistuje"
 
+#: ../fileio.c:5907
+#, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Udalos» alebo skupina %s neexistuje"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1677,541 +2477,808 @@ msgstr ""
 "\n"
 "--- Automatické príkazy ---"
 
+#: ../fileio.c:6293
+#, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: chybné èíslo bufferu"
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Automatické príkazy sa nedajú spusti» pre V©ETKY udalosti"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "®iadne vyhovujúce automatické príkazy"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: vnorenia automatického príkazu sú príli¹ hlboké"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Automatické príkazy pre \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Spú¹»am %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "automatický príkaz %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Chýba {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Chýba }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Nebol nájdené ¾iadne vnorenie"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Nedá sa vytvori» vnorenie s aktuálnou metódou 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Nedá sa zru¹i» vnorenie s aktuálnou metódou 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld riadkov zahnutých "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Prida» do bufferu pre èítanie"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekurzívne mapovanie"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: pre %s u¾ globálna skratka existuje"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: pre %s u¾ globálne mapovanie existuje"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: pre %s u¾ skratka existuje"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: pre %s u¾ mapovanie existuje"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "®iadna skratka nebola nájdená"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "®iadne mapovanie nebolo nájdené"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: neprípustný mód"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Nedá sa spusti» GUI (grafické rozhranie)"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Buffer neobsahuje ¾iadne riadky--"
 
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Nedá sa èíta» z \"%s\""
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Príkaz preru¹ený"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Nemo¾no na¹tartova» grafické rozhranie, nenájdený ¾iaden pou¾itelný font"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Je vy¾adovaný argument"
 
-msgid "E231: 'guifontwide' invalid"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: po \\ by malo nasledova» /, ? alebo &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr ""
-"E231: voµba 'guifontwide' (nastavenie ¹irokého písma) je chybne nastavená"
+"E11: Chybný príkaz v okne príkazového riadku; <Enter> spú¹»a, CTRL-C ukonèuje"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Hodnota 'imactivatekey' je nesprávne nastavená"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Nedá sa alokova» farba %s"
-
-msgid "No match at cursor, finding next"
-msgstr "®iadna zhoda na pozícii kurzora, hµadám ïalej"
-
-msgid "<cannot open> "
-msgstr "<nedá sa otvori»> "
-
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: písmo %s nie je dostupné"
-
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: nedá sa vráti» do aktuálneho adresára"
-
-msgid "Pathname:"
-msgstr "Názov cesty:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: nedá sa zisti» aktuálny adresár"
-
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Zru¹i»"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Prípravok posuvnej li¹ty: nedá sa zisti» geometria náhµadu obrázku."
-
-msgid "Vim dialog"
-msgstr "Vim dialóg"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: BalloonEval nedá sa vytvori» správou a zároveò spätným volaním"
-
-msgid "Vim dialog..."
-msgstr "Vim dialóg.."
-
-# TODO: Translate as "&Ano\n&Nie\n&Zru¹i»" ?
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Ano\n"
-"&Nie\n"
-"&Zru¹i»"
+"E12: Príkaz nie je z exrc/vimrc v aktuálnom adresári alebo pri hµadaní tagu "
+"povolený."
 
-msgid "Input _Methods"
-msgstr "Vstupné metódy (_Methods)"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Chýba :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Nájs» a nahradi»..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Chýba :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Nájs»..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Chýba :endwhile"
 
-msgid "Find what:"
-msgstr "Vyhµada»:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Chýba :endfor"
 
-msgid "Replace with:"
-msgstr "Nahradi» s:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile bez zodpovedajúceho :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Hµada» len celé slová"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor bez zodpovedajúceho :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Zhoda veµkosti písmen"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Súbor existuje (pou¾ite ! pre prepísanie)"
 
-msgid "Direction"
-msgstr "Smer"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Príkaz zlyhal"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Hore"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Vnútorná chyba"
 
-msgid "Down"
-msgstr "Dolu"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Preru¹ené"
 
-msgid "Find Next"
-msgstr "Nájs» ïal¹ie"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Chybná adresa"
 
-msgid "Replace"
-msgstr "Nahradi»"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Chybný argument"
 
-msgid "Replace All"
-msgstr "Nahradi» V¹etko"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Prijatá po¾iadavka na ukonèenie (die) od mana¾éra sedení\n"
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Hlavné okno neoèakávane zru¹ené\n"
-
-msgid "Font Selection"
-msgstr "Výber Písma"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Pou¾itý CUT_BUFFER0 namiesto prázdneho výberu"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Zru¹i»"
-
-msgid "Directories"
-msgstr "Adresáre"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Pomocník"
-
-msgid "Files"
-msgstr "Súbory"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Výber"
-
-msgid "Find &Next"
-msgstr "Nájs» ïa&l¹ie"
-
-msgid "&Replace"
-msgstr "&Nahradi»"
-
-msgid "Replace &All"
-msgstr "Nahradi» &V¹etko"
-
-msgid "&Undo"
-msgstr "&Spä»"
-
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Nemo¾no nájs» okno s titulkom \"%s\""
-
+#: ../globals.h:1015
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument nie je podporovaný: \"-%s\"; Pou¾ite OLE verziu."
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Chybný argument: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Nemo¾no otvori» okno vnútri MDI aplikácie"
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Chybný výraz: %s"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Nájs» re»azec (pou¾ite '\\\\' ak chete nájs» '\\')"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Chybný rozsah"
 
-# Following warning can be ignored:
-# msgfmt -v --statistics --check -C --check-accelerators="&" -o sk.mo sk.po
-# sk.po:2497: msgstr lacks the keyboard accelerator mark '&'
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Nájs» a Nahradi» (pou¾ite '\\\\' ak chcete nájs» '\\')"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Chybný príkaz"
 
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "[neupravovaný]"
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" je adresárom"
 
-msgid "Directory\t*.nothing\n"
-msgstr "Adresár\t*.niè\n"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Chybná hodnota veµkosti rolovania"
 
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Nedá sa alokova» polo¾ka mapy farieb, niektoré farby mô¾u by» "
-"nesprávne"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Chýba písmo pre nasledujúce znakové sady %s:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Názov sady písiem: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Písmo '%s' nemá pevnou ¹írku"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Názov sady písiem: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Písmo0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Písmo1: %s\n"
-
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Písmo%<PRId64> nie je dvakrát ¹ir¹ie ako písmo0\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "©írka písma0: %<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"©írka písma1: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "Chybná ¹pecifikácia písma"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Vyvolanie kni¾niènej funkcia zlyhalo pre \"%s()\""
 
-msgid "&Dismiss"
-msgstr "&Zru¹i»"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Znaèka má chybné èíslo riadku"
 
-msgid "no specific match"
-msgstr "¾iadna ¹pecifická zhoda"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Znaèka nie je nastavená"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Výber písma"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Nemo¾no robi» zmeny, voµba 'modifiable' je vypnutá"
 
-msgid "Name:"
-msgstr "Meno:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skripty vnorené príli¹ hlboko"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Ukazuj veµkos» v bodoch"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: ®iadny alternatívny súbor"
 
-msgid "Encoding:"
-msgstr "Kódujem:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Taká skratka neexistuje"
 
-msgid "Font:"
-msgstr "Písmo:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! nie je povolený"
 
-msgid "Style:"
-msgstr "©týl"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Nedá sa pou¾í» GUI: nebolo zapnuté pri preklade programu"
 
-msgid "Size:"
-msgstr "Veµkos»:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Skupina zvýraznenia %s neexistuje"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul ERROR - chyba kórejského spôsobu vkladania znakov"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Zatiaµ nie je vlo¾ený ¾iaden text"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: ®iadny predchádzajúci príkazový riadok"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Mapovanie nenájdené"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: ®iadna zhoda"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: ®iadna zhoda: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ®iadny názov súboru"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: ®iadny predchádzajúci prislúchajúci správny výraz"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: ®iadny predchádzajúci príkaz"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: ®iadny predchádzajúci regulárny výraz"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Rozsah nie je povolený"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Nedostatok miesta"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Nedá sa vytvori» súbor %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Nedá sa získa» názov doèasného súboru"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Nedá sa otvori» súbor %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Nedá sa èíta» súbor %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Neulo¾ené zmeny (pou¾ite ! pre vynútenie)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Neulo¾ené zmeny]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Nulový argument"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Oèakávané èíslo"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Nedá sa otvori» chybový súbor %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Nedostatok pamäti!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Vzor nenájdený"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Vzor nenájdený: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument musí by» kladný"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: ®iadny predchádzajúci adresár"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: ®iadne chyby"
+
+#: ../globals.h:1067
+#, fuzzy
+msgid "E776: No location list"
+msgstr "E760: Chýajúci poèet slov v %s"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Po¹kodený re»azac pre vyhµadávanie"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Po¹kodený regexp program"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr ""
+"E45: voµba 'readonly' (iba na èítanie) je nastavená (pou¾ite ! pre "
+"prepísanie)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Nedá sa nastavi» premenná len na èítanie \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Nedá sa nastavi» premenná v bezpeènostnej schránke: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Chyba pri èítaní chybového súboru"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Nie je dovolené v bezpeènostnej schránke"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Nie je na povolené na tomto mieste"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Nastavovanie re¾imu obrazovky nie je podporované"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Chybná hodnota veµkosti rolovania"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: voµba 'shell' je prázdna"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Chyba -- nedájú sa preèíta» oznaèovacie dáta!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Chyba pri uzatváraní odkladacieho súboru"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: zoznam tagov je prázdny"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Príkaz je príli¹ zlo¾itý"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Názov je príli¹ dlhý"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Príli¹ mnoho ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Príli¹ mnoho názvov súborov"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Nadbytoèné znaky na konci"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Neznáma znaèka"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Nemo¾no expandova» ¾olíkové znaky (wildcards)"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr ""
+"E591: hodnota voµby 'winheight' (vý¹ka okna) nesmie by» men¹ia ne¾ hodnota "
+"voµby 'winminheight' (minimálna vý¹ka okna)"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr ""
+"E592: hodnota voµby 'winwidth' (¹írka okna) nesmie by» men¹ia ne¾ hodnota "
+"volµy 'winminwidth' (minimálna ¹írka okna)"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Chyba pri ukladaní"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Nulový poèet"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Pou¾itie <SID> mimo kontext skriptu"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Vnútorná chyba: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: vzor pou¾íva viac pamäte ako 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: prázdny buffer"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Neprípustný hµadaný re»azec alebo oddeµovaè"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Súbor je naèítaný v inom buffere"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Voµba \"%s\" nie je nastavená"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: '%s' nie je prístupné meno registru"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "hµadanie dosiahlo zaèiatok, pokraèovanie od konca"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "hµadanie dosiahlo koniec, pokraèovanie od zaèiatku"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Chýba dvojbodka"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Neprípustný komponent"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: oèakávaná èíslica"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Strana %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "®iadny text na tlaè"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Tlaèím stranu %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kópia %d z %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Vytlaèené: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Tlaè bola zru¹ená"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Nedá sa zapisova» do výstupného PostScriptového súboru"
 
+#: ../hardcopy.c:1747
+#, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Nedá sa otvori» súbor \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Nedá sa èíta» PostScriptový súbor \"%s\""
 
+#: ../hardcopy.c:1772
+#, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: súbor \"%s\" nie je vo formáte PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: súbor \"%s\" nie je podporvaný PostScriptový súbor"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" zdrojový súbor má zlé èíslo verzie"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: nekompatibilné viacbajtové kódovanie a znaková sada."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
-msgstr "E674: voµba printmbcharset nemô¾e by» prázdna pri viacbajtovom kódovaní."
+msgstr ""
+"E674: voµba printmbcharset nemô¾e by» prázdna pri viacbajtovom kódovaní."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Nie je ¹pecifikované ¾iadne písmo pre viacbajtové tlaèenie."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Nedá sa otvori» výstupný PostScriptový súbor"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Nedá sa otvori» súbor \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Nemo¾no nájs» PostScriptový zdrojový súbor \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Nemo¾no nájs» PostScriptový zdrojový súbor \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Nemo¾no nájs» PostScriptový zdrojový súbor \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Nemo¾no skonvertova» do kódovania na tlaèenie \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Posielam na tlaèiareò..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScriptový súbor sa nepodarilo vytlaèi»"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Tlaèová úloha bola odoslaná."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Prida» novú databázu"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Hµadanie vzoru"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Zobrazi» túto správu"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Ukonèi» spojenie"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Znovu inicializova» v¹etky spojenia"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Zobrazi» spojenia"
 
+#: ../if_cscope.c:101
+#, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Pou¾itie: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Tento cscope príkaz nepodporuje rozdeµovanie okna.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Pou¾itie: cstag <odsadenie>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tag nenájdený"
 
+#: ../if_cscope.c:461
+#, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) chyba: %d"
 
-msgid "E563: stat error"
-msgstr "E563: chyba stat"
-
+#: ../if_cscope.c:551
+#, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s nie je ani adresárom ani správnou cscope databázou"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Pridaná cscope databáza %s"
 
+#: ../if_cscope.c:616
+#, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: chyba pri èítaní cscope spojenia %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: neznámy typ cscope hµadania"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Nedajú sa vytvori» cscope rúry"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Nemo¾no spusti» proces pre cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "spustenie cs_create_connection zlyhalo"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "spustenie cs_create_connection zlyhalo"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Nedajú sa vytvori» cscope rúry"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: volanie fdopen pre to_fp zlyhalo"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: volanie fdopen pre fr_fp zlyhalo"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Nedajú sa vytvori» cscope rúry"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: ¾iadne cscope spojenia"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: cscope hµadanie %s vo vzore %s nena¹lo ¾iadnu zhodu"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: chybný cscopequickfix príznak %c pre %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: cscope hµadanie %s vo vzore %s nena¹lo ¾iadnu zhodu"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "príkazy cscope:\n"
 
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Pou¾itie: %s)"
 
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: nemo¾no otvori» cscope databázu: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: nemo¾no získa» cscope databázové informácie"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: duplicitná cscope databáza nebola pridaná"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: dosiahnutý maximálny poèet cscope spojení"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope spojenie %s nenájdené"
 
+#: ../if_cscope.c:1364
+#, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope spojenie %s ukonèené"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: vá¾na chyba v cs_manage_matches"
 
+#: ../if_cscope.c:1693
+#, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2219,372 +3286,88 @@ msgstr ""
 "\n"
 "   #   riadok"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "názov súboru/ kontext / riadok\n"
 
+#: ../if_cscope.c:1809
+#, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Chyba cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "V¹etky cscope databáze resetované"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "¾iadne cscope spojenia\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    názov databázy                      predpona cesty\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr "???: Prepáète, tento príkaz je vypnutý, MzScheme kni¾nica nemô¾e by» naèítaná."
-
-msgid "invalid expression"
-msgstr "chybný výraz"
-
-msgid "expressions disabled at compile time"
-msgstr "podpora výrazov bola vypnutá pri preklade programu"
-
-msgid "hidden option"
-msgstr "skrytá voµba"
-
-msgid "unknown option"
-msgstr "neznáma voµba"
-
-msgid "window index is out of range"
-msgstr "èíslo okna mimo rozsah"
-
-msgid "couldn't open buffer"
-msgstr "nemo¾no otvori» buffer"
-
-msgid "cannot save undo information"
-msgstr "nedajú sa ulo¾i» zálo¾ne (opravné) informácie"
-
-msgid "cannot delete line"
-msgstr "nedá sa vymaza» riadok"
-
-msgid "cannot replace line"
-msgstr "nedá sa nahradi» riadok"
-
-msgid "cannot insert line"
-msgstr "nedá sa vlo¾i» riadok"
-
-msgid "string cannot contain newlines"
-msgstr "re»azec nesmie obsahova» znaky nového riadku"
-
-msgid "Vim error: ~a"
-msgstr "Chyba Vim: ~a"
-
-msgid "Vim error"
-msgstr "Chyba Vim"
-
-msgid "buffer is invalid"
-msgstr "buffer je neplatný"
-
-msgid "window is invalid"
-msgstr "okno je neplatné"
-
-msgid "linenr out of range"
-msgstr "èíslo riadka mimo rozsah"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "nie je dovolené v bezpeènostnej schránke"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E262: Prepáète, tento príkaz je vypnutý, Python kni¾nica nemô¾e by» naèítaná."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Python nemô¾e by» spustený rekurzívne"
-
-msgid "can't delete OutputObject attributes"
-msgstr "nedá sa vymaza» vlastnos» OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "softspace musí by» kladné celé èíslo"
-
-msgid "invalid attribute"
-msgstr "chybná vlastnos»"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() vy¾aduje zoznam re»azcov"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Chyba pri inicializácii I/O objektov"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "pokus o odkaz na vymazaný buffer"
-
-msgid "line number out of range"
-msgstr "èíslo riadka mimo rozsah"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<objekt bufferu (vymazaný) na %8lX>"
-
-msgid "invalid mark name"
-msgstr "chybné meno znaèky"
-
-msgid "no such buffer"
-msgstr "¾iadny taký buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "pokus o odkaz na vymazané okno"
-
-msgid "readonly attribute"
-msgstr "vlastnos» iba pre èítanie"
-
-msgid "cursor position outside buffer"
-msgstr "umiestnenie kurzoru mimo buffer"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<objekt okna (vymazaný) na %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<objekt okna (neznámy) na %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<okno %d>"
-
-msgid "no such window"
-msgstr "¾iadne také okno"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Prepáète, tento príkaz je vypnutý, Ruby kni¾nica nemô¾e by» naèítaná."
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Neznámy 'longjmp' stav %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Prepnú» implementáciu/definíciu"
-
-msgid "Show base class of"
-msgstr "Ukáza» základnú triedu"
-
-msgid "Show overridden member function"
-msgstr "Ukáza» pre»a¾enú èlenskú funkciu"
-
-msgid "Retrieve from file"
-msgstr "Obnovi» zo súboru"
-
-msgid "Retrieve from project"
-msgstr "Obnovi» z projektu"
-
-msgid "Retrieve from all projects"
-msgstr "Obnovi» zo v¹etkých projektov"
-
-msgid "Retrieve"
-msgstr "Obnovi»"
-
-msgid "Show source of"
-msgstr "Ukáza» zdroj"
-
-msgid "Find symbol"
-msgstr "Nájs» znak"
-
-msgid "Browse class"
-msgstr "Prezrie» triedu"
-
-msgid "Show class in hierarchy"
-msgstr "Ukáza» triedu v hierarchii"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Ukáza» triedu v obmedzenej hierarchii"
-
-msgid "Xref refers to"
-msgstr "Xref odkazuje na"
-
-msgid "Xref referred by"
-msgstr "Xref odkázaný z"
-
-msgid "Xref has a"
-msgstr "Xref má"
-
-msgid "Xref used by"
-msgstr "Xref pou¾itý"
-
-msgid "Show docu of"
-msgstr "Ukáza» dokumentáciu"
-
-msgid "Generate docu for"
-msgstr "Vytvori» dokumentáciu pre"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Zlyhalo pripojenie na SNiFF+, Preverte prostredie (sniffemacs sa musí "
-"nachádza» v $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Chyba poèas èítania. Odpojené"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ je aktuálne "
-
-msgid "not "
-msgstr "ne"
-
-msgid "connected"
-msgstr "pripojený"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Neznáma SNiFF+ po¾iadavka: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Chyba pripojenia na SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ nie je pripojený"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Nie je SNiFF+ bufferom"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Chyba zápisu. Odpojené"
-
-msgid "invalid buffer number"
-msgstr "chybné èíslo bufferu"
-
-msgid "not implemented yet"
-msgstr "nie je e¹te podporované"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "nedajú sa nastavi» riadky"
-
-msgid "mark not set"
-msgstr "znaèka nie je nastavená"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "riadok %d ståpec %d"
-
-msgid "cannot insert/append line"
-msgstr "nedá sa vlo¾i»/pripoji» riadok"
-
-msgid "unknown flag: "
-msgstr "neznámy príznak: "
-
-msgid "unknown vimOption"
-msgstr "neznáma voµba (vimOption)"
-
-msgid "keyboard interrupt"
-msgstr "preru¹enie z klávesnice"
-
-msgid "vim error"
-msgstr "chyba Vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "nedá sa vytvori» príkaz bufferu/okna: objekt bude vymazaný"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"nedá sa zaregistrova» príkaz spätného volania: buffer/okno u¾ bol vymazaný"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL FATAL ERROR: reflist po¹kodený!? Oznámte, prosím, túto chybu na "
-"vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"nedá sa zaregistrova» príkaz spätného volania: odkaz na buffer/okno nenájdený"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Prepáète, tento príkaz je vypnutý, Tcl kni¾nica nemô¾e by» naèítaná."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL CHYBA: návratový kód nie je celé èíslo!? Oznámte, prosím, túto "
-"chybu na vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: návratový kód %d"
-
-msgid "cannot get line"
-msgstr "nedá sa preèíta» riadok"
-
-msgid "Unable to register a command server name"
-msgstr "Nemô¾em zaregistrova» meno príkazového servra"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Chyba poèas prenosu príkazu do cieµového programu"
-
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Pou¾íté chybné èíslo servera: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM registrová vlastnos» je zle formátovaná.  Vymazané!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Neznámy parameter voµby"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Príli¹ mnoho upravovacích argumentov"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Chýba argument po"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Chyby za parametrom voµby"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
-msgstr "Príli¹ mnoho \"+príkaz\", \"-c príkaz\" alebo \"--cmd príkaz\" argumentov"
+msgstr ""
+"Príli¹ mnoho \"+príkaz\", \"-c príkaz\" alebo \"--cmd príkaz\" argumentov"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Chybný argument pre"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d súborov pre úpravu\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Tento Vim nebol kompilovaný s porovnávacími funkciami."
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Pokus o opätovné otvorenie skriptu: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Nedá sa otvori» pre zápis: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Nedá sa otvori» pre výstup skriptu: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Chyba: Chyba spú¹»ania gvim pre NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Varovanie: Výstup nesmeruje na terminál\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Varovanie: Vstup nepochádza z terminálu\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc príkazový riadok"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Nedá sa èíta» z \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2592,18 +3375,23 @@ msgstr ""
 "\n"
 "Podrobnej¹ie informácie získáte pomocou \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[súbor ..] ..       upravi» súbor(y)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                   èíta» text z ¹tandardného vstupu"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          upravi» súbor na mieste definície tagu"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [chybový súbor]  upravi» súbor na mieste výskytu prvej chyby"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2613,9 +3401,11 @@ msgstr ""
 "\n"
 "pou¾itie:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr "vim [argumenty] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2623,10 +3413,7 @@ msgstr ""
 "\n"
 "   alebo:"
 
-#. TODO: is translation correct?
-msgid "where case is ignored prepend / to make flag upper case"
-msgstr "v prípade, ¾e je ignorovaná veµkos» písmen, pou¾ite znak '/' na zaèiatku, aby mal príznak význam veµkého písmena"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2636,335 +3423,191 @@ msgstr ""
 "\n"
 "Argumenty:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tMô¾u nasledova» iba názvy súborov"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tNexpandova» ¾olíkové znaky (wildcards)"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tPrihlási» gvim na OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-register\t\tOdhlási» gvim z OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tSpusti» v grafickom (GUI) móde (rovnaké ako \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr ""
-"-f  alebo  --nofork\tPopredie: Pri spustení grafického (GUI) módu sa nepresunie do pozadia"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi mód (rovnaké ako \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx mód (rovnaké ako \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tTichý (dávkový) mód (iba pre \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tPorovnávací mód (rovnaké ako \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tJednoduchý mód (rovnaké ako \"evim\", bezmódový)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMód iba pre èítanie (ako \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tObmedzený mód (rovnaké ako \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmeny (ukladanie súborov) zakázané"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tZmeny v texte zakázané"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinárny mód"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp mód"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatabilný s Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tKompatibilita s Vi vypnutá: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tÚroveò výpisu hlá¹ok"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tLadiaci mód"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tNevytvára» odkladací súbor, pou¾íva» iba pamä»"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tVypí¹ zoznam odkladacích súborov a skonèi"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (s názvom súboru)\tObnoví preru¹ené sedenie"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tRovnaké ako -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tNebude pou¾íva» newcli pre otvorenie okna"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <zariadenie>\t\tPou¾i» <zariadenie> pre I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tspusti v Arabic móde"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tspusti v hebrejskom móde"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tspusti vo Farsi móde"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminál>\tNastaví typ terminálu na <terminál>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tPou¾ije <vimrc> namiesto akéhokoµvek .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tPou¾ije <gvimrc> namiesto akéhokoµvek .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tNenahrá zásuvné moduly(plugin skripty)"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tOtvorí N okien (implicitne jedno pre ka¾dý súbor)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tOtvorí N okien (implicitne jedno pre ka¾dý súbor)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tAko -o ale rozdelí vertikálne"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tNastaví kurzor na koniec súboru"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<riadok>\t\tNastaví kurzor na <riadok>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <príkaz>\t\tVykoná <príkaz> pred nahratím vimrc súboru"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <príkaz>\t\tPo nahratí prvého súboru vykoná <príkaz>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr ""
 "-S <sedenie>\t\tPo nahratí prvého súboru vykoná príkazy v súbore <sedenie>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <skript>\t\tNaèíta príkazy normálneho módu zo <skriptu>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <skript>\t\tPripojí v¹etky napísané príkazy do súboru <skript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <skript>\t\tUlo¾í v¹etky napísané príkazy do súboru <skript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tÚprava za¹ifrovaných súborov"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <displej>\tPripojí vim na príslu¹ný X-server"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tNepripojí sa k X serveru"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <súbory>\tUpravi» <súbory> na Vim servri ak je to mo¾né"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <súbory>\tTo isté, ale nes»a¾uj si, ak neexistuje server"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-wait <súbory>\tAko --remote ale èaká na súbory pre ukonèenie úprav"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <súbory>\tTo isté, ale nes»a¾uj si, ak neexistuje server"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <voµby>\tOdo¹le <voµby> na Vim server a skonèí"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <výraz>\tSpusti <výraz> na servri a vytlaèí výsledok"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tVypí¹e zoznam mien dostupných Vim servrov a skonèí"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <názov>\tOdo¹le na Vim server <názov>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tPou¾ije <viminfo> namiesto akéhokoµvek .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  alebo  --help\tVypí¹e túto nápovedu a skonèí"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tVypí¹e informácie o verzii a skonèí"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (Motif verzia):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (neXtaw verzia):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (Athena verzia):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <displej>\tSpustí vim na <displej>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tSpustí vim minimalizované"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <názov>\t\tPou¾ije resource ako by vim mal <názov>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (nie je implementované)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <farba>\tNastaví sa <farba> pozadia (tie¾ -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <farba>\tNastaví sa <farba> popredia (tie¾ -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <písmo>\t\tNastaví <písmo> normálneho textu (tie¾ -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <písmo>\tNastaví <písmo> pre zvýraznený text"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <písmo>\tNastaví <písmo> pre kurzívu"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geometrie>\tNastaví sa <geometria> (tie¾ -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <¹írka>\tNastaví <¹írku> okrajov (tie¾ -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <¹írka>  Nastaví <¹írku> posuvnej li¹ty (tie¾ -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <vý¹ka>\tNastaví <vý¹ku> ponuky (tie¾ -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tPou¾ije reverzné farby (tie¾ -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tNepou¾ije reverzné farby (tie¾ +rv)"
-
-# TODO: howto translate 'resource' in this case?
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\tNastaví zadaný <resource>"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (RISC OS verzia):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <poèet>\tPoèiatoèná ¹írka okna v ståpcoch"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <poèet>\tPoèiatoèná vý¹ka okna v riadkoch"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre gvim (GTK+ verzia):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <displej>\tSpustí vim na <displej> (tie¾ --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "-role <rola>\tNastaví unikátnu rolu pre identifikáciu hlavného okna"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tOtvorí Vim vnútri iného GTK programu."
-
-msgid ""
-"\n"
-"Arguments recognised by kvim (KDE version):\n"
-msgstr ""
-"\n"
-"Argumenty dostupné pre kvim (KDE verzia):\n"
-
-msgid "-black\t\tUse reverse video"
-msgstr "-black\t\tPou¾ije reverzné farby"
-
-msgid "-tip\t\t\tDisplay the tip dialog on startup"
-msgstr "-tip\t\t\tZobraz tip pri ¹tarte"
-
-msgid "-notip\t\tDisable the tip dialog"
-msgstr "-notip\t\tNezobrazuj tip pri ¹tarte"
-
-msgid "--display <display>\tRun vim on <display>"
-msgstr "-display <displej>\tSpustí vim na <displej>"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <titulok rodièa>\tOtvor Vim vnútri materskej aplikácie"
-
-msgid "No display"
-msgstr "Bez grafického rozhrania"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Odoslanie zlyhalo.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Odoslanie zlyhalo. Pokú¹am sa spusti» lokálne\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d upravených súborov z %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "®iaden graf. mód: Odoslanie výrazu zlyhalo.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Odoslanie výrazu zlyhalo.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Nie sú nastavené ¾iadne znaèky"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283:\"%s\" nevyhovujú ¾iadne znaèky"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2973,6 +3616,7 @@ msgstr ""
 "znaèka riadok  ståpec súbor/text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2981,6 +3625,7 @@ msgstr ""
 " skok riadok ståpec súbor/text"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -2988,7 +3633,7 @@ msgstr ""
 "\n"
 "znaèka riadok  ståpec text"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2997,7 +3642,7 @@ msgstr ""
 "# Súborové znaèky:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3005,7 +3650,7 @@ msgstr ""
 "\n"
 "# Zoznam skokov (zaèínajúci najnov¹ou polo¾kou):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3013,95 +3658,85 @@ msgstr ""
 "\n"
 "# História znaèiek v súboroch (zaèínajúci najnov¹ou polo¾kou):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Chýba '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Chybná kódová stránka"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Nedajú sa nastavi» IC hodnoty"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Nepodarilo sa vytvori» vstupný kontext"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Nepodarilo sa otvori» vstupnú metódu"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Varovanie: likvidaèné spätné volanie sa nedá nastavi» na IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: vstupná metóda nepodporuje ¾iadny ¹týl"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: vstupná metóda nepodporuje môj 'preedit' typ"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: Nadbodový ¹týl vy¾aduje sadu fontov (fontset)"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Máte GTK+ verziu star¹iu ne¾ 1.2.3. Stavová plocha vypnutá."
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Server vstupných metód nebe¾í"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: blok nebol zamknutý"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Chyba posunu pri èítaní odkladacieho súboru"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Chyba pri èítaní odkladacieho súboru"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Chyba posunu pri ukladaní do odkladacieho súboru"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Chyba pri ukladaní do odkladacieho súboru"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Odkladací súbor u¾ existuje (symlink útok?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Nedá sa získa» blok 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Nedá sa získa» blok 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Nedá sa získa» blok 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ups, odkladací súbor bol stratený!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Nedá sa premenova» odkladací súbor"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Nedá sa otvori» odkladací súbor pre \"%s\", oprava nemo¾ná"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): nedá sa získa» blok 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Odkladací súbor pre %s nebol nájdený"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Zadajte èíslo odkladacieho súboru, ktorý sa má pou¾it (0 pre ukonèenie): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Nedá sa otvori» %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Nedá sa èíta» blok 0 z "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3109,22 +3744,28 @@ msgstr ""
 "\n"
 "Mo¾no nedo¹lo k ¾iadnym zmenám, alebo Vim neaktualizoval odkladací súbor."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " nedá sa pou¾i» s touto verziou Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Pou¾ite Vim verziu 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s sa nezdá by» odkladacím súborom Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " nedá sa pou¾í» na tomto poèítaèi.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Súbor bol vytvorený "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3132,63 +3773,85 @@ msgstr ""
 ",\n"
 "alebo bol súbor po¹kodený."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Pou¾ívam odkladací súbor \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Pôvodný súbor \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Varovanie: Pôvodný súbor mohol by» zmenený"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Nedá sa èíta» blok 1 z %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???CHÝBA MNOHO RIADKOV"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???CHYBNÝ POÈET RIADKOV"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???PRÁZDNY BLOK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???CHÝBAJÚCE RIADKY"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: ID bloku 1 je chybné (je %s odkladacím súborom?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???CHÝBA BLOK"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "od ??? po ???END mô¾u by» riadky pomie¹ané"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "od ??? po ???END mô¾u by» riadky vlo¾ené/vymazané"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???KONIEC"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Obnova preru¹ená"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: V priebehu obnovy do¹lo k chybám; skontrolujte riadky zaèínajúce na ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Pozrite \":help E312\" pre ïal¹ie informácie"
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Obnova dokonèená. Skontrolujte, èi je v¹etko v poriadku."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3196,48 +3859,69 @@ msgstr ""
 "\n"
 "(Zvá¾te ulo¾enie tohoto súboru pod iným menom\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "a pomocou programu diff zistite zmeny oproti pôvodnému súboru)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr "Potom vyma¾te odkladací súbor s príponou .swp.\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Nájdené odkladacie súbory:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   V aktuálnom adresári:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   So zadaným menom:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   V adresári "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- ¾iadne --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            vlastník: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    dátum vytvorenia: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "    dátum vytvorenia: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [od Vim verzie 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [nevyzerá ako odkladací súbor Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "        názov súboru: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3245,12 +3929,15 @@ msgstr ""
 "\n"
 "             zmenený: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ÁNO"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nie"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3258,9 +3945,11 @@ msgstr ""
 "\n"
 "    u¾ívateµské meno: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   názov poèítaèa: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3268,6 +3957,7 @@ msgstr ""
 "\n"
 "         názov poèítaèa: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3275,16 +3965,11 @@ msgstr ""
 "\n"
 "         ID procesu : "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (stále be¾í)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [nepou¾iteµné s touto verziou Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3292,71 +3977,97 @@ msgstr ""
 "\n"
 "         [nepou¾itelné na tomto poèítaèi]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [nedá sa preèíta»]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [nedá sa otvori»]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Nedá sa zachova» - odkladací súbor neexistuje"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Súbor zachovaný"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Uchovanie sa nepodarilo"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: chybné èíslo riadku: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: nedá sa nájs» riadok %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné èíslo ukazovateµa na blok 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx by mal ma» hodnotu 3"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Aktualizovaných príli¹ veµa blokov?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: chybné èíslo ukazovateµa na blok 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "vymazaný blok 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Nedá sa nájs» riadok %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné èíslo ukazovateµa na blok"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovú hodnotu"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: èíslo riadku je mimo rozsah: %<PRId64> (za koncom)"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: chybný poèet riadkov v bloku %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Nárast veµkosti zásobníku"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: chybný èíslo ukazovateµa na blok 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: POZOR"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3364,38 +4075,44 @@ msgstr ""
 "\n"
 "Nájdený odkladací súbor s menom \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Pri otváraní súboru \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NOV©Í ako odkladací súbor!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Súbor mô¾e by» upravovaný iným programom.\n"
 "    Ak je tomu tak, potom si dajte pozor, aby ste po ulo¾ení zmien\n"
 "    nemali dve rôzne verzie toho istého súboru.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Ukonèite program, alebo opatrne pokraèujte v úpravách.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Úprava tohoto súboru bola preru¹ená neoèakávaným ukonèením programu.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Ak je tomu tak, potom pou¾ite \":recover\" alebo \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3403,9 +4120,11 @@ msgstr ""
 "\"\n"
 "    pre obnovenie zmien (viï \":help recovery)\".\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Pokiaµ ste tak u¾ urobili, tak vyma¾te odkladací súbor \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3413,18 +4132,23 @@ msgstr ""
 "\"\n"
 "    a táto správa sa u¾ nebude objavova».\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Odkladací súbor \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" u¾ existuje!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - POZOR"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Odkladací súbor u¾ existuje!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3438,44 +4162,73 @@ msgstr ""
 "&Koniec\n"
 "&Zru¹i»"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Abort\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "&Otvori» iba pre èítanie\n"
-"&Pokraèovat v úpravách\n"
+"&Pokraèova» v úpravách\n"
 "O&bnovi» súbor\n"
 "&Koniec\n"
-"&Zru¹i»\n"
-"Z&maza»"
+"&Zru¹i»"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Príli¹ mnoho odkladacích súborov"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatok pamäte! (alokujem %<PRIu64> bajtov)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Èas» cesty k predmetu ponuky nie je podponukou"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Ponuka existuje iba v inom móde"
 
+#: ../menu.c:64
+#, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Ponuka \"%s\" neexistuje"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+#, fuzzy
+msgid "E792: Empty menu name"
+msgstr "E749: prázdny buffer"
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Cesta ponuky nesmie vies» do podponuky"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Polo¾ky ponuky sa nejdú pridáva» priamo na li¹tu"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Oddeµovaè nesmie by» èas»ou cesty ponuky"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3483,57 +4236,74 @@ msgstr ""
 "\n"
 "--- Ponuky ---"
 
-msgid "Tear off this menu"
-msgstr "Odtrhnú» tuto ponuku"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Cesta ponuky musí vies» k polo¾ke ponuky"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Ponuka nenájdená: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: V %s móde nie je ponuka definovaná"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Cesta ponuky musí vies» do podponuky"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Ponuka nenájdená - skontrolujte názvy ponúk"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Chyba pri spracovaní %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "riadok %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: '%s' nie je prístupné meno registru"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Správca prekladu: Lubomir Host <rajo@platon.sk>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Preru¹enie: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Stlaète ENTER alebo zadajte príkaz pre pokraèovanie"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, riadok %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Pokraèovanie --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " MEDZERA/d/j: obrazovka/stránka/riadok dole, b/u/k: hore, q: koniec "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Otázka"
 
 # TODO: Translate as "&Ano\n&Nie" ?
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3541,7 +4311,19 @@ msgstr ""
 "&Ano\n"
 "&Nie"
 
+# TODO: Translate as "&Ano\n&Nie\n&Zru¹i»" ?
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ano\n"
+"&Nie\n"
+"&Zru¹i»"
+
 # TODO: Translate as "&Ano\n&Nie\n&Ulo¾i» v¹etko\nZahodi» &v¹etko\n&Zru¹i»" ?
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3555,250 +4337,178 @@ msgstr ""
 "Zahodi» &v¹etko\n"
 "&Zru¹i»"
 
-msgid "Select Directory dialog"
-msgstr "Dialóg pre vytvorenie adresára"
-
-msgid "Save File dialog"
-msgstr "Dialóg pre ukladanie súborov"
-
-msgid "Open File dialog"
-msgstr "Dialóg pre otváranie súborov"
-
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: ¥utujem, ale konzolová verzia nepodporuje prehliadaè súborov"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Chybné argumenty pre funkciu printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Chybné argumenty pre funkciu printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Príli¹ mnoho argumentov pre funkciu printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Varovanie: mením súbor iba pre èítanie"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Zadajte èíslo ale kliknite my¹ou (<Enter> zru¹í): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Zvoµte èíslo (<Enter> zru¹í): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 nový riadok"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 vymazaný riadok"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> nových riadkov"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> vymazaných riadkov"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Preru¹ené)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Piip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: zachovávam súbory...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: ukonèený\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "CHYBA: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[bajtov] celkom uvolnené-alokované %<PRIu64>-%<PRIu64>, vyu¾ité %<PRIu64>, maximálne vyu¾itie %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[volanie] celkom re/malloc(): %<PRIu64>, celkom free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Riadok sa stáva príli¹ dlhým"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Nedostatok pamäte! (alokujem %<PRIu64> bajtov)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Volám shell na spustenie: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Chýba dvojbodka"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Neprípustný mód"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Chybný tvar my¹i"
-
-msgid "E548: digit expected"
-msgstr "E548: oèakávaná èíslica"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Neprípustné percento"
-
-msgid "Enter encryption key: "
-msgstr "Zadajte ¹ifrovací kµúè: "
-
-msgid "Enter same key again: "
-msgstr "Vlo¾te ten istý kµúè znova: "
-
-msgid "Keys don't match!"
-msgstr "Kµúèe sa nezhodujú!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Chybná cesta: '**[èíslo] musí by» buï na konci cesty, alebo musí by»\n"
-"nasledované '%s. Viï :help path."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Adresár \"%s\" sa nedá nájs» v cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Súbor \"%s\" sa nepodarilo nájs»"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: ®iadny ïal¹í adresár \"%s\" nebol v cdpath nájdený"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: ®iadny ïal¹í súbor \"%s\" nebol v ceste nájdený"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Nedá sa pripoji» na Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Nedá sa pripoji» na Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Zlé prístupové práva pre súbor s informáciami pre NetBeans spojenie: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "èítanie z Netbeans soketu"
-
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Stratené NetBeans spojenie pre buffer %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Varovanie: terminál nepodporuje zvýrazòovanie"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Pod kurzorom nie je ¾iadny re»azec"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Pod kurzorom nie je ¾iadny identifikátor"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E91: voµba 'shell' je prázdna"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Varovanie: terminál nepodporuje zvýrazòovanie"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Pod kurzorom nie je ¾iadny re»azec"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Pomocou 'foldmethod' sa nedá vymaza» vnorenie"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: zoznam zmien je prázdny"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Na zaèiatku zoznamu zmien"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "poèet riadkov upravených naraz pomocou %s: 1"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 riadok upravený pomocou %s %d krát"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> riadkov upravených naraz pomocou %s"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> riadkov upravených pomocou %s %d krát"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> riadkov pre odsadenie..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 riadok odsadený "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> riadkov odsadených "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: ®iadny predtým pou¾ívaný register"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "nedá sa kopírova»; napriek tomu vymazané"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 riadok zmenený"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> zmenených riadkov"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "uvolòujem %<PRId64> riadkov"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "skopírovaný blok 1 riadku"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 riadok skopírovaný"
 
+#: ../ops.c:2525
+#, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "skopírovaný blok %<PRId64> riadkov"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> skopírovaných riadkov"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Register %s je prázdny"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3806,10 +4516,11 @@ msgstr ""
 "\n"
 "--- Registre ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Neprípustný názov registra"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3817,151 +4528,197 @@ msgstr ""
 "\n"
 "# Registre:\n"
 
+#: ../ops.c:4575
+#, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Neznámy typ registra %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Ståpcov; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Vybraných %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Bajtov"
-
-msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "Vybraných %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Znakov; %<PRId64> z %<PRId64> Bajtov"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
-msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybraných %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; "
+"%<PRId64> z %<PRId64> Bajtov"
 
+#: ../ops.c:5105
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Vybraných %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; "
+"%<PRId64> z %<PRId64> Znakov; %<PRId64> z %<PRId64> Bajtov"
+
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; "
+"Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> pre BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strana %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Ïakujeme za pou¾itie Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Neznáma voµba"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Voµba nie je podporovaná"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Nie je v modeline povolené"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Po = je vy¾adované èíslo"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Nenájdený v termcape"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Neprípustný znak <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Voµba 'term' nemô¾e by» prázdna"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: V grafickom móde (GUI) sa nedá meni» typ terminálu"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Pou¾ite \"gui\" pre spustenie GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: voµby 'backupext' a 'patchmode' majú rovnakú hodnotu"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Nedá sa zmeni» v grafickom rozhraní GTK+ 2"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Chýba dvojbodka"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Re»azec s nulovou då¾kou"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Po <%s> chýba èíslo"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Chýba èiarka"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Je nutné zada» hodnotu '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: obsahuje netlaèiteµné znaky"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Chybné písma"
-
-msgid "E597: can't select fontset"
-msgstr "E597: nedá sa vybra» sada písiem"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Chybná sada písiem"
-
-msgid "E533: can't select wide font"
-msgstr "E533: nedá sa vybra» ¹iroký font"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Chybné ¹iroké písmo"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Neprípustný znak po <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: je nutná èiarka"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
-msgstr "E537: 'commentstring' (komentár) musí by» prázdny alebo musí obsahova» %s"
+msgstr ""
+"E537: 'commentstring' (komentár) musí by» prázdny alebo musí obsahova» %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Bez podpory my¹i"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Neuzatvorené zoskupenie výrazov"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: príli¹ mnoho polo¾iek"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: nevyvá¾ené skupiny"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Okno náhµadu u¾ existuje"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
-msgstr "W17: Mód Arabic vy¾aduje kódovanie UTF-8, nastavte to príkazom ':set encoding=utf-8'"
+msgstr ""
+"W17: Mód Arabic vy¾aduje kódovanie UTF-8, nastavte to príkazom ':set "
+"encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Minimálny potrebný poèet riadkov je %d"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Minimálne potrebný poèet ståpcov je %d"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Neznáma voµba: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Po = je vy¾adované èíslo"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3969,6 +4726,7 @@ msgstr ""
 "\n"
 "--- Kódy terminálu ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3976,6 +4734,7 @@ msgstr ""
 "\n"
 "--- Nastavenie globálnych volieb ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3983,6 +4742,7 @@ msgstr ""
 "\n"
 "--- Nastavenie lokálnych volieb ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3990,134 +4750,21 @@ msgstr ""
 "\n"
 "--- Mo¾nosti ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp CHYBA"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': pre %s chýba vyhovujúci znak"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': nadbytoèné znaky po bodkoèiarke: %s"
 
-msgid "cannot open "
-msgstr "nedá sa otvori» "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Nedá sa otvori» okno!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Je potrebná Amigados verzia 2.04 alebo nov¹ia\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Potrebná %s verzia %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Nedá sa otvori» NIL:\n"
-
-msgid "Cannot create "
-msgstr "Nedá sa vytvori» "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim ukonèený s %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "nemô¾em zmeni» konzolový mód ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: nie je konzolou??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Nedá sa spusti» shell s -f voµbou"
-
-msgid "Cannot execute "
-msgstr "Nedá sa spusti» "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " vrátené\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE príli¹ malá."
-
-msgid "I/O ERROR"
-msgstr "I/O CHYBA"
-
-msgid "...(truncated)"
-msgstr "...(skrátené)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'ståpce' nie je 80, nemô¾em spusti» externý príkaz"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Zlyhal výber tlaèiarne"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "%s na %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Neznámy font tlaèiarne: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Chyba tlaèe: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Tlaèím '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Chybný názov znakovej sady \"%s\" v názve písma \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Chybný znak '%c' v názve písma \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: dvojitý signál, konèím\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Zachytený smrtiaci signál %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Zachytený smrtiaci signál\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Otvorenie X displej zabralo %<PRId64> msec"
-
-#. KDE sometimes produces X error that we want to ignore
-msgid ""
-"\n"
-"Vim: Got X error but we continue...\n"
-msgstr ""
-"\n"
-"Vim: Chyba X ale pokraèujem ...\n"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Chyba X\n"
-
-msgid "Testing the X display failed"
-msgstr "Testovanie X displeja zlyhalo"
-
-msgid "Opening the X display timed out"
-msgstr "Uplynul èas otvorenia X displeja"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4125,13 +4772,7 @@ msgstr ""
 "\n"
 "Nedá sa spusti» shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Nedá sa spusti» sh shell\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4139,668 +4780,958 @@ msgstr ""
 "\n"
 " návratová hodnota shellu "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Nedjú sa vytvori» rúry\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Vyvolanie fork zlyhalo\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Príkaz ukonèený\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP stratilo ICE spojenie"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Otvorenie X displeja zlyhalo"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP spracuváva po¾iadavku na samoulo¾enie"
-
-msgid "XSMP opening connection"
-msgstr "XSMP otvára spojenie"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP kontrola spojenia ICE zlyhala"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection zlyhalo: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Súbor \"%s\" sa nedá nájs» v ceste"
 
-msgid "At line"
-msgstr "Na riadku"
-
-msgid "Could not load vim32.dll!"
-msgstr "Nemô¾em nahra» vim32.dll!"
-
-msgid "VIM Error"
-msgstr "VIM Chyba"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Nemô¾em opravi» odkazy funkcií na DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "návratová hodnota shellu %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Zachytená udalos» %s\n"
-
-msgid "close"
-msgstr "zavrie»"
-
-msgid "logoff"
-msgstr "odhlási»"
-
-msgid "shutdown"
-msgstr "vypnú»"
-
-msgid "E371: Command not found"
-msgstr "E371: Príkaz nenájdený"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE nenájdený v $PATH.\n"
-"Po dokonèení externých príkazov nebude výstup pozastavený.\n"
-"Pozrite  :help win32-vimrun  pre viac informácií."
-
-msgid "Vim Warning"
-msgstr "Vim Varovanie"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Príli¹ mnoho %%%c vo formátovacom re»azci"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Neoèakávaný výskyt %%%c vo formátovacom re»azci"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Vo formátovacom re»azci chýba ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr ""
 "E375: Nepodporovaná formátová ¹pecifikácia %%%c vo formátovacom re»azci"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Neprístupné %%%c v prefixe formátovacieho re»azca"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Neprístupné %%%c vo formátovacom re»azci"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' neobsahuje ¾iadny vzor"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Chýbajúci alebo prázdny názov adresára"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: ®iadne ïal¹ie polo¾ky"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d z %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (riadok vymazaný)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Koniec quickfix zoznamu"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Zaèiatok quickfix zoznamu"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "zoznam chýb %d z %d; %d chýb"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Nedá sa ulo¾i», je nastavená voµba 'buftype'"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Chýba meno súboru alebo chybný vzor"
 
+#: ../quickfix.c:2911
+#, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Nedá sa otvori» súbor \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Buffer nie je naèítaný"
 
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E552: oèakávaná èíslica"
+
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: chybná polo¾ka v %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Vzor je príli¹ dlhý"
-
-msgid "E50: Too many \\z("
-msgstr "E50: Príli¹ mnoho \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Príli¹ mnoho %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Nespárované \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Nespárované %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Nespárované %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Nespárované %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: Neprípustný znak po %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Príli¹ komplexné %s{...}"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Vnorený %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Vnorený %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: Chybne pou¾ité \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c niè nenasleduje"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Chybná spätná referencia"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( tu nie je povolené"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 a spol. tu nie je povolené"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Neprípustný znak po \\z"
-
-#,  c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Chýbajúca ] po %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Prázdny %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Neprípustný znak po %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Neprípustný znak po %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Chýbajúca ] po %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Nespárované %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Nespárované %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Nespárované %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( tu nie je povolené"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 a spol. tu nie je povolené"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Chýbajúca ] po %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Prázdny %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Vzor je príli¹ dlhý"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Príli¹ mnoho \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Príli¹ mnoho %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Nespárované \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: Neprípustný znak po %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Príli¹ komplexné %s{...}"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Vnorený %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Vnorený %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: Chybne pou¾ité \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c niè nenasleduje"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Chybná spätná referencia"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Neprípustný znak po \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Neprípustný znak po %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Neprípustný znak po %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Chyba syntaxe v %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Vnútorné podradené zhody:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Príli¹ mnoho \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Nedá sa nájs» doèasný súbor pre ukladanie"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " NAHRADI« VERTIKÁLNE"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " NAHRADI«"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " OBRÁTI«"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " VLO®I«"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (vlo¾i»)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (nahradi»)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (nahradi» vertikálne)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrejský"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabský"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (jazyk)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (vlo¾i»)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VIZUÁLNE"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VIZUÁLNY RIADOK"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VIZUÁLNY BLOK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ZHODY"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " OZNAÈ RIADOK"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " OZNAÈ BLOK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "nahrávam"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Neprípustný hµadaný re»azec: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: hµadanie dosiahlo zaèiatok bez nájdenia %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: hµadanie dosiahlo koniec bez nájdenia %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Po ';' oèakávam '?' alebo '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (vrátane u¾ vypísaných zhôd)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Vlo¾ené súbory"
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "nenájdené "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "v ceste ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (U¾ vypísané)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " NENÁJDENÉ"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Prehµadávam vlo¾ené súbory: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "Prehµadávam vlo¾ené súbory: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Zhoda je na aktuálnom riadku"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "V¹etky vlo¾ené súbory boli nájdené"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "®iadne vlo¾ené súbory"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Nedá sa nájs» definícia"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Nedá sa nájs» vzor"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 nahradenie"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Chyba formátovania v spell súbore (kontrola pravopisu)"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Odseknutý spell súbor (kontrola pravopisu)"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Prebytoèný text v %s na riadku %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Prípona príli¶ dlhá v %s riadok %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
-msgstr "E761: Chyba formátovania v súbore prípon FOL, LOW alebo UPP (NASLEDUJE, MALÉ alebo VE¥KÉ)"
+msgstr ""
+"E761: Chyba formátovania v súbore prípon FOL, LOW alebo UPP (NASLEDUJE, MALÉ "
+"alebo VE¥KÉ)"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
-msgstr "E762: Znak v FOL, LOW alebo UPP (NASLEDUJE, MALÉ alebo VE¥KÉ) je mimo rozsah"
+msgstr ""
+"E762: Znak v FOL, LOW alebo UPP (NASLEDUJE, MALÉ alebo VE¥KÉ) je mimo rozsah"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Robím kompresiu stromu slov..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Kontrola pravopisu nie je zapnutá"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr "Varovanie: Nemo¾no nájs» zoznam slov \"%s.%s.spl\" alebo \"%s.ascii.spl\""
+msgstr ""
+"Varovanie: Nemo¾no nájs» zoznam slov \"%s.%s.spl\" alebo \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Èítam slovníkový súbor \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Toto sa nezdá by» slovníkovým súborom"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Starý slovníkový súbor, potrebuje by» zaktualizovaný"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Slovníkový súbor je pre nov¹iu verziu Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Nepodporovaná sekcia v slovníkovom súbore"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Varovanie: región %s nie je podporovaný"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Naèítavam súbor s príponami %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konverzia slova zlyhala v %s riadok %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konverzia v %s nie je podporovaná: z %s do %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konverzia v %s nie je podporovaná"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Neplatná hodnota pre príznak (FLAG) v %s riadok %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "Príznak (FLAG) po pou¾ití príznakov v %s riadok %d: %s"
 
+#: ../spell.c:4723
 #, c-format
-msgid "Character used for SLASH must be ASCII; in %s line %d: %s"
-msgstr "Znak pou¾itý pre SLASH musí by» ASCII; v %s riadok %d: %s"
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-msgid "Wrong COMPOUNDMAX value in %s line %d: %s"
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Zlá hodnota COMPOUNDMAX v %s riadok %d: %s"
 
+#: ../spell.c:4771
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr "Zlá hodnota COMPOUNDMAX v %s riadok %d: %s"
+
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Zlá hodnota COMPOUNDMIN v %s riadok %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Zlá hodnota COMPOUNDSYLMAX v %s riadok %d: %s"
 
+#: ../spell.c:4795
+#, fuzzy, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr "Zlá hodnota COMPOUNDMIN v %s riadok %d: %s"
+
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr "Rozdielna kombinácia príznakov v nasledujúcom bloku prípon v %s riadok %d: %s"
+msgstr ""
+"Rozdielna kombinácia príznakov v nasledujúcom bloku prípon v %s riadok %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Duplicitná prípona v %s riadok %d: %s"
 
-#, c-format
+#: ../spell.c:4871
+#, fuzzy, c-format
 msgid ""
-"Affix also used for BAD/RAR/KEP/NEEDAFFIX/NEEDCOMPOUND in %s line %d: %s"
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
 msgstr ""
 "Prípona pou¾itá aj pre BAD/RAR/KEP/NEEDAFFIX/NEEDCOMPOUND in %s line %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Oèakávane Y alebo N v %s riadok %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Naru¹ená podmienka v %s riadok %d: %s"
 
-#, c-format
-msgid "Expected REP count in %s line %d"
+#: ../spell.c:5091
+#, fuzzy, c-format
+msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Oèakávam poèet REP v %s riadok %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Oèakávam poèet MAP v %s riadok %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Opakovaný znak v MAP v %s riadok %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Nerozpoznaná alebo opakujúca sa polo¾ka v %s riadok %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Chýbajúci riadok FOL/LOW/UPP v %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX pou¾itý bez SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Príli¹ mnoho odlo¾ených prípon"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Príli¹ mnoho upravovacích príznakov"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Príli¹ mnoho odlo¾ených prípon a/alebo upravovacích príznakov"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Chýba SOFO%s riadok v %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "SAL a SOFO riadky zároveò v %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Príznak nie je èíslo v %s na riadku %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Neprípustný príznak v %s riadok %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Hodnota %s sa odli¹uje od hodnoty pou¾itej v inom .aff súbore"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Naèítavam slovník %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Chýajúci poèet slov v %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "riadok %6d, slovo %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Opakujúce sa slovo v %s riadok %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Prvé duplicitné slovo v %s riadok %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d duplicitné slovo(á) v %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ignorovaných %d slov s nepísmennými znakmi v %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Naèítavam súbor so slovami %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Duplicitný riadok /encoding= v %s riadok %d ignorovaný: %s "
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "/encoding= riadok nasledujúci po slove v %s riadok %d ignorovaný: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Duplicitný riadok /regions= v %s riadok %d ignorovaný: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Príli¹ mnoho regiónov v %s riadok %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Riadok / v %s riadok %d ignorovaný: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Pou¾íté chybné èíslo regiónu v %s riadok %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nerozpoznaný príznak v %s riadok %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignorovaných %d slov s nepísmennými znakmi"
 
-#, c-format
-msgid "Compressed %d of %d nodes; %d%% remaining"
+#: ../spell.c:6656
+#, fuzzy, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Skomprimovaných %d z %d uzlov; %d%% zostáva"
 
-msgid "E751: Output file name must not have region name"
-msgstr "E751: Výstupné meno súboru nesmie ma» názov regiónu"
+#: ../spell.c:7340
+#, fuzzy
+msgid "Reading back spell file..."
+msgstr "Èítam slovníkový súbor \"%s\""
 
-msgid "E754: Only up to 8 regions supported"
-msgstr "E754: Podporovaných max. 8 regiónov"
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
 
+#: ../spell.c:7368
 #, c-format
-msgid "E755: Invalid region in %s"
-msgstr "E755: Chybný región v %s"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
 
-msgid "Warning: both compounding and NOBREAK specified"
-msgstr "Varovanie: ¹pecifikované spájanie a nezalamovanie"
-
+#: ../spell.c:7476
 #, c-format
-msgid "Writing spell file %s ..."
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
 msgstr "Ukládám slovníkový súbor %s ..."
 
-msgid "Done!"
-msgstr "Hotovo!"
-
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Veµkos» pou¾ívanej pamäte: %d bajtov"
 
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr "E751: Výstupné meno súboru nesmie ma» názov regiónu"
+
+#: ../spell.c:7822
+msgid "E754: Only up to 8 regions supported"
+msgstr "E754: Podporovaných max. 8 regiónov"
+
+#: ../spell.c:7846
+#, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E755: Chybný región v %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr "Varovanie: ¹pecifikované spájanie a nezalamovanie"
+
+#: ../spell.c:7920
+#, c-format
+msgid "Writing spell file %s ..."
+msgstr "Ukládám slovníkový súbor %s ..."
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr "Hotovo!"
+
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' nemá %<PRId64> polo¾iek"
 
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaky slov sa odli¹ujú medzi slovníkovými súbormi"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Prepáète, ¾iadne návrhy"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Prepáète, iba %<PRId64> návrhov"
 
+#. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Zmeni» \"%.*s\" na:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: ®iadny predchádzajúce nahradenie podµa slovníka"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Nenájdené: %s"
 
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E757: Toto sa nezdá by» slovníkovým súborom"
+
+#: ../spell.c:9282
+#, fuzzy, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr "E771: Starý slovníkový súbor, potrebuje by» zaktualizovaný"
+
+#: ../spell.c:9286
+#, fuzzy, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr "E772: Slovníkový súbor je pre nov¹iu verziu Vim"
+
+#: ../spell.c:9295
+#, fuzzy, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr "E746: Meno funkcie sa nezhoduje s menom interpretovaného súboru: %s"
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Chyba pri èítaní chybového súboru"
+
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: duplicitný znak v MAP polo¾ke"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Pre tento buffer nie sú definované ¾iadne polo¾ky syntaxe"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Neprípustný argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Syntaktická zostava %s neexistuje"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Pre tento buffer nie sú definované ¾iadne polo¾ky syntaxe"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synchronizujem podµa komentárov jazyka C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "¾iadne synchronizácie"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synchronizácia zaèína "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " riadkov pred zaèiatkom"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -4808,6 +5739,7 @@ msgstr ""
 "\n"
 "--- Polo¾ky synchronizácie syntaxe ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -4815,6 +5747,7 @@ msgstr ""
 "\n"
 "synchronizujem polo¾ky"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -4822,198 +5755,274 @@ msgstr ""
 "\n"
 "--- Polo¾ky syntaxe ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Syntaktická zostava %s neexistuje"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimálne "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximálne "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; zhoda "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " zalomení riadkov"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: obsahuje argumenty, ktoré tu nie sú povolené"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: obsahuje argumenty, ktoré tu nie sú povolené"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Chybný argument"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here nesmie by» na tomto mieste"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Pre %s chýba polo¾ka regiónu"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Vy¾adovaný názov súboru"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Príli¹ mnoho názvov súborov"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Chýba ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Chýba '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Príli¹ málo argumentov: oblas» syntaxe %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Syntaktická zostava %s neexistuje"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Nebola zadaná ¾iadna zostava"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Oddeµovaè vzoru %s nenájdený"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Chyba za vzorom: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: synchronizácia syntaxe: vzor pokraèovania riadkov zadaný dvakrát"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Chybné argumenty: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Chýba znamienko rovná sa: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Prázdny argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s tu nie je povolené"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s musí by» prvý v 'contains' zozname"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Neznámy názov skupiny: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Chybný podradený príkaz :syntax : %s "
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekurzívna sluèka pri naèítavaní syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: skupina zvýraznenia %s nebola nájdená"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Príli¹ málo argumentov: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Príli¹ mnoho argumentov: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: skupina je nastavená, odkaz na zvýrazòovaciu skupinu ignorovaný"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: neoèakávané znamienko rovná sa: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: chýba znamienko rovná sa: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: chýba argument: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Neprípustná hodnota: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: farba popredia nie je známa"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: farba pozadia nie je známa"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Názov alebo èíslo farby nebolo rozpoznané: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminálový kód je príli¹ dlhý: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Neprípustný argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Pou¾ívaných príli¹ veµa odli¹ných zvýrazòovacích vlastností"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Netlaèitelný znak v mene skupiny"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Chybný znak v mene skupiny"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: na konci zoznamu tagov"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: na zaèiatku zoznamu tagov"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Nedá sa skoèi» pred prvý vyhovujúci tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tag %s nenájdený"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri typ tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "súbor\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Vyhovuje iba jeden tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Za posledný vyhovujúci tag sa nedá preskoèi»"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Súbor \"%s\" neexistuje"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tag %d z %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " alebo viac"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Pou¾ívam tag s písmom inej veµkosti!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Súbor \"%s\" neexistuje"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5021,59 +6030,79 @@ msgstr ""
 "\n"
 "  # CIE¥ tag        ©TART riadok  v súbore/texte"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Prehµadávam súbor tagov %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Cesta k súboru tagov %s bola orezaná\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátovania v súbore tagov \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Pred bajtom %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Obsah súboru tagov %s nie je zoradený"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: ®iadny súbor tagov"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Nedá sa nájs» vzor tagov"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Tag sa nedá nájs», iba hádam!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Duplicitná prípona v %s riadok %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' nie je známy. Dostupné vstavané terminály:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "nastavujem na '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Nedá sa otvori» termcap súbor"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Terminfo neobsahuje polo¾ku pre tento terminál"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Termcap neobsahuje polo¾ku pre tento terminál"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Termcap neobsahuje polo¾ku \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminál musí ma» schopnos» \"cm\" (schopnos» pohybu kurzora)"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5081,109 +6110,176 @@ msgstr ""
 "\n"
 "--- Klávesy terminálu ---"
 
-msgid "new shell started\n"
-msgstr "spustený nový shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Chyba pri èítaní vstupu, konèím...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Odstránenie zmien nie je mo¾né; chcete napriek tomu pokraèova»"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Súbor sa nedá otvori» pre ukladanie"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Ukládám viminfo súboru \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Chyba pri ukladaní do odkladacieho súboru"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Naèítavam súbor so slovami %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Súbor viminfo sa nedá sa otvori» na èítanie"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Nenájdené: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Nedá sa otvori» súbor %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "dokonèená interpretácia %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> nenájdený"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: èísla riadkov sú chybné"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "1 nový riadok"
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "1 nový riadok"
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "1 vymazaný riadok"
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "%<PRId64> vymazaných riadkov"
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "1 zmena"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "%<PRId64> zmien"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "1 zmena"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> riadkov upravených pomocou %s %d krát"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "®iadne mapovanie nebolo nájdené"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> Ståpcov; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s tu nie je povolené"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmenách po¹kodený"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: chýba opravný riadok"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"16/32 bitová GUI verzia pre MS Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"32 bitová GUI verzia pre MS Windows"
-
-msgid " in Win32s mode"
-msgstr " vo Win32 re¾ime"
-
-msgid " with OLE support"
-msgstr " s OLE podporou"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"32 bitová verzia pre MS Windows konzolu"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"16 bitová verzia pre MS Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 bitová verzia pre MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 bitová MS-DOS verzia"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) verzia"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X verzia"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS verzia"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS verzia"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5191,9 +6287,18 @@ msgstr ""
 "\n"
 "Pou¾ité záplaty: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Vnútorné podradené zhody:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Zmenil "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5201,9 +6306,11 @@ msgstr ""
 "\n"
 "Prelo¾ená "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5211,611 +6318,1646 @@ msgstr ""
 "\n"
 "Maximálna verzia"
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Veµká verzia "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normálna verzia"
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Malá verzia "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Minimálna verzia "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "bez grafického rozhrania."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "s grafickým rozhraním GTK2-GNOME."
-
-msgid "with GTK-GNOME GUI."
-msgstr "s grafickým rozhraním GTK-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "s grafickým rozhraním GTK2."
-
-msgid "with GTK GUI."
-msgstr "s grafickým rozhraním GTK."
-
-msgid "with X11-Motif GUI."
-msgstr "s grafickým rozhraním X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "s grafickým rozhraním X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "s grafickým rozhraním X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "s grafickým rozhraním Photon."
-
-msgid "with GUI."
-msgstr "s grafickým rozhraním."
-
-msgid "with Carbon GUI."
-msgstr "s grafickým rozhraním Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "s grafickým rozhraním Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "s klasickým grafickým rozhraním."
-
-msgid "with KDE GUI."
-msgstr "s grafickým rozhraním KDE."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Vlastnosti zahrnuté (+) a nezahrnuté (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "          systémový vimrc súbor: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "        u¾ívateµský vimrc súbor: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  druhý u¾ívateµský vimrc súbor: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  tretí u¾ívateµský vimrc súbor: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         u¾ívateµský exrc súbor: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   druhý u¾ívateµský exrc súbor: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  systémový gvimrc súbor: \""
-
-msgid "    user gvimrc file: \""
-msgstr "      u¾ívateµský gvimrc súbor: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "druhý u¾ívateµský gvimrc súbor: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "tretí u¾ívateµský gvimrc súbor: \""
-
-msgid "    system menu file: \""
-msgstr "     systémový súbor s ponukou: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "       implicitná hodnota $VIM:\""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " f-b pre $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Preklad: "
 
-msgid "Compiler: "
-msgstr "Prekladaè: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Zlinkované: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  PODPORA LADENIA"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "verzia "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "od Brama Moolenaara a ïal¹ích"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim je voµne ¹íriteµný program s otvoreným kódom"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Pomô¾te chudobným de»om v Ugande!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "zadajte  :help iccf<Enter>          pre informácie         "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "zadajte  :q<Enter>                  pre ukonèenie programu "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "zadajte  :help<Enter>  alebo  <F1>  pre pomocníka          "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "zadajte  :help version7<Enter>      pre informácie o verzii"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Pracujem v re¾ime kompatibility s Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "zadajte  :set nocp<Enter>           pre implicitné nastavenie Vim"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "podrobnej¹ie informácie získate pomocou :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "bli¾¹ie informácie v ponuke  Pomocník->Samostatné"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Spú¹»am v bezmódovom re¾ime, písaný text je vlo¾ený"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "ponuka  Úpravy->Globálne mo¾nosti->Prepnú» re¾im vlo¾enia "
-
-msgid "                              for two modes      "
-msgstr "                            pre dva re¾imy       "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "ponuka  Úpravy->Globálne mo¾nostt->Prepnú» Vi kompatibilný re¾im"
-
-msgid "                              for Vim defaults   "
-msgstr "                 pre predvolené vlastnosti Vim   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Zasponzorujte vývoj Vimu!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Staòte sa registrovaným u¾ívateµom Vimu!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "zadajte  :help sponsor<Enter>          pre informácie         "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "zadajte  :help register<Enter>      pre informácie         "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "bli¾¹ie informácie v ponuke  Pomocník->Sponzor/Registrácia"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "VAROVANIE: detekované Windows 95/98/ME"
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "Existuje u¾ iba jedno okno"
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "zadajte  :help windows95<Enter>  pre podrobnej¹ie informácie"
-
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Nenájdené ¾iadne okno náhµadu"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr ""
 "E442: Okno sa nedá rozdeli» zároveò v móde 'vrchný-µavý' a 'spodný-"
 "pravý' ('topleft' a 'botright')"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Nedá sa rotova», ak je iné okno rozdelené"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Posledné okno sa nedá zatvori»"
 
-msgid "Already only one window"
-msgstr "Existuje u¾ iba jedno okno"
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Posledné okno sa nedá zatvori»"
 
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Posledné okno sa nedá zatvori»"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Iné okno obsahuje zmeny"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Pod kurzorom sa nenachádza názov súboru"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Súbor \"%s\" sa nedá nájs» v ceste"
+#~ msgid "[Error List]"
+#~ msgstr "[Zoznam chýb]"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Nepodarilo sa nahra» kni¾nicu %s"
+#~ msgid "Patch file"
+#~ msgstr "Záplatový súbor"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Prepáète, tento príkaz je vypnutý, Perl kni¾nica nemô¾e by» naèítaná."
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Zru¹i»"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Vykonanie kódu v jazyku Perl nie je mo¾né v bezpeènostnej schránke bez bezpeènostného modulu"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Neexistuje pripojenie k Vim serveru"
 
-msgid "Edit with &multiple Vims"
-msgstr "Upravi» s viacerý&mi Vimmi"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Nemô¾em posla» na %s"
 
-msgid "Edit with single &Vim"
-msgstr "Upravi» s jedným &Vimom"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Nemô¾em èíta» odpoveï servra"
 
-msgid "Diff with Vim"
-msgstr "Porovna» &Vimom"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Nemô¾em posla» klientovi"
 
-msgid "Edit with &Vim"
-msgstr "Upravi» s &Vimom"
+#~ msgid "Save As"
+#~ msgstr "Ulo¾i» ako"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Upravi» s existujúcim Vimom - "
+#~ msgid "Edit File"
+#~ msgstr "Upravova» súbor"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Upravi» vybrané súbory s Vimom"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (NENÁJDENÉ)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Chyba vytvárania procesu: Skontrolujte, èi je gvim vo va¹ej ceste!"
+#~ msgid "Source Vim script"
+#~ msgstr "Zdrojový skript Vim"
 
-msgid "gvimext.dll error"
-msgstr "chyba gvimext.dll"
+#~ msgid "Edit File in new window"
+#~ msgstr "Upravi» súbor v novom okne"
 
-msgid "Path length too long!"
-msgstr "Príli¹ dlhá cesta!"
+#~ msgid "Append File"
+#~ msgstr "Pripoji» súbor"
 
-msgid "--No lines in buffer--"
-msgstr "--Buffer neobsahuje ¾iadne riadky--"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Pozícia okna: X %d, Y %d"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Príkaz preru¹ený"
+#~ msgid "Save Redirection"
+#~ msgstr "Ulo¾i» presmerovanie"
 
-msgid "E471: Argument required"
-msgstr "E471: Je vy¾adovaný argument"
+#~ msgid "Save View"
+#~ msgstr "Ulo¾i» pohµad"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: po \\ by malo nasledova» /, ? alebo &"
+#~ msgid "Save Session"
+#~ msgstr "Ulo¾i» sedenie"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chybný príkaz v okne príkazového riadku; <Enter> spú¹»a, CTRL-C ukonèuje"
+#~ msgid "Save Setup"
+#~ msgstr "Ulo¾i» nastavenie"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Príkaz nie je z exrc/vimrc v aktuálnom adresári alebo pri hµadaní tagu "
-"povolený."
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: V tejto verzi nie sú digraphy podporované"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Chýba :endif"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Èítam zo ¹tandardného vstupu..."
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Chýba :endtry"
+#~ msgid "[NL found]"
+#~ msgstr "[nájdené NL]"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Chýba :endwhile"
+#~ msgid "[crypted]"
+#~ msgstr "[¹ifrovaný]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Chýba :endfor"
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "[CHYBA PREVODU]"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile bez zodpovedajúceho :while"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans rozhranie nedovolilo zapísa» nemodifikované buffre"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor bez zodpovedajúceho :for"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Èiastoèné zápisy nie sú povolené pre NetBeans buffre"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Súbor existuje (pou¾ite ! pre prepísanie)"
+# TODO: resource fork ?! Note: used only in MACOS_X version
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: 'Resource fork' bude stratený (pou¾ite ! pre vynútenie)"
 
-msgid "E472: Command failed"
-msgstr "E472: Príkaz zlyhal"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Nedá sa spusti» GUI (grafické rozhranie)"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Neznáma sada písiem: %s"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Nedá sa èíta» z \"%s\""
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Neznáme písmo: %s"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Nemo¾no na¹tartova» grafické rozhranie, nenájdený ¾iaden pou¾itelný "
+#~ "font"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Písmo \"%s\" nemá pevnú ¹írku"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr ""
+#~ "E231: voµba 'guifontwide' (nastavenie ¹irokého písma) je chybne nastavená"
 
-msgid "E473: Internal error"
-msgstr "E473: Vnútorná chyba"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Hodnota 'imactivatekey' je nesprávne nastavená"
 
-msgid "Interrupted"
-msgstr "Preru¹ené"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Nedá sa alokova» farba %s"
 
-msgid "E14: Invalid address"
-msgstr "E14: Chybná adresa"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "®iadna zhoda na pozícii kurzora, hµadám ïalej"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Chybný argument"
+#~ msgid "<cannot open> "
+#~ msgstr "<nedá sa otvori»> "
 
-#,  c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Chybný argument: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: písmo %s nie je dostupné"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Chybný výraz: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: nedá sa vráti» do aktuálneho adresára"
 
-msgid "E16: Invalid range"
-msgstr "E16: Chybný rozsah"
+#~ msgid "Pathname:"
+#~ msgstr "Názov cesty:"
 
-msgid "E476: Invalid command"
-msgstr "E476: Chybný príkaz"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: nedá sa zisti» aktuálny adresár"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" je adresárom"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Vyvolanie kni¾niènej funkcia zlyhalo pre \"%s()\""
+#~ msgid "Cancel"
+#~ msgstr "Zru¹i»"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Nepodarilo sa nahra» funkciu kni¾nice %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Prípravok posuvnej li¹ty: nedá sa zisti» geometria náhµadu obrázku."
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Znaèka má chybné èíslo riadku"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim dialóg"
 
-msgid "E20: Mark not set"
-msgstr "E20: Znaèka nie je nastavená"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: BalloonEval nedá sa vytvori» správou a zároveò spätným volaním"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Nemo¾no robi» zmeny, voµba 'modifiable' je vypnutá"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim dialóg.."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skripty vnorené príli¹ hlboko"
+#~ msgid "Input _Methods"
+#~ msgstr "Vstupné metódy (_Methods)"
 
-msgid "E23: No alternate file"
-msgstr "E23: ®iadny alternatívny súbor"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Nájs» a nahradi»..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Taká skratka neexistuje"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Nájs»..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: ! nie je povolený"
+#~ msgid "Find what:"
+#~ msgstr "Vyhµada»:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Nedá sa pou¾í» GUI: nebolo zapnuté pri preklade programu"
+#~ msgid "Replace with:"
+#~ msgstr "Nahradi» s:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E26: Nedá sa pou¾í» hebrejský re¾im: nebol zapnutý pri preklade programu\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Hµada» len celé slová"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Nedá sa pou¾í» farsi re¾im: nebol zapnutý pri preklade programu\n"
+#~ msgid "Match case"
+#~ msgstr "Zhoda veµkosti písmen"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Nedá sa pou¾í» arabic re¾im: nebol zapnutý pri preklade programu\n"
+#~ msgid "Direction"
+#~ msgstr "Smer"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Skupina zvýraznenia %s neexistuje"
+#~ msgid "Up"
+#~ msgstr "Hore"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Zatiaµ nie je vlo¾ený ¾iaden text"
+#~ msgid "Down"
+#~ msgstr "Dolu"
 
-msgid "E30: No previous command line"
-msgstr "E30: ®iadny predchádzajúci príkazový riadok"
+#~ msgid "Find Next"
+#~ msgstr "Nájs» ïal¹ie"
 
-msgid "E31: No such mapping"
-msgstr "E31: Mapovanie nenájdené"
+#~ msgid "Replace"
+#~ msgstr "Nahradi»"
 
-msgid "E479: No match"
-msgstr "E479: ®iadna zhoda"
+#~ msgid "Replace All"
+#~ msgstr "Nahradi» V¹etko"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: ®iadna zhoda: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Prijatá po¾iadavka na ukonèenie (die) od mana¾éra sedení\n"
 
-msgid "E32: No file name"
-msgstr "E32: ®iadny názov súboru"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Hlavné okno neoèakávane zru¹ené\n"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: ®iadny predchádzajúci prislúchajúci správny výraz"
+#~ msgid "Font Selection"
+#~ msgstr "Výber Písma"
 
-msgid "E34: No previous command"
-msgstr "E34: ®iadny predchádzajúci príkaz"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Pou¾itý CUT_BUFFER0 namiesto prázdneho výberu"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: ®iadny predchádzajúci regulárny výraz"
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
 
-msgid "E481: No range allowed"
-msgstr "E481: Rozsah nie je povolený"
+#~ msgid "&Cancel"
+#~ msgstr "&Zru¹i»"
 
-msgid "E36: Not enough room"
-msgstr "E36: Nedostatok miesta"
+#~ msgid "Directories"
+#~ msgstr "Adresáre"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: ¾iaden registrovaný server pomenovaný \"%s\""
+#~ msgid "Filter"
+#~ msgstr "Filter"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Nedá sa vytvori» súbor %s"
+#~ msgid "&Help"
+#~ msgstr "&Pomocník"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Nedá sa získa» názov doèasného súboru"
+#~ msgid "Files"
+#~ msgstr "Súbory"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Nedá sa otvori» súbor %s"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Nedá sa èíta» súbor %s"
+#~ msgid "Selection"
+#~ msgstr "Výber"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Neulo¾ené zmeny (pou¾ite ! pre vynútenie)"
+#~ msgid "Find &Next"
+#~ msgstr "Nájs» ïa&l¹ie"
 
-msgid "E38: Null argument"
-msgstr "E38: Nulový argument"
+#~ msgid "&Replace"
+#~ msgstr "&Nahradi»"
 
-msgid "E39: Number expected"
-msgstr "E39: Oèakávané èíslo"
+#~ msgid "Replace &All"
+#~ msgstr "Nahradi» &V¹etko"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Nedá sa otvori» chybový súbor %s"
+#~ msgid "&Undo"
+#~ msgstr "&Spä»"
 
-msgid "E233: cannot open display"
-msgstr "E233: nedá sa otvori» displej"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Nemo¾no nájs» okno s titulkom \"%s\""
 
-msgid "E41: Out of memory!"
-msgstr "E41: Nedostatok pamäti!"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument nie je podporovaný: \"-%s\"; Pou¾ite OLE verziu."
 
-msgid "Pattern not found"
-msgstr "Vzor nenájdený"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Nemo¾no otvori» okno vnútri MDI aplikácie"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Vzor nenájdený: %s"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Nájs» re»azec (pou¾ite '\\\\' ak chete nájs» '\\')"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument musí by» kladný"
+# Following warning can be ignored:
+# msgfmt -v --statistics --check -C --check-accelerators="&" -o sk.mo sk.po
+# sk.po:2497: msgstr lacks the keyboard accelerator mark '&'
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Nájs» a Nahradi» (pou¾ite '\\\\' ak chcete nájs» '\\')"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: ®iadny predchádzajúci adresár"
+#~ msgid "Not Used"
+#~ msgstr "[neupravovaný]"
 
-msgid "E42: No Errors"
-msgstr "E42: ®iadne chyby"
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Adresár\t*.niè\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Po¹kodený re»azac pre vyhµadávanie"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Nedá sa alokova» polo¾ka mapy farieb, niektoré farby mô¾u by» "
+#~ "nesprávne"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Po¹kodený regexp program"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Chýba písmo pre nasledujúce znakové sady %s:"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr ""
-"E45: voµba 'readonly' (iba na èítanie) je nastavená (pou¾ite ! pre "
-"prepísanie)"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Názov sady písiem: %s"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Nedá sa nastavi» premenná len na èítanie \"%s\""
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Písmo '%s' nemá pevnou ¹írku"
 
-#, c-format
-msgid "E46: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: Nedá sa nastavi» premenná v bezpeènostnej schránke: \"%s\""
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Názov sady písiem: %s\n"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Chyba pri èítaní chybového súboru"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Písmo0: %s\n"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Nie je dovolené v bezpeènostnej schránke"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Písmo1: %s\n"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Nie je na povolené na tomto mieste"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Písmo%<PRId64> nie je dvakrát ¹ir¹ie ako písmo0\n"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Nastavovanie re¾imu obrazovky nie je podporované"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "©írka písma0: %<PRId64>\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Chybná hodnota veµkosti rolovania"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "©írka písma1: %<PRId64>\n"
+#~ "\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: voµba 'shell' je prázdna"
+#~ msgid "Invalid font specification"
+#~ msgstr "Chybná ¹pecifikácia písma"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Chyba -- nedájú sa preèíta» oznaèovacie dáta!"
+#~ msgid "&Dismiss"
+#~ msgstr "&Zru¹i»"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Chyba pri uzatváraní odkladacieho súboru"
+#~ msgid "no specific match"
+#~ msgstr "¾iadna ¹pecifická zhoda"
 
-msgid "E73: tag stack empty"
-msgstr "E73: zoznam tagov je prázdny"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Výber písma"
 
-msgid "E74: Command too complex"
-msgstr "E74: Príkaz je príli¹ zlo¾itý"
+#~ msgid "Name:"
+#~ msgstr "Meno:"
 
-msgid "E75: Name too long"
-msgstr "E75: Názov je príli¹ dlhý"
+#~ msgid "Show size in Points"
+#~ msgstr "Ukazuj veµkos» v bodoch"
 
-msgid "E76: Too many ["
-msgstr "E76: Príli¹ mnoho ["
+#~ msgid "Encoding:"
+#~ msgstr "Kódujem:"
 
-msgid "E77: Too many file names"
-msgstr "E77: Príli¹ mnoho názvov súborov"
+#~ msgid "Font:"
+#~ msgstr "Písmo:"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Nadbytoèné znaky na konci"
+#~ msgid "Style:"
+#~ msgstr "©týl"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Neznáma znaèka"
+#~ msgid "Size:"
+#~ msgstr "Veµkos»:"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Nemo¾no expandova» ¾olíkové znaky (wildcards)"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul ERROR - chyba kórejského spôsobu vkladania znakov"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr ""
-"E591: hodnota voµby 'winheight' (vý¹ka okna) nesmie by» men¹ia ne¾ hodnota voµby 'winminheight' (minimálna vý¹ka okna)"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: chyba stat"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr ""
-"E592: hodnota voµby 'winwidth' (¹írka okna) nesmie by» men¹ia ne¾ hodnota volµy 'winminwidth' (minimálna ¹írka okna)"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: nemo¾no otvori» cscope databázu: %s"
 
-msgid "E80: Error while writing"
-msgstr "E80: Chyba pri ukladaní"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: nemo¾no získa» cscope databázové informácie"
 
-msgid "Zero count"
-msgstr "Nulový poèet"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: dosiahnutý maximálny poèet cscope spojení"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Pou¾itie <SID> mimo kontext skriptu"
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Prepáète, tento príkaz je vypnutý, MzScheme kni¾nica nemô¾e by» "
+#~ "naèítaná."
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Bol prijatý chybný výraz"
+#~ msgid "invalid expression"
+#~ msgstr "chybný výraz"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Región je uzamknutý, nemo¾no modifikova»"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "podpora výrazov bola vypnutá pri preklade programu"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans nepovoµuje zmeny v súboroch len na èítanie"
+#~ msgid "hidden option"
+#~ msgstr "skrytá voµba"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Vnútorná chyba: %s"
+#~ msgid "unknown option"
+#~ msgstr "neznáma voµba"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: vzor pou¾íva viac pamäte ako 'maxmempattern'"
+#~ msgid "window index is out of range"
+#~ msgstr "èíslo okna mimo rozsah"
 
-msgid "E749: empty buffer"
-msgstr "E749: prázdny buffer"
+#~ msgid "couldn't open buffer"
+#~ msgstr "nemo¾no otvori» buffer"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Neprípustný hµadaný re»azec alebo oddeµovaè"
+#~ msgid "cannot save undo information"
+#~ msgstr "nedajú sa ulo¾i» zálo¾ne (opravné) informácie"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Súbor je naèítaný v inom buffere"
+#~ msgid "cannot delete line"
+#~ msgstr "nedá sa vymaza» riadok"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Voµba \"%s\" nie je nastavená"
+#~ msgid "cannot replace line"
+#~ msgstr "nedá sa nahradi» riadok"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "hµadanie dosiahlo zaèiatok, pokraèovanie od konca"
+#~ msgid "cannot insert line"
+#~ msgstr "nedá sa vlo¾i» riadok"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "hµadanie dosiahlo koniec, pokraèovanie od zaèiatku"
+#~ msgid "string cannot contain newlines"
+#~ msgstr "re»azec nesmie obsahova» znaky nového riadku"
 
+#~ msgid "Vim error: ~a"
+#~ msgstr "Chyba Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Chyba Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffer je neplatný"
+
+#~ msgid "window is invalid"
+#~ msgstr "okno je neplatné"
+
+#~ msgid "linenr out of range"
+#~ msgstr "èíslo riadka mimo rozsah"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "nie je dovolené v bezpeènostnej schránke"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E262: Prepáète, tento príkaz je vypnutý, Python kni¾nica nemô¾e by» "
+#~ "naèítaná."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Python nemô¾e by» spustený rekurzívne"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "nedá sa vymaza» vlastnos» OutputObject"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace musí by» kladné celé èíslo"
+
+#~ msgid "invalid attribute"
+#~ msgstr "chybná vlastnos»"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() vy¾aduje zoznam re»azcov"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Chyba pri inicializácii I/O objektov"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "pokus o odkaz na vymazaný buffer"
+
+#~ msgid "line number out of range"
+#~ msgstr "èíslo riadka mimo rozsah"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<objekt bufferu (vymazaný) na %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "chybné meno znaèky"
+
+#~ msgid "no such buffer"
+#~ msgstr "¾iadny taký buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "pokus o odkaz na vymazané okno"
+
+#~ msgid "readonly attribute"
+#~ msgstr "vlastnos» iba pre èítanie"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "umiestnenie kurzoru mimo buffer"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<objekt okna (vymazaný) na %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<objekt okna (neznámy) na %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<okno %d>"
+
+#~ msgid "no such window"
+#~ msgstr "¾iadne také okno"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Prepáète, tento príkaz je vypnutý, Ruby kni¾nica nemô¾e by» "
+#~ "naèítaná."
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Neznámy 'longjmp' stav %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Prepnú» implementáciu/definíciu"
+
+#~ msgid "Show base class of"
+#~ msgstr "Ukáza» základnú triedu"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Ukáza» pre»a¾enú èlenskú funkciu"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Obnovi» zo súboru"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Obnovi» z projektu"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Obnovi» zo v¹etkých projektov"
+
+#~ msgid "Retrieve"
+#~ msgstr "Obnovi»"
+
+#~ msgid "Show source of"
+#~ msgstr "Ukáza» zdroj"
+
+#~ msgid "Find symbol"
+#~ msgstr "Nájs» znak"
+
+#~ msgid "Browse class"
+#~ msgstr "Prezrie» triedu"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Ukáza» triedu v hierarchii"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Ukáza» triedu v obmedzenej hierarchii"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref odkazuje na"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref odkázaný z"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref má"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref pou¾itý"
+
+#~ msgid "Show docu of"
+#~ msgstr "Ukáza» dokumentáciu"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Vytvori» dokumentáciu pre"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Zlyhalo pripojenie na SNiFF+, Preverte prostredie (sniffemacs sa musí "
+#~ "nachádza» v $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Chyba poèas èítania. Odpojené"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ je aktuálne "
+
+#~ msgid "not "
+#~ msgstr "ne"
+
+#~ msgid "connected"
+#~ msgstr "pripojený"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Neznáma SNiFF+ po¾iadavka: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Chyba pripojenia na SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ nie je pripojený"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Nie je SNiFF+ bufferom"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Chyba zápisu. Odpojené"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "chybné èíslo bufferu"
+
+#~ msgid "not implemented yet"
+#~ msgstr "nie je e¹te podporované"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "nedajú sa nastavi» riadky"
+
+#~ msgid "mark not set"
+#~ msgstr "znaèka nie je nastavená"
+
+#~ msgid "row %d column %d"
+#~ msgstr "riadok %d ståpec %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "nedá sa vlo¾i»/pripoji» riadok"
+
+#~ msgid "unknown flag: "
+#~ msgstr "neznámy príznak: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "neznáma voµba (vimOption)"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "preru¹enie z klávesnice"
+
+#~ msgid "vim error"
+#~ msgstr "chyba Vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "nedá sa vytvori» príkaz bufferu/okna: objekt bude vymazaný"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "nedá sa zaregistrova» príkaz spätného volania: buffer/okno u¾ bol vymazaný"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL FATAL ERROR: reflist po¹kodený!? Oznámte, prosím, túto chybu na "
+#~ "vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "nedá sa zaregistrova» príkaz spätného volania: odkaz na buffer/okno "
+#~ "nenájdený"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Prepáète, tento príkaz je vypnutý, Tcl kni¾nica nemô¾e by» naèítaná."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL CHYBA: návratový kód nie je celé èíslo!? Oznámte, prosím, túto "
+#~ "chybu na vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: návratový kód %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "nedá sa preèíta» riadok"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Nemô¾em zaregistrova» meno príkazového servra"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Chyba poèas prenosu príkazu do cieµového programu"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Pou¾íté chybné èíslo servera: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM registrová vlastnos» je zle formátovaná.  Vymazané!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Tento Vim nebol kompilovaný s porovnávacími funkciami."
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Chyba: Chyba spú¹»ania gvim pre NetBeans\n"
+
+#~ msgid "where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "v prípade, ¾e je ignorovaná veµkos» písmen, pou¾ite znak '/' na zaèiatku, "
+#~ "aby mal príznak význam veµkého písmena"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tPrihlási» gvim na OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-register\t\tOdhlási» gvim z OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tSpusti» v grafickom (GUI) móde (rovnaké ako \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  alebo  --nofork\tPopredie: Pri spustení grafického (GUI) módu sa "
+#~ "nepresunie do pozadia"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tÚroveò výpisu hlá¹ok"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tNebude pou¾íva» newcli pre otvorenie okna"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <zariadenie>\t\tPou¾i» <zariadenie> pre I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tPou¾ije <gvimrc> namiesto akéhokoµvek .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tÚprava za¹ifrovaných súborov"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <displej>\tPripojí vim na príslu¹ný X-server"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tNepripojí sa k X serveru"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <súbory>\tUpravi» <súbory> na Vim servri ak je to mo¾né"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <súbory>\tTo isté, ale nes»a¾uj si, ak neexistuje server"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <súbory>\tAko --remote ale èaká na súbory pre ukonèenie "
+#~ "úprav"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <súbory>\tTo isté, ale nes»a¾uj si, ak neexistuje "
+#~ "server"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <voµby>\tOdo¹le <voµby> na Vim server a skonèí"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <výraz>\tSpusti <výraz> na servri a vytlaèí výsledok"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tVypí¹e zoznam mien dostupných Vim servrov a skonèí"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <názov>\tOdo¹le na Vim server <názov>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (Motif verzia):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (neXtaw verzia):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (Athena verzia):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <displej>\tSpustí vim na <displej>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tSpustí vim minimalizované"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <názov>\t\tPou¾ije resource ako by vim mal <názov>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (nie je implementované)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <farba>\tNastaví sa <farba> pozadia (tie¾ -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <farba>\tNastaví sa <farba> popredia (tie¾ -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <písmo>\t\tNastaví <písmo> normálneho textu (tie¾ -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <písmo>\tNastaví <písmo> pre zvýraznený text"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <písmo>\tNastaví <písmo> pre kurzívu"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geometrie>\tNastaví sa <geometria> (tie¾ -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <¹írka>\tNastaví <¹írku> okrajov (tie¾ -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <¹írka>  Nastaví <¹írku> posuvnej li¹ty (tie¾ -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <vý¹ka>\tNastaví <vý¹ku> ponuky (tie¾ -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tPou¾ije reverzné farby (tie¾ -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tNepou¾ije reverzné farby (tie¾ +rv)"
+
+# TODO: howto translate 'resource' in this case?
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\tNastaví zadaný <resource>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (RISC OS verzia):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <poèet>\tPoèiatoèná ¹írka okna v ståpcoch"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <poèet>\tPoèiatoèná vý¹ka okna v riadkoch"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre gvim (GTK+ verzia):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <displej>\tSpustí vim na <displej> (tie¾ --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "-role <rola>\tNastaví unikátnu rolu pre identifikáciu hlavného okna"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tOtvorí Vim vnútri iného GTK programu."
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by kvim (KDE version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argumenty dostupné pre kvim (KDE verzia):\n"
+
+#~ msgid "-black\t\tUse reverse video"
+#~ msgstr "-black\t\tPou¾ije reverzné farby"
+
+#~ msgid "-tip\t\t\tDisplay the tip dialog on startup"
+#~ msgstr "-tip\t\t\tZobraz tip pri ¹tarte"
+
+#~ msgid "-notip\t\tDisable the tip dialog"
+#~ msgstr "-notip\t\tNezobrazuj tip pri ¹tarte"
+
+#~ msgid "--display <display>\tRun vim on <display>"
+#~ msgstr "-display <displej>\tSpustí vim na <displej>"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <titulok rodièa>\tOtvor Vim vnútri materskej aplikácie"
+
+#~ msgid "No display"
+#~ msgstr "Bez grafického rozhrania"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Odoslanie zlyhalo.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Odoslanie zlyhalo. Pokú¹am sa spusti» lokálne\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d upravených súborov z %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "®iaden graf. mód: Odoslanie výrazu zlyhalo.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Odoslanie výrazu zlyhalo.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Chybná kódová stránka"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Nepodarilo sa vytvori» vstupný kontext"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Nepodarilo sa otvori» vstupnú metódu"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Varovanie: likvidaèné spätné volanie sa nedá nastavi» na IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: vstupná metóda nepodporuje ¾iadny ¹týl"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: vstupná metóda nepodporuje môj 'preedit' typ"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: Nadbodový ¹týl vy¾aduje sadu fontov (fontset)"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Máte GTK+ verziu star¹iu ne¾ 1.2.3. Stavová plocha vypnutá."
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Server vstupných metód nebe¾í"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [nepou¾iteµné s touto verziou Vim]"
+
+#~ msgid ""
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
+#~ msgstr ""
+#~ "&Otvori» iba pre èítanie\n"
+#~ "&Pokraèovat v úpravách\n"
+#~ "O&bnovi» súbor\n"
+#~ "&Koniec\n"
+#~ "&Zru¹i»\n"
+#~ "Z&maza»"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Odtrhnú» tuto ponuku"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Dialóg pre vytvorenie adresára"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Dialóg pre ukladanie súborov"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Dialóg pre otváranie súborov"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: ¥utujem, ale konzolová verzia nepodporuje prehliadaè súborov"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: zachovávam súbory...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: ukonèený\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "CHYBA: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bajtov] celkom uvolnené-alokované %<PRIu64>-%<PRIu64>, vyu¾ité "
+#~ "%<PRIu64>, maximálne vyu¾itie %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[volanie] celkom re/malloc(): %<PRIu64>, celkom free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Riadok sa stáva príli¹ dlhým"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Chybný tvar my¹i"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Zadajte ¹ifrovací kµúè: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Vlo¾te ten istý kµúè znova: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Kµúèe sa nezhodujú!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Nedá sa pripoji» na Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Nedá sa pripoji» na Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Zlé prístupové práva pre súbor s informáciami pre NetBeans "
+#~ "spojenie: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "èítanie z Netbeans soketu"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Stratené NetBeans spojenie pre buffer %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "uvolòujem %<PRId64> riadkov"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: V grafickom móde (GUI) sa nedá meni» typ terminálu"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Pou¾ite \"gui\" pre spustenie GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Nedá sa zmeni» v grafickom rozhraní GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Chybné písma"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: nedá sa vybra» sada písiem"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Chybná sada písiem"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: nedá sa vybra» ¹iroký font"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Chybné ¹iroké písmo"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Bez podpory my¹i"
+
+#~ msgid "cannot open "
+#~ msgstr "nedá sa otvori» "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Nedá sa otvori» okno!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Je potrebná Amigados verzia 2.04 alebo nov¹ia\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Potrebná %s verzia %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Nedá sa otvori» NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Nedá sa vytvori» "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim ukonèený s %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "nemô¾em zmeni» konzolový mód ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: nie je konzolou??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Nedá sa spusti» shell s -f voµbou"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Nedá sa spusti» "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " vrátené\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE príli¹ malá."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O CHYBA"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(skrátené)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'ståpce' nie je 80, nemô¾em spusti» externý príkaz"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Zlyhal výber tlaèiarne"
+
+#~ msgid "to %s on %s"
+#~ msgstr "%s na %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Neznámy font tlaèiarne: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Chyba tlaèe: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Tlaèím '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Chybný názov znakovej sady \"%s\" v názve písma \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Chybný znak '%c' v názve písma \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: dvojitý signál, konèím\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Zachytený smrtiaci signál %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Zachytený smrtiaci signál\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Otvorenie X displej zabralo %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error but we continue...\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Chyba X ale pokraèujem ...\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Chyba X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Testovanie X displeja zlyhalo"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Uplynul èas otvorenia X displeja"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nedá sa spusti» sh shell\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Nedjú sa vytvori» rúry\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vyvolanie fork zlyhalo\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Príkaz ukonèený\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP stratilo ICE spojenie"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Otvorenie X displeja zlyhalo"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP spracuváva po¾iadavku na samoulo¾enie"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP otvára spojenie"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP kontrola spojenia ICE zlyhala"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection zlyhalo: %s"
+
+#~ msgid "At line"
+#~ msgstr "Na riadku"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Nemô¾em nahra» vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM Chyba"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Nemô¾em opravi» odkazy funkcií na DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "návratová hodnota shellu %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Zachytená udalos» %s\n"
+
+#~ msgid "close"
+#~ msgstr "zavrie»"
+
+#~ msgid "logoff"
+#~ msgstr "odhlási»"
+
+#~ msgid "shutdown"
+#~ msgstr "vypnú»"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Príkaz nenájdený"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE nenájdený v $PATH.\n"
+#~ "Po dokonèení externých príkazov nebude výstup pozastavený.\n"
+#~ "Pozrite  :help win32-vimrun  pre viac informácií."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Varovanie"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konverzia v %s nie je podporovaná"
+
+#~ msgid "Character used for SLASH must be ASCII; in %s line %d: %s"
+#~ msgstr "Znak pou¾itý pre SLASH musí by» ASCII; v %s riadok %d: %s"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: obsahuje argumenty, ktoré tu nie sú povolené"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Cesta k súboru tagov %s bola orezaná\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "spustený nový shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Odstránenie zmien nie je mo¾né; chcete napriek tomu pokraèova»"
+
+#~ msgid "%<PRId64> changes"
+#~ msgstr "%<PRId64> zmien"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "16/32 bitová GUI verzia pre MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová GUI verzia pre MS Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " vo Win32 re¾ime"
+
+#~ msgid " with OLE support"
+#~ msgstr " s OLE podporou"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verzia pre MS Windows konzolu"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová verzia pre MS Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 bitová verzia pre MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 bitová MS-DOS verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Veµká verzia "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normálna verzia"
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Malá verzia "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Minimálna verzia "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "s grafickým rozhraním GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "s grafickým rozhraním GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "s grafickým rozhraním GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "s grafickým rozhraním GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "s grafickým rozhraním X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "s grafickým rozhraním X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "s grafickým rozhraním X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "s grafickým rozhraním Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "s grafickým rozhraním."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "s grafickým rozhraním Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "s grafickým rozhraním Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "s klasickým grafickým rozhraním."
+
+#~ msgid "with KDE GUI."
+#~ msgstr "s grafickým rozhraním KDE."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  systémový gvimrc súbor: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "      u¾ívateµský gvimrc súbor: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "druhý u¾ívateµský gvimrc súbor: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "tretí u¾ívateµský gvimrc súbor: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "     systémový súbor s ponukou: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Prekladaè: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "bli¾¹ie informácie v ponuke  Pomocník->Samostatné"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Spú¹»am v bezmódovom re¾ime, písaný text je vlo¾ený"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "ponuka  Úpravy->Globálne mo¾nosti->Prepnú» re¾im vlo¾enia "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                            pre dva re¾imy       "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "ponuka  Úpravy->Globálne mo¾nostt->Prepnú» Vi kompatibilný re¾im"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                 pre predvolené vlastnosti Vim   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "VAROVANIE: detekované Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "zadajte  :help windows95<Enter>  pre podrobnej¹ie informácie"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Nepodarilo sa nahra» kni¾nicu %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Prepáète, tento príkaz je vypnutý, Perl kni¾nica nemô¾e by» naèítaná."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Vykonanie kódu v jazyku Perl nie je mo¾né v bezpeènostnej schránke "
+#~ "bez bezpeènostného modulu"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Upravi» s viacerý&mi Vimmi"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Upravi» s jedným &Vimom"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Porovna» &Vimom"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Upravi» s &Vimom"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Upravi» s existujúcim Vimom - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Upravi» vybrané súbory s Vimom"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Chyba vytvárania procesu: Skontrolujte, èi je gvim vo va¹ej ceste!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "chyba gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Príli¹ dlhá cesta!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Neznáma sada písiem: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Neznáme písmo: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Písmo \"%s\" nemá pevnú ¹írku"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Nepodarilo sa nahra» funkciu kni¾nice %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E26: Nedá sa pou¾í» hebrejský re¾im: nebol zapnutý pri preklade programu\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E27: Nedá sa pou¾í» farsi re¾im: nebol zapnutý pri preklade programu\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Nedá sa pou¾í» arabic re¾im: nebol zapnutý pri preklade programu\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: ¾iaden registrovaný server pomenovaný \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: nedá sa otvori» displej"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Bol prijatý chybný výraz"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Región je uzamknutý, nemo¾no modifikova»"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans nepovoµuje zmeny v súboroch len na èítanie"

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -5,148 +5,215 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-05-09 14:27+0200\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2007-05-09 14:52\n"
 "Last-Translator: Johan Svedberg <johan@svedberg.com>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "Skräp efter flaggargument"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Positionslista]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Quickfix-lista]"
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Kan inte allokera någon buffert, avslutar..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Kan inte allokera buffert, använder en annan..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Inga buffertar blev urladdade"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Inga buffertar blev borttagna"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Inga buffertar blev utraderade"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 buffert laddades ur"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d buffertar laddades ur"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 buffert borttagen"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d buffertar borttagna"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 buffert utraderad"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d buffertar utraderade"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Kan inte ladda ur senaste buffert"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Ingen modifierad buffert hittad"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Det finns inga listade buffertar"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Buffert %<PRId64> existerar inte"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan inte gå bortom sista buffert"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan inte gå före första buffert"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Ingen skrivning sedan senaste ändring för buffert %<PRId64> (lägg till ! för "
-"att tvinga)"
+"E89: Ingen skrivning sedan senaste ändring för buffert %<PRId64> (lägg "
+"till ! för att tvinga)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Kan inte ladda ur senaste buffert"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varning: Lista över filnamn flödar över"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Buffer %<PRId64> hittades inte"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Fler än en träff för %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Ingen matchande buffert för %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "rad %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer med det här namnet existerar redan"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Modifierad]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Inte redigerad]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Ny fil]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Läsfel]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[EL]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[skrivskyddad]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 rad --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> rader --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "rad %<PRId64> av %<PRId64> --%d%%-- kol "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Inget Namn]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "hjälp"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Hjälp]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Förhandsvisning]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Alla"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Bott"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Topp"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -154,12 +221,11 @@ msgstr ""
 "\n"
 "# Buffertlista:\n"
 
-msgid "[Location List]"
-msgstr "[Positionslista]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[Quickfix List]"
-msgstr "[Quickfix-lista]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -167,133 +233,202 @@ msgstr ""
 "\n"
 "--- Tecken ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Tecken för %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    line=%<PRId64>  id=%d  namn=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Saknar kolon"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Otillåtet läge"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: siffra förväntades"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Otillåten procentsats"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Kan inte skilja fler än %<PRId64> buffertar"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Kan inte öppna termcap-fil"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan inte skapa skiljare"
 
-msgid "Patch file"
-msgstr "Patchfil"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Kan inte läsa skiljeutdata"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Kan inte läsa skiljeutdata"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktuell buffert är inte i skiljeläge"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Ingen annan buffert i skiljeläge är ändringsbar"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Ingen annan buffert i skiljeläge"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Fler än två buffertar i skiljeläge, vet inte vilken som ska användas"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Kan inte hitta buffert \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Buffert \"%s\" är inte i skiljeläge"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Buffert ändrades oväntat"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Escape inte tillåtet i digraf"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Keymap-fil hittades inte"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Användning av :loadkeymap utanför en körd fil"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Tomt tangentbords-post"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Nyckelordskomplettering (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X-läge (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Helradskomplettering (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Filnamnskomplettering (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Taggkomplettering (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Sökvägsmönsterkomplettering (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Definitionskomplettering (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Ordbokskomplettering (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Tesaurkomplettering (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Kommandoradskomplettering (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Användardefinierad komplettering (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Omnikomplettering (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Stavningsförslag (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokal nyckelordskomplettering (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Stötte på slutet på stycket"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "'dictionary'-flagga är tom"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "'thesaurus'-flagga är tom"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Söker igenom ordbok: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (infoga) Rulla (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (ersätt) Rulla (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Söker igenom: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Söker igenom taggar."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Lägger till"
 
@@ -301,396 +436,587 @@ msgstr " Lägger till"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Söker..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Tillbaka på orginalet"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Ord från annan rad"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Den enda träffen"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "träff %d av %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "träff %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Oväntade tecken i :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: listindex utanför område: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Odefinierad variabel: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Saknar ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Argument av %s måste vara en List"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Argument av %s måste vara en Lista eller Tabell"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Kan inte använda tom nyckel för Tabell"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Lista krävs"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Tabell krävs"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: För många argument till funktion: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Tangent finns inte i Tabell: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Funktionen %s existerar redan, lägg till ! för att ersätta den"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Tabell-post existerar redan"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Funcref krävs"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Kan inte använda [:] med en Tabell"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Fel variabeltyp för %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Okänd funktion: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Otillåtet variabelnamn: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: använder Lista som en Sträng"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Färre mål än List-poster"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Fler mål än List-poster"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Double ; i listan med variabler"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Kan inte lista variabler för %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Kan bara indexera en Lista eller Tabell"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] måste komma sist"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] kräver ett List-värde"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: List-värde har mer föremål än mål"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: List-värde har inte tillräckligt med föremål"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Saknar \"in\" efter :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Saknar hakparantes: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Ingen sådan variabel: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: variabel nästlade för djupt för (un)lock"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Saknar ':' efter '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Kan bara jämföra Lista med Lista"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Ogiltig operation för Listor"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Kan bara jämföra Tabell med Tabell"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Ogiltig operation för Tabell"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Kan bara jämföra Funcref med Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Ogiltig operation för Funcrefs"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Kan inte använda [:] med en Tabell"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Saknar ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Kan inte indexera en Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Flaggnamn saknas: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Okänd flagga: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Saknar citattecken: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Saknar citattecken: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Saknar komma i Lista: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Saknar slut på Lista ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Saknar kolon i Tabell: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Duplicerad nyckel i Tabell: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Saknar komma i Tabell: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Saknar slut på Tabell '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: variabel nästlad för djupt för att visas"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: För många argument till funktion: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: För många argument till funktion: %s"
+
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Okänd funktion: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: För få argument till funktion: %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Använder inte <SID> i ett skriptsammanhang: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Anropar tabell-funktion utan Tabell: %s"
 
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Nummer krävs efter ="
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c argument"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: För många argument"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() kan bara användas i infogningsläge"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Tangenten finns redan: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd argument"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c argument"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c argument"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld rader: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Okänd funktion: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Avbryt"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "anropade inputrestore() oftare än inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c argument"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Område otillåtet"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Ogiltig typ för len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Kliv är noll"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Start efter slut"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<tom>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Ingen anslutning till Vim-server"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd argument"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Kunde inte sända till %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Kunde inte läsa ett serversvar"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: För många symboliska länkar (slinga?)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Kunde inte sända till klient"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c argument"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c argument"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c argument"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Jämförelsefunktionen för sortering misslyckades"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Jämförelsefunktionen för sortering misslyckades"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Ogiltig)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Fel vid skrivning av temporär fil"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Använder en Lista som en siffra"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Använder en Funcref som en siffra"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: Använder en Lista som en siffra"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Använder en Tabell som en siffra"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: använder Funcref som en Sträng"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: använder Lista som en Sträng"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: använder Tabell som en Sträng"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Variabelnamn för Funcref måste börja med en versal: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Variabelnamn konflikterar med existerande funktion %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Variabeltyp matchar inte för: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Kan inte ta bort variabel %s"
 
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Variabelnamn för Funcref måste börja med en versal: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Variabelnamn konflikterar med existerande funktion %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Värde är låst: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Okänd"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Kan inte ändra värde av %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: variabel nästlad för djupt för att skapa en kopia"
 
+#: ../eval.c:17249
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Okänd funktion: %s"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Saknar '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Kan inte ställa in IC-värden"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Otillåtet argument: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: Otillåtet argument: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Saknar :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: Funktionsnamn matchar inte skriptfilnamn: %s"
+
+#: ../eval.c:17549
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Kan inte ta bort funktion %s: Den används"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Funktionsnamn matchar inte skriptfilnamn: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Funktionsnamn krävs"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Funktionsnamn måste börja med en versal eller innehålla ett kolon: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Funktionsnamn måste börja med en versal eller innehålla ett kolon: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Kan inte ta bort funktion %s: Den används"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Djupet på funktionsanropet är högre än 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "anropar %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s avbröts"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s returnerar #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s returnerar %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "fortsätter i %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return inte inom en funktion"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -698,6 +1024,7 @@ msgstr ""
 "\n"
 "# globala variabler:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -705,207 +1032,106 @@ msgstr ""
 "\n"
 "\tSenast satt från "
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Går in i felsökningsläge.  Skriv \"cont\" för att fortsätta."
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "Inga inkluderade filer"
 
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "rad %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "kommando: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Brytpunkt i \"%s%s\" rad %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Brytpunkt hittades inte: %s"
-
-msgid "No breakpoints defined"
-msgstr "Inga brytpunkter definierade"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  rad %<PRId64>"
-
-msgid "E750: First use :profile start <fname>"
-msgstr "E750: Använd :profile start <fnamn> först"
-
-msgid "Save As"
-msgstr "Spara som"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Spara ändringar till \"%s\"?"
-
-msgid "Untitled"
-msgstr "Namnlös"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Ingen skrivning sedan senaste ändring för buffert \"%s\""
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "Varning: Gick in i andra buffertar oväntat (kontrollera autokommandon)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Det finns bara en fil att redigera"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Kan inte gå före första filen"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Kan inte gå bortom sista filen"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: kompilator stöds inte: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Söker efter \"%s\" i \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Söker efter \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "hittades inte i 'runtimepath': \"%s\""
-
-msgid "Source Vim script"
-msgstr "Läs Vim-skript"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Kan inte läsa en katalog: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "kunde inte läsa \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "rad %<PRId64>: kunde inte läsa \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "läser \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "rad %<PRId64>: läser \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "läste klart %s"
-
-msgid "modeline"
-msgstr "lägesrad"
-
-msgid "--cmd argument"
-msgstr "--cmd argument"
-
-msgid "-c argument"
-msgstr "-c argument"
-
-msgid "environment variable"
-msgstr "miljövariabel"
-
-msgid "error handler"
-msgstr "felhanterare"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Varning: Fel radavskiljare, ^M kan saknas"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: :scriptencoding används utanför en körd fil"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: :finish används utanför en körd fil"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Aktuellt %sspråk: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Kan inte sätta språk till \"%s\""
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktalt %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x,  Oktalt %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktalt %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Flytta rader in i dem själva"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "1 rad flyttad"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> rader flyttade"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> rader filtrerade"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-Autokommandon får inte ändra aktuell buffert"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Ingen skrivning sedan senaste ändring]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s på rad: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: För många fel, hoppar över resten av filen"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Läser viminfo-fil \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " info"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " märken"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "Inga inkluderade filer"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " MISSLYCKADES"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo-fil är inte skrivbar: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Kan inte skriva viminfo-fil %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Skriver viminfo-fil \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Den här viminfo-filen genererades av Vim %s.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -913,38 +1139,47 @@ msgstr ""
 "# Du får redigera den om du är försiktig!\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Värde av 'encoding' när den här filen blev skriven\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Otillåtet starttecken"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Skriv ofullständig fil?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Använd ! för att skriva ofullständig buffert"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Skriv över befintlig fil \"%s\"?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Växlingsfil \"%s\" existerar, skriv över ändå?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Växlingsfil existerar: %s (:silent! tvingar)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Inget filnamn för buffert %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Filen skrevs inte: Skrivning är inaktiverat med 'write'-flaggan"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -953,61 +1188,91 @@ msgstr ""
 "'readonly' flaggan är satt för \"%s\".\n"
 "Önskar du att skriva ändå?"
 
-msgid "Edit File"
-msgstr "Redigera fil"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "är skrivskyddad (lägg till ! för att tvinga)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokommandon tog oväntat bort ny buffert %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: ickenumeriskt argument till :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Skalkommandon inte tillåtna i rvim"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Reguljära uttryck kan inte vara åtskilda av bokstäver"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "ersätt med %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Avbruten) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 träff"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 ersättning"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> träffar"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> ersättningar"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " på 1 rad"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " på %<PRId64> rader"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan inte göra :global rekursivt"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Reguljärt uttryck saknas från global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Mönster funnet i varje rad: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Mönster hittades inte"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1017,136 +1282,335 @@ msgstr ""
 "# Senaste ersättningssträng:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Få inte panik!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Tyvärr, ingen \"%s\"-hjälp för %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Tyvärr, ingen hjälp för %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Tyvärr, hjälpfil \"%s\" hittades inte"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Inte en katalog: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Kan inte öppna %s för skrivning"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Kunde inte öppna %s för läsning"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Blandning av hjälpfilskodning inom ett språk: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Duplicerad tagg \"%s\" i fil %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Okänt signaturkommando: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Saknar signaturnamn"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: För många signaturer definierade"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Ogiltig signaturtext: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Okänd signatur: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Saknar signaturnummer"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ogiltigt buffertnamn: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Ogiltigt signatur-ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (INTE HITTADE)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (stöds inte)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Borttagen]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Går in i felsökningsläge.  Skriv \"cont\" för att fortsätta."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "rad %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "kommando: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Brytpunkt i \"%s%s\" rad %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Brytpunkt hittades inte: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Inga brytpunkter definierade"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  rad %<PRId64>"
+
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Använd :profile start <fnamn> först"
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Spara ändringar till \"%s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Namnlös"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Ingen skrivning sedan senaste ändring för buffert \"%s\""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "Varning: Gick in i andra buffertar oväntat (kontrollera autokommandon)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Det finns bara en fil att redigera"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Kan inte gå före första filen"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Kan inte gå bortom sista filen"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: kompilator stöds inte: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Söker efter \"%s\" i \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Söker efter \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "hittades inte i 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Kan inte läsa en katalog: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "kunde inte läsa \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "rad %<PRId64>: kunde inte läsa \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "läser \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "rad %<PRId64>: läser \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "läste klart %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "lägesrad"
+
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd argument"
+
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c argument"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "miljövariabel"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "felhanterare"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Varning: Fel radavskiljare, ^M kan saknas"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: :scriptencoding används utanför en körd fil"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: :finish används utanför en körd fil"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Aktuellt %sspråk: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Kan inte sätta språk till \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Går in i Ex-läge.  Skriv \"visual\" för att gå till Normal-läge."
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Vid filslut"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Kommando för rekursivt"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Undantag inte fångat: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Slut på läst fil"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Slut på funktion"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Otydlig användning av användardefinierat kommando"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Inte ett redigerarkommando"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Bakåtområde givet"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Bakåtområde givet, OK att växla"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Använd w eller w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Tyvärr, kommandot är inte tillgängligt i den här versionen"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Bara ett filnamn tillåtet"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "1 fil till att redigera.  Avsluta ändå?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d filer till att redigera.  Avsluta ändå?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 fil till att redigera"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> filer till att redigera"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Kommando existerar redan: lägg till ! för att ersätta det"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1154,277 +1618,341 @@ msgstr ""
 "\n"
 "    Namn        Arg Område Färdigt  Definition"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Inga användardefinierade kommandon hittade"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Inga attribut angivna"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Ogiltigt antal argument"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Antal kan inte anges två gånger"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Ogiltigt standardvärde för antal"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: argument krävs för -complete"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Ogiltigt attribut: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Ogiltigt kommandonamn"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Användardefinierade kommandon måste börja med en stor bokstav"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Otydlig användning av användardefinierat kommando"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Inget sådant användardefinierat kommando: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Ogiltigt kompletteringsvärde: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Kompletteringsargument bara tillåtet för specialkomplettering"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Specialkomplettering kräver ett funktionsargument"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Kan inte hitta färgschema %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Välkommen, Vim-användare!"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Kan inte stänga senaste flik"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Redan bara en flik"
 
-msgid "Edit File in new window"
-msgstr "Redigera fil i nytt fönster"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Flik %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Ingen växlingsfil"
 
-msgid "Append File"
-msgstr "Lägg till fil"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Kan inte ändra katalog, buffert är ändrad (lägg till ! för att tvinga)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Ingen tidigare katalog"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Okänt"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize kräver två sifferargument"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Fönsterposition: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Förskaffa fönsterposition inte implementerat för den här plattformen"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos kräver två sifferargument"
 
-msgid "Save Redirection"
-msgstr "Spara omdirigering"
-
-msgid "Save View"
-msgstr "Spara vy"
-
-msgid "Save Session"
-msgstr "Spara session"
-
-msgid "Save Setup"
-msgstr "Spara konfiguration"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Kan inte skapa katalog: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existerar (lägg till ! för att tvinga)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Kan inte öppna \"%s\" för skrivning"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr ""
 "E191: Argument måste vara en bokstav eller framåt-/bakåtvänt citattecken"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursiv användning av :normal för djup"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Inget alternativt filnamn att byta ut '#' med"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: inget autokommando-filnamn att ersätta \"<afile>\" med"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: inget autokommando-buffernummer att ersätta \"<abuf>\" med"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: inget autokommando-träffnamn att byta ut \"<amatch>\" med"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: inget :source-filnamn att byta ut \"<sfile>\" med"
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: inget :source-filnamn att byta ut \"<sfile>\" med"
+
+#: ../ex_docmd.c:7903
+#, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Tomt filnamn för '%' or '#', fungerar bara med \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Evaluerar till en tom sträng"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Kan inte öppna viminfo-fil för läsning"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Inga digrafer i den här versionen"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Kan inte :throw undantag med 'Vim'-prefix"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Undantag kastade: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Undantag färdiga: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Undantag förkastade: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, rad %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Undantag fångade: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s gjordes avvaktande"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s återupptagen"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s förkastad"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Undantag"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Fel och avbrytet"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Fel"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Avbryt"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if nästlad för djupt"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif utan :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else utan :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif utan :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: flera :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif efter :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for nästlad för djupt"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue utan :while eller :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break utan :while eller :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Använder :endfor med :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Använder :endwhile med :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try nästlad för djupt"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch utan :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch efter :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally utan :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: flera :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry utan :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction inte inom en funktion"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Inte tillåtet att redigera en annan buffert nu"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: Inte tillåtet att redigera en annan buffert nu"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "taggnamn"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " snäll fil\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "'history'-flagga är noll"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1433,214 +1961,307 @@ msgstr ""
 "\n"
 "# %s Historia (nyaste till äldsta):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Kommandorad"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Söksträng"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Uttryck"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Inmatningsrad"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar bortom kommandolängden"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktivt fönster eller buffert borttagen"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Ogiltig sökväg: '**[nummer]' måste vara i slutet på sökvägen eller "
+"följas av '%s'."
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Kan inte hitta katalog \"%s\" i cdpath"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Kan inte hitta fil \"%s\" i sökväg"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Ingen katalog \"%s\" hittades i cdpath"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Ingen fil \"%s\" hittades i sökvägen"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter*-Autokommandon får inte ändra aktuell buffert"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Otillåtet filnamn"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "är en katalog"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "är inte en fil"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "är en enhet (inaktiverad med 'opendevice'-flagga)"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Ny fil]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Ny KATALOG]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Fil för stor]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Tillåtelse nekas]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre autokommandon gjorde filen oläsbar"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre autokommandon får inte ändra nuvarande buffert"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Läser från standard in...\n"
 
-msgid "Reading from stdin..."
-msgstr "Läser från standard in..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Konvertering gjorde filen oläsbar!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/uttag]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[uttag]"
 
-msgid "[RO]"
-msgstr "[EL]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 tecken"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[CR saknas]"
 
-msgid "[NL found]"
-msgstr "[NL hittat]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[långa rader delade]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[INTE konverterad]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[konverterad]"
 
-msgid "[crypted]"
-msgstr "[krypterad]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[KONVERTERINGSFEL på rad %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[OTILLÅTEN BIT på rad %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LÄSFEL]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Kan inte hitta temporär fil för konvertering"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Konvertering med 'charconvert' misslyckades"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "kan inte läsa utdata av 'charconvert'"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Inga matchande autokommandon för acwrite buffert"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Autokommandon tog bort eller laddade ur buffert som skulle skrivas"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autokommado ändrade antal rader på ett oväntat sätt"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans tillåter inte skrivning av omodifierade buffertar"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Delvisa skrivningar tillåts inte i NetBeans-buffertar"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "är inte en fil eller skrivbar enhet"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "skriver till en enhet inaktiverad med 'opendevice'-flagga"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "är skrivskyddad (lägg till ! för att tvinga)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Kan inte skriva till säkerhetskopia (lägg till ! för att tvinga)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Stängningsfel för säkerhetskopia (lägg till ! för att tvinga)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Kan inte läsa fil för säkerhetskopia (lägg till ! för att tvinga)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Kan inte skapa säkerhetskopia (lägg till ! för att tvinga)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Kan inte göra säkerhetskopia (lägg till ! för att tvinga)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Resursgrenen skulle tappas bort (lägg till ! för att tvinga)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Kan inte hitta temporär fil för skrivning"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Kan inte konvertera (lägg till ! för att skriva utan konvertering)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Kan inte öppna länkad fil för skrivning"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Kan inte öppna fil för skrivning"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync misslyckades"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Stängning misslyckades"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: skrivfel, konvertering misslyckades (gör 'fenc' tom för att tvinga)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+"E513: skrivfel, konvertering misslyckades (gör 'fenc' tom för att tvinga)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: skrivfel (filsystem fullt?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " KONVERTERINGSFEL"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "rad %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Enhet]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Ny]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [l]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " lade till"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [s]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " skriven"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchläge: kan inte spara orginalfil"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchläge: kan inte skapa tom orginalfil"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Kan inte ta bort säkerhetskopia"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1648,75 +2269,96 @@ msgstr ""
 "\n"
 "VARNING: Orginalfilen kan vara förlorad eller skadad\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "avsluta inte redigeraren innan filen är framgångsrikt skriven"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos-format]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac-format]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix-format]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 rad, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> rader, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 tecken"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> tecken"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[inget radslut]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Ofullständig sistarad]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "VARNING: Filen har ändrats sedan den lästes in!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Vill du verkligen skriva till den"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Fel vid skrivning till \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Fel vid stängning av \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Fel vid läsning av \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell-autokommandot tog bort buffert"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Filen \"%s\" är inte längre tillgänglig"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1724,32 +2366,40 @@ msgid ""
 msgstr ""
 "W12: Varning: Filen \"%s\" har ändrats och bufferten ändrades i Vim också"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Se \":help W12\" för mer info."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Varning: Filen \"%s\" har ändrats sedan redigeringen började"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Se \":help W11\" för mer info."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Varning: Rättigheterna på filen \"%s\" har ändrats sedan redigeringen "
 "började"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Se \":help W16\" för mer info."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Varning: Filen \"%s\" har skapats efter redigeringen började"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Varning"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1757,39 +2407,48 @@ msgstr ""
 "&OK\n"
 "&Läs in filen"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Kunde inte förbereda för att läsa om \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Kunde inte läsa om \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Borttagen--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "tar bort autokommando automatiskt: %s <buffert=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Ingen sådan grupp: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Otillåtet tecken efter *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Ingen sådan händelse: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Ingen sådan grupp eller händelse: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1797,567 +2456,800 @@ msgstr ""
 "\n"
 "--- Autokommandon ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffert=%d>: ogiltigt buffertnummer "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Kan inte köra autokommandon för ALLA händelser"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Inga matchande autokommandon"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autokommando nästlad för djupt"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokommandon för \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Kör %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autokommando %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Saknar {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Saknar }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Inget veck funnet"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Kan inte skapa veck med nuvarande 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Kan inte ta bort veck med nuvarande 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld rader vikta "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Lägg till i läsbuffert"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: rekursiv mappning"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: global förkortning existerar redan för %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: global mappning existerar redan för %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: förkortning existerar redan för %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: mappning existerar redan för %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Ingen förkortning hittades"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Ingen mappning hittades"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Otillåtet läge"
 
-msgid "<cannot open> "
-msgstr "<kan inte öppna> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Inga rader i buffert--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: kan inte hämta typsnitt %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Kommando avbrutet"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: Kan inte återvända till aktuell katalog"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Argument krävs"
 
-msgid "Pathname:"
-msgstr "Sökväg:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ borde följas av /, ? eller &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: kan inte hämta aktuell katalog"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Felaktighet i kommandoradsfönster; <CR> kör, CTRL-C avslutar"
 
-msgid "OK"
-msgstr "OK"
-
-msgid "Cancel"
-msgstr "Avbryt"
-
-msgid "Vim dialog"
-msgstr "Vim-dialog"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Rullningslist: Kunde inte hämta geometrin på miniatyrbild."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Kan inte skapa BalloonEval med både meddelande och återkallning"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Kan inte starta GUI"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Kan inte läsa från \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Kan inte starta GUI, ingen giltig font hittad"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' ogiltig"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Värdet av 'imactivatekey' är ogiltigt"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Kan inte allokera färg %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Ingen matchning vid markör, söker nästa"
-
-msgid "Vim dialog..."
-msgstr "Vim-dialog..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Ja\n"
-"&Nej\n"
-"&Avbryt"
+"E12: Kommando inte tillåtet från exrc/vimrc i aktuell katalog eller "
+"taggsökning"
 
-msgid "Input _Methods"
-msgstr "Inmatnings_metoder"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Saknar :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Sök och ersätt..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Saknar :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Sök..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Saknar :endwhile"
 
-msgid "Find what:"
-msgstr "Hitta vad:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Saknar :endfor"
 
-msgid "Replace with:"
-msgstr "Ersätt med:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile utan :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Matcha endast hela ord"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor utan :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Skilj på stora/små bokstäver"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Fil existerar (lägg till ! för att tvinga)"
 
-msgid "Direction"
-msgstr "Riktning"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Kommando misslyckades"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Upp"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Internt fel"
 
-msgid "Down"
-msgstr "Ned"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Avbruten"
 
-msgid "Find Next"
-msgstr "Hitta nästa"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Ogiltig address"
 
-msgid "Replace"
-msgstr "Ersätt"
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Ogiltigt argument"
 
-msgid "Replace All"
-msgstr "Ersätt alla"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Tog emot \"die\"-begäran från sessionshanteraren\n"
-
-msgid "Close"
-msgstr "Stäng"
-
-msgid "New tab"
-msgstr "Ny flik"
-
-msgid "Open Tab..."
-msgstr "Öppna flik..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Huvudfönster oväntat förstört\n"
-
-msgid "Font Selection"
-msgstr "Typsnittsval"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Använd CUT_BUFFER0 istället för tomt val"
-
-msgid "&Filter"
-msgstr "&Filter"
-
-msgid "&Cancel"
-msgstr "&Avbryt"
-
-msgid "Directories"
-msgstr "Kataloger"
-
-msgid "Filter"
-msgstr "Filter"
-
-msgid "&Help"
-msgstr "&Hjälp"
-
-msgid "Files"
-msgstr "Filer"
-
-msgid "&OK"
-msgstr "&OK"
-
-msgid "Selection"
-msgstr "Val"
-
-msgid "Find &Next"
-msgstr "Hitta &nästa"
-
-msgid "&Replace"
-msgstr "&Ersätt"
-
-msgid "Replace &All"
-msgstr "Ersätt &alla"
-
-msgid "&Undo"
-msgstr "&Ångra"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Kan inte hitta fönstertitel \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Ogiltigt argument: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argument stöds inte: \"-%s\"; Används OLE-versionen."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Ogiltigt uttryck: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Kunde inte öppna fönster inuti MDI-applikation"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Ogiltigt område"
 
-msgid "Close tab"
-msgstr "Stäng flik"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Ogiltigt kommando"
 
-msgid "Open tab..."
-msgstr "Öppna flik..."
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" är en katalog"
 
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Sök sträng (använd '\\\\' för att hitta '\\')"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Ogiltig rullningsstorlek"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Sök & ersätt (använd '\\\\' för att hitta '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Inte använd"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Katalog\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Kan inte allokera post i färgkarta, några färger kan bli felaktiga"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"E250: Typsnitt för följande teckenkoder saknas i typsnittsuppsättningen %s:"
 
+#: ../globals.h:1024
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Typsnittsuppsättningsnamn: %s"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Biblioteksanrop misslyckades för \"%s()\""
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Font '%s' är inte fast bredd"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Markering har ogiltigt radnummer"
 
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Typsnittsuppsättningsnamn: %s\n"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Markering inte satt"
 
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Typsnitt0: %s\n"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Kan inte göra ändringar, 'modifiable' är av"
 
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Typsnitt1: %s\n"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skript nästlade för djupt"
 
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "Typsnitt%<PRId64> är inte dubbelt så bred som font0\n"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Ingen alternativ fil"
 
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Typsnitt0 bredd: %<PRId64>\n"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Ingen sådan förkortning"
 
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Inget ! tillåtet"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: GUI kan inte användas: Inte aktiverat vid kompilering"
+
+#: ../globals.h:1036
 #, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Inget sådant framhävningsgruppnamn: %s"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Ingen infogad text än"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Ingen tidigare kommandorad"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Ingen sådan mappning"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Ingen träff"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Ingen träff: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Inget filnamn"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Inget tidigare utbytningsreguljäruttryck"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Inget tidigare kommando"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Inget tidigare reguljärt uttryck"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Inget område tillåtet"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Inte tillräckligt med utrymme"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Kan inte skapa fil %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Kan inte hämta temporärt filnamn"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Kan inte öppna fil %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Kan inte läsa fil %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
 msgstr ""
-"Typsnitt1 bredd: %<PRId64>\n"
-"\n"
+"E37: Ingen skrivning sedan senaste ändring (lägg till ! för att tvinga)"
 
-msgid "Invalid font specification"
-msgstr "Ogiltig typsnittsuppsättning"
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Ingen skrivning sedan senaste ändring]\n"
 
-msgid "&Dismiss"
-msgstr "&Förkasta"
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Null-argument"
 
-msgid "no specific match"
-msgstr "ingen specifik matchning"
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Nummer väntat"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - Typsnittsväljare"
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Kan inte öppna felfil %s"
 
-msgid "Name:"
-msgstr "Namn:"
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Slut på minne!"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Visa storlek i punkter"
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Mönster hittades inte"
 
-msgid "Encoding:"
-msgstr "Teckenkodning:"
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Mönster hittades inte: %s"
 
-msgid "Font:"
-msgstr "Typsnitt:"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Argument måste vara positivt"
 
-msgid "Style:"
-msgstr "Stil:"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Kan inte gå tillbaka till tidigare katalog"
 
-msgid "Size:"
-msgstr "Storlek:"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Inga fel"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul automata FEL"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Ingen positionslista"
 
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Skadad träffsträng"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Trasigt program för reguljära uttryck"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' flagga är satt (lägg till ! för att tvinga)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Kan inte ändra skrivskyddad variabel \"%s\""
+
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Kan inte sätta variabel i sandlådan: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Fel vid läsning av felfil"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Inte tillåtet i sandlåda"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Inte tillåtet här"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Skärmläge inställning stöds inte"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Ogiltig rullningsstorlek"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' flagga är tom"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Kunde inte läsa in teckendata!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Stängningsfel på växlingsfil"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: taggstack tom"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Kommando för komplext"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Namn för långt"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: För många ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: För många filnamn"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Eftersläpande tecken"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Okänt märke"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Kan inte expandera jokertecken"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' kan inte vara mindre än 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' kan inte vara mindre än 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Fel vid skrivning"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Noll-längd"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Använder inte <SID> i ett skriptsammanhang"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Internt fel: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: mönster använder mer minne än 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: tom buffert"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Ogiltigt sökmönster eller delimiter"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Filen är inläst i en annan buffert"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Flagga '%s' är inte satt"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Otillåtet registernamn: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "sökning nådde TOPPEN, fortsätter vid BOTTEN"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "sökning nådde BOTTEN, forsätter vid TOPPEN"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Saknar kolon"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Otillåten komponent"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: siffra förväntades"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Sida %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Ingen text att skriva ut"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Skriver ut sida %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopia %d av %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Skrev ut: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Utskrift avbruten"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Fel vid skrivning av utdata till PostScript-fil"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Kan inte öppna fil \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Kan inte läsa PostScript-resursfil \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: fil \"%s\" är inte en PostScript-resursfil"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: fil \"%s\" är inte en PostScript-resursfil som stöds"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\"-källfilen har fel version"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Inkompatibel flerbitskodning och teckenuppsättning."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset kan inte vara tom med flerbitskodning."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Ingen standardfont angiven för flerbitsutskrifter."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Kan inte öppna PostScript-utfil"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Kan inte öppna fil \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Kan inte hitta PostScript-källfilen \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Kan inte hitta PostScript-källfilen \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Kan inte hitta PostScript-källfilen \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Kunde inte konvertera från utskriftkodning \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Skickar till skrivare..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Misslyckades med att skriva ut PostScript-fil"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Skrivarjobb skickat."
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Lägg till en ny databas"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Fråga efter ett mönster"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Visa detta meddelande"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Döda en anslutning"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Ominitiera alla anslutningar"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Visa anslutningar"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Användning: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Det här scope-kommandot stöder inte delning av fönstret.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Användning: cstag <identifierare>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: tagg hittades inte"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s)-fel: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat-fel"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s är inte en katalog eller en godkänd cscope-databas"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Lade till cscope-databas %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: fel vid läsning av cscope-anslutning %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: okänd cscope-söktyp"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Kunde inte skapa cscope-rör"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Kunde inte grena för cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection-exekvering misslyckades"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection-exekvering misslyckades"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Kunde inte starta cscope-process"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen för to_fp misslyckades"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen för fr_fp misslyckades"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Kunde inte starta cscope-process"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: inga cscope-anslutningar"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: inga träffar funna för cscope-förfrågan %s av %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: ogiltig cscopequickfix flagga %c för %c"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: inga träffar funna för cscope-förfrågan %s av %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope-kommandon:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Användning: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: kan inte öppna cscope-databas: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: kan inte hämta cscope-databasinformation"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: dubblerad cscope-databas inte lagd till"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: maximalt antal av cscope-anslutningar nått"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope-anslutning %s hittades inte"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope-anslutning %s stängd"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: ödesdigert fel i cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope-tagg: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2365,403 +3257,88 @@ msgstr ""
 "\n"
 "   #   rad"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "filnamn / sammanhang / rad\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope-fel: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Alla cscope-databaser återställda"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "inga cscope-anslutningar\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    databasnamn                        först i sökväg\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr ""
-"???: Tyvärr, det här kommandot är inaktiverat: MzScheme-biblioteket kunde "
-"inte läsas in."
-
-msgid "invalid expression"
-msgstr "ogiltigt uttryck"
-
-msgid "expressions disabled at compile time"
-msgstr "uttryck inaktiverat vid kompilering"
-
-msgid "hidden option"
-msgstr "gömd flagga"
-
-msgid "unknown option"
-msgstr "okänd flagga"
-
-msgid "window index is out of range"
-msgstr "fönsterindex är utanför område"
-
-msgid "couldn't open buffer"
-msgstr "kunde inte öppna buffert"
-
-msgid "cannot save undo information"
-msgstr "kan inte spara ångra-information"
-
-msgid "cannot delete line"
-msgstr "kan inte ta bort rad"
-
-msgid "cannot replace line"
-msgstr "kan inte ersätta rad"
-
-msgid "cannot insert line"
-msgstr "kan inte infoga rad"
-
-msgid "string cannot contain newlines"
-msgstr "sträng kan inte innehålla nyrader"
-
-msgid "Vim error: ~a"
-msgstr "Vim-fel: ~a"
-
-msgid "Vim error"
-msgstr "Vim-fel"
-
-msgid "buffer is invalid"
-msgstr "buffert är ogiltig"
-
-msgid "window is invalid"
-msgstr "fönster är ogiltigt"
-
-msgid "linenr out of range"
-msgstr "radnummer utanför område"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "inte tillåtet i Vim-sandlådan"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Tyvärr, detta kommandot är inaktiverat, Python-biblioteket kunde inte "
-"läsas in."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Kan inte anropa Python rekursivt"
-
-msgid "can't delete OutputObject attributes"
-msgstr "kan inte ta bort OutputObject-attribut"
-
-msgid "softspace must be an integer"
-msgstr "softspace måste vara ett heltal"
-
-msgid "invalid attribute"
-msgstr "ogiltigt attribut"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() kräver lista av strängar"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Fel vid initiering av I/O-objekt"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "försök att referera till borttagen buffert"
-
-msgid "line number out of range"
-msgstr "radnummer utanför område"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<buffertobjekt (borttaget) vid %8lX>"
-
-msgid "invalid mark name"
-msgstr "ogiltigt märknamn"
-
-msgid "no such buffer"
-msgstr "ingen sådan buffert"
-
-msgid "attempt to refer to deleted window"
-msgstr "försök att referera till borttaget fönster"
-
-msgid "readonly attribute"
-msgstr "skrivskyddad attribut"
-
-msgid "cursor position outside buffer"
-msgstr "markörposition utanför buffert"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<fönsterobjekt (borttaget) vid %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<fönsterobjekt (okänt) vid %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<fönster %d>"
-
-msgid "no such window"
-msgstr "inget sådant fönster"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ måste vara en instans av String"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Tyvärr, detta kommandot är inaktiverat, Ruby-biblioteket kunde inte "
-"läsas in."
-
-msgid "E267: unexpected return"
-msgstr "E267: oväntad returnering"
-
-msgid "E268: unexpected next"
-msgstr "E268: oväntad next"
-
-msgid "E269: unexpected break"
-msgstr "E269: oväntad break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: oväntad redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry utanför rescue-block"
-
-msgid "E272: unhandled exception"
-msgstr "E272: ohanterat undantag"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: okänt longjmp-status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Växla mellan implementation/definition"
-
-msgid "Show base class of"
-msgstr "Visa basklass av"
-
-msgid "Show overridden member function"
-msgstr "Visa åsidosatt medlemsfunktion"
-
-msgid "Retrieve from file"
-msgstr "Hämta från fil"
-
-msgid "Retrieve from project"
-msgstr "Hämta från projekt"
-
-msgid "Retrieve from all projects"
-msgstr "Hämta från alla projekt"
-
-msgid "Retrieve"
-msgstr "Hämta"
-
-msgid "Show source of"
-msgstr "Visa källa för"
-
-msgid "Find symbol"
-msgstr "Hitta symbol"
-
-msgid "Browse class"
-msgstr "Bläddra i klass"
-
-msgid "Show class in hierarchy"
-msgstr "Visa klass i hierarki"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Visa klass i begränsad hierarki"
-
-msgid "Xref refers to"
-msgstr "Xref refererar till"
-
-msgid "Xref referred by"
-msgstr "Xref refereras av"
-
-msgid "Xref has a"
-msgstr "Xref har en"
-
-msgid "Xref used by"
-msgstr "Xref används av"
-
-msgid "Show docu of"
-msgstr "Visa docu av"
-
-msgid "Generate docu for"
-msgstr "Generera docu för"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Kan inte ansluta till SNiFF+. Kontrollera miljö (sniffemacs måste kunna "
-"hittas i $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Fel vid läsning. Frånkopplad"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ är för närvarande "
-
-msgid "not "
-msgstr "inte "
-
-msgid "connected"
-msgstr "ansluten"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Okänd SNiFF+-begäran: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Fel vid anslutning till SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ inte ansluten"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Inte en SNiFF+-buffert"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Fel vid skrivning. Frånkopplad"
-
-msgid "invalid buffer number"
-msgstr "ogiltigt buffertnummer"
-
-msgid "not implemented yet"
-msgstr "inte implementerat än"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "kan inte ställa in rad(er)"
-
-msgid "mark not set"
-msgstr "märke inte satt"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "rad %d kolumn %d"
-
-msgid "cannot insert/append line"
-msgstr "kan inte infoga/lägga till rad"
-
-msgid "unknown flag: "
-msgstr "okänd flagga: "
-
-msgid "unknown vimOption"
-msgstr "okänd vimOption"
-
-msgid "keyboard interrupt"
-msgstr "tangentbordsavbrott"
-
-msgid "vim error"
-msgstr "vim-fel"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "kan inte skapa buffert/fönster-kommando: objekt håller på att tas bort"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr ""
-"kan inte registera återkallningskommando: buffert/fönster håller redan på "
-"att tas bort"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: TCL ÖDESDIGERT FEL: reflist trasig!? Var snäll och rapportera detta "
-"till vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"kan inte registrera återkallningskommando: buffert-/fönsterreferens hittades "
-"inte"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Tyvärr, detta kommando är inaktiverat: Tcl-biblioteket kunde inte "
-"läsas in."
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: TCL-FEL: Avslutningskoden är inte int!? Var snäll och rapportera detta "
-"till vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: avslutningskod %d"
-
-msgid "cannot get line"
-msgstr "kan inte hämta rad"
-
-msgid "Unable to register a command server name"
-msgstr "Kunde inte registrera ett kommandoservernamn"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Misslyckades att skicka kommando till målprogrammet"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Ogiltigt server-id använt: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM instansregisteregenskap är dåligt format.  Borttaget!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Okänt flaggargument"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "För många redigeringsargument"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Argument saknas efter"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Skräp efter flaggargument"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "För många \"+kommando\"-, \"-c kommando\"- eller \"--cmd kommando\"-argument"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Ogiltigt argument för"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d filer att redigera\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Denna Vim blev inte kompilerad med diff-funktionen."
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Försök att öppna skriptfil igen: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Kan inte öppna för läsning: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Kan inte öppna för skriptutmatning: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Fel: Misslyckades att starta gvim från NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Varning: Utmatning är inte till en terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Varning: Inmatning är inte från en terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc kommandorad"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kan inte läsa från \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2769,18 +3346,23 @@ msgstr ""
 "\n"
 "Mer info med: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[fil ..]       redigera angivna fil(er)"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-              läs text från standard in"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tagg        redigera fil där tagg är definierad"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [felfil]    redigera fil med första fel"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2790,9 +3372,11 @@ msgstr ""
 "\n"
 "användning:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [argument] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2800,13 +3384,7 @@ msgstr ""
 "\n"
 "     eller:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Där storlek ignoreras börja med / för att göra flagga versal"
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2816,328 +3394,189 @@ msgstr ""
 "\n"
 "Argument:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tBara filnamn efter det här"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tExpandera inte jokertecken"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tRegistrera gvim för OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tAvregistrera gvim för OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tKör som GUI (som \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  eller --nofork\tFörgrund: Grena inte vid start av GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi-läge (som \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx-läge (som \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tTyst (batch) läge (bara för \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff-läge (som \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tLätt läge (som \"evim\", lägeslös)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivskyddat läge (som \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tBegränsat läge (som \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifieringar (skriva filer) inte tillåtet"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModifieringar i text inte tillåtet"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinärläge"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp-läge"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatibelt med Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tInte fullt Vi-kompatibel: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][fnamn]\t\tVar mångordig [nivå N] [logga meddelanden till fnamn]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tFelsökningsläge"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tIngen växlingsfil, använd endast minnet"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tLista växlingsfiler och avsluta"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (med filnamn)\tÅterskapa kraschad session"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tSamma som -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tAnvända inte newcli för att öppna fönster"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <enhet>\t\tAnvänd <enhet> för I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tstarta i arabiskt läge"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tStarta i hebreiskt läge"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tStarta i persiskt läge (Farsi)"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tStäll in terminaltyp till <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tAnvänd <vimrc> istället för någon .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tAnvänd <gvimrc> istället för någon .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tLäs inte in insticksskript"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tÖppna N flikar (standard: en för varje fil)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tÖppna N fönster (standard: ett för varje fil)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tSom -o men dela vertikalt"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tStarta vid slut av fil"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnr>\t\tStarta på rad <rnr>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <kommando>\tKör <kommando> före inläsning av någon vimrc fil"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <kommando>\tKör <kommando> efter inläsning av den första filen"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\tKör fil <session> efter inläsning av den första filen"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <inskript>\tLäs Normallägeskommandon från fil <inskript>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <utskript>\tLägg till alla skrivna kommandon till fil <utskript>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <utskript>\tSkriv alla skrivna kommandon till fil <utskript>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tRedigera krypterade filer"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\tAnslut vim till just denna X-server"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tAnslut inte till X server"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <filer>\tRedigera <filer> i en Vim-server om möjligt"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-silent <filer>\tSamma, klaga inte om det inte finns någon server"
 
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <filer>\tSom --remote men vänta på att filer har blivit "
-"redigerade"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <filer>\tSamma, klaga inte om det inte finns någon "
-"server"
-
-msgid "--remote-tab <files>  As --remote but open tab page for each file"
-msgstr "--remote-tab <filer>  Som --remote men öppna flik för varje fil"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr ""
-"--remote-send <nycklar>\tSkicka <nycklar> till en Vim-server och avsluta"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <uttryck>\tEvaluera <uttryck> i en Vim-server och skriv ut "
-"resultatet"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tLista tillgängliga Vim-servernamn och avsluta"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <namn>\tSkicka till/för att bli Vim-servern <namn>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tAnvänd <viminfo> istället för .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  eller  --help\tSkriv ut Hjälp (det här meddelandet) och avsluta"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tSkriv ut versionsinformation och avsluta"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Argument som stöds av gvim (Motif-version):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Argument som stöds av gvim (neXtaw-version):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Argument som stöds av gvim (Athena-version):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\tKör vim på <display>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tStarta vim som ikon"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <namn>\t\tAnvänd resurs som om vim var <namn>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t   (Oimplementerat)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <färg>\tAnvänd <färg> för bakgrunden (även: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <färg>\tAnvänd <färg> för vanlig text (även: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <typsnitt>\t\tAnvänd <typsnitt> för vanlig text (även: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "­boldfont <typsnitt>\tAnvänd <typsnitt> för fet text"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <typsnitt>\tAnvänd <typsnitt> för kursiv text"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tAnvänd <geom> för inledande fönsterplacering (även: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <bredd>\tAnvänd en rambredd med <bredd> (även: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <bredd>  Använd en rullningslistbredd på <bredd> (även: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <höjd>\tAnvänd en menyradshöjd med <höjd> (även: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tAnvänd omvänd video (även: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tAnvänd inte omvänd video (även: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <tillgång>\tStäll in den angivna tillgången"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Argument igenkända av gvim (RISC OS-version):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <antal>\tInledande bredd på fönster i kolumner"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <antal>\tInledande höjd på fönster i rader"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Argument igenkända av gvim (GTK+-version):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\tKör vim på <display> (även: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <roll>\tStäll in en unik roll för att identifiera huvudfönstret"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tÖppna Vim innanför en annan GTK-widget"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <förälder fönster>\tÖppna Vim inuti förälderapplikation"
-
-msgid "No display"
-msgstr "Ingen display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Överföring misslyckades.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Överföring misslyckades. Försöker att köra lokalt\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d av %d redigerade"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Ingen display: Överföringsuttryck misslyckades.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Överföringsuttryck misslyckades.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Inga märken satta"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Inga märken matchade \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3146,6 +3585,7 @@ msgstr ""
 "märke rad  kol fil/text"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3154,6 +3594,7 @@ msgstr ""
 " hopp rad kol fil/text"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3161,7 +3602,7 @@ msgstr ""
 "\n"
 "ändring rad  kol text"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3170,7 +3611,7 @@ msgstr ""
 "# Filmärken:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3178,7 +3619,7 @@ msgstr ""
 "\n"
 "# Hopplista (nyaste först):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3186,94 +3627,84 @@ msgstr ""
 "\n"
 "# Historia för märken inne i filer (nyaste till äldsta):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Saknar '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Inte en godkänd teckentabell"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Kan inte ställa in IC-värden"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Misslyckades att skapa inmatningsmiljö"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Misslyckades att öppna inmatningsmetod"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Varning: Kunde inte ställa in förstörningsåterkallning till IM"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: inmatningsmetod stöder inte någon stil"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: inmatningsmetod stöder inte min förredigeringstyp"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: över-pricken-stil kräver typsnittsuppsättning"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: Din GTK+ är äldre än 1.2.3. Statusområde inaktiverat"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Inmatningsmetodserver körs inte"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: block låstes inte"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Sökfel i växelfilsläsning"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Läsfel i växelfil"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Sökfel i växelfilskrivning"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Skrivfel i växelfil"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Växelfil existerar redan (symlänksattack?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Tog inte emot block nr 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Tog inte emot block nr 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Tog inte emot block nr 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Hoppsan, tappat bort växelfilen!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Kunde inte döpa om växelfil"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Kunde inte öppna växelfil för \"%s\", återskapning omöjlig"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Tog inte emot block 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Ingen växelfil hittad för %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Ange nummer på växelfil att använda (0 för att avsluta): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Kan inte öppna %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Kunde inte läsa block 0 från "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3282,22 +3713,28 @@ msgstr ""
 "Kanske gjordes inte några förändringar eller så uppdaterade inte Vim "
 "växlingsfilen."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " kan inte användas med den här versionen av Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Använd Vim version 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ser inte ut som en Vim-växlingsfil"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " kan inte användas på den här datorn.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Filen skapades på "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3305,66 +3742,85 @@ msgstr ""
 ",\n"
 "eller så har filen blivit skadad."
 
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " har skadats (sid-storlek är mindre än minimumvärdet).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Använder växlingsfil \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Orginalfil \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Varning: Orginalfilen kan ha blivit skadad"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Kunde inte läsa block 1 från %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???MÅNGA RADER SAKNAS"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???RADANTAL FEL"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???TOMT BLOCK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???RADER SAKNAS"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Block 1 ID fel (%s inte en .swp-fil?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???BLOCK SAKNAS"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? från här till ???SLUT kan rader vara tillstökade"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? från här till ???SLUT kan rader ha blivit infogade/borttagna"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "??SLUT"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Återskapning avbruten"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Fel upptäckt vid återskapning; titta efter rader som börjar med ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Se \":help E312\" för mer information."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Återskapning klar. Du borde kontrollera om allting är OK."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3372,51 +3828,72 @@ msgstr ""
 "\n"
 "(Du kanske vill spara den här filen under ett annat namn\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr ""
 "och kör diff med orginalfilen för att kontrollera efter förändringar)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Ta bort .swp-filen efteråt.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Växlingsfiler hittade:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   I aktuell katalog:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Använder angivet namn:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   I katalog "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- inget --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          ägd av: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   daterad: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             daterad: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [från Vim version 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [ser inte ut som en Vim-växlingsfil]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         filnamn: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3424,12 +3901,15 @@ msgstr ""
 "\n"
 "          modifierad: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "JA"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "nej"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3437,9 +3917,11 @@ msgstr ""
 "\n"
 "         användarnamn: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   värdnamn: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3447,6 +3929,7 @@ msgstr ""
 "\n"
 "         värdnamn: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3454,16 +3937,11 @@ msgstr ""
 "\n"
 "        process-ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (körs fortfarande)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [inte användbar med den här versionen av Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3471,75 +3949,97 @@ msgstr ""
 "\n"
 "         [inte användbar på den här datorn]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [kan inte läsas]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [kan inte öppnas]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Kan inte bevara, det finns ingen växlingsfil"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Fil bevarad"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Bevaring misslyckades"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: ogiltigt lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: kan inte hitta rad %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: pekarblock-id fel 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx ska vara 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Uppdaterade för många block?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: pekarblock-id fel 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "tagit bort block 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Kan inte hitta rad %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: pekarblock-id fel"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count är noll"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: radnummer utanför område: %<PRId64> bakom slutet"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: radantal fel i block %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Stackstorlek ökar"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: pekarblock-id fel 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Symbolisk länk-loop för \"%s\""
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: LYSTRING"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3547,38 +4047,44 @@ msgstr ""
 "\n"
 "Hittade en växlingsfil med namnet \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Vid öppning av fil \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      NYARE än växelfil!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Ett annat program kan redigera samma fil.\n"
 "    Om så är fallet, var försiktig så att det inte slutar med två\n"
 "    versioner av samma fil vid förändringar.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Avsluta, eller fortsätt på egen risk.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) En redigeringssession för den här filen kraschade.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Om så är fallet, använd \":recover\" eller \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3586,9 +4092,11 @@ msgstr ""
 "\"\n"
 "    för att återskapa förändringarna (se \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Om du redan har gjort det, ta bort växlingsfilen \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3596,18 +4104,23 @@ msgstr ""
 "\"\n"
 "    för att undvika det här meddelandet.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Växlingsfil \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" existerar redan!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - LYSTRING"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Växlingsfil existerar redan!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3621,6 +4134,7 @@ msgstr ""
 "&Avsluta\n"
 "A&vbryt"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3636,34 +4150,56 @@ msgstr ""
 "&Avsluta\n"
 "A&vbryt"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: För många växlingsfiler hittade"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Slut på minne!  (allokerar %<PRIu64> byte)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Del av menyföremål sökväg är inte undermeny"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Meny existerar bara i ett annat läge"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Ingen meny \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Tomt menynamn"
 
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Menysökväg får inte leda till en undermeny"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Får inte lägga till menyföremål direkt till menyrad"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Avskiljare kam inte vara en del av en menysökväg"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3671,60 +4207,73 @@ msgstr ""
 "\n"
 "--- Menyer ---"
 
-msgid "Tear off this menu"
-msgstr "Ta loss den här menyn"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Menysökväg måste leda till ett menyföremål"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Meny hittades inte: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Meny inte definierad för %s läge"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Menysökväg måste leda till en undermeny"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Meny hittades inte - kontrollera menynamn"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Fel upptäcktes vid bearbetning av %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "rad %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Otillåtet registernamn: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Meddelandeansvarig: Johan Svedberg <johan@svedberg.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Avbrott: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Tryck RETUR eller skriv kommando för att fortsätta"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s rad %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Mer --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " BLANKSTEG/d/j: skärm/sida/rad ned, b/u/k: upp, q: quit "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Fråga"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3732,6 +4281,17 @@ msgstr ""
 "&Ja\n"
 "&Nej"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Ja\n"
+"&Nej\n"
+"&Avbryt"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3745,260 +4305,177 @@ msgstr ""
 "&Kasta bort alla\n"
 "&Avbryt"
 
-msgid "Select Directory dialog"
-msgstr "Välj katalog-dialog"
-
-msgid "Save File dialog"
-msgstr "Spara fil-dialog"
-
-msgid "Open File dialog"
-msgstr "Öppna fil-dialog"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Tyvärr, ingen filbläddrare i konsoll-läge"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Otillräckliga argument för printf()"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: Otillräckliga argument för printf()"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: För många argument till printf()"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Varning: Ändrar en skrivskyddad fil"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Skriv siffra eller klicka med musen (<Retur> avbryter): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "Välj siffra (<Retur> avbryter): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "1 rad till"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "1 rad mindre"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> rad till"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> färre rader"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Avbruten)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Piip!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: bevarar filer...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Färdig.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "FEL: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[byte] sammanlagd allok-frigjord %<PRIu64>-%<PRIu64>, i användning %<PRIu64>, toppanvändning %"
-"lu\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[anrop] sammanlagda om/malloc()'s %<PRIu64>, sammanlagda free()'s %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Rad börjar bli för lång"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Internt fel: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Slut på minne!  (allokerar %<PRIu64> byte)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Anropar skal att köra: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Saknar kolon"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Otillåtet läge"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Otillåten musform"
-
-msgid "E548: digit expected"
-msgstr "E548: siffra förväntades"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Otillåten procentsats"
-
-msgid "Enter encryption key: "
-msgstr "Ange krypteringsnyckel: "
-
-msgid "Enter same key again: "
-msgstr "Ange samma nyckel igen: "
-
-msgid "Keys don't match!"
-msgstr "Nycklar matchar inte!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Ogiltig sökväg: '**[nummer]' måste vara i slutet på sökvägen eller "
-"följas av '%s'."
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Kan inte hitta katalog \"%s\" i cdpath"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Kan inte hitta fil \"%s\" i sökväg"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Ingen katalog \"%s\" hittades i cdpath"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Ingen fil \"%s\" hittades i sökvägen"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Kan inte ansluta till Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Kan inte ansluta till Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: Fel rättighetsläge för NetBeans-anslutningens info fil: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "läs från Netbeans-uttag"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: NetBeans-anslutning tappad för buffert %<PRId64>"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' är tom"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: Eval-funktionen inte tillgänglig"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Varning: terminal kan inte framhäva"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Ingen sträng under markör"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Ingen identifierare under markör"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' är tom"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Varning: terminal kan inte framhäva"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Ingen sträng under markör"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Kan inte ta bort veck med aktuell 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: ändringslista är tom"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Vid början av ändringslista"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Vid slutet av ändringslista"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "skriv  :q<Enter>                för att avsluta Vim         "
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 rad %sad 1 gång"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 rad %sade %d gånger"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> rader %sad 1 gång"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> rader %sade %d gånger"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> rader att indentera... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "1 rad indenterad "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> rader indenterade "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Inget tidigare använt register"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "kan inte kopiera; ta bort ändå"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 rad ändrad"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> rader ändrade"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "frigör %<PRId64> rader"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "block om 1 rad kopierat"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "1 rad kopierad"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "block om %<PRId64> rader kopierade"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> rader kopierade"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Ingenting i register %s"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4006,10 +4483,11 @@ msgstr ""
 "\n"
 "--- Register ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Otillåtet registernamn"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4017,157 +4495,194 @@ msgstr ""
 "\n"
 "# Register:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Okänd registertyp %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> kolumner; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Markerade %s%<PRId64> av %<PRId64> rader; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> bitar"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Markerade %s%<PRId64> av %<PRId64> rader; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> tecken; %<PRId64> av %<PRId64> "
-"bitar"
+"Markerade %s%<PRId64> av %<PRId64> rader; %<PRId64> av %<PRId64> ord; "
+"%<PRId64> av %<PRId64> bitar"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Kol %s av %s; rad %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; bit %<PRId64> av %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Kol %s av %s; rad %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tecken %<PRId64> av %<PRId64>; bit %<PRId64> av %"
-"ld"
+"Markerade %s%<PRId64> av %<PRId64> rader; %<PRId64> av %<PRId64> ord; "
+"%<PRId64> av %<PRId64> tecken; %<PRId64> av %<PRId64> bitar"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s av %s; rad %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; bit "
+"%<PRId64> av %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Kol %s av %s; rad %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tecken "
+"%<PRId64> av %<PRId64>; bit %<PRId64> av %ld"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> för BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Sida %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Tack för att du flyger med Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Okänd flagga"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Flagga stöds inte"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Inte tillåtet i en lägesrad"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Nummer krävs efter ="
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Inte hittat i termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Otillåtet tecken <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Kan inte sätta 'term' till tom sträng"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Kan inte ändra term i GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Använd \":gui\" för att starta GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backuptext' och 'patchmode' är lika"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Kan inte bli ändrat i GTK+ 2-GUI"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Saknar kolon"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Nollängdssträng"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Saknar nummer efter <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Saknar komma"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Måste ange ett '-värde"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: innehåller outskrivbara eller breda tecken"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Ogiltig(a) typsnitt"
-
-msgid "E597: can't select fontset"
-msgstr "E597: kan inte välja typsnittsuppsättning"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Ogiltig typsnittsuppsättning"
-
-msgid "E533: can't select wide font"
-msgstr "E533: kan inte välja brett typsnitt"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Ogiltigt brett typsnitt"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Otillåtet tecken efter <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: komma krävs"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' måste vara tom eller innehålla %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Inget musstöd"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Ostängd uttryckssekvens"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: för många föremål"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: obalanserade grupper"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Ett förhandsvisningsfönster existerar redan"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabiska kräver UTF-8, gör ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Behöver åtminstone %d rader"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Behöver åtminstone %d kolumner"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Okänd flagga: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Nummer krävs efter ="
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4175,6 +4690,7 @@ msgstr ""
 "\n"
 "--- Terminalkoder ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4182,6 +4698,7 @@ msgstr ""
 "\n"
 "--- Globala flaggvärden ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4189,6 +4706,7 @@ msgstr ""
 "\n"
 "--- Lokala flaggvärden ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4196,126 +4714,21 @@ msgstr ""
 "\n"
 "--- Flaggor ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp-FEL"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Matchande tecken saknas för %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Extra tecken efter semikolon: %s"
 
-msgid "cannot open "
-msgstr "kan inte öppna "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Kan inte öppna fönster!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Behöver Amigados version 2.04 eller senare\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Behöver %s version %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Kan inte öppna NIL:\n"
-
-msgid "Cannot create "
-msgstr "Kan inte skapa "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim avslutar med %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "kan inte ändra konsoll-läge ?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: inte en konsoll??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Kan inte köra skal med -f-flagga"
-
-msgid "Cannot execute "
-msgstr "Kan inte köra "
-
-msgid "shell "
-msgstr "skal "
-
-msgid " returned\n"
-msgstr " returnerade\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE för liten."
-
-msgid "I/O ERROR"
-msgstr "I/O-FEL"
-
-msgid "Message"
-msgstr "Meddelande"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' är inte 80, kan inte köra externa kommandon"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Skrivarval misslyckades"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "till %s på %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Okänt skrivartypsnitt: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Skrivarfel: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Skriver ut '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Otillåtet teckenkodsnamn \"%s\" i typsnittsnamn \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Otillåtet tecken '%c' i typsnittsnamn \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Dubbelsignal, avslutar\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Fångade dödlig signal %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Fångade dödlig signal\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Öppning av X-display tog %<PRId64> ms"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Fick X-error\n"
-
-msgid "Testing the X display failed"
-msgstr "Testning av X-displayen misslyckades"
-
-msgid "Opening the X display timed out"
-msgstr "Öppning av X-displayen tog för lång tid"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4323,13 +4736,7 @@ msgstr ""
 "\n"
 "Kan inte köra skal "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Kan inte köra skal sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4337,361 +4744,468 @@ msgstr ""
 "\n"
 "skal returnerade "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Kan inte skapa rör\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Kan inte grena\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Kommando avslutades\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP tappade ICE-anslutning"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlfel = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "Öppning av X-displayen misslyckades"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP hanterar spara-själv-förfrågan"
-
-msgid "XSMP opening connection"
-msgstr "XSMP öppnar anslutning"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE-anslutning övervakning misslyckades"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection misslyckades: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Kan inte hitta fil \"%s\" i sökväg"
 
-msgid "Could not load vim32.dll!"
-msgstr "Kunde inte läsa in vim32.dll!"
-
-msgid "VIM Error"
-msgstr "VIM-fel"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Kunde inte ordna upp funktionspekare till DLL:en!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "skal returnerade %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Fångade %s-händelse\n"
-
-msgid "close"
-msgstr "stäng"
-
-msgid "logoff"
-msgstr "logga ut"
-
-msgid "shutdown"
-msgstr "stäng av"
-
-msgid "E371: Command not found"
-msgstr "E371: Kommando hittades inte"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"VIMRUN.EXE hittades inte i din $PATH.\n"
-"Externa kommandon vill inte stå stilla efter färdigställning.\n"
-"Se  :help win32-vimrun  för mer information."
-
-msgid "Vim Warning"
-msgstr "Vim-varning"
-
-msgid "At line"
-msgstr "På rad"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: För många %%%c i formatsträng"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Oväntad %%%c i formatsträng"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Saknar ] i formatsträng"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: Ostödd %%%c i formatsträng"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Ogiltig %%%c i formatsträngprefix"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Ogiltig %%%c i formatsträng"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' innehåller inga mönster"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Saknar eller tomt katalognamn"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Inga fler föremål"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d av %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (rad borttagen)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: På botten av quickfix-stack"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: På toppen av quickfix-stack"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "fellista %d av %d; %d fel"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Kan inte skriva, 'buftype'-flagga är satt"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Filnamn saknas eller ogiltigt mönster"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Kan inte öppna fil \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Buffert är inte laddad"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Sträng eller Lista förväntades"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: ogiltigt föremål i %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Mönster för långt"
-
-msgid "E50: Too many \\z("
-msgstr "E50: För många \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: För många %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Omatchade \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Omatchade %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Omatchade %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Omatchade %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: ogiltigt tecken efter %s@"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: För många komplexa %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: Nästlade %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: Nästlade %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: ogiltig användning av \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c följer ingenting"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Otillåten bakåtreferens"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z{ inte tillåtet här"
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 m.fl. inte tillåtet här"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Ogiltigt tecken efter \\z"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Saknar ] efter %s%%["
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: Tom %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: Ogiltigt tecken efter %s%%[dxouU]"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: Ogiltigt tecken efter %s%%"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Saknar ] efter %s["
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Omatchade %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Omatchade %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Omatchade %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z{ inte tillåtet här"
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: \\z1 m.fl. inte tillåtet här"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Saknar ] efter %s%%["
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Tom %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Mönster för långt"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: För många \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: För många %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Omatchade \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: ogiltigt tecken efter %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: För många komplexa %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: Nästlade %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: Nästlade %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: ogiltig användning av \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c följer ingenting"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Otillåten bakåtreferens"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Ogiltigt tecken efter \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: Ogiltigt tecken efter %s%%[dxouU]"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: Ogiltigt tecken efter %s%%"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaxfel i %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Externa underträffar:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: För många \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Kan inte hitta temporär fil för skrivning"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " VERSÄTT"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ERSÄTT"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " OMVÄND"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " INFOGA"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (infoga)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (ersätt)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (versätt)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebreiska"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabiska"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (språk)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (klistra in)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " VISUELL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " VISUELL RAD"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " VISUELLT BLOCK"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " MARKERA"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " MARKERA RAD"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " MARKERA BLOCK"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "spelar in"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Ogiltig söksträng: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: sökning nådde TOPPEN utan träff av: %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: sökning nådde BOTTEN utan träff av: %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Förväntade '?' eller '/' efter ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (inkluderar tidigare listad träff)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Inkluderade filer "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "hittades inte "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "i sökväg ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Redan listade)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " INTE HITTADE"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Söker igenom inkluderad fil: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Söker igenom inkluderad fil %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Matchning är på aktuell rad"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Alla inkluderade filer hittades"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Inga inkluderade filer"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Kunde inte hitta definition"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Kunde inte hitta mönster"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 ersättning"
+
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -4702,80 +5216,97 @@ msgstr ""
 "# Senaste %sSökmönster:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Formateringsfel i stavningsfil"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Trunkerad stavningsfil"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Eftersläpande text i %s rad %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affix-namn för långt i %s rad %d: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Formateringsfel i affix-fil FOL, LOW eller UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Tecken i FOL, LOW eller UPP är utanför område"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Komprimerar ordträd..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Stavningskontroll är inte aktiverat"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "Varning: Kan inte hitta ordlista \"%s.%s.spl\" eller \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Läser stavningsfil \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Det här ser inte ut som en stavningsfil"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Gammal stavningsfil, behöver bli uppdaterad"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Stavningsfil är för nyare version av Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Ostödd sektion i stavningsfil"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Varning: region %s stöds inte"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Läser affix-fil %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Konvertering misslyckades för ord i %s rad %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Konvertering i %s stöds inte: från %s till %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Konvertering i %s stöds inte"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Ogiltigt värde för FLAG i %s rad %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG efter användning av flags i %s rad %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -4783,306 +5314,386 @@ msgid ""
 msgstr ""
 "Definiera COMPOUNDFORBIDFLAG efter PFX-post kan ge fel resultat i %s rad %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
 "%d"
-msgstr "Definiera COMPOUNDPERMITFLAG efter PFX-post kan ge fel resultat i %s "
-"rad %d"
+msgstr ""
+"Definiera COMPOUNDPERMITFLAG efter PFX-post kan ge fel resultat i %s rad %d"
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "Fel COMPOUNDMIN-värde i %s rad %d: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Fel COMPOUNDWORDMAX-värde i %s rad %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Fel COMPOUNDMIN-värde i %s rad %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Fel COMPOUNDSYLMAX-värde i %s rad %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Fel CHECKCOMPOUNDPATTERN-värde i %s rad %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "Annan kombinerande flagga i efterföljande affix-block i %s rad %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Duplicerad affix i %s rad %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
 "line %d: %s"
 msgstr ""
-"Affix också använd för BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST i %"
-"s rad %d: %s"
+"Affix också använd för BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST i "
+"%s rad %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Förväntade Y eller N i %s rad %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Trasigt villkor i %s rad %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Förväntade REP(SAL)-antal i %s rad %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Förväntade MAP-antal i %s rad %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Duplicerat tecken i MAP i %s rad %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Okänd eller duplicerad post i %s rad %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Saknar FOL/LOW/UPP rad i %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX använd utan SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "För många uppskjutna prefix"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "För många sammansatta flaggor"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "För många uppskjutna prefix och/eller sammansatta flaggor"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Saknar SOFO%s rad i %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Både SAL och SOFO rader i %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flagga är inte ett nummer i %s rad %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Ogiltig flagga i %s rad %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s värde skiljer sig från vad som används i en annan .aff-fil."
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Läser ordboksfil %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Inget ordantal i %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "rad %6d, ord %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Duplicerat ord i %s rad %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Första duplicerade ordet i %s rad %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d duplicerade ord i %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Ignorerade %d ord med icke-ASCII tecken i %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Läser ordfil %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Duplicerad /encoding=-rad ignorerad i %s rad %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "/encoding=-rad efter ord ignorerad i %s rad %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Duplicerad /regions=-rad ignorerad i %s rad %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "För många regioner i %s rad %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "/-rad ignorerad i %s rad %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Ogiltigt regionsnr i %s rad %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Okända flaggot i %s rad %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Ignorerade %d ord med icke-ASCII tecken"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Komprimerade %d av %d noder; %d (%d%%) återstår"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Läser tillbaka stavningsfil..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Utför ljudvikning..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Antal ord efter ljudvikning: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Totalt antal ord: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Skriver förslagsfil %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Beräknat körtidsminne använt: %d byte"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Utmatningsfilnamn får inte ha regionnamn"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Bara upp till 8 regioner stöds"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Ogiltig region i %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Varning: både sammansättning och NOBREAK specifierad"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Skriver stavningsfil %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Klar!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' har inte %<PRId64> poster"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "Ord borttaget från %s"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "Ord lagd till %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Ordtecken skiljer sig mellan stavningsfiler"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Tyvärr, inga föreslag"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Tyvärr, bara %<PRId64> föreslag"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Ändra \"%.*s\" till:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Ingen tidigare stavningsersättning"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Hittades inte: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Det här ser inte ut som en .sug-fil: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Gammal .sug-fil, behöver bli uppdaterad: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug-fil är för nyare version av Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug-fil matchar inte .spl-fil: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: fel vid läsning av .sug-fil: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: dubblerat tecken i MAP-post"
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Inga syntax-föremål definierade för den här bufferten"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Otillåtet argument: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Inget sådant syntax-kluster: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Inga syntax-föremål definierade för den här bufferten"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "synkning av C-stil-kommentarer"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "ingen synkning"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "synkning startar"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " rader före topprad"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5090,6 +5701,7 @@ msgstr ""
 "\n"
 "--- Syntax-synkföremål ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5097,6 +5709,7 @@ msgstr ""
 "\n"
 "synkning av föremål"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5104,198 +5717,274 @@ msgstr ""
 "\n"
 "--- Syntax föremål ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Inga sådana syntaxkluster: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "minimal "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "maximal "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; träff "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " radbrytningar"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: innehåller argument som inte är tillåtna här"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: innehöll argument som inte är tillåtna här"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Ogiltigt argument"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: grupper inte tillåtna här"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Hittade inte regionföremål för %s"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Filnamn krävs"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: För många filnamn"
+
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Saknar ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Saknar '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Inte tillräckliga argument: syntaxregion %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Inget sådant syntax-kluster: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Inget kluster angivet"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Mönsteravgränsare hittades inte: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Skräp efter mönster: %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: syntax-synk: radfortsättningsmönster angivet två gånger"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Otillåtna argument: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Saknar likamed-tecken: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Tomt argument: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s inte tillåtet här"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s måste vara först i innehållslista"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Okänt gruppnamn: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Ogiltigt :syntax-underkommando: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: rekursiv loop laddar syncolor.vim"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: framhävningsgrupp hittades inte: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Inte tillräckliga argument: \":highlight länk %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: För många argument: \":highlight länk %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: grupp har inställningar, framhävningslänk ignorerad"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: oväntat likamed-tecken: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: saknar likamed-tecken: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: saknar argument: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Otillåtet värde: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: FG-färg okänd"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: BG-färg okänd"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Färgnamn eller nummer inte igenkänt: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: terminalkod för lång: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Otillåtet argument: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: För många olika framhävningsattribut i användning"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Outskrivbart tecken i gruppnamn"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Ogiltigt tecken i gruppnamn"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: på botten av taggstack"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: på toppen av taggstack"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Kan inte gå före första matchande tagg"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: tagg hittades inte: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri-typ-tagg"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "fil\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Det finns bara en matchande tagg"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Kan inte gå bortom sista matchande tagg"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Fil \"%s\" existerar inte"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "tagg %d av %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " eller fler"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Använder tagg med annan storlek!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Fil \"%s\" existerar inte"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5303,59 +5992,79 @@ msgstr ""
 "\n"
 "  # TILL tagg          FRÅN LINJE  i fil/text"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Söker tagg-fil %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Taggfilsökväg trunkerades för %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formateringsfel i tagg-fil \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Före byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tagg-fil inte sorterad: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Ingen tagg-fil"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Kan inte hitta taggmönster"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Kunde inte hitta tagg, gissar bara!"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "Duplicerad affix i %s rad %d: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' inte känd. Tillgängliga inbyggda terminaler är:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "använder standard '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Kan inte öppna termcap-fil"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Terminalnotering hittades inte i terminfo"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Terminalnotering hittades inte i termcap"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Ingen \"%s\"-notering i termcap"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: terminalkapacitet \"cm\" krävs"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5363,160 +6072,169 @@ msgstr ""
 "\n"
 "--- Terminalnycklar ---"
 
-msgid "new shell started\n"
-msgstr "nytt skal startat\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Fel vid läsning av inmatning, avslutar...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Ingen ångring möjlig; fortsätter ändå"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: Buffert ändrades oväntat"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Kan inte öppna fil för skrivning"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Skriver viminfo-fil \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Skrivfel i växelfil"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Läser ordfil %s ..."
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Kan inte öppna viminfo-fil för läsning"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: Hittades inte: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Kan inte öppna fil %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "läste klart %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Redan vid äldsta ändring"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Redan vid nyaste ändring"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "Ångra-nummer %<PRId64> hittades inte"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: radnummer fel"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "en rad till"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "fler rader"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "en rad mindre"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "färre rader"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "ändring"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "ändringar"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "före"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "efter"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Inget att ångra"
 
-msgid "number changes  time"
-msgstr "antal ändringar  tid"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> sekunder sedan"
 
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin är inte tillåtet efter undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: ångra-lista trasig"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: ångra-rad saknas"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32-bitars GUI-version"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 64-bitars GUI-version"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32-bitars GUI-version"
-
-msgid " in Win32s mode"
-msgstr " i Win32s-läge"
-
-msgid " with OLE support"
-msgstr " med OLE-stöd"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32-bitars konsollversion"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16-bitars version"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32-bitars MS-DOS-version"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16-bitars MS-DOS-version"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X-version (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X-version"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS-version"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS-version"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5524,9 +6242,18 @@ msgstr ""
 "\n"
 "Inkluderade patchar: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Externa underträffar:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Modifierad av "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5534,9 +6261,11 @@ msgstr ""
 "\n"
 "Kompilerad "
 
+#: ../version.c:649
 msgid "by "
 msgstr "av "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5544,605 +6273,1645 @@ msgstr ""
 "\n"
 "Enorm version "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Stor version "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Normal version "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Liten version "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Jätteliten version "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "utan GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "med GTK2-GNOME-GUI."
-
-msgid "with GTK-GNOME GUI."
-msgstr "med GTK-GNOME-GUI."
-
-msgid "with GTK2 GUI."
-msgstr "med GTK2-GUI."
-
-msgid "with GTK GUI."
-msgstr "med GTK-GUI."
-
-msgid "with X11-Motif GUI."
-msgstr "med X11-Motif-GUI."
-
-msgid "with X11-neXtaw GUI."
-msgstr "med X11-neXtaw-GUI."
-
-msgid "with X11-Athena GUI."
-msgstr "med X11-Athena-GUI."
-
-msgid "with Photon GUI."
-msgstr "med Photon-GUI."
-
-msgid "with GUI."
-msgstr "med GUI."
-
-msgid "with Carbon GUI."
-msgstr "med Carbon-GUI."
-
-msgid "with Cocoa GUI."
-msgstr "med Cocoa-GUI."
-
-msgid "with (classic) GUI."
-msgstr "med (klassiskt) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Funktioner inkluderade (+) eller inte (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   system-vimrc-fil: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     användar-vimrc-fil: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " Andra användar-vimrc-fil: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " Tredje användar-vimrc-fil: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      användar-exrc-fil: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  Andra användar-exrc-fil: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  system-gvimrc-fil: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    användar-gvimrc-fil: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "Andra användar-gvimrc-fil: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "Tredje användar-gvimrc-fil: \""
-
-msgid "    system menu file: \""
-msgstr "    systemmenyfil: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  reserv för $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " reserv för $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Kompilering: "
 
-msgid "Compiler: "
-msgstr "Kompilator: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Länkning: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  FELSÖKNINGSBYGGD"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "version "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "av Bram Moolenaar m.fl."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim är öppen källkod och fri att distribuera"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Hjälp fattiga barn i Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "skriv  :help iccf<Enter>        för information          "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "skriv  :q<Enter>                för att avsluta          "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "skriv  :help<Enter> eller <F1>  för online-hjälp         "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "skriv  :help version7<Enter>    för versioninformation   "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Kör i Vi-kompatibelt läge"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "skriv  :set nocp<Enter>        för Vim- standarder       "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "skriv  :help cp-default<Enter> för information om det här"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "meny  Hjälp->Föräldralösa           för information    "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Kör lägeslöst, skriven text blir infogad"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "meny Redigera->Globala inställningar->Växla infogningsläge  "
-
-msgid "                              for two modes      "
-msgstr "                              för två lägen      "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "meny  Redigera->Globala Inställningar->Växla Vi Komptaibel"
-
-msgid "                              for Vim defaults   "
-msgstr "                              för vim-standardalternativ   "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Stöd utvecklingen av Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Bli en registrerad Vim-användare!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "skriv  :help sponsor<Enter>     för information          "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "skriv  :help register<Enter>    för information          "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "meny  Hjälp->Stöd/Registrera           för information    "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "VARNING: Windows 95/98/ME upptäckt"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "skriv  :help windows95<Enter>  för info om det här"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Redan bara ett fönster"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Det finns inget förhandsvisningsfönster"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Kan inte dela toppvänster och bottenhöger samtidigt"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Kan inte rotera när ett annat fönster är delat"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Kan inte stänga senaste fönstret"
 
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Kan inte stänga senaste fönstret"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Kan inte stänga senaste fönstret"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Andra fönster innehåller ändringar"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Inget filnamn under markör"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Kan inte hitta fil \"%s\" i sökväg"
+#~ msgid "Patch file"
+#~ msgstr "Patchfil"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Kunde inte läsa in bibliotek %s"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Avbryt"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Tyvärr, det här kommandot är inaktiverat: Perl-biblioteket kunde inte läsas "
-"in."
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Ingen anslutning till Vim-server"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Perl-evaluering förbjuden i sandlåda utan Safe-modulen"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Kunde inte sända till %s"
 
-msgid "Edit with &multiple Vims"
-msgstr "Redigera med &flera Vims"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Kunde inte läsa ett serversvar"
 
-msgid "Edit with single &Vim"
-msgstr "Redigera med en &Vim"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Kunde inte sända till klient"
 
-msgid "Diff with Vim"
-msgstr "Diff med Vim"
+#~ msgid "Save As"
+#~ msgstr "Spara som"
 
-msgid "Edit with &Vim"
-msgstr "Redigera med &Vim"
+#~ msgid "Source Vim script"
+#~ msgstr "Läs Vim-skript"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Redigera med befintlig Vim - "
+#~ msgid "Edit File"
+#~ msgstr "Redigera fil"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Redigerar markerade fil(erna) med Vim"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (INTE HITTADE)"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Felskapande process: Kontrollera om gvim är i din sökväg!"
+#~ msgid "Edit File in new window"
+#~ msgstr "Redigera fil i nytt fönster"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll-fel"
+#~ msgid "Append File"
+#~ msgstr "Lägg till fil"
 
-msgid "Path length too long!"
-msgstr "Sökvägslängd för lång!"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Fönsterposition: X %d, Y %d"
 
-msgid "--No lines in buffer--"
-msgstr "--Inga rader i buffert--"
+#~ msgid "Save Redirection"
+#~ msgstr "Spara omdirigering"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Kommando avbrutet"
+#~ msgid "Save View"
+#~ msgstr "Spara vy"
 
-msgid "E471: Argument required"
-msgstr "E471: Argument krävs"
+#~ msgid "Save Session"
+#~ msgstr "Spara session"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ borde följas av /, ? eller &"
+#~ msgid "Save Setup"
+#~ msgstr "Spara konfiguration"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Felaktighet i kommandoradsfönster; <CR> kör, CTRL-C avslutar"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Inga digrafer i den här versionen"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Kommando inte tillåtet från exrc/vimrc i aktuell katalog eller "
-"taggsökning"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "är en enhet (inaktiverad med 'opendevice'-flagga)"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Saknar :endif"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Läser från standard in..."
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Saknar :endtry"
+#~ msgid "[NL found]"
+#~ msgstr "[NL hittat]"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Saknar :endwhile"
+#~ msgid "[crypted]"
+#~ msgstr "[krypterad]"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Saknar :endfor"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans tillåter inte skrivning av omodifierade buffertar"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile utan :while"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Delvisa skrivningar tillåts inte i NetBeans-buffertar"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor utan :for"
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "skriver till en enhet inaktiverad med 'opendevice'-flagga"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Fil existerar (lägg till ! för att tvinga)"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resursgrenen skulle tappas bort (lägg till ! för att tvinga)"
 
-msgid "E472: Command failed"
-msgstr "E472: Kommando misslyckades"
+#~ msgid "<cannot open> "
+#~ msgstr "<kan inte öppna> "
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Okänd typsnittsuppsättning: %s"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: kan inte hämta typsnitt %s"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Okänt typsnitt: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: Kan inte återvända till aktuell katalog"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Typsnitt \"%s\" är inte bredd-fixerad"
+#~ msgid "Pathname:"
+#~ msgstr "Sökväg:"
 
-msgid "E473: Internal error"
-msgstr "E473: Internt fel"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: kan inte hämta aktuell katalog"
 
-msgid "Interrupted"
-msgstr "Avbruten"
+#~ msgid "OK"
+#~ msgstr "OK"
 
-msgid "E14: Invalid address"
-msgstr "E14: Ogiltig address"
+#~ msgid "Cancel"
+#~ msgstr "Avbryt"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Ogiltigt argument"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim-dialog"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Ogiltigt argument: %s"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Rullningslist: Kunde inte hämta geometrin på miniatyrbild."
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Ogiltigt uttryck: %s"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: Kan inte skapa BalloonEval med både meddelande och återkallning"
 
-msgid "E16: Invalid range"
-msgstr "E16: Ogiltigt område"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Kan inte starta GUI"
 
-msgid "E476: Invalid command"
-msgstr "E476: Ogiltigt kommando"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Kan inte läsa från \"%s\""
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" är en katalog"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Kan inte starta GUI, ingen giltig font hittad"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Biblioteksanrop misslyckades för \"%s()\""
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' ogiltig"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Kunde inte läsa in biblioteksfunktion %s"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Värdet av 'imactivatekey' är ogiltigt"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Markering har ogiltigt radnummer"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Kan inte allokera färg %s"
 
-msgid "E20: Mark not set"
-msgstr "E20: Markering inte satt"
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Ingen matchning vid markör, söker nästa"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Kan inte göra ändringar, 'modifiable' är av"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim-dialog..."
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Skript nästlade för djupt"
+#~ msgid "Input _Methods"
+#~ msgstr "Inmatnings_metoder"
 
-msgid "E23: No alternate file"
-msgstr "E23: Ingen alternativ fil"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Sök och ersätt..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Ingen sådan förkortning"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Sök..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: Inget ! tillåtet"
+#~ msgid "Find what:"
+#~ msgstr "Hitta vad:"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: GUI kan inte användas: Inte aktiverat vid kompilering"
+#~ msgid "Replace with:"
+#~ msgstr "Ersätt med:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Hebreiska kan inte användas: Inte aktiverat vid kompilering\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Matcha endast hela ord"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Persiska kan inte användas: Inte aktiverat vid kompilering\n"
+#~ msgid "Match case"
+#~ msgstr "Skilj på stora/små bokstäver"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Arabiska kan inte användas: Inte aktiverat vid kompilering\n"
+#~ msgid "Direction"
+#~ msgstr "Riktning"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Inget sådant framhävningsgruppnamn: %s"
+#~ msgid "Up"
+#~ msgstr "Upp"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Ingen infogad text än"
+#~ msgid "Down"
+#~ msgstr "Ned"
 
-msgid "E30: No previous command line"
-msgstr "E30: Ingen tidigare kommandorad"
+#~ msgid "Find Next"
+#~ msgstr "Hitta nästa"
 
-msgid "E31: No such mapping"
-msgstr "E31: Ingen sådan mappning"
+#~ msgid "Replace"
+#~ msgstr "Ersätt"
 
-msgid "E479: No match"
-msgstr "E479: Ingen träff"
+#~ msgid "Replace All"
+#~ msgstr "Ersätt alla"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Ingen träff: %s"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Tog emot \"die\"-begäran från sessionshanteraren\n"
 
-msgid "E32: No file name"
-msgstr "E32: Inget filnamn"
+#~ msgid "Close"
+#~ msgstr "Stäng"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Inget tidigare utbytningsreguljäruttryck"
+#~ msgid "New tab"
+#~ msgstr "Ny flik"
 
-msgid "E34: No previous command"
-msgstr "E34: Inget tidigare kommando"
+#~ msgid "Open Tab..."
+#~ msgstr "Öppna flik..."
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Inget tidigare reguljärt uttryck"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Huvudfönster oväntat förstört\n"
 
-msgid "E481: No range allowed"
-msgstr "E481: Inget område tillåtet"
+#~ msgid "Font Selection"
+#~ msgstr "Typsnittsval"
 
-msgid "E36: Not enough room"
-msgstr "E36: Inte tillräckligt med utrymme"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Använd CUT_BUFFER0 istället för tomt val"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: ingen registrerad server med namnet \"%s\""
+#~ msgid "&Filter"
+#~ msgstr "&Filter"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Kan inte skapa fil %s"
+#~ msgid "&Cancel"
+#~ msgstr "&Avbryt"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Kan inte hämta temporärt filnamn"
+#~ msgid "Directories"
+#~ msgstr "Kataloger"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Kan inte öppna fil %s"
+#~ msgid "Filter"
+#~ msgstr "Filter"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Kan inte läsa fil %s"
+#~ msgid "&Help"
+#~ msgstr "&Hjälp"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr ""
-"E37: Ingen skrivning sedan senaste ändring (lägg till ! för att tvinga)"
+#~ msgid "Files"
+#~ msgstr "Filer"
 
-msgid "E38: Null argument"
-msgstr "E38: Null-argument"
+#~ msgid "&OK"
+#~ msgstr "&OK"
 
-msgid "E39: Number expected"
-msgstr "E39: Nummer väntat"
+#~ msgid "Selection"
+#~ msgstr "Val"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Kan inte öppna felfil %s"
+#~ msgid "Find &Next"
+#~ msgstr "Hitta &nästa"
 
-msgid "E233: cannot open display"
-msgstr "E233: kan inte öppna display"
+#~ msgid "&Replace"
+#~ msgstr "&Ersätt"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Slut på minne!"
+#~ msgid "Replace &All"
+#~ msgstr "Ersätt &alla"
 
-msgid "Pattern not found"
-msgstr "Mönster hittades inte"
+#~ msgid "&Undo"
+#~ msgstr "&Ångra"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Mönster hittades inte: %s"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Kan inte hitta fönstertitel \"%s\""
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Argument måste vara positivt"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Argument stöds inte: \"-%s\"; Används OLE-versionen."
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Kan inte gå tillbaka till tidigare katalog"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Kunde inte öppna fönster inuti MDI-applikation"
 
-msgid "E42: No Errors"
-msgstr "E42: Inga fel"
+#~ msgid "Close tab"
+#~ msgstr "Stäng flik"
 
-msgid "E776: No location list"
-msgstr "E776: Ingen positionslista"
+#~ msgid "Open tab..."
+#~ msgstr "Öppna flik..."
 
-msgid "E43: Damaged match string"
-msgstr "E43: Skadad träffsträng"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Sök sträng (använd '\\\\' för att hitta '\\')"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Trasigt program för reguljära uttryck"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Sök & ersätt (använd '\\\\' för att hitta '\\')"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 'readonly' flagga är satt (lägg till ! för att tvinga)"
+#~ msgid "Not Used"
+#~ msgstr "Inte använd"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Kan inte ändra skrivskyddad variabel \"%s\""
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Katalog\t*.nothing\n"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Kan inte sätta variabel i sandlådan: \"%s\""
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Kan inte allokera post i färgkarta, några färger kan bli "
+#~ "felaktiga"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Fel vid läsning av felfil"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr ""
+#~ "E250: Typsnitt för följande teckenkoder saknas i typsnittsuppsättningen "
+#~ "%s:"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Inte tillåtet i sandlåda"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Typsnittsuppsättningsnamn: %s"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Inte tillåtet här"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Font '%s' är inte fast bredd"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Skärmläge inställning stöds inte"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Typsnittsuppsättningsnamn: %s\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Ogiltig rullningsstorlek"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Typsnitt0: %s\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'shell' flagga är tom"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Typsnitt1: %s\n"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Kunde inte läsa in teckendata!"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "Typsnitt%<PRId64> är inte dubbelt så bred som font0\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Stängningsfel på växlingsfil"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Typsnitt0 bredd: %<PRId64>\n"
 
-msgid "E73: tag stack empty"
-msgstr "E73: taggstack tom"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Typsnitt1 bredd: %<PRId64>\n"
+#~ "\n"
 
-msgid "E74: Command too complex"
-msgstr "E74: Kommando för komplext"
+#~ msgid "Invalid font specification"
+#~ msgstr "Ogiltig typsnittsuppsättning"
 
-msgid "E75: Name too long"
-msgstr "E75: Namn för långt"
+#~ msgid "&Dismiss"
+#~ msgstr "&Förkasta"
 
-msgid "E76: Too many ["
-msgstr "E76: För många ["
+#~ msgid "no specific match"
+#~ msgstr "ingen specifik matchning"
 
-msgid "E77: Too many file names"
-msgstr "E77: För många filnamn"
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Typsnittsväljare"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Eftersläpande tecken"
+#~ msgid "Name:"
+#~ msgstr "Namn:"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Okänt märke"
+#~ msgid "Show size in Points"
+#~ msgstr "Visa storlek i punkter"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Kan inte expandera jokertecken"
+#~ msgid "Encoding:"
+#~ msgstr "Teckenkodning:"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' kan inte vara mindre än 'winminheight'"
+#~ msgid "Font:"
+#~ msgstr "Typsnitt:"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' kan inte vara mindre än 'winminwidth'"
+#~ msgid "Style:"
+#~ msgstr "Stil:"
 
-msgid "E80: Error while writing"
-msgstr "E80: Fel vid skrivning"
+#~ msgid "Size:"
+#~ msgstr "Storlek:"
 
-msgid "Zero count"
-msgstr "Noll-längd"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata FEL"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Använder inte <SID> i ett skriptsammanhang"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat-fel"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Ogiltigt uttryck mottaget"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: kan inte öppna cscope-databas: %s"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Region är vaktad, kan inte modifiera"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: kan inte hämta cscope-databasinformation"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans tillåter inte ändringar i skrivskyddade filer"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: maximalt antal av cscope-anslutningar nått"
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Internt fel: %s"
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "???: Tyvärr, det här kommandot är inaktiverat: MzScheme-biblioteket kunde "
+#~ "inte läsas in."
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: mönster använder mer minne än 'maxmempattern'"
+#~ msgid "invalid expression"
+#~ msgstr "ogiltigt uttryck"
 
-msgid "E749: empty buffer"
-msgstr "E749: tom buffert"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "uttryck inaktiverat vid kompilering"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Ogiltigt sökmönster eller delimiter"
+#~ msgid "hidden option"
+#~ msgstr "gömd flagga"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Filen är inläst i en annan buffert"
+#~ msgid "unknown option"
+#~ msgstr "okänd flagga"
 
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Flagga '%s' är inte satt"
+#~ msgid "window index is out of range"
+#~ msgstr "fönsterindex är utanför område"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "sökning nådde TOPPEN, fortsätter vid BOTTEN"
+#~ msgid "couldn't open buffer"
+#~ msgstr "kunde inte öppna buffert"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "sökning nådde BOTTEN, forsätter vid TOPPEN"
+#~ msgid "cannot save undo information"
+#~ msgstr "kan inte spara ångra-information"
+
+#~ msgid "cannot delete line"
+#~ msgstr "kan inte ta bort rad"
+
+#~ msgid "cannot replace line"
+#~ msgstr "kan inte ersätta rad"
+
+#~ msgid "cannot insert line"
+#~ msgstr "kan inte infoga rad"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "sträng kan inte innehålla nyrader"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim-fel: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim-fel"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "buffert är ogiltig"
+
+#~ msgid "window is invalid"
+#~ msgstr "fönster är ogiltigt"
+
+#~ msgid "linenr out of range"
+#~ msgstr "radnummer utanför område"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "inte tillåtet i Vim-sandlådan"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Tyvärr, detta kommandot är inaktiverat, Python-biblioteket kunde "
+#~ "inte läsas in."
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Kan inte anropa Python rekursivt"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "kan inte ta bort OutputObject-attribut"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace måste vara ett heltal"
+
+#~ msgid "invalid attribute"
+#~ msgstr "ogiltigt attribut"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() kräver lista av strängar"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Fel vid initiering av I/O-objekt"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "försök att referera till borttagen buffert"
+
+#~ msgid "line number out of range"
+#~ msgstr "radnummer utanför område"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffertobjekt (borttaget) vid %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "ogiltigt märknamn"
+
+#~ msgid "no such buffer"
+#~ msgstr "ingen sådan buffert"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "försök att referera till borttaget fönster"
+
+#~ msgid "readonly attribute"
+#~ msgstr "skrivskyddad attribut"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "markörposition utanför buffert"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<fönsterobjekt (borttaget) vid %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<fönsterobjekt (okänt) vid %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<fönster %d>"
+
+#~ msgid "no such window"
+#~ msgstr "inget sådant fönster"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ måste vara en instans av String"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Tyvärr, detta kommandot är inaktiverat, Ruby-biblioteket kunde inte "
+#~ "läsas in."
+
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: oväntad returnering"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: oväntad next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: oväntad break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: oväntad redo"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry utanför rescue-block"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: ohanterat undantag"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: okänt longjmp-status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Växla mellan implementation/definition"
+
+#~ msgid "Show base class of"
+#~ msgstr "Visa basklass av"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Visa åsidosatt medlemsfunktion"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Hämta från fil"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Hämta från projekt"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Hämta från alla projekt"
+
+#~ msgid "Retrieve"
+#~ msgstr "Hämta"
+
+#~ msgid "Show source of"
+#~ msgstr "Visa källa för"
+
+#~ msgid "Find symbol"
+#~ msgstr "Hitta symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "Bläddra i klass"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Visa klass i hierarki"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Visa klass i begränsad hierarki"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref refererar till"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref refereras av"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref har en"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref används av"
+
+#~ msgid "Show docu of"
+#~ msgstr "Visa docu av"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Generera docu för"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Kan inte ansluta till SNiFF+. Kontrollera miljö (sniffemacs måste kunna "
+#~ "hittas i $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Fel vid läsning. Frånkopplad"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ är för närvarande "
+
+#~ msgid "not "
+#~ msgstr "inte "
+
+#~ msgid "connected"
+#~ msgstr "ansluten"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Okänd SNiFF+-begäran: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Fel vid anslutning till SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ inte ansluten"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Inte en SNiFF+-buffert"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Fel vid skrivning. Frånkopplad"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "ogiltigt buffertnummer"
+
+#~ msgid "not implemented yet"
+#~ msgstr "inte implementerat än"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "kan inte ställa in rad(er)"
+
+#~ msgid "mark not set"
+#~ msgstr "märke inte satt"
+
+#~ msgid "row %d column %d"
+#~ msgstr "rad %d kolumn %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "kan inte infoga/lägga till rad"
+
+#~ msgid "unknown flag: "
+#~ msgstr "okänd flagga: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "okänd vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "tangentbordsavbrott"
+
+#~ msgid "vim error"
+#~ msgstr "vim-fel"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "kan inte skapa buffert/fönster-kommando: objekt håller på att tas bort"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "kan inte registera återkallningskommando: buffert/fönster håller redan på "
+#~ "att tas bort"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: TCL ÖDESDIGERT FEL: reflist trasig!? Var snäll och rapportera detta "
+#~ "till vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "kan inte registrera återkallningskommando: buffert-/fönsterreferens "
+#~ "hittades inte"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Tyvärr, detta kommando är inaktiverat: Tcl-biblioteket kunde inte "
+#~ "läsas in."
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: TCL-FEL: Avslutningskoden är inte int!? Var snäll och rapportera "
+#~ "detta till vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: avslutningskod %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "kan inte hämta rad"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Kunde inte registrera ett kommandoservernamn"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Misslyckades att skicka kommando till målprogrammet"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Ogiltigt server-id använt: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM instansregisteregenskap är dåligt format.  Borttaget!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Denna Vim blev inte kompilerad med diff-funktionen."
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Fel: Misslyckades att starta gvim från NetBeans\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Där storlek ignoreras börja med / för att göra flagga versal"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tRegistrera gvim för OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tAvregistrera gvim för OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tKör som GUI (som \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  eller --nofork\tFörgrund: Grena inte vid start av GUI"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tAnvända inte newcli för att öppna fönster"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <enhet>\t\tAnvänd <enhet> för I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tAnvänd <gvimrc> istället för någon .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tRedigera krypterade filer"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\tAnslut vim till just denna X-server"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tAnslut inte till X server"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <filer>\tRedigera <filer> i en Vim-server om möjligt"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <filer>\tSamma, klaga inte om det inte finns någon server"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <filer>\tSom --remote men vänta på att filer har blivit "
+#~ "redigerade"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <filer>\tSamma, klaga inte om det inte finns någon "
+#~ "server"
+
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr "--remote-tab <filer>  Som --remote men öppna flik för varje fil"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <nycklar>\tSkicka <nycklar> till en Vim-server och avsluta"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <uttryck>\tEvaluera <uttryck> i en Vim-server och skriv ut "
+#~ "resultatet"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tLista tillgängliga Vim-servernamn och avsluta"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <namn>\tSkicka till/för att bli Vim-servern <namn>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argument som stöds av gvim (Motif-version):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argument som stöds av gvim (neXtaw-version):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argument som stöds av gvim (Athena-version):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\tKör vim på <display>"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tStarta vim som ikon"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <namn>\t\tAnvänd resurs som om vim var <namn>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t   (Oimplementerat)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <färg>\tAnvänd <färg> för bakgrunden (även: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <färg>\tAnvänd <färg> för vanlig text (även: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <typsnitt>\t\tAnvänd <typsnitt> för vanlig text (även: -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "­boldfont <typsnitt>\tAnvänd <typsnitt> för fet text"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <typsnitt>\tAnvänd <typsnitt> för kursiv text"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <geom>\tAnvänd <geom> för inledande fönsterplacering (även: -"
+#~ "geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <bredd>\tAnvänd en rambredd med <bredd> (även: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <bredd>  Använd en rullningslistbredd på <bredd> (även: -"
+#~ "sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <höjd>\tAnvänd en menyradshöjd med <höjd> (även: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tAnvänd omvänd video (även: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tAnvänd inte omvänd video (även: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <tillgång>\tStäll in den angivna tillgången"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argument igenkända av gvim (RISC OS-version):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <antal>\tInledande bredd på fönster i kolumner"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <antal>\tInledande höjd på fönster i rader"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Argument igenkända av gvim (GTK+-version):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\tKör vim på <display> (även: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <roll>\tStäll in en unik roll för att identifiera huvudfönstret"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tÖppna Vim innanför en annan GTK-widget"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <förälder fönster>\tÖppna Vim inuti förälderapplikation"
+
+#~ msgid "No display"
+#~ msgstr "Ingen display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Överföring misslyckades.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Överföring misslyckades. Försöker att köra lokalt\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d av %d redigerade"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Ingen display: Överföringsuttryck misslyckades.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Överföringsuttryck misslyckades.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Inte en godkänd teckentabell"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Misslyckades att skapa inmatningsmiljö"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Misslyckades att öppna inmatningsmetod"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Varning: Kunde inte ställa in förstörningsåterkallning till IM"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: inmatningsmetod stöder inte någon stil"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: inmatningsmetod stöder inte min förredigeringstyp"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: över-pricken-stil kräver typsnittsuppsättning"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: Din GTK+ är äldre än 1.2.3. Statusområde inaktiverat"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Inmatningsmetodserver körs inte"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [inte användbar med den här versionen av Vim]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Ta loss den här menyn"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "Välj katalog-dialog"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Spara fil-dialog"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Öppna fil-dialog"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Tyvärr, ingen filbläddrare i konsoll-läge"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: bevarar filer...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Färdig.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "FEL: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[byte] sammanlagd allok-frigjord %<PRIu64>-%<PRIu64>, i användning "
+#~ "%<PRIu64>, toppanvändning %lu\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[anrop] sammanlagda om/malloc()'s %<PRIu64>, sammanlagda free()'s "
+#~ "%<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Rad börjar bli för lång"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Internt fel: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Otillåten musform"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Ange krypteringsnyckel: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Ange samma nyckel igen: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Nycklar matchar inte!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Kan inte ansluta till Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Kan inte ansluta till Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Fel rättighetsläge för NetBeans-anslutningens info fil: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "läs från Netbeans-uttag"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: NetBeans-anslutning tappad för buffert %<PRId64>"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Eval-funktionen inte tillgänglig"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "frigör %<PRId64> rader"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Kan inte ändra term i GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Använd \":gui\" för att starta GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Kan inte bli ändrat i GTK+ 2-GUI"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Ogiltig(a) typsnitt"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: kan inte välja typsnittsuppsättning"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Ogiltig typsnittsuppsättning"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: kan inte välja brett typsnitt"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Ogiltigt brett typsnitt"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Inget musstöd"
+
+#~ msgid "cannot open "
+#~ msgstr "kan inte öppna "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Kan inte öppna fönster!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Behöver Amigados version 2.04 eller senare\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Behöver %s version %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Kan inte öppna NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Kan inte skapa "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim avslutar med %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "kan inte ändra konsoll-läge ?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: inte en konsoll??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Kan inte köra skal med -f-flagga"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Kan inte köra "
+
+#~ msgid "shell "
+#~ msgstr "skal "
+
+#~ msgid " returned\n"
+#~ msgstr " returnerade\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE för liten."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O-FEL"
+
+#~ msgid "Message"
+#~ msgstr "Meddelande"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' är inte 80, kan inte köra externa kommandon"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Skrivarval misslyckades"
+
+#~ msgid "to %s on %s"
+#~ msgstr "till %s på %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Okänt skrivartypsnitt: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Skrivarfel: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Skriver ut '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Otillåtet teckenkodsnamn \"%s\" i typsnittsnamn \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Otillåtet tecken '%c' i typsnittsnamn \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Dubbelsignal, avslutar\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Fångade dödlig signal %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Fångade dödlig signal\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Öppning av X-display tog %<PRId64> ms"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Fick X-error\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Testning av X-displayen misslyckades"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Öppning av X-displayen tog för lång tid"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan inte köra skal sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan inte skapa rör\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kan inte grena\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kommando avslutades\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP tappade ICE-anslutning"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Öppning av X-displayen misslyckades"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP hanterar spara-själv-förfrågan"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP öppnar anslutning"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE-anslutning övervakning misslyckades"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection misslyckades: %s"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Kunde inte läsa in vim32.dll!"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM-fel"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Kunde inte ordna upp funktionspekare till DLL:en!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "skal returnerade %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Fångade %s-händelse\n"
+
+#~ msgid "close"
+#~ msgstr "stäng"
+
+#~ msgid "logoff"
+#~ msgstr "logga ut"
+
+#~ msgid "shutdown"
+#~ msgstr "stäng av"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Kommando hittades inte"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "VIMRUN.EXE hittades inte i din $PATH.\n"
+#~ "Externa kommandon vill inte stå stilla efter färdigställning.\n"
+#~ "Se  :help win32-vimrun  för mer information."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim-varning"
+
+#~ msgid "At line"
+#~ msgstr "På rad"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Konvertering i %s stöds inte"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: innehöll argument som inte är tillåtna här"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Taggfilsökväg trunkerades för %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "nytt skal startat\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Ingen ångring möjlig; fortsätter ändå"
+
+#~ msgid "number changes  time"
+#~ msgstr "antal ändringar  tid"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32-bitars GUI-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 64-bitars GUI-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bitars GUI-version"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " i Win32s-läge"
+
+#~ msgid " with OLE support"
+#~ msgstr " med OLE-stöd"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32-bitars konsollversion"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16-bitars version"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32-bitars MS-DOS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16-bitars MS-DOS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X-version (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS-version"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Stor version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Normal version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Liten version "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Jätteliten version "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "med GTK2-GNOME-GUI."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "med GTK-GNOME-GUI."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "med GTK2-GUI."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "med GTK-GUI."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "med X11-Motif-GUI."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "med X11-neXtaw-GUI."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "med X11-Athena-GUI."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "med Photon-GUI."
+
+#~ msgid "with GUI."
+#~ msgstr "med GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "med Carbon-GUI."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "med Cocoa-GUI."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "med (klassiskt) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  system-gvimrc-fil: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    användar-gvimrc-fil: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "Andra användar-gvimrc-fil: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "Tredje användar-gvimrc-fil: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    systemmenyfil: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Kompilator: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "meny  Hjälp->Föräldralösa           för information    "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Kör lägeslöst, skriven text blir infogad"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "meny Redigera->Globala inställningar->Växla infogningsläge  "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              för två lägen      "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "meny  Redigera->Globala Inställningar->Växla Vi Komptaibel"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              för vim-standardalternativ   "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "VARNING: Windows 95/98/ME upptäckt"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "skriv  :help windows95<Enter>  för info om det här"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Kunde inte läsa in bibliotek %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Tyvärr, det här kommandot är inaktiverat: Perl-biblioteket kunde inte "
+#~ "läsas in."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: Perl-evaluering förbjuden i sandlåda utan Safe-modulen"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Redigera med &flera Vims"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Redigera med en &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Diff med Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Redigera med &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Redigera med befintlig Vim - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Redigerar markerade fil(erna) med Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Felskapande process: Kontrollera om gvim är i din sökväg!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll-fel"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Sökvägslängd för lång!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Okänd typsnittsuppsättning: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Okänt typsnitt: %s"
+
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Typsnitt \"%s\" är inte bredd-fixerad"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Kunde inte läsa in biblioteksfunktion %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Hebreiska kan inte användas: Inte aktiverat vid kompilering\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Persiska kan inte användas: Inte aktiverat vid kompilering\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Arabiska kan inte användas: Inte aktiverat vid kompilering\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: ingen registrerad server med namnet \"%s\""
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: kan inte öppna display"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Ogiltigt uttryck mottaget"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Region är vaktad, kan inte modifiera"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans tillåter inte ändringar i skrivskyddade filer"

--- a/src/nvim/po/uk.cp1251.po
+++ b/src/nvim/po/uk.cp1251.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-09-29 09:05+0300\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-06-18 21:53+0300\n"
 "Last-Translator: Анатолій Сахнік <sakhnik@gmail.com>\n"
 "Language-Team: Bohdan Vlasyuk <bohdan@vstu.edu.ua>\n"
@@ -21,164 +21,204 @@ msgstr ""
 "Content-Type: text/plain; charset=cp1251\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: Викликано bf_key_init() з порожнім паролем"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "не вдалося отримати значення опції"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "внутрішня помилка: невідомий тип опції"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Неправильне використання порядку байтів Blowfish (BE/LE)"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: Не пройшла перевірка sha256"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Не пройшла перевірка Blowfish"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Список місць]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Список виправлень]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Автокоманди призвели до скасування команди"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Немає можливості розмістити хоч один буфер, завершення роботи..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Немає можливості розмістити буфер, буде використано інший..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Жоден з буферів не був вивантажений"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Жоден з буферів не знищено"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Жоден з буферів не витерто"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Вивантажено один буфер"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Вивантажено %d буфери(ів)"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Знищено один буфер"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Знищено %d буфери(ів)"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Витерто один буфер"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Витерто %d буфери(ів)"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Не можу вивантажити останній буфер"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Жоден буфер не змінено"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: У списку немає буферів"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Буфера %<PRId64> немає"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Це вже останній буфер"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Це вже найперший буфер"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Буфер %<PRId64> має зміни (! щоб не зважати)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Не можу вивантажити останній буфер"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Обережно: Список назв файлів переповнено"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Буфер %<PRId64> не знайдено"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Знайдено кілька збігів з %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Не знайдено буфер, схожий на %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "рядок %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер з такою назвою вже існує"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Змінено]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Не редаговано]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Новий файл]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Помилки читання]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[RO]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[лише читати]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "один рядок --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> рядки(ів) --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "рядок %<PRId64> з %<PRId64> --%d%%-- колонка "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Без назви]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "допомога"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Допомога]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Перегляд]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Усе"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Знизу"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Вгорі"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -186,9 +226,11 @@ msgstr ""
 "\n"
 "# Список буферів:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[З нуля]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -196,146 +238,202 @@ msgstr ""
 "\n"
 "--- Позначки ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Позначки для %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    рядок=%<PRId64>  id=%d назва=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Пропущено двокрапку"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Неправильний режим"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Потрібна цифра"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Неправильний відсоток"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Не можна порівнювати понад %<PRId64> буфери(ів)"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Не можна читати чи записувати тимчасові файли"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Не вдалося створити порівняння"
 
-msgid "Patch file"
-msgstr "Латка"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Не вдалося прочитати результат patch"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Не вдалося прочитати результат diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Цей буфер не в режимі порівняння"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Немає більше модифіковних буферів в режимі порівняння"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Немає інших буферів в режимі порівняння"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Понад два буфери у режимі порівняння, не зрозуміло, котрий із них "
 "використати"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Не вдалося знайти буфер «%s»"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Буфер «%s» не в режимі порівняння"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Буфер несподівано змінився"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: У диграфах не може міститися escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Не знайдено файл розкладки"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap використано не у файлі команд"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Елемент розкладки порожній"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Доповнення ключових слів (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Режим ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Доповнення усього рядка (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Доповнення назви файлу (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Доповнення теґів (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Доповнення шляху за зразком (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Доповнення визначення (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Доповнення зі словника (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Доповнення з тезаурусу (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Доповнення команд (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Користувацьке доповнення (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Кмітливе доповнення (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Орфографічна підказка (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Доповнення місцевих ключових слів (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Трапився кінець параграфа"
 
 # msgstr "E443: "
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Функція доповнення змінила вікно"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Функція доповнення знищила текст"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "Опція 'dictionary' порожня"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "Опція 'thesaurus' порожня"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Сканується словник: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (вставка) Прогорнути (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (заміна) Прогорнути (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Пошук у: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Пошук серед теґів."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Додається"
 
@@ -343,480 +441,598 @@ msgstr " Додається"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Пошук..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Початковий варіант"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Слово з іншого рядка"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Єдиний збіг"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "збіг %d з %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "збіг %d"
 
 # msgstr "E17: "
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неочікувані символи у :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Індекс списку поза межами: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Невизначена змінна: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Бракує ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Аргумент у %s має бути списком"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Аргумент у %s має бути списком чи словником"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Ключ словника не може бути порожнім"
 
 # msgstr "E396: "
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Потрібен список"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Потрібен словник"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Забагато аргументів для функції: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Немає такого ключа у словнику: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Функція %s уже існує, ! щоб замінити"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Запис у словнику вже існує"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Треба посилання на функцію"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Не можна використати [:] зі словником"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Неправильний тип змінної для %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Невідома функція: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Неприпустима назва змінної: %s"
 
 # msgstr "E373: "
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: Float вжито як String"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Цілей менше, ніж елементів списку"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Цілей більше, ніж елементів списку"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Друга ; у списку змінних"
 
 # msgstr "E235: "
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Не можна перерахувати змінні у %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Індексний доступ може бути тільки до списку чи словника"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] має бути останньою"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] вимагає список"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Список має більше елементів, ніж ціль"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Список має недостатньо елементів"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Пропущено «in» після :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Пропущено дужки: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Змінної немає: «%s»"
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Змінна має забагато вкладень щоб бути за-/відкритою."
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Бракує ':' після '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Список можна порівняти тільки зі списком"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Некоректна операція над списком"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Словник можна порівняти тільки із словником"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Некоректна операція над словником"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Функцію можна порівняти тільки з функцією"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Некоректна операція над функцією"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Не можна виконати '%' над Float"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Пропущено ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Функція не має індексації"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Бракує назви опції: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Невідома опція: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Бракує лапки: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Бракує лапки: %s"
 
 # msgstr "E404: "
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Бракує коми у списку: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Немає кінцівки списку ']': %s"
 
 # msgstr "E235: "
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Бракує двокрапки у словнику: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Повторення ключа в словнику: «%s»"
 
 # msgstr "E235: "
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Бракує коми у словнику: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Немає кінцівки словника '}': %s"
 
 # msgstr "E21: "
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: У змінній забагато вкладень щоб її показати"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Забагато аргументів для функції %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Неправильні аргументи функції %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Невідома функція: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Замало аргументів для функції %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> використовується не у контексті скрипту: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Виклик dict-функції без словника: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Треба вказати Number чи Float"
 
 # msgstr "E14: "
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "аргумент add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Забагато аргументів"
 
 # msgstr "E327: "
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() можна вживати тільки в режимі вставки"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&O:Гаразд"
 
 # msgstr "E226: "
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Ключ вже існує: %s"
 
 # msgstr "E14: "
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "аргумент extend()"
 
 # msgstr "E14: "
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "аргумент map()"
 
 # msgstr "E14: "
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "аргумент filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld рядків: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Невідома функція: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&O:Гаразд\n"
-"&C:Скасувати"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Виклики до inputrestore() частіше, ніж до inputsave()"
 
 # msgstr "E14: "
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "аргумент insert()"
 
 # msgstr "E406: "
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Інтервал не дозволено"
 
 # msgstr "E177: "
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Некоректний тип для len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Крок нульовий"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Початок за кінцем"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<нічого>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Немає з'єднання із сервером Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Не вдалося відіслати до %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Не вдалося прочитати відповідь сервера"
-
 # msgstr "E14: "
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "аргумент remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Забагато символьних посилань (цикл?)"
 
 # msgstr "E14: "
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "аргумент reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Не вдалося надіслати клієнту"
-
 # msgstr "E14: "
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "аргумент sort()"
 
+# msgstr "E14: "
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "аргумент add()"
+
 # msgstr "E364: "
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Помилка у функції порівняння"
 
+# msgstr "E364: "
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Помилка у функції порівняння"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Неможливо)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Не вдалося записати тимчасовий файл"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float вжито як Number"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref вжито як Number"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: List вжито як Number"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Dictionary вжито як Number"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref вжито як String"
 
 # msgstr "E373: "
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: List вжито як String"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Dictionary вжито як String"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Неправильний тип змінної: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Не можна знищити змінну %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Назва змінної Funcref має починатися з великої літери: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Назва змінної співпадає з існуючою функцією: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Значення захищене: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Невідомо"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Не можна змінити значення %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Змінна вкладена занадто глибоко щоб зробити її копію"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Невизначена функція: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Бракує '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Тут не можна використати g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Недозволений аргумент: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Назва аргументу повторюється: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Бракує :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Назва функції співпадає зі змінною: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Не вдалося перевизначити функцію %s: вона використовується"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Назва функції не збігається з назвою файлу скрипту: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Не вказано назву функції"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Назва функції має починатися з великої літери або містити двокрапку: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Назва функції має починатися з великої літери або містити двокрапку: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Не вдалося знищити функцію %s: Вона використовується"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Глибина викликів функції перевищує 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "викликається %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s припинено"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s повертає #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s повертає %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "продовження в %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return поза межами функції"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -824,6 +1040,7 @@ msgstr ""
 "\n"
 "# глобальні змінні:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -831,216 +1048,104 @@ msgstr ""
 "\n"
 "\tВостаннє змінена у "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Жодного старого файлу"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Режим налагодження.  Щоб продовжити введіть «cont»."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "рядок %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "команда: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Точка зупинки в «%s%s» рядок %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Точку зупинки не знайдено: %s"
-
-msgid "No breakpoints defined"
-msgstr "Не визначено жодної точки зупинки"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d %s %s   рядок %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Спочатку зробіть «:profile start {файл}»"
-
-msgid "Save As"
-msgstr "Зберегти як"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Зберегти зміни в «%s»?"
-
-msgid "Untitled"
-msgstr "Неназваний"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Буфер «%s» має незбережені зміни"
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr ""
-"Обережно: Несподівано опинилися у іншому буфері (перевірте автокоманди)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Редагується лише один файл"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Це вже найперший файл"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Це вже останній файл"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: Компілятор не підтримується: %s"
-
-# msgstr "E195: "
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Пошук «%s» в «%s»"
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Пошук «%s»"
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "В 'runtimepath' не знайдено «%s»"
-
-msgid "Source Vim script"
-msgstr "Прочитати скрипт Vim"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Не вдалося прочитати каталог: «%s»"
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "Не вдалося виконати «%s»"
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "рядок %<PRId64>: не вдалося виконати «%s»"
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "виконується «%s»"
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "рядок %<PRId64>: виконується «%s»"
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "закінчено виконання %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-# msgstr "E14: "
-msgid "--cmd argument"
-msgstr "--cmd аргумент"
-
-# msgstr "E14: "
-msgid "-c argument"
-msgstr "-c аргумент"
-
-msgid "environment variable"
-msgstr "змінна оточення"
-
-msgid "error handler"
-msgstr "обробник помилки"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Застереження: Неправильний роздільник рядків, можливо, бракує ^M"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: :scriptencoding використано поза виконуваним файлом"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: :finish використано поза виконуваним файлом"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Мова (%s): «%s»"
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Не вдалося встановити мову «%s»"
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  шіст %02x, віс %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, шіст %04x, віс %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, шіст %08x, віс %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Неможливо перемістити рядки самі в себе"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Переміщено один рядок"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Переміщено %<PRId64> рядки(ів)"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Відфільтровано %<PRId64> рядки(ів)"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманди *Filter* не повинні змінювати поточний буфер"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Зміни не записано]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s в рядку: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Забагато помилок, решта файлу буде пропущено"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Зчитується файл viminfo: «%s»%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " інформація"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " позначки"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " старі файли"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " НЕ ВДАЛОСЯ"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Не дозволено запис у файл viminfo: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Не вдалося записати файл viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Записується файл viminfo «%s»"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Цей файл автоматично створений Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1048,37 +1153,47 @@ msgstr ""
 "# Можете редагувати, але ОБЕРЕЖНО!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Значення 'encoding' під час створення цього файлу\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Недозволений символ на початку рядка"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Записати частину файлу?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Використайте ! для запису частини буфера"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Переписати існуючий файл «%s»?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Файл обміну «%s» існує, перезаписати?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Файл обміну існує: %s (:silent! переважує)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Немає вхідного файлу для буфера %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не записано: запис заборонено опцією 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1087,6 +1202,7 @@ msgstr ""
 "Для «%s» встановлено 'readonly'.\n"
 "Бажаєте все одно продовжити запис?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1097,69 +1213,84 @@ msgstr ""
 "Проте, можливо, його можна записати.\n"
 "Хочете спробувати?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: «%s» тільки для читання (! щоб не зважати)"
 
-msgid "Edit File"
-msgstr "Редагувати Файл"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Автокоманди несподівано знищили новий буфер %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: нечисловий аргумент для :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: У rvim не дозволені команди оболонки"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регулярні вирази не можна розділяти літерами"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "Замінити на %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Перервано) "
 
 # msgstr "E31: "
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "Один збіг"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "Одна заміна"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> збіги(ів)"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> замін(и)"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " в одному рядку"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " в %<PRId64> рядках"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global не можна вживати рекурсивно"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: У global бракує зразка"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Зразок знайдено у кожному рядку: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Зразок не знайдено: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1169,136 +1300,338 @@ msgstr ""
 "# Остання заміна:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Без паніки!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Вибачте, немає допомоги '%s' для %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Вибачте, немає допомоги для %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Вибачте, файл допомоги «%s» не знайдено"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Не є каталогом: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Не вдалося відкрити %s для запису"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Не вдалося відкрити %s для читання"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Мішанина кодувань файлу допомоги для мови %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Повторення теґу «%s» у файлі %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Невідома команда надпису: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Пропущено назву надпису"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Визначено забагато надписів"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Некоректний надпис: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Невідомий надпис: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Пропущено номер надпису"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Некоректна назва буфера: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Неправильний ID надпису: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (НЕ ЗНАЙДЕНО)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (не підтримується)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Знищено]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Режим налагодження.  Щоб продовжити введіть «cont»."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "рядок %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "команда: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Точка зупинки в «%s%s» рядок %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Точку зупинки не знайдено: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Не визначено жодної точки зупинки"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d %s %s   рядок %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Спочатку зробіть «:profile start {файл}»"
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Зберегти зміни в «%s»?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Неназваний"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Буфер «%s» має незбережені зміни"
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr ""
+"Обережно: Несподівано опинилися у іншому буфері (перевірте автокоманди)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Редагується лише один файл"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Це вже найперший файл"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Це вже останній файл"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: Компілятор не підтримується: %s"
+
+# msgstr "E195: "
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Пошук «%s» в «%s»"
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Пошук «%s»"
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "В 'runtimepath' не знайдено «%s»"
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Не вдалося прочитати каталог: «%s»"
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "Не вдалося виконати «%s»"
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "рядок %<PRId64>: не вдалося виконати «%s»"
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "виконується «%s»"
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "рядок %<PRId64>: виконується «%s»"
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "закінчено виконання %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+# msgstr "E14: "
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd аргумент"
+
+# msgstr "E14: "
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c аргумент"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "змінна оточення"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "обробник помилки"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Застереження: Неправильний роздільник рядків, можливо, бракує ^M"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: :scriptencoding використано поза виконуваним файлом"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: :finish використано поза виконуваним файлом"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Мова (%s): «%s»"
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Не вдалося встановити мову «%s»"
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Режим Ex. Для повернення до нормального режиму виконайте «visual»"
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Кінець файлу"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Команда занадто рекурсивна"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Виняткова ситуація не оброблена: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Кінець виконуваного файлу"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Кінець функції"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Неоднозначний вжиток команди користувача"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Це не команда редактора"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Інтервал задано навиворіт"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Інтервал задано навиворіт, щоб поміняти місцями — ГАРАЗД"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Спробуйте w або w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Вибачте, цієї команди немає у цій версії"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Дозволено тільки одну назву файлу"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Залишилося відредагувати ще один файл. Все одно вийти?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Ще є %d не редагованих файлів. Все одно вийти?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Залишилося відредагувати ще один файл"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Залишилося %<PRId64> не редагованих файлів"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда вже існує, ! щоб замінити її"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1306,310 +1639,353 @@ msgstr ""
 "\n"
 "    Назва       Арг. Межа  Доповнення Визначення"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Не знайдено команд користувача"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Не вказано атрибутів"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Неправильна кількість аргументів"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Лічильник не може бути вказано двічі"
 
 # msgstr "E177: "
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Неправильне початкове значення лічильника"
 
 # msgstr "E178: "
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: для -complete потрібний аргумент"
 
 # msgstr "E180: "
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Неправильний атрибут: %s"
 
 # msgstr "E181: "
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Неправильна назва команди"
 
 # msgstr "E182: "
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Команди користувача повинні починатися з великої літери"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr ""
 "E841: Зарезервована назва, не можна використати для користувацької команди"
 
 # msgstr "E183: "
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Команду користувача не знайдено: %s"
 
 # msgstr "E179: "
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Неправильне доповнення: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Аргумент дозволений тільки для користувацького доповнення"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Користувацьке доповнення вимагає аргумент-функцію"
 
-msgid "unknown"
-msgstr "Невідомо"
-
 # msgstr "E184: "
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Не вдалося знайти схему кольорів «%s»"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Вітання, користувачу Vim!"
 
 # msgstr "E443: "
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Не можна закрити останню вкладку"
 
 # msgstr "E444: "
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Вже й так лише одна вкладка"
 
-# msgstr "E185: "
-msgid "Edit File in new window"
-msgstr "Редагувати файл у новому вікні"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Вкладка %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Немає файлу обміну"
 
-msgid "Append File"
-msgstr "Дописати файл"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: Не вдалося змінити каталог, буфер має зміни (! щоб не зважати)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Це вже найперший каталог"
 
 # msgstr "E186: "
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Невідомо"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize вимагає два числових аргументи"
 
-# msgstr "E187: "
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Позиція вікна: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Не можна отримати позицію вікна на цій платформі"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos вимагає два числових аргументи"
 
-# msgstr "E188: "
-msgid "Save Redirection"
-msgstr "Зберегти переадресований вивід"
-
-msgid "Save View"
-msgstr "Зберегти вигляд"
-
-msgid "Save Session"
-msgstr "Зберегти сеанс"
-
-msgid "Save Setup"
-msgstr "Зберегти налаштування"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Не вдалося створити каталог: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: Файл «%s» існує (! щоб не зважати)"
 
 # msgstr "E189: "
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Не вдалося відкрити «%s» для запису"
 
 # msgstr "E190: "
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Аргумент має бути літерою, ` або '"
 
 # msgstr "E191: "
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Забагато вкладених :normal"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< не доступна без можливості +eval"
-
 # msgstr "E193: "
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Немає назви вторинного файлу для заміни '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Немає назви файлу автокоманди для заміни «<afile>»"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Немає номера буфера автокоманди для заміни «<abuf>»"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Немає назви збігу автокоманди для заміни «<amatch>»"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: Немає назви файлу :source для заміни «<sfile>»"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: немає номера рядка, щоб використати з «<sfile>»"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Назва файлу для '%' чи '#' порожня, працює лише з «:p:h»"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Результат — порожній рядок"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Не вдалося прочитати файл viminfo"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: У цій версії немає диграфів"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Не можна викидати (:throw) винятки з префіксом 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Виняткова ситуація: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Виняток закінчено: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Виняток скинуто: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, рядок %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Спіймано виняткову ситуацію: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "Очікується %s"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "Відновлено %s"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "Скинуто %s"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Виняток"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Помилка, перервано"
 
 # msgstr "E231: "
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Помилка"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Перервано"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Занадто багато вкладених :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif без :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else без :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif без :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Не одне :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif після :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Забагато вкладених :while/:for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue без :while чи :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break без :while чи :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Вжито :endfor із :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Вжито :endwhile із :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Забагато вкладених :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch без :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch після :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally без :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Не одне :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :entry без :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction поза межами функції"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Зараз не можна редагувати інший буфер"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Зараз не можна змінювати інформацію буфера"
 
 # msgstr "E197: "
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "назва теґу"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " тип файлу\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "Опція 'history' порожня"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1618,235 +1994,313 @@ msgstr ""
 "\n"
 "# Попередні %s (від найновіших):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "команди"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "шукані рядки"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "вирази"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "введені рядки"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar поза межами команди"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Активне вікно або буфер було знищено"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: шлях занадто довгий для доповнення"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Некоректний шлях: `**[число]' повинне бути наприкінці шляху або перед "
+"'%s'."
+
+# msgstr "E343: "
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Не вдалося знайти каталог «%s» у cdpath"
+
+# msgstr "E344: "
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Не вдалося знайти файл «%s» у path"
+
+# msgstr "E345: "
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: У cdpath немає більше каталогу «%s»"
+
+# msgstr "E346: "
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: У шляху пошуку більше немає файлів «%s»"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Автокоманди змінили буфер чи його назву"
 
 # msgstr "E199: "
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Недозволена назва файлу"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "каталог"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "не файл"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "є пристроєм (вимкнено опцією 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Новий файл]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Новий каталог]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Файл завеликий]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Відмовлено]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Автокоманди *ReadPre унеможливили читання файлу"
 
 # msgstr "E200: "
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Автокоманди *ReadPre не повинні змінювати цей буфер"
 
 # msgstr "E201: "
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Читається з stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Читається з stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Конвертація унеможливила читання файлу!"
 
 # msgstr "E202: "
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[канал/сокет]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[канал]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[сокет]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[спец. символьний]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[Бракує CR]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[Розбито довгі рядки]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[НЕ конвертовано]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[конвертовано]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[зашифровано]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ПОМИЛКА КОНВЕРТАЦІЇ у рядку %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[НЕКОРЕКТНИЙ БАЙТ у рядку %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ПОМИЛКА ЧИТАННЯ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Не вдалося підшукати тимчасовий файл для конвертації"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Конвертація з 'charconvert' не вдалася"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "не вдалося прочитати вивід 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Файл зашифровано невідомим методом"
-
 # msgstr "E217: "
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Немає відповідних автокоманд"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Автокоманда знищила або вивантажила буфер, що мав бути записаний"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Автокоманда несподіваним чином змінила кількість рядків"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans не дозволяє записувати у незмінені буфери"
-
-# msgstr "E391: "
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Часткові записи заборонені для буферів NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "Не придатний для запису"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "Запис до пристрою заборонено опцією 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "лише для читання (! щоб не зважати)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Не вдалося записати резервний файл (! щоб не зважати)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Помилка закриття резервного файлу (! щоб не зважати)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Не вдалося прочитати файл щоб створити резервну копію (! щоб не "
 "зважати)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Не вдалося створити резервну копію (! щоб не зважати)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Не вдалося зробити резервну копію (! щоб не зважати)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Гілку ресурсів можна втратити (! щоб не зважати)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Не вдалося підшукати тимчасовий файл для запису"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Не вдалося перетворити (! щоб записати без конвертації)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Не вдалося відкрити для запису зв'язаний файл"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Не вдалося відкрити файл для запису"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Не вдалося виконати fsync"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Не вдалося закрити"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: Помилка запису, конвертація не вдалася (скиньте 'fenc')"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Помилка запису, конвертація не вдалася у рядку %<PRId64> (скиньте 'fenc')"
+"E513: Помилка запису, конвертація не вдалася у рядку %<PRId64> (скиньте "
+"'fenc')"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Помилка запису (скінчилось вільне місце?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ПОМИЛКА КОНВЕРТАЦІЇ"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " у рядку %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Пристрій]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Новий]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr "[д]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " дописаний"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr "[з]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " записаний"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Латання: не вдалося зберегти оригінал"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Латання: не вдалося створити оригінал"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Не вдалося знищити резервний файл"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1854,110 +2308,134 @@ msgstr ""
 "\n"
 "ЗАСТЕРЕЖЕННЯ: Оригінал, мабуть, втрачений чи пошкоджений\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "Не виходьте з редактора, доки файл не записано!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[формат dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[формат mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[формат unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "один рядок, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> рядків, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "один символ"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> символів"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> символів"
-
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Неповний останній рядок]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ЗАСТЕРЕЖЕННЯ: Файл змінився з часу останнього читання!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Ви справді хочете його переписати??"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Помилка запису у «%s»"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Помилка закриття «%s»"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Помилка читання «%s»"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Автокоманда FileChangedShell знищила буфер"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Файл «%s» більше не досяжний"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: Застереження: Файл «%s» змінився, але й буфер у Vim також"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Див. «:help W12» для уточнення."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Застереження: Файл «%s» змінився після початку редагування"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Див. «:help W11» для уточнення."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Застереження: Режим файлу «%s» змінився після початку редагування"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Див. «:help W16» для уточнення."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Застереження: Файл «%s» було створено після початку редагування"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Застереження"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1965,42 +2443,51 @@ msgstr ""
 "&O:Гаразд\n"
 "&L:Завантажити"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Не вдалося підготувати «%s», щоб перечитати"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Не вдалося перечитати «%s»"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Знищено--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "Автоматичне знищення автокоманди: %s <буфер=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Немає такої групи: «%s»"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Недозволений символ після *: %s"
 
 # msgstr "E215: "
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Немає такої події: %s"
 
 # msgstr "E215: "
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Немає такої групи чи події: %s"
 
 # msgstr "E216: "
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -2008,560 +2495,800 @@ msgstr ""
 "\n"
 "--- Автокоманди ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <буфер=%d>: некоректний номер буфера "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Не можу виконувати автокоманди для УСІХ подій"
 
 # msgstr "E217: "
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Немає відповідних автокоманд"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Забагато вкладених автокоманд"
 
 # msgstr "E218: "
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "Автокоманди %s для «%s»"
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Виконується %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "автокоманда %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Бракує {."
 
 # msgstr "E219: "
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Бракує }."
 
 # msgstr "E220: "
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Згорток не знайдено"
 
 # msgstr "E349: "
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Не вдалося створити згортку методом 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Не вдалося знищити згортку методом 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+-- згорнуто %3ld рядків "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Додати до буфера читання"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Заміна рекурсивна"
 
 # msgstr "E223: "
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Загальне скорочення для %s вже існує"
 
 # msgstr "E224: "
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Загальна заміна для %s вже існує"
 
 # msgstr "E225: "
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Вже є скорочення для %s"
 
 # msgstr "E226: "
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Вже є заміна для %s"
 
 # msgstr "E227: "
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Скорочення не знайдено"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Заміни не знайдено"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Неприпустимий режим"
 
-msgid "<cannot open> "
-msgstr "<не відкривається> "
+# msgstr "E447: "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Жодного рядка--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: не вдалося отримати шрифт %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Команду перервано"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: не вдалося повернутися в поточний каталог"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Необхідно вказати аргумент"
 
-msgid "Pathname:"
-msgstr "Шлях:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: За \\ має йти /, ? або &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: не вдалося отримати поточний каталог"
+# msgstr "E10: "
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Неприпустимо у вікні команд, <CR> виконує, CTRL-C виходить"
 
-msgid "OK"
-msgstr "Гаразд"
-
-msgid "Cancel"
-msgstr "Скасувати"
-
-msgid "Vim dialog"
-msgstr "Діалог Vim"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Не вдалося визначити розмір скороченої картинки."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Не вдалося створити BalloonEval з повідомленням і функцією"
-
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Не вдалося створити новий процес для GUI"
-
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Дочірній процес не зміг запустити GUI"
-
-# msgstr "E228: "
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Не вдалося запустити GUI"
-
-# msgstr "E229: "
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Не вдалося прочитати з «%s»"
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Не вдалося запустити GUI, не знайдено шрифт"
-
-# msgstr "E230: "
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Некоректний 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Значення 'imactivatekey' некоректне"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Не вдалося отримати колір %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Немає над курсором, пошук триває"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Y:Так\n"
-"&N:Ні\n"
-"&C:Скасувати"
+"E12: Команда не дозволена у exrc/vimrc у пошуку поточного каталогу чи теґу"
 
-msgid "Input _Methods"
-msgstr "Методи введення"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Бракує :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Знайти й замінити..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Бракує :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Пошук..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Бракує :endwhile"
 
-msgid "Find what:"
-msgstr "Знайти:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Бракує :endfor"
 
-msgid "Replace with:"
-msgstr "Замінити на:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile без :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Лише повне слово"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor без :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Зважати на регістр"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Файл існує (! щоб не зважати)"
 
-msgid "Direction"
-msgstr "Напрям"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Команда на вдалась"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Вгору"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Внутрішня помилка"
 
-msgid "Down"
-msgstr "Униз"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Перервано"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Наступне"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Неправильна адреса"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "Замінити"
+# msgstr "E14: "
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Некоректний аргумент"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Замінити усі"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Отримав запит «die» від менеджера сесій\n"
-
-msgid "Close"
-msgstr "Закрити"
-
-msgid "New tab"
-msgstr "Нова вкладка"
-
-msgid "Open Tab..."
-msgstr "Відкрити вкладку..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Несподівано знищилося головне вікно\n"
-
-msgid "&Filter"
-msgstr "&F:Фільтрувати"
-
-msgid "&Cancel"
-msgstr "&C:Скасувати"
-
-msgid "Directories"
-msgstr "Каталоги"
-
-msgid "Filter"
-msgstr "Фільтр"
-
-msgid "&Help"
-msgstr "&H:Допомога"
-
-msgid "Files"
-msgstr "Файли"
-
-msgid "&OK"
-msgstr "&O:Гаразд"
-
-msgid "Selection"
-msgstr "Виділення"
-
-msgid "Find &Next"
-msgstr "&N:Знайти далі"
-
-msgid "&Replace"
-msgstr "&R:Замінити"
-
-msgid "Replace &All"
-msgstr "&A:Замінити усі"
-
-msgid "&Undo"
-msgstr "&U:Скасувати"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Не вдалося знайти вікно «%s»"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Некоректний аргумент: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Аргумент не підтримується: «-%s»; користуйтесь версією з OLE."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Неправильний вираз: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Не вдалося відкрити вікно всередині програми MDI"
+# msgstr "E15: "
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Неправильні межі"
 
-msgid "Close tab"
-msgstr "Закрити вкладку"
+# msgstr "E16: "
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Некоректна команда"
 
-msgid "Open tab..."
-msgstr "Відкрити вкладку..."
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: «%s» — це каталог"
 
-# msgstr "E245: "
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Знайти рядок ('\\\\' щоб знайти '\\')"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Некоректний розмір зсуву"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Знайти і замінити ('\\\\' щоб знайти '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Немає"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Каталог\t*.нічого\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Немає вільних комірок у палітрі, деякі кольори можуть бути "
-"неправильні"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Шрифти для цих символів відсутні у наборі %s:"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
-# msgstr "E250: "
+#: ../globals.h:1024
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Назва набору шрифтів: %s"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Бібліотечний виклик до «%s()» не вдався"
 
-# msgstr "E252: "
+# msgstr "E18: "
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: У помітки некоректний номер рядка"
+
+# msgstr "E19: "
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Помітку не встановлено"
+
+# msgstr "E20: "
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Зміни не дозволені: вимкнено 'modifiable'"
+
+# msgstr "E21: "
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Забагато вкладених скриптів"
+
+# msgstr "E22: "
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Немає вторинного файлу"
+
+# msgstr "E23: "
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Такого скорочення немає"
+
+# msgstr "E24: "
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! не дозволено"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Не можна використати GUI: Не ввімкнено під час компіляції"
+
+# msgstr "E25: "
+#: ../globals.h:1036
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Шрифт '%s' не є моноширинним"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Немає такої групи підсвічування: %s"
 
+# msgstr "E28: "
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Текст ще не було додано"
+
+# msgstr "E29: "
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Ще не було команд"
+
+# msgstr "E30: "
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Немає такої заміни"
+
+# msgstr "E31: "
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Жодного збігу"
+
+#: ../globals.h:1041
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Назва набору шрифтів: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Жодного збігу: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Бракує назви файлу"
+
+# msgstr "E32: "
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Заміна зразків ще не використовувалась"
+
+# msgstr "E33: "
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Команд ще не було"
+
+# msgstr "E34: "
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Зразків пошуку ще не було"
+
+# msgstr "E35: "
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Не дозволено вказувати межі"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Місця не вистачить"
+
+# msgstr "E36: "
+#: ../globals.h:1049
 #, c-format
-msgid "Font0: %s"
-msgstr "Шрифт0: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Не вдалося створити файл %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Не вдалося сформувати назву тимчасового файлу"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font1: %s"
-msgstr "Шрифт1: %s"
+msgid "E484: Can't open file %s"
+msgstr "E484: Не вдалося відкрити файл %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Ширина шрифту%<PRId64> не більша удвічі за ширину шрифту0"
+msgid "E485: Can't read file %s"
+msgstr "E485: Не вдалося прочитати файл %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Зміни не було записано (! щоб не зважати)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Зміни не записано]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Відсутній аргумент"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Очікується число"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Ширина шрифту0: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Не вдалося відкрити файл помилок %s"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Забракло пам'яті!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Зразок не знайдено"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Ширина шрифту1: %<PRId64>"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Зразок не знайдено: %s"
 
-msgid "Invalid font specification"
-msgstr "Некоректна специфікація шрифту"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Аргумент має бути додатний"
 
-msgid "&Dismiss"
-msgstr "&D:Припинити"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Не вдалося перейти до попереднього каталогу"
 
-msgid "no specific match"
-msgstr "немає конкретного збігу"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Жодної помилки"
 
-# msgstr "E234: "
-msgid "Vim - Font Selector"
-msgstr "Vim - Вибір шрифту"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Немає списку місць"
 
-msgid "Name:"
-msgstr "Назва:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Текст збігу пошкоджено"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Показати розмір у пунктах"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Зіпсована програма регулярних виразів"
 
-msgid "Encoding:"
-msgstr "Кодування:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Встановлено опцію 'readonly' (! щоб не зважати)"
 
-msgid "Font:"
-msgstr "Шрифт:"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Змінна тільки для читання: «%s»"
 
-msgid "Style:"
-msgstr "Стиль:"
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Не можна встановити змінну у пісочниці: «%s»"
 
-msgid "Size:"
-msgstr "Розмір:"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Помилка читання файлу помилок"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Помилка автомату Hangul"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: На дозволено у пісочниці"
 
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Не дозволено тут"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Режим екрану не підтримується"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Некоректний розмір зсуву"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Опція 'shell' порожня"
+
+# msgstr "E254: "
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Не можна зчитати дані напису!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Помилка під час закриття файлу обміну"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: Стек теґів порожній"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Занадто складна команда"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Задовге ім'я"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Забагато '['"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Забагато назв файлів"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Надлишкові символи"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Невідома помітка"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Не вдалося розкрити шаблон"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' не може бути меншим за 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' не може бути меншим за 'winminwidth'"
+
+# msgstr "E79: "
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Помилка під час запису"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Нульова кількість"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> використовується не в контексті скрипту"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Внутрішня помилка: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Зразок використовує більше, ніж 'maxmempattern', пам'яті"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Порожній буфер"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Некоректний зразок для пошуку чи роздільник"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Файл уже завантажено в інший буфер"
+
+# msgstr "E235: "
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Опція '%s' не встановлена"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Неправильна назва регістру"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Пошук дійшов до ПОЧАТКУ, продовжується з КІНЦЯ"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Пошук дійшов до КІНЦЯ, продовжується з ПОЧАТКУ"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Пропущено двокрапку"
 
 # msgstr "E347: "
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Некоректний компонент"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: очікується цифра"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Сторінка %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Нічого друкувати"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Друкується сторінка %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Копія %d з %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Надруковано: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Друк перервано"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Не вдалося записати вихідний файл PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Не вдалося відкрити файл «%s»"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Не вдалося прочитати файл ресурсів PostScript «%s»"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: «%s» не є файлом ресурсів PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: «%s» не є підтримуваним файлом ресурсів PostScript"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Неправильна версія файлу ресурсів «%s»"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Несумісні багатобайтове кодування й набір символів."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr ""
 "E674: printmbcharset не може бути порожнім з багатобайтовим кодуванням."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Не зазначено шрифт для багатобайтового друку."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Не вдалося відкрити файл PostScript для виводу"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Не вдалося відкрити файл «%s»"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Не вдалося знайти файл ресурсів PostScript «prolog.ps»"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Не вдалося знайти файл ресурсів PostScript «cidfont.ps»"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Не вдалося знайти файл ресурсів PostScript «%s.ps»"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Не вдалося перетворити до кодування друку «%s»"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Відсилається на принтер..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Не вдалося надрукувати файл PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Завдання друку відіслано."
 
 # msgstr "E255: "
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Додати нову базу даних"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Запит за зразком"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Показати це повідомлення"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Знищити з'єднання"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Перезапустити усі з'єднання"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Показати з'єднання"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Використання: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Ця команда cscope не вміє ділити вікно.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Використання: cstag <ідентиф-ор>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: теґ не знайдено"
 
 # msgstr "E257: "
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) помилка: %d"
 
-msgid "E563: stat error"
-msgstr "E563: помилка stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s не є ні каталогом, ні базою даних cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Додано базу даних cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Помилка читання зі з'єднання cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Невідомий тип пошуку cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Не вдалося створити канали до cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Не вдалося розділити процес для cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection: помилка setpgid"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection: помилка під час виконання"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen для to_fp не вдався"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen для fr_fp не вдався"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Не вдалося створити процес cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: жодного з'єднання із cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Некоректний прапорець cscopequickfix %c для %c"
 
 # msgstr "E258: "
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: Для запиту cscope %s з %s нічого не знайдено"
 
 # msgstr "E259: "
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "Команди cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Використання: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2583,33 +3310,32 @@ msgstr ""
 "       s: Знайти цей символ C\n"
 "       t: Знайти цей текст\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Не вдалося відкрити базу даних cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Не вдалося отримати інформацію з бази даних cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Повторна база даних cscope не додана"
 
 # msgstr "E260: "
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: З'єднання з cscope %s не знайдено"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "З'єднання з cscope %s закінчено"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Фатальна помилка в cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Теґ cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2617,365 +3343,89 @@ msgstr ""
 "\n"
 "   #   рядок"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "файл / контекст / рядок\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Помилка cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Усі бази даних cscope перезавантажено"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "Жодного з'єднання з cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    назва бази даних                    шлях\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Не вдалося завантажити бібліотеку Lua"
-
-msgid "cannot save undo information"
-msgstr "не вдалося зберегти інформацію для скасування"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Вибачте, ця команда вимкнена, бібліотеки MzScheme не можуть бути "
-"завантажені."
-
-msgid "invalid expression"
-msgstr "некоректний вираз"
-
-msgid "expressions disabled at compile time"
-msgstr "обробку виразів вимкнено під час компіляції"
-
-msgid "hidden option"
-msgstr "прихована опція"
-
-msgid "unknown option"
-msgstr "невідома опція"
-
-msgid "window index is out of range"
-msgstr "некоректний номер вікна"
-
-msgid "couldn't open buffer"
-msgstr "не вдалося відкрити буфер"
-
-msgid "cannot delete line"
-msgstr "неможливо знищити рядок"
-
-msgid "cannot replace line"
-msgstr "неможливо замінити рядок"
-
-msgid "cannot insert line"
-msgstr "не вдалося вставити рядок"
-
-msgid "string cannot contain newlines"
-msgstr "більше ніж один рядок"
-
-msgid "error converting Scheme values to Vim"
-msgstr "не вдалося перетворити значення Scheme у Vim"
-
-msgid "Vim error: ~a"
-msgstr "Помилка Vim: ~a"
-
-msgid "Vim error"
-msgstr "Помилка Vim"
-
-msgid "buffer is invalid"
-msgstr "буфер непридатний"
-
-msgid "window is invalid"
-msgstr "вікно непридатне"
-
-msgid "linenr out of range"
-msgstr "номер рядка за межами файлу"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "не дозволено у пісочниці Vim"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Python: Не можна використати :py і :py3 в одному сеансі"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Вибачте, ця команда вимкнена, бібліотека Python не може бути "
-"завантажена."
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: Не можна використати :py і :py3 в одному сеансі"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Не можна рекурсивно викликати Python"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ має бути екземпляром String"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Вибачте, ця команда вимкнена, бібліотека Ruby не може бути завантажена."
-
-# msgstr "E414: "
-msgid "E267: unexpected return"
-msgstr "E267: несподіваний return"
-
-msgid "E268: unexpected next"
-msgstr "E268: несподіваний next"
-
-msgid "E269: unexpected break"
-msgstr "E269: несподіваний break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: несподіваний redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry поза rescue"
-
-msgid "E272: unhandled exception"
-msgstr "E272: Необроблений виняток"
-
-# msgstr "E233: "
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Невідомий статус longjmp: %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Перемкнути реалізацію/визначення"
-
-msgid "Show base class of"
-msgstr "Знайти базовий клас"
-
-msgid "Show overridden member function"
-msgstr "Показати замінені функції-члени"
-
-msgid "Retrieve from file"
-msgstr "Прочитати з файлу"
-
-msgid "Retrieve from project"
-msgstr "Отримати з проекту"
-
-msgid "Retrieve from all projects"
-msgstr "Отримати з усіх проектів"
-
-msgid "Retrieve"
-msgstr "Отримати"
-
-msgid "Show source of"
-msgstr "Джерело"
-
-msgid "Find symbol"
-msgstr "Знайти символ"
-
-msgid "Browse class"
-msgstr "Переглянути клас"
-
-msgid "Show class in hierarchy"
-msgstr "Показати клас в ієрархії"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Показати клас в обмеженій ієрархії"
-
-msgid "Xref refers to"
-msgstr "Xref вказує на"
-
-msgid "Xref referred by"
-msgstr "На Xref вказано з"
-
-msgid "Xref has a"
-msgstr "Xref має"
-
-msgid "Xref used by"
-msgstr "Xref використано"
-
-msgid "Show docu of"
-msgstr "Показати docu"
-
-msgid "Generate docu for"
-msgstr "Створити docu для"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Не вдалося з'єднатися зі SNiFF+. Перевірте оточення (sniffemacs має бути у "
-"$PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Помилка під час читання. Від'єднано"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ зараз "
-
-msgid "not "
-msgstr "не "
-
-msgid "connected"
-msgstr "під'єднаний"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Невідомий запит до SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Помилка з'єднання до SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ не під'єднано"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Не є буфером SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Помилка запису. Від'єднано"
-
-msgid "invalid buffer number"
-msgstr "неправильна назва буфера"
-
-msgid "not implemented yet"
-msgstr "ще не реалізовано"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "не вдалося встановити рядки"
-
-msgid "invalid mark name"
-msgstr "неправильна назва позначки"
-
-# msgstr "E19: "
-msgid "mark not set"
-msgstr "помітку не вказано"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "рядок %d колонка %d"
-
-msgid "cannot insert/append line"
-msgstr "Не вдалося вставити/додати рядок"
-
-msgid "line number out of range"
-msgstr "номер рядка за межами файлу"
-
-msgid "unknown flag: "
-msgstr "невідомий прапорець: "
-
-msgid "unknown vimOption"
-msgstr "Невідома vimOption"
-
-msgid "keyboard interrupt"
-msgstr "перервано з клавіатури"
-
-msgid "vim error"
-msgstr "помилка Vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "не вдалося створити команду вікна/буфера: об'єкт знищується"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "Не вдалося зареєструвати подію: буфер/вікно уже знищується"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: ФАТАЛЬНА ПОМИЛКА TCL: можливо пошкоджено список посилань!? Будь ласка, "
-"повідомте у vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"Не вдалося зареєструвати команду події: посилання на буфер/вікно не знайдено"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Вибачте, ця команда вимкнена, бібліотека Tcl не може бути завантажена."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Код виходу %d"
-
-msgid "cannot get line"
-msgstr "не вдалося дістати рядок"
-
-msgid "Unable to register a command server name"
-msgstr "Не вдалося зареєструвати назву сервера команд"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Не вдалося відіслати команду до програми-цілі"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Використано некоректний ідентифікатор сервера: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Реквізит реєстру зразку VIM сформований неправильно.  Знищено!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Невідомий аргумент опції"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Забагато аргументів"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Пропущено аргумент після"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Сміття після аргументу опції"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Забагато аргументів у «+команда», «-c команда» або «--cmd команда»"
 
 # msgstr "E14: "
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Неправильний аргумент у"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d файли(ів)\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans не підтримується з цим GUI\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Ця версія Vim не була скомпільована з підтримкою порівняння."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "Не можна використати '-nb': не дозволено під час компіляції\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Спроба повторно відкрити скрипт: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Не вдалося прочитати: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Не вдалося відкрити як вихідний файл: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Помилка: Не вдалося запустити gvim для NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Застереження: Вивід не у термінал\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Застереження: Уведення не з терміналу\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "команди перед vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Не вдалося прочитати з «%s»"
 
 # msgstr "E282: "
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2983,18 +3433,23 @@ msgstr ""
 "\n"
 "Дізнайтеся більше: «vim -h»\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[файл ..]       редагувати вказані файли"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               читати текст з stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t помітка      перейти до теґу"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [файл]       перейти до першої помилки"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -3004,9 +3459,11 @@ msgstr ""
 "\n"
 "Вжиток:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [аргументи] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -3014,14 +3471,7 @@ msgstr ""
 "\n"
 "   або:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Якщо регістр ігнорується, додайте / спереду щоб прапорець був у верхньому "
-"регістрі."
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -3031,325 +3481,192 @@ msgstr ""
 "\n"
 "Аргументи:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tЛише назви файлів після цього"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tНе розкривати шаблони"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tЗареєструвати цей gvim для OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tСкасувати реєстрацію цього gvim для OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tЗапустити GUI (ніби «gvim»)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  чи  --nofork\tПередній план: тримати термінал після запуску GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tРежим Vi (ніби «vi»)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tРежим Ex (ніби «ex»)"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tПокращений режим Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tМовчазний (пакетний) режим (лише для «ex»)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tРежим порівняння (ніби «vimdiff»)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tПростий режим (ніби «evim», без режимів)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tРежим перегляду (ніби «view»)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tОбмежений режим (ніби «rvim»)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tЗміни (запис файлів) не дозволено"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tЗміни в тексті файлів не дозволено"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tДвійковий режим"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tРежим lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tСумісний з Vi режим: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tНе зовсім сумісний з Vi режим: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][файл]\t\tБільше повідомлень [рівень N] [файл журн. повідомлень]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tРежим налагодження"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tНе використовувати файл обміну, тримати усе в пам'яті"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tПоказати файли обміну і вийти"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (назва файлу)\tВідновити аварійно закінчений сеанс"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tТе саме, що й -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tНе використовувати newcli для відкриття вікна"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <пристрій>\t\t\tВикористовувати <пристрій> для вводу/виводу"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tЗапустити в режимі арабської мови"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tЗапустити в режимі івриту"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tЗапустити в режимі перської мови"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <термінал>\tВстановити тип терміналу у <термінал>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tВикористати поданий файл замість .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-u <gvimrc>\t\tВикористати поданий файл замість .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tНе вантажити скрипти доповнення"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tВідкрити N вкладок (або по одній для кожного файлу)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tВідкрити N вікон (або по одному для кожного файлу)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tНіби -o, але поділити вікна вертикально"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tРозпочати в кінці файлу"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<рядок>\t\tРозпочати у вказаному <рядку>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <команда>\tВиконати <команду> перед завантаженням vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <команда>\t\tВиконати <команду> після завантаження першого файлу"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <сеанс>\t\tВиконати поданий файл після першого завантаженого файлу"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <скрипт>\t\tЗчитати команди нормального режиму з файлу <скрипт>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <скрипт>\t\tДописати усі набрані команди до файлу <скрипт>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-w <скрипт>\t\tЗаписати усі набрані команди у файл <скрипт>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tРедагувати зашифровані файли"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <дисплей>\tПід'єднати vim до заданого дисплею сервера X"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tНе з'єднуватися з X сервером"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <файли>\tРедагувати <файли> на сервері Vim, якщо це можливо"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-silent <файли>  Те саме, тільки не скаржитися на відсутність сервера"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <файли>   ..., але зачекати поки усі файли будуть відредаговані"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <файли>  Те саме, тільки не скаржитися, якщо сервера "
-"немає"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <файли>  Так само, як --remote, але по вкладці "
-"на файл"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <символи> Відіслати <символи> серверу і завершити роботу"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <вираз> Виконати <вираз> у сервері Vim і надрукувати результат"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr ""
-"--serverlist\t\tПоказати список наявних серверів Vim і завершити роботу"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <назва>\tНадіслати до/стати Vim сервером з <назвою>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <файл>\tЗаписати запускні повідомлення з часовими відмітками "
 "до <файлу>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tВикористати <viminfo> замість .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  чи  --help\tНадрукувати це повідомлення і вийти"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tНадрукувати інформацію про версію програми і вийти"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Аргументи для gvim (версія Motif)\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Аргументи для gvim (версія neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Аргументи для gvim (версія Athena)\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <дисплей>\tВиконати vim на заданому <дисплеї>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tЗапустити Vim і згорнути його вікно"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <колір>\tВикористати <колір> для фону (також: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <колір>\tВикористати <колір> для звичайного тексту (також: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <шрифт>\tВикористати <шрифт> для звичайного тексту (також: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <шрифт>\tВикористати <шрифт> для жирного тексту"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <шрифт>\tВикористати <шрифт> для похилого тексту"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <геом>\tЗадати розміри й положення (також: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <товщ>\tВстановити товщину меж <товщ> (також: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <товщ>  Встановити товщину лінійки зсуву (також: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <висота>\tВстановити висоту меню <висота> (також: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tОбернути кольори (також: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tНе обертати кольори (також: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ресурс>\t\tВстановити зазначений ресурс"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Аргументи gvim (версія GTK+)\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <дисплей>\tВиконати vim на <дисплеї> (також: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <роль>\tВстановити унікальну роль для ідентифікації головного вікна"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tВідкрити Vim в іншому елементі інтерфейсу GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tХай gvim надрукує ідентифікатор вікна на stdout"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <заголовок батька>\tВідкрити Vim всередині батьківського вікна"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tВідкрити Vim всередині іншого елементу win32"
-
-msgid "No display"
-msgstr "Немає дисплею"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Не вдалося відіслати.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Не вдалося відіслати. Спроба виконати на місці\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "відредаговано %d з %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Немає дисплею: Відіслати вираз не вдалося.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Відіслати вираз не вдалося.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Не встановлено жодної помітки"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Помітку «%s» не знайдено"
 
 # msgstr "E283: "
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3358,6 +3675,7 @@ msgstr ""
 "пом. ряд.  кол. файл/текст"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3367,6 +3685,7 @@ msgstr ""
 
 # msgstr "E283: "
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3375,6 +3694,7 @@ msgstr ""
 "змінити ряд. стовп. текст"
 
 # TODO
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3383,6 +3703,7 @@ msgstr ""
 "# Помітки:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3391,6 +3712,7 @@ msgstr ""
 "# Список переходів (від найновіших):\n"
 
 # TODO
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3398,98 +3720,90 @@ msgstr ""
 "\n"
 "# Попередні помітки в файлах (від найновіших):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Пропущено '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Некоректна кодова сторінка"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Не вдалося встановити значення контексту вводу"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Не вдалося створити контекст вводу"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Не вдалося створити метод вводу"
-
-# msgstr "E286: "
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Застереження: Не вдалося встановити в методі вводу подію знищення"
-
-# msgstr "E287: "
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Метод вводу не підтримує стилі"
-
-# msgstr "E288: "
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: Метод вводу не підтримує відредаговані типи"
-
 # msgstr "E292: "
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Блок не було зафіксовано"
 
 # msgstr "E293: "
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Помилка зміни позиції у файлі обміну"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Помилка зчитування файлу обміну"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Помилка зміни позиції під час запису у файл обміну"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Помилка запису файлу обміну"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Файл обміну вже існує (атака символьним посиланням?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Немає блоку 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Немає блоку 1?"
 
 # msgstr "E298: "
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Немає блоку 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Помилка поновлення шифрування файлу обміну"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ой, втрачено файл обміну!!!"
 
 # msgstr "E301: "
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Не вдалося перейменувати файлу обміну"
 
 # msgstr "E302: "
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Не вдалося прочитати файл обміну для «%s», відновлення неможливе"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Немає блоку 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Не знайдено файлу обміну для %s"
 
 # msgstr "E305: "
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Введіть номер файлу обміну, котрий використати, (0 для виходу):"
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Не вдалося відкрити %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Не вдалося прочитати блок 0 з "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3497,22 +3811,28 @@ msgstr ""
 "\n"
 "Напевно, змін не було, або Vim не поновив файл обміну."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " не можна використати з цією версією Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Знайдіть Vim 3.0\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s не схоже на файл обміну Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " не можна використати на цьому комп'ютері.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Файл було створено на "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3520,107 +3840,89 @@ msgstr ""
 ",\n"
 "або файл було пошкоджено."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s зашифровано, а ця версія Vim не підтримує шифрування"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " пошкоджений (розмір сторінки менший мінімального значення).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Використовується файл обміну «%s»"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Початковий файл «%s»"
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Застереження: Можливо, початковий файл було змінено"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Файл обміну зашифрований: «%s»"
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Якщо ви задали новий ключ шифру, але не записали текстовий файл,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"введіть новий ключ шифру."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Якщо ви записали текстовий файл після зміни ключа шифру, натисніть enter"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"щоб використати однаковий ключ для текстового файлу та файлу обміну"
-
 # msgstr "E308: "
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Не вдалося прочитати блок 1 з %s"
 
 # msgstr "E309: "
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "??? БРАКУЄ БАГАТЬОХ РЯДКІВ"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "??? НЕПРАВИЛЬНА КІЛЬКІСТЬ РЯДКІВ"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "??? ПОРОЖНІЙ БЛОК"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "??? ПРОПУЩЕНІ РЯДКИ"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Ідентифікатор блоку 1 неправильний (%s не є файлом обміну?)"
 
 # msgstr "E310: "
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "??? ПРОПУЩЕНО БЛОК"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? звідси і до `??? КІНЕЦЬ' рядки, можливо, сплутані"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? звідси і до `??? КІНЕЦЬ' рядки, можливо, були додані/знищені"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "??? КІНЕЦЬ"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Відновлення перервано"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Під час відновлення знайдено помилки. Перегляньте рядки, що "
 "починаються з ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Див. «:help E312» для уточнення."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Відновлення закінчено, перевірте чи все гаразд."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3628,12 +3930,15 @@ msgstr ""
 "\n"
 "(Можливо, потрібно записати цей файл під іншою назвою\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "і запустити diff з оригіналом щоб перевірити зміни)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Відновлення закінчено. Вміст буфера співпадає зі вмістом файлу."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3643,43 +3948,52 @@ msgstr ""
 "Можливо, тепер ви хочете знищити файл обміну .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Для текстового файлу використовується ключ шифру з файлу обміну.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Знайдено файли обміну:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   В поточному каталозі:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Використовуючи вказану назву:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   У каталозі "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- жодного --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "           власник: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   дата: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             дата: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [від Vim 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "        [не схоже на файл обміну]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         назва файлу: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3687,12 +4001,15 @@ msgstr ""
 "\n"
 "           змінено: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ТАК"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ні"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3700,9 +4017,11 @@ msgstr ""
 "\n"
 "          користувач: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   назва вузла: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3710,6 +4029,7 @@ msgstr ""
 "\n"
 "          назва вузла: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3717,16 +4037,11 @@ msgstr ""
 "\n"
 "         ID процесу: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (виконується)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [не придатний для цієї версії Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3734,84 +4049,106 @@ msgstr ""
 "\n"
 "         [непридатний на цьому комп'ютері]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [не можна прочитати]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [не можна відкрити]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Не вдалося заготовити, немає файлу обміну"
 
 # msgstr "E313: "
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Файл збережено"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Збереження не вдалося"
 
 # msgstr "E314: "
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: неправильний lnum: %<PRId64>"
 
 # msgstr "E315: "
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: не знайшов рядок %<PRId64>"
 
 # msgstr "E316: "
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Вказівник блоку помилковий 3"
 
 # msgstr "E317: "
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx має бути рівним 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Поновлено забагато блоків?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Вказівник блоку помилковий 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "блок 1 знищено?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Не вдалося знайти рядок %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Вказівник блоку помилковий"
 
 # msgstr "E317: "
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count дорівнює 0"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Номер рядка вийшов за межі: %<PRId64> за кінцем"
 
 # msgstr "E322: "
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Кількість рядків у блоці %<PRId64>"
 
 # msgstr "E323: "
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Розмір стеку збільшується"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Вказівник блоку помилковий 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Циклічні символьні посилання «%s»"
 
 # msgstr "E317: "
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: УВАГА"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3819,14 +4156,15 @@ msgstr ""
 "\n"
 "Знайдено файл обміну з назвою \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "При відкритті файлу \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      НОВІШИЙ за файл обміну!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3838,15 +4176,19 @@ msgstr ""
 "    будьте обережні, щоб не залишилися два різні екземпляри\n"
 "    одного й того самого файлу після змін."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Вийдіть або продовжуйте обережно.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сеанс редагування цього файлу зазнав краху.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Якщо це справді трапилося, спробуйте «:recover» або «vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3854,9 +4196,11 @@ msgstr ""
 "»\n"
 "    щоб відновити зміни (див. «:help recovery»).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Якщо ви вже це зробили, знищіть файл обміну «"
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3865,18 +4209,23 @@ msgstr ""
 "    щоб позбутися цього повідомлення.\n"
 "\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Файл обміну «"
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "» вже існує!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM — УВАГА"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Файл обміну вже існує!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3890,6 +4239,7 @@ msgstr ""
 "&Q:Вийти\n"
 "&A:Перервати"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3905,41 +4255,64 @@ msgstr ""
 "&Q:Вийти\n"
 "&A:Перервати"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Знайдено забагато файлів обміну"
 
+# msgstr "E341: "
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Забракло пам'яті!  (потрібно було %<PRIu64> байтів)"
+
 # msgstr "E326: "
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Частина шляху до елемента меню не є підменю"
 
 # msgstr "E327: "
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Меню може бути тільки в іншому режимі"
 
 # msgstr "E328: "
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Немає меню «%s»"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Порожня назва меню"
 
 # msgstr "E329: "
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Шлях до меню не повинен вести до підменю"
 
 # msgstr "E330: "
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Не можна додавати елементи меню просто до верхнього меню"
 
 # msgstr "E331: "
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Роздільник не може бути частиною шляху меню"
 
 # msgstr "E332: "
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3947,65 +4320,78 @@ msgstr ""
 "\n"
 "--- Меню ---"
 
-msgid "Tear off this menu"
-msgstr "Відірвати це меню"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Шлях повинен вести до елемента меню"
 
 # msgstr "E333: "
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Меню не знайдено: %s"
 
 # msgstr "E334: "
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Для режиму %s меню не визначено"
 
 # msgstr "E335: "
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Шлях повинен вести до підменю"
 
 # msgstr "E336: "
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Меню не знайдено — перевірте назву"
 
 # msgstr "E337: "
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Виявлено помилку під час виконання %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "рядок %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Неправильна назва регістру: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Українізація: Анатолій Сахнік <sakhnik@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Перервано: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Натисніть ENTER або введіть команду для продовження"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s рядок %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Ще --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " ПРОБІЛ/d/j: вниз на екран/сторінку/рядок, b/u/k: вгору, q: вийти "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Запитання"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -4013,6 +4399,17 @@ msgstr ""
 "&Y:Так\n"
 "&N:Ні"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Y:Так\n"
+"&N:Ні\n"
+"&C:Скасувати"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4026,275 +4423,178 @@ msgstr ""
 "&D:Жодного\n"
 "&C:Скасувати"
 
-msgid "Select Directory dialog"
-msgstr "Вибрати каталог"
-
-msgid "Save File dialog"
-msgstr "Запам'ятати файл"
-
-msgid "Open File dialog"
-msgstr "Відкрити файл"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Вибачте, але в консолі немає діалогу вибору файлу"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Недостатньо аргументів для printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Очікується аргумент Float для printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Забагато аргументів для printf()"
 
 # msgstr "E338: "
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Застереження: Змінюється файл призначений лише для читання"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Наберіть число й <Enter> чи клацніть мишкою (порожнє скасовує): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Наберіть число й <Enter> (порожнє скасовує): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "додано один рядок"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "знищено один рядок"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "додано рядків: %<PRId64>"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "знищено рядків: %<PRId64>"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Перервано)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Дзень!"
 
-msgid "ERROR: "
-msgstr "ПОМИЛКА: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[байт]  всього розм/знищ. %<PRIu64>/%<PRIu64>, викор. %<PRIu64>, макс. %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[виклики] усього re/malloc() - %<PRIu64>, усього free() - %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Рядок стає занадто довгим"
-
-# msgstr "E340: "
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
-
-# msgstr "E341: "
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Забракло пам'яті!  (потрібно було %<PRIu64> байтів)"
-
 # msgstr "E342: "
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Викликається оболонка щоб виконати: «%s»"
 
-msgid "E545: Missing colon"
-msgstr "E545: Пропущено двокрапку"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Неправильний режим"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Неправильний вигляд миші"
-
-msgid "E548: digit expected"
-msgstr "E548: Потрібна цифра"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Неправильний відсоток"
-
-msgid "Enter encryption key: "
-msgstr "Вкажіть ключ шифру: "
-
-msgid "Enter same key again: "
-msgstr "Повторіть ключ: "
-
-msgid "Keys don't match!"
-msgstr "Ключі не однакові!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: шлях занадто довгий для доповнення"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Некоректний шлях: `**[число]' повинне бути наприкінці шляху або перед "
-"'%s'."
-
-# msgstr "E343: "
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Не вдалося знайти каталог «%s» у cdpath"
-
-# msgstr "E344: "
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Не вдалося знайти файл «%s» у path"
-
-# msgstr "E345: "
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: У cdpath немає більше каталогу «%s»"
-
-# msgstr "E346: "
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: У шляху пошуку більше немає файлів «%s»"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Не вдалося з'єднатися із Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Не вдалося з'єднатися із Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Неправильний режим доступу до файлу інформації про з'єднання з "
-"NetBenans: «%s»"
-
-msgid "read from Netbeans socket"
-msgstr "читається з сокета Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Втрачено зв'язок із NetBeans для буфера %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans не підтримується з цим GUI"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans вже під'єднано"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s тільки для читання (! щоб не зважати)"
-
 # msgstr "E348: "
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Немає ідентифікатора над курсором"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' порожня"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Можливість eval недоступна"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Застереження: Термінал не підтримує кольори"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Немає рядка на курсорі"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Не вдалося знищити згортки поточним методом 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Список змін порожній"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Початок списку змін"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "Один рядок %s-но"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Один рядок %s-но %d разів"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> рядків %s-но"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> рядків %s-но %d разів"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "Залишилося вирівняти %<PRId64> рядків..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "Вирівняно один рядок"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "Вирівняно рядків: %<PRId64>"
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Регістри перед цим не вживались"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "не вдалося запам'ятати; все одно знищити?"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "Один рядок змінено"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "Змінено рядків: %<PRId64>"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "Звільнено рядків: %<PRId64>"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "Запам'ятав блок з одного рядка"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "Запам'ятав один рядок"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "Запам'ятав блок із %<PRId64> рядків"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "Запам'ятав рядків: %<PRId64>"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: У регістрі %s нічого немає"
 
 # msgstr "E353: "
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4302,9 +4602,11 @@ msgstr ""
 "\n"
 "--- Регістри ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Неправильна назва регістру"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4312,163 +4614,182 @@ msgstr ""
 "\n"
 "# Регістри:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Невідомий тип регістру %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "довж.: %<PRId64>; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> з %<PRId64> байтів"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> of %<PRId64> символів; %<PRId64> з %<PRId64> "
-"байтів"
+"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; "
+"%<PRId64> з %<PRId64> байтів"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; байт %<PRId64> з %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; символ %<PRId64> of %<PRId64>; байт "
-"%<PRId64> з %<PRId64>"
+"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; "
+"%<PRId64> of %<PRId64> символів; %<PRId64> з %<PRId64> байтів"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; "
+"байт %<PRId64> з %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; "
+"символ %<PRId64> of %<PRId64>; байт %<PRId64> з %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> для BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стор. %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Дякуємо за вибір Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Невідома опція"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Опція не підтримується"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Не дозволено у modeline"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Код ключа не встановлено"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Після = потрібно вказати число"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Не знайдено серед можливостей терміналів"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Недозволений символ <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Не вдалося спорожнити 'term'"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Не вдалося змінити term в GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Застосуйте «:gui» для запуску GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: Опції 'backupext' і 'patchmode' однакові"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Конфліктує із значенням 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Конфліктує із значенням 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Не можна змінити в GUI GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Бракує двокрапки"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Рядок порожній"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Після <%s> бракує числа"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Бракує коми"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Потрібно вказати значення '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Містить недруковні або розширені символи"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Некоректний(і) шрифт(и)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Не вдалося вибрати набір шрифтів"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Неправильний набір шрифтів"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Не вдалося використати розширений шрифт"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Некоректний розширений шрифт"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Недозволений символ після <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Потрібна кома"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' має бути порожньою чи містити %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Миша не підтримується"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Послідовність виразів не завершено"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Забагато елементів"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Групи не збалансовано"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Вікно перегляду вже існує"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: Для арабської мови потрібне UTF-8, виконайте ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Потрібно щонайменше %d рядків"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Потрібно щонайменше %d стовпців"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Невідома опція: %s"
@@ -4476,11 +4797,13 @@ msgstr "E355: Невідома опція: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Потрібно вказати Number: &%s = '%s'"
 
 # msgstr "E355: "
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4488,6 +4811,7 @@ msgstr ""
 "\n"
 "--- Коди терміналу ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4495,6 +4819,7 @@ msgstr ""
 "\n"
 "--- Значення загальних опцій ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4502,6 +4827,7 @@ msgstr ""
 "\n"
 "--- Значення локальних опцій ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4509,135 +4835,23 @@ msgstr ""
 "\n"
 "--- Опції ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: Помилка get_varp"
 
 # msgstr "E356: "
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Для символу %s немає пари"
 
 # msgstr "E357: "
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Зайві символи після `;': %s"
 
-# msgstr "E358: "
-msgid "cannot open "
-msgstr "не вдалося відкрити "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Не вдалося відкрити вікно!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Потрібна Amigados 2.04 або пізніша\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Потрібно %s версії %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Не вдалося відкрити NIL:\n"
-
-msgid "Cannot create "
-msgstr "Не вдалося створити "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim завершує роботу з %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "не можу змінити режим консолі ?!\n"
-
-# msgstr "E359: "
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: не консоль??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Не вдалося запустити оболонку з опцією -f"
-
-# msgstr "E360: "
-msgid "Cannot execute "
-msgstr "Не вдалося виконати "
-
-msgid "shell "
-msgstr "оболонку "
-
-msgid " returned\n"
-msgstr " повернуто\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE замалий"
-
-msgid "I/O ERROR"
-msgstr "Помилка вводу/виводу"
-
-msgid "Message"
-msgstr "Повідомлення"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' не 80, не можна виконувати зовнішні команди"
-
-# msgstr "E364: "
-msgid "E237: Printer selection failed"
-msgstr "E237: Не вдалося вибрати принтер"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "на %s з %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Невідомий шрифт принтера: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Помилка друку: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Друкується '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Некоректна назва набору символів «%s» у назві шрифту «%s»"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Помилковий символ %c в назві шрифту «%s»"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "На відкриття дисплею X пішло %<PRId64> мілісекунд"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Помилка X\n"
-
-msgid "Testing the X display failed"
-msgstr "Дисплей Х не пройшов перевірку"
-
-msgid "Opening the X display timed out"
-msgstr "Сплив час очікування відкриття дисплею Х"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Не вдалося отримати контекст безпеки для "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Не вдалося встановити контекст безпеки для "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4645,14 +4859,8 @@ msgstr ""
 "\n"
 "Не вдалося запустити оболонку"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Не вдалося запустити оболонку `sh'\n"
-
 # msgstr "E362: "
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4660,318 +4868,313 @@ msgstr ""
 "\n"
 "оболонка повернула: "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Не можна створити канали\n"
+"Не вдалося отримати контекст безпеки для "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Не вдалося роздвоїтися\n"
+"Не вдалося встановити контекст безпеки для "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Команда закінчила виконання\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP втратив з'єднання ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = «%s»"
 
-msgid "Opening the X display failed"
-msgstr "Не вдалося відкрити дисплей X"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP обробляється запит 'збережи себе'"
-
-msgid "XSMP opening connection"
-msgstr "XSMP відкривається з'єднання"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP спостереження за з'єднанням з ICE не вдалося"
-
+# msgstr "E446: "
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP не вдалося SmcOpenConnection: %s"
-
-msgid "At line"
-msgstr "Рядок:"
-
-msgid "Could not load vim32.dll!"
-msgstr "Не вдалося завантажити vim32.dll"
-
-msgid "VIM Error"
-msgstr "Помилка VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Не вдалося виправити вказівники на функції DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "оболонка повернула %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Виявлено подію %s\n"
-
-msgid "close"
-msgstr "close"
-
-msgid "logoff"
-msgstr "logoff"
-
-msgid "shutdown"
-msgstr "shutdown"
-
-msgid "E371: Command not found"
-msgstr "E371: Команду не знайдено"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"Файл VIMRUN.EXE не знайдено у шляху пошуку.\n"
-"Зовнішні команди не будуть призупинені після виконання.\n"
-"Гляньте  :help win32-vimrun щоб отримати подробиці."
-
-msgid "Vim Warning"
-msgstr "Застереження Vim"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Файл «%s» не знайдено у шляху пошуку"
 
 # msgstr "E371: "
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Забагато %%%c у рядку формату"
 
 # msgstr "E372: "
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Неочікуваний `%%%c' у рядку формату"
 
 # msgstr "E373: "
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Пропущено ] у рядку формату"
 
 # msgstr "E374: "
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c у рядку формату не підтримується"
 
 # msgstr "E375: "
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Помилковий `%%%c' у префіксі рядку формату"
 
 # msgstr "E376: "
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Помилковий `%%%c' у рядку формату"
 
 # msgstr "E377: "
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' не містить зразок"
 
 # msgstr "E378: "
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Пропущена чи порожня назва каталогу"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Немає більше елементів"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d з %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (рядок знищено)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Дно стеку виправлень"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Вершина стеку виправлень"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "список помилок %d з %d; %d помилок"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Не можу записати, вказана опція 'buftype'"
 
-# msgstr "E231: "
-msgid "Error file"
-msgstr "Файл помилок"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Пропущено назву файлу чи некоректний шаблон"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Не вдалося відкрити файл «%s»"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Буфер не завантажено"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Очікується String чи List"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Некоректний елемент у %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Бракує ] після %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Немає пари %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Немає пари %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Немає пари %s)"
 
 # msgstr "E406: "
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( тут не дозволено"
 
 # msgstr "E406: "
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 та ін. тут не дозволено"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Пропущено ] після %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] порожній"
 
 # msgstr "E382: "
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Зразок занадто довгий"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Забагато \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Забагато %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Немає пари \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: Недозволений символ після %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Забагато складних %s{...}"
 
 # msgstr "E339: "
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Вкладені %s*"
 
 # msgstr "E61: "
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Вкладені %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Некоректно вжито \\_"
 
 # msgstr "E62: "
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: Після %s%c нічого немає"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Некоректне зворотнє посилання"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Неправильний символ після \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Недозволений символ після %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Недозволений символ після %s%%"
 
 # msgstr "E64: "
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Синтаксична помилка в %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Зовнішні під-збіги:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
-"E864: після \\%#= може бути тільки 0, 1, or 2. Буде використано автоматичний механізм "
+"E864: після \\%#= може бути тільки 0, 1, or 2. Буде використано автоматичний "
+"механізм "
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) Зарано трапився кінець регулярного виразу"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA regexp) Не на місці %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) Зарано трапився кінець регулярного виразу"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Невідомий оператор '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) Невідомий оператор '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Не вдалося побудувати NFA з класом еквівалентності!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Невідомий оператор '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFA regexp) Не вдалося прочитати межі повторення"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (NFA regexp) Мульти не може бути за мульти!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA regexp) Забагато '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA regexp) Забагато \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA regexp) помилка належного припинення"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Стек порожній!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
@@ -4979,139 +5182,178 @@ msgstr ""
 "E875: (NFA regexp) (Під час перетворення з постфікс у NFA) залишилося "
 "забагато станів у стеку"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA regexp) Недостатньо пам’яті, щоб зберегти весь NFA "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Не вдалося отримати пам’ять для обходу гілок!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
-"Не вдалося відкрити тимчасовий файл журналу для запису, показується на stderr ... "
+"Не вдалося відкрити тимчасовий файл журналу для запису, показується на "
+"stderr ... "
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) НЕ ВДАЛОСЯ ВІДКРИТИ %s!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Не вдалося відкрити тимчасовий файл журналу для запису "
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " ВІРТ ЗАМІНА"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ЗАМІНА"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " НАВИВОРІТ"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " ВСТАВКА"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (вставка)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (заміна)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (вірт заміна)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Іврит"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Арабська"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (мова)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (клей)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ВИБІР"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ВИБІР РЯДКІВ"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ВИБІР БЛОКУ"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ВИДІЛЕННЯ"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ВИДІЛЕННЯ РЯДКІВ"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ВИДІЛЕННЯ БЛОКУ"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "йде запис"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Неправильний зразок для пошуку: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Пошук дійшов до ПОЧАТКУ без збігів з %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Пошук дійшов до КІНЦЯ без збігів з %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Після `;' має бути `?' або `/'"
 
 # msgstr "E386: "
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (разом з попередніми збігами)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Включені файли "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "не знайдено "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "у шляху пошуку ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Уже у списку)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  НЕ ЗНАЙДЕНО"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Пошук у включеному файлі: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Шукається у включеному файлі %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Збіг у поточному рядку"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Були знайдені всі включені файли"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Жодного включеного файлу"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Визначення не знайдено"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Зразок не знайдено"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Заміна "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5122,88 +5364,100 @@ msgstr ""
 "# Ост. %sЗразок пошуку:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Помилка формату у файлі орфографії"
 
 # msgstr "E364: "
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Обірваний файл орфографії"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Зайвий текст у %s у рядку %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Назва афіксу завелика у %s у рядку %d: %s"
 
 # msgstr "E430: "
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Помилка формату у файлі афіксів FOL, LOW чи UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Символ у FOL, LOW чи UPP поза межами"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Стискується дерево слів..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Перевірка орфографії не дозволена"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Застереження: Не вдалося знайти список слів «%s_%s.spl» чи «%s_ascii.spl»"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Застереження: Не вдалося знайти список слів «%s.%s.spl» чи «%s.ascii.spl»"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Читається файл орфографії «%s»"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Не схоже на файл орфографії"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Файл орфографії старий, треба поновити"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Файл орфографії призначений для більш нової версії Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Недозволена секція у файлі орфографії"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Застереження: регіон %s не підтримується"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Читається файл афіксів %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Помилка перетворення слова у %s у рядку %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Перетворення у %s не підтримується: з %s до %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Перетворення у %s не підтримується"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Некоректне значення FLAG у %s у рядку %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG після використання прапорців у %s у рядку %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5212,6 +5466,7 @@ msgstr ""
 "Визначення COMPOUNDFORBIDFLAG після елементу PFX може дати неправильний "
 "результат у %s у рядку %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5220,35 +5475,43 @@ msgstr ""
 "Визначення COMPOUNDPERMITFLAG після елементу PFX можу дати неправильний "
 "результат у %s у рядку %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDRULES у %s у рядку %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDWORDMAX у %s у рядку %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDMIN у %s у рядку %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDSYLMAX у %s у рядку %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Неправильне значення CHECKCOMPOUNDPATTERN у %s у рядку %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Інший прапорець комбінації у продовженні блоку афіксів у %s у рядку %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Подвійний афікс у %s у рядку %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5257,273 +5520,337 @@ msgstr ""
 "Афікс також використовується для BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
 "NOSUGGEST у %s у рядку %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Треба Y чи N у %s у рядку %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Непридатна умова у %s у рядку %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Треба кількість REP(SAL) у %s у рядку %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Треба кількість MAP у %s у рядку %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Повторення символу у MAP у %s у рядку %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Нерозпізнаний чи повторний елемент у %s у рядку %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Пропущено рядок FOL/LOW/UPP у %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "Вжито COMPOUNDSYLMAX без SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Забагато відкладених префіксів"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Забагато складних прапорців"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Забагато відкладених префіксів і/або складних прапорців"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Пропущено рядок SOFO%s у %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Обидва рядки SAL і SOFO у %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Прапорець не є числом у %s у рядку %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Неправильний прапорець у %s у рядку %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Значення %s відрізняється від того, що вжито у іншому файлі .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Зчитується словниковий файл %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Немає кількості слів у %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "рядок %6d, слово %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Повторення слова у %s у рядку %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Перше повторення слова у %s у рядку %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d повторюваних слів у %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Пропущено %d слів(~) із не-ASCII символами у %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Читається файл слів %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Повторення рядка /encoding= проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Рядок /encoding= після слова проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Повторення рядка /regions= проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Забагато регіонів у %s у рядку %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Рядок / проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Некоректний номер регіону у %s у рядку %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Нерозпізнані прапорці у %s у рядку %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Проігноровано %d слів із не-ASCII символами"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Недостатньо пам’яті, список слів буде неповним"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Стиснено %d з %d вузлів; залишилося %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Перечитується файл орфографії..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Виконується згортання звуків..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Кількість слів після згортання звуків: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Повна кількість слів: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Записується файл припущень %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Оцінка споживання пам'яті: %d байт"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Вихідний файл не повинен мати назву регіону"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Підтримується тільки до восьми регіонів"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Некоректний регіон у %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Застереження: зазначено обидва `складні слова' і NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Записується файл орфографії %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Зроблено!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' не містить %<PRId64> елементів"
 
+#: ../spell.c:8074
 #, c-format
 msgid "Word '%.*s' removed from %s"
 msgstr "Слово '%.*s' знищено з %s"
 
+#: ../spell.c:8117
 #, c-format
 msgid "Word '%.*s' added to %s"
 msgstr "Слово '%.*s' додано до %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Символи у слові відрізняються у файлах орфографії"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Пробачте, немає пропозицій"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Пробачте, тільки %<PRId64> пропозицій"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Замінити «%.*s» на:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < «%.*s»"
 
 # msgstr "E34: "
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Немає попередньої заміни"
 
 # msgstr "E333: "
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Не знайдено: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Не схоже на файл .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Застарілий файл .sug, треба поновити: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Файл .sug для більш нової версії Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Файл .sug не відповідає файлу .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Помилка читання файлу .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Повторено символ у елементі MAP"
 
 # msgstr "E391: "
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Для буфера не визначено елементів синтаксису"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Неправильний аргумент: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Немає такого синтаксичного кластера: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "синхронізується по коментарях стилю С"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "без синхронізації"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "починається синхронізація за "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " рядків перед першим рядком"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5531,6 +5858,7 @@ msgstr ""
 "\n"
 "--- Елементи синхронізації синтаксису ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5538,6 +5866,7 @@ msgstr ""
 "\n"
 "синхронізація по елементах"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5545,240 +5874,300 @@ msgstr ""
 "\n"
 "--- Елементи синтаксису ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Немає такого синтаксичного кластера: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "мінімальний "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "максимальний "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; збіг "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " розриви рядків"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: Містить неприйнятні тут аргументи"
 
 # msgstr "E14: "
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Некоректне значення cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]hete тут неприйнятний"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Не знайдено елемент регіону для %s"
 
 # msgstr "E396: "
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Потрібна назва файлу"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Забагато синтаксичних включень"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Пропущено ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Пропущено `=': %s"
 
 # ---------------------------------------
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Бракує аргументів: синтаксичний регіон %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Забагато синтаксичних кластерів"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Кластер не вказано"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Кінець зразку не знайдено: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Сміття після зразку: %s"
 
 # msgstr "E402: "
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: Синтаксична синхронізація: зразок для продовження рядка вказано двічі"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Неправильні аргументи: %s"
 
 # msgstr "E404: "
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Пропущено знак рівності: %s"
 
 # msgstr "E405: "
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Порожній аргумент: %s"
 
 # msgstr "E406: "
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s тут не дозволено"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s має бути першим рядком у списку contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Невідома назва групи: %s"
 
 # msgstr "E409: "
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Неправильна підкоманда :syntax: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  ВСЬОГО     К-ТЬ   СПІВП.  НАЙПОВІЛ.   СЕРЕДН.   НАЗВА              ШАБЛОН"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Рекурсивний цикл читання syncolor.vim"
 
 # msgstr "E410: "
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Групу підсвічування не знайдено: %s"
 
 # msgstr "E411: "
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Недостатньо аргументів: «:highlight link %s»"
 
 # msgstr "E412: "
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Забагато аргументів: «:highlight link %s»"
 
 # msgstr "E413: "
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Грума має settings, highlight link проігноровано"
 
 # msgstr "E414: "
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Несподіваний знак рівності: %s"
 
 # msgstr "E415: "
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Пропущено знак рівності: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Пропущено аргумент: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Неправильне значення: %s"
 
 # msgstr "E418: "
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Невідомий колір тексту"
 
 # msgstr "E419: "
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Невідомий колір фону"
 
 # msgstr "E420: "
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Нерозпізнана назва або номер кольору: %s"
 
 # msgstr "E421: "
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Занадто довгий код терміналу: %s"
 
 # msgstr "E422: "
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Неправильний аргумент: %s"
 
 # msgstr "E423: "
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Використано забагато різних атрибутів кольору"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Недруковний символ у назві групи"
 
 # msgstr "E181: "
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Некоректний символ у назві групи"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Забагато груп підсвічування і синтаксису"
 
 # msgstr "E424: "
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: Кінець стеку теґів"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: Вершина стеку теґів"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Це вже найперший відповідний теґ"
 
 # msgstr "E425: "
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Теґ не знайдено: %s"
 
 # msgstr "E426: "
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # прі тип теґ"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "файл\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Лише один відповідний теґ"
 
 # msgstr "E427: "
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Це вже останній відповідний теґ"
 
 # msgstr "E428: "
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Файл «%s» не існує"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "теґ %d з %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " або більше"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Використано теґ, не розрізняючи великі й малі літери"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Файл «%s» не існує"
 
 # msgstr "E429: "
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5786,72 +6175,85 @@ msgstr ""
 "\n"
 "  # ДО теґу        З рядка  у файлі/тексті"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Шукається у файлі теґів %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Шлях файлу теґів скорочено до %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ігнорується довгий рядок у файлі з позначками"
 
 # msgstr "E430: "
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Помилка формату у файлі теґів «%s»"
 
 # msgstr "E431: "
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Перед байтом %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Файл теґів не впорядкований: %s"
 
 # msgstr "E432: "
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Немає файлу теґів"
 
 # msgstr "E433: "
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Не вдалося знайти зразок теґу"
 
 # msgstr "E434: "
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Не вдалося знайти теґ, тільки припущення!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Назва поля повторюється: %s"
 
 # msgstr "E435: "
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' не відомий. Вбудовані термінали:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "початково '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Не вдалося відкрити файл можливостей терміналів"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Немає інформації про термінал"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Немає інформації про можливості терміналу"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Немає запису «%s» про можливості терміналу"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Потрібна можливість терміналу «cm»"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5859,252 +6261,174 @@ msgstr ""
 "\n"
 "--- Клавіші терміналу ---"
 
-msgid "new shell started\n"
-msgstr "запущено нову оболонку\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Помилка читання вводу, робота завершується...\n"
 
-# msgstr "E242: "
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Використано CUT_BUFFER0 замість порожнього виділення"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Кількість рядків несподівано змінилася"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Скасування буде неможливе, все одно продовжити"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Не вдалося відкрити файл історії для запису: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Файл історії пошкоджено (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Не вдалося записати файл історії у жодну з директорій у 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Will not overwrite with undo file, cannot read: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Не можна перезаписати, це не файл історії: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Файл історії не записується, нічого повертати"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Записується файл історії: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Помилка запису у файлі історії: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Файл історії прочитано не буде, власник інший: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Читається файл історії: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Не вдалося відкрити файл для читання: %s"
 
 # msgstr "E333: "
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Не файл історії: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Незашифрований файл має зашифрований файл історії: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Не вдалося розшифрувати файл історії: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Файл історії зашифрований: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Несумісний файл історії: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Вміст файлу змінився, не можна використати інформацію про історію"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Закінчено читання файлу історії %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Вже на найстаршій зміні"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Вже на найновішій зміні"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Зміну %<PRId64> не знайдено в історії"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильні номери рядків"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "додано рядок"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "рядків додано"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "знищено рядок"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "рядків знищено"
 
 # msgstr "E438: "
+#: ../undo.c:2193
 msgid "change"
 msgstr "зміна"
 
 # msgstr "E438: "
+#: ../undo.c:2195
 msgid "changes"
 msgstr "змін"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "перед"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "після"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Немає нічого скасовувати"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "номер  зміни    час             збережено"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> секунд тому"
 
 # msgstr "E406: "
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: Не можна виконати undojoin після undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: Список скасування пошкоджено"
 
 # msgstr "E439: "
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Відсутній рядок скасування"
 
-# msgstr "E440: "
-# ---------------------------------------
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Версія з GUI для 16/32-розрядної Windows"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Версія з GUI для 64-розрядної MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Версія з GUI для 32-розрядної Windows"
-
-msgid " in Win32s mode"
-msgstr " в режимі Win32s"
-
-msgid " with OLE support"
-msgstr " з підтримкою OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Консольна версія для 64-розрядної Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Консольна версія для 32-розрядної Windows"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Версія для 16-розрядної Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версія для 32-розрядної MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версія для 16-розрядної MS-DOS"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Версія для MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Версія для MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Версія для MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Версія для OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -6112,6 +6436,7 @@ msgstr ""
 "\n"
 "Включені латки: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -6119,9 +6444,11 @@ msgstr ""
 "\n"
 "Додаткові латки: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Змінив "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -6129,9 +6456,11 @@ msgstr ""
 "\n"
 "Скомпілював "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6139,889 +6468,1921 @@ msgstr ""
 "\n"
 "Гігантська версія "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Велика версія "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Нормальна версія "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Мала версія "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Крихітна версія "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "без GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "з GUI GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "з GUI GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "з GUI X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "з GUI X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "з GUI X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "з GUI Photon."
-
-msgid "with GUI."
-msgstr "з GUI."
-
-msgid "with Carbon GUI."
-msgstr "з GUI Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "з GUI Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "з (класичним) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Включені (+) або не включені (-) компоненти:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   системний vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     vimrc користувача: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " другий vimrc користувача: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " третій vimrc користувача: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      exrc користувача: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  другий exrc користувача: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  системний gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    gvimrc користувача: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "другий gvimrc користувача: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "третій gvimrc користувача: \""
-
-msgid "    system menu file: \""
-msgstr "    системне меню: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  заміна для $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " заміна для $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Скомпільовано: "
 
-msgid "Compiler: "
-msgstr "Компілятор: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Скомпоновано: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  ВЕРСІЯ ДЛЯ НАЛАГОДЖЕННЯ"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Покращений Vi"
 
+#: ../version.c:769
 msgid "version "
 msgstr "версія "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "автор: Bram Moolenaar та ін."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim — це відкрита й вільно розповсюджувана програма"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Допоможіть сиротам з Уганди!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr ":help iccf<Enter>         подробиці                "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr ":q<Enter>                 вихід з Vim              "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr ":help<Enter> або <F1>     перегляд допомоги        "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr ":help version7<Enter>     інформація про версію    "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Ви працюєте в режимі сумісному з Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr ":set nocp<Enter>          режим несумісний з Vi    "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr ":help cp-default<Enter>   інформація про сумісність"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "меню  Help->Orphans       подальша інформація      "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Без режимів, текст що набрано вставляється"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "меню  Edit->Global Settings->Toggle Insert Mode    "
-
-msgid "                              for two modes      "
-msgstr "                          для двох режимів         "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "меню  Edit->Global Settings->Toggle Vi Compatible  "
-
-msgid "                              for Vim defaults   "
-msgstr "              щоб починати в режимі сумісності з Vi"
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Підтримайте розробку редактора Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Станьте зареєстрованим користувачем Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr ":help sponsor<Enter>      подальша інформація      "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr ":help register<Enter>     подальша інформація      "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "меню  Допомога->Спонсор/Реєстрація  подробиці      "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ЗАСТЕРЕЖЕННЯ: Ви користуєтеся Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr ":help windows95<Enter>    інформація про це        "
-
 # msgstr "E444: "
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Це вже єдине вікно"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Немає вікна перегляду"
 
 # msgstr "E441: "
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Не вдалося одночасно розбити topleft і botright"
 
 # msgstr "E442: "
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Не вдалося перемістити вікно, заважають інші"
 
 # msgstr "E443: "
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Не вдалося закрити останнє вікно"
 
 # msgstr "E443: "
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Не вдалося закрити вікно autocmd"
 
 # msgstr "E443: "
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Не вдалося закрити вікно, залишилося б тільки вікно autocmd"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: У іншому вікні є зміни"
 
 # msgstr "E445: "
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Немає назви файлу над курсором"
 
-# msgstr "E446: "
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Файл «%s» не знайдено у шляху пошуку"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: Викликано bf_key_init() з порожнім паролем"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Не вдалося завантажити бібліотеку %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Вибачте, ця команда вимкнена, бібліотека Perl не може бути завантажена."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Неправильне використання порядку байтів Blowfish (BE/LE)"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Обчислення виразів Perl заборонене у пісочниці без модуля Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: Не пройшла перевірка sha256"
 
-msgid "Edit with &multiple Vims"
-msgstr "Редагувати у (&m)різних Vim"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Не пройшла перевірка Blowfish"
 
-msgid "Edit with single &Vim"
-msgstr "Редагувати у одному &Vim"
+#~ msgid "Patch file"
+#~ msgstr "Латка"
 
-msgid "Diff with Vim"
-msgstr "Порівняти з допомогою Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&O:Гаразд\n"
+#~ "&C:Скасувати"
 
-msgid "Edit with &Vim"
-msgstr "Редагувати за допомогою &Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Немає з'єднання із сервером Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Редагувати у вже запущеному Vim - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Не вдалося відіслати до %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Редагує вибрані файли з допомогою Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Не вдалося прочитати відповідь сервера"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Помилка створення процесу, перевірте чи є gvim у шляху пошуку!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Не вдалося надіслати клієнту"
 
-msgid "gvimext.dll error"
-msgstr "помилка gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Зберегти як"
 
-msgid "Path length too long!"
-msgstr "Шлях занадто довгий!"
+#~ msgid "Source Vim script"
+#~ msgstr "Прочитати скрипт Vim"
 
-# msgstr "E447: "
-msgid "--No lines in buffer--"
-msgstr "--Жодного рядка--"
+#~ msgid "Edit File"
+#~ msgstr "Редагувати Файл"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Команду перервано"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (НЕ ЗНАЙДЕНО)"
 
-msgid "E471: Argument required"
-msgstr "E471: Необхідно вказати аргумент"
+#~ msgid "unknown"
+#~ msgstr "Невідомо"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: За \\ має йти /, ? або &"
+# msgstr "E185: "
+#~ msgid "Edit File in new window"
+#~ msgstr "Редагувати файл у новому вікні"
 
-# msgstr "E10: "
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Неприпустимо у вікні команд, <CR> виконує, CTRL-C виходить"
+#~ msgid "Append File"
+#~ msgstr "Дописати файл"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Команда не дозволена у exrc/vimrc у пошуку поточного каталогу чи теґу"
+# msgstr "E187: "
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Позиція вікна: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Бракує :endif"
+# msgstr "E188: "
+#~ msgid "Save Redirection"
+#~ msgstr "Зберегти переадресований вивід"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Бракує :endtry"
+#~ msgid "Save View"
+#~ msgstr "Зберегти вигляд"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Бракує :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Зберегти сеанс"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Бракує :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Зберегти налаштування"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile без :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< не доступна без можливості +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor без :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: У цій версії немає диграфів"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Файл існує (! щоб не зважати)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "є пристроєм (вимкнено опцією 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Команда на вдалась"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Читається з stdin..."
+
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[зашифровано]"
+
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Файл зашифровано невідомим методом"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans не дозволяє записувати у незмінені буфери"
+
+# msgstr "E391: "
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Часткові записи заборонені для буферів NetBeans"
+
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "Запис до пристрою заборонено опцією 'opendevice'"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Гілку ресурсів можна втратити (! щоб не зважати)"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<не відкривається> "
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: не вдалося отримати шрифт %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: не вдалося повернутися в поточний каталог"
+
+#~ msgid "Pathname:"
+#~ msgstr "Шлях:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: не вдалося отримати поточний каталог"
+
+#~ msgid "OK"
+#~ msgstr "Гаразд"
+
+#~ msgid "Cancel"
+#~ msgstr "Скасувати"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Діалог Vim"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Scrollbar Widget: Не вдалося визначити розмір скороченої картинки."
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Не вдалося створити BalloonEval з повідомленням і функцією"
+
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Не вдалося створити новий процес для GUI"
+
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Дочірній процес не зміг запустити GUI"
+
+# msgstr "E228: "
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Не вдалося запустити GUI"
+
+# msgstr "E229: "
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Не вдалося прочитати з «%s»"
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Не вдалося запустити GUI, не знайдено шрифт"
+
+# msgstr "E230: "
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Некоректний 'guifontwide'"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Значення 'imactivatekey' некоректне"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Не вдалося отримати колір %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Немає над курсором, пошук триває"
+
+#~ msgid "Input _Methods"
+#~ msgstr "Методи введення"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Знайти й замінити..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Пошук..."
+
+#~ msgid "Find what:"
+#~ msgstr "Знайти:"
+
+#~ msgid "Replace with:"
+#~ msgstr "Замінити на:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "Лише повне слово"
+
+#~ msgid "Match case"
+#~ msgstr "Зважати на регістр"
+
+#~ msgid "Direction"
+#~ msgstr "Напрям"
+
+#~ msgid "Up"
+#~ msgstr "Вгору"
+
+#~ msgid "Down"
+#~ msgstr "Униз"
+
+#~ msgid "Find Next"
+#~ msgstr "Наступне"
+
+#~ msgid "Replace"
+#~ msgstr "Замінити"
+
+#~ msgid "Replace All"
+#~ msgstr "Замінити усі"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Отримав запит «die» від менеджера сесій\n"
+
+#~ msgid "Close"
+#~ msgstr "Закрити"
+
+#~ msgid "New tab"
+#~ msgstr "Нова вкладка"
+
+#~ msgid "Open Tab..."
+#~ msgstr "Відкрити вкладку..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Несподівано знищилося головне вікно\n"
+
+#~ msgid "&Filter"
+#~ msgstr "&F:Фільтрувати"
+
+#~ msgid "&Cancel"
+#~ msgstr "&C:Скасувати"
+
+#~ msgid "Directories"
+#~ msgstr "Каталоги"
+
+#~ msgid "Filter"
+#~ msgstr "Фільтр"
+
+#~ msgid "&Help"
+#~ msgstr "&H:Допомога"
+
+#~ msgid "Files"
+#~ msgstr "Файли"
+
+#~ msgid "&OK"
+#~ msgstr "&O:Гаразд"
+
+#~ msgid "Selection"
+#~ msgstr "Виділення"
+
+#~ msgid "Find &Next"
+#~ msgstr "&N:Знайти далі"
+
+#~ msgid "&Replace"
+#~ msgstr "&R:Замінити"
+
+#~ msgid "Replace &All"
+#~ msgstr "&A:Замінити усі"
+
+#~ msgid "&Undo"
+#~ msgstr "&U:Скасувати"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Не вдалося знайти вікно «%s»"
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Аргумент не підтримується: «-%s»; користуйтесь версією з OLE."
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Не вдалося відкрити вікно всередині програми MDI"
+
+#~ msgid "Close tab"
+#~ msgstr "Закрити вкладку"
+
+#~ msgid "Open tab..."
+#~ msgstr "Відкрити вкладку..."
+
+# msgstr "E245: "
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Знайти рядок ('\\\\' щоб знайти '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Знайти і замінити ('\\\\' щоб знайти '\\')"
+
+#~ msgid "Not Used"
+#~ msgstr "Немає"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Каталог\t*.нічого\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Немає вільних комірок у палітрі, деякі кольори можуть бути "
+#~ "неправильні"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Шрифти для цих символів відсутні у наборі %s:"
+
+# msgstr "E250: "
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Назва набору шрифтів: %s"
+
+# msgstr "E252: "
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Шрифт '%s' не є моноширинним"
+
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Назва набору шрифтів: %s"
+
+#~ msgid "Font0: %s"
+#~ msgstr "Шрифт0: %s"
+
+#~ msgid "Font1: %s"
+#~ msgstr "Шрифт1: %s"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "Ширина шрифту%<PRId64> не більша удвічі за ширину шрифту0"
+
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Ширина шрифту0: %<PRId64>"
+
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Ширина шрифту1: %<PRId64>"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "Некоректна специфікація шрифту"
+
+#~ msgid "&Dismiss"
+#~ msgstr "&D:Припинити"
+
+#~ msgid "no specific match"
+#~ msgstr "немає конкретного збігу"
+
+# msgstr "E234: "
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Вибір шрифту"
+
+#~ msgid "Name:"
+#~ msgstr "Назва:"
+
+#~ msgid "Show size in Points"
+#~ msgstr "Показати розмір у пунктах"
+
+#~ msgid "Encoding:"
+#~ msgstr "Кодування:"
+
+#~ msgid "Font:"
+#~ msgstr "Шрифт:"
+
+#~ msgid "Style:"
+#~ msgstr "Стиль:"
+
+#~ msgid "Size:"
+#~ msgstr "Розмір:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Помилка автомату Hangul"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: помилка stat"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Не вдалося відкрити базу даних cscope: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Не вдалося отримати інформацію з бази даних cscope"
+
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Не вдалося завантажити бібліотеку Lua"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "не вдалося зберегти інформацію для скасування"
+
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Вибачте, ця команда вимкнена, бібліотеки MzScheme не можуть бути "
+#~ "завантажені."
+
+#~ msgid "invalid expression"
+#~ msgstr "некоректний вираз"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "обробку виразів вимкнено під час компіляції"
+
+#~ msgid "hidden option"
+#~ msgstr "прихована опція"
+
+#~ msgid "unknown option"
+#~ msgstr "невідома опція"
+
+#~ msgid "window index is out of range"
+#~ msgstr "некоректний номер вікна"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "не вдалося відкрити буфер"
+
+#~ msgid "cannot delete line"
+#~ msgstr "неможливо знищити рядок"
+
+#~ msgid "cannot replace line"
+#~ msgstr "неможливо замінити рядок"
+
+#~ msgid "cannot insert line"
+#~ msgstr "не вдалося вставити рядок"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "більше ніж один рядок"
+
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "не вдалося перетворити значення Scheme у Vim"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Помилка Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Помилка Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "буфер непридатний"
+
+#~ msgid "window is invalid"
+#~ msgstr "вікно непридатне"
+
+#~ msgid "linenr out of range"
+#~ msgstr "номер рядка за межами файлу"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "не дозволено у пісочниці Vim"
+
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Python: Не можна використати :py і :py3 в одному сеансі"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Вибачте, ця команда вимкнена, бібліотека Python не може бути "
+#~ "завантажена."
+
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Python: Не можна використати :py і :py3 в одному сеансі"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Не можна рекурсивно викликати Python"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ має бути екземпляром String"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Вибачте, ця команда вимкнена, бібліотека Ruby не може бути "
+#~ "завантажена."
+
+# msgstr "E414: "
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: несподіваний return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: несподіваний next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: несподіваний break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: несподіваний redo"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry поза rescue"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Необроблений виняток"
 
 # msgstr "E233: "
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Невідомий набір шрифтів: %s"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Невідомий статус longjmp: %d"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Невідомий шрифт: %s"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Перемкнути реалізацію/визначення"
 
-# msgstr "E235: "
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Шрифт «%s» не моноширинний"
+#~ msgid "Show base class of"
+#~ msgstr "Знайти базовий клас"
 
-msgid "E473: Internal error"
-msgstr "E473: Внутрішня помилка"
+#~ msgid "Show overridden member function"
+#~ msgstr "Показати замінені функції-члени"
 
-msgid "Interrupted"
-msgstr "Перервано"
+#~ msgid "Retrieve from file"
+#~ msgstr "Прочитати з файлу"
 
-msgid "E14: Invalid address"
-msgstr "E14: Неправильна адреса"
+#~ msgid "Retrieve from project"
+#~ msgstr "Отримати з проекту"
 
-# msgstr "E14: "
-msgid "E474: Invalid argument"
-msgstr "E474: Некоректний аргумент"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Отримати з усіх проектів"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Некоректний аргумент: %s"
+#~ msgid "Retrieve"
+#~ msgstr "Отримати"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Неправильний вираз: %s"
+#~ msgid "Show source of"
+#~ msgstr "Джерело"
 
-# msgstr "E15: "
-msgid "E16: Invalid range"
-msgstr "E16: Неправильні межі"
+#~ msgid "Find symbol"
+#~ msgstr "Знайти символ"
 
-# msgstr "E16: "
-msgid "E476: Invalid command"
-msgstr "E476: Некоректна команда"
+#~ msgid "Browse class"
+#~ msgstr "Переглянути клас"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: «%s» — це каталог"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Показати клас в ієрархії"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Бібліотечний виклик до «%s()» не вдався"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Показати клас в обмеженій ієрархії"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Не вдалося завантажити бібліотечну функцію %s"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref вказує на"
 
-# msgstr "E18: "
-msgid "E19: Mark has invalid line number"
-msgstr "E19: У помітки некоректний номер рядка"
+#~ msgid "Xref referred by"
+#~ msgstr "На Xref вказано з"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref має"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref використано"
+
+#~ msgid "Show docu of"
+#~ msgstr "Показати docu"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Створити docu для"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Не вдалося з'єднатися зі SNiFF+. Перевірте оточення (sniffemacs має бути "
+#~ "у $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Помилка під час читання. Від'єднано"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ зараз "
+
+#~ msgid "not "
+#~ msgstr "не "
+
+#~ msgid "connected"
+#~ msgstr "під'єднаний"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Невідомий запит до SNiFF+: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Помилка з'єднання до SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ не під'єднано"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Не є буфером SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Помилка запису. Від'єднано"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "неправильна назва буфера"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ще не реалізовано"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "не вдалося встановити рядки"
+
+#~ msgid "invalid mark name"
+#~ msgstr "неправильна назва позначки"
 
 # msgstr "E19: "
-msgid "E20: Mark not set"
-msgstr "E20: Помітку не встановлено"
+#~ msgid "mark not set"
+#~ msgstr "помітку не вказано"
 
-# msgstr "E20: "
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Зміни не дозволені: вимкнено 'modifiable'"
+#~ msgid "row %d column %d"
+#~ msgstr "рядок %d колонка %d"
 
-# msgstr "E21: "
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Забагато вкладених скриптів"
+#~ msgid "cannot insert/append line"
+#~ msgstr "Не вдалося вставити/додати рядок"
 
-# msgstr "E22: "
-msgid "E23: No alternate file"
-msgstr "E23: Немає вторинного файлу"
+#~ msgid "line number out of range"
+#~ msgstr "номер рядка за межами файлу"
 
-# msgstr "E23: "
-msgid "E24: No such abbreviation"
-msgstr "E24: Такого скорочення немає"
+#~ msgid "unknown flag: "
+#~ msgstr "невідомий прапорець: "
 
-# msgstr "E24: "
-msgid "E477: No ! allowed"
-msgstr "E477: ! не дозволено"
+#~ msgid "unknown vimOption"
+#~ msgstr "Невідома vimOption"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Не можна використати GUI: Не ввімкнено під час компіляції"
+#~ msgid "keyboard interrupt"
+#~ msgstr "перервано з клавіатури"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Не можна використати іврит: Не ввімкнено під час компіляції\n"
+#~ msgid "vim error"
+#~ msgstr "помилка Vim"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Не можна використати фарсі: Не ввімкнено під час компіляції\n"
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "не вдалося створити команду вікна/буфера: об'єкт знищується"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E800: Не можна використати арабську мову: Не ввімкнено під час компіляції\n"
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "Не вдалося зареєструвати подію: буфер/вікно уже знищується"
 
-# msgstr "E25: "
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Немає такої групи підсвічування: %s"
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ФАТАЛЬНА ПОМИЛКА TCL: можливо пошкоджено список посилань!? Будь "
+#~ "ласка, повідомте у vim-dev@vim.org"
 
-# msgstr "E28: "
-msgid "E29: No inserted text yet"
-msgstr "E29: Текст ще не було додано"
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "Не вдалося зареєструвати команду події: посилання на буфер/вікно не "
+#~ "знайдено"
 
-# msgstr "E29: "
-msgid "E30: No previous command line"
-msgstr "E30: Ще не було команд"
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Вибачте, ця команда вимкнена, бібліотека Tcl не може бути "
+#~ "завантажена."
 
-# msgstr "E30: "
-msgid "E31: No such mapping"
-msgstr "E31: Немає такої заміни"
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Код виходу %d"
 
-# msgstr "E31: "
-msgid "E479: No match"
-msgstr "E479: Жодного збігу"
+#~ msgid "cannot get line"
+#~ msgstr "не вдалося дістати рядок"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Жодного збігу: %s"
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Не вдалося зареєструвати назву сервера команд"
 
-msgid "E32: No file name"
-msgstr "E32: Бракує назви файлу"
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Не вдалося відіслати команду до програми-цілі"
 
-# msgstr "E32: "
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Заміна зразків ще не використовувалась"
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Використано некоректний ідентифікатор сервера: %s"
 
-# msgstr "E33: "
-msgid "E34: No previous command"
-msgstr "E34: Команд ще не було"
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Реквізит реєстру зразку VIM сформований неправильно.  Знищено!"
 
-# msgstr "E34: "
-msgid "E35: No previous regular expression"
-msgstr "E35: Зразків пошуку ще не було"
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans не підтримується з цим GUI\n"
 
-# msgstr "E35: "
-msgid "E481: No range allowed"
-msgstr "E481: Не дозволено вказувати межі"
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Ця версія Vim не була скомпільована з підтримкою порівняння."
 
-msgid "E36: Not enough room"
-msgstr "E36: Місця не вистачить"
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "Не можна використати '-nb': не дозволено під час компіляції\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Помилка: Не вдалося запустити gvim для NetBeans\n"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Немає зареєстрованих серверів з назвою «%s»"
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Якщо регістр ігнорується, додайте / спереду щоб прапорець був у верхньому "
+#~ "регістрі."
 
-# msgstr "E36: "
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Не вдалося створити файл %s"
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tЗареєструвати цей gvim для OLE"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Не вдалося сформувати назву тимчасового файлу"
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tСкасувати реєстрацію цього gvim для OLE"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Не вдалося відкрити файл %s"
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tЗапустити GUI (ніби «gvim»)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  чи  --nofork\tПередній план: тримати термінал після запуску GUI"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Не вдалося прочитати файл %s"
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tНе використовувати newcli для відкриття вікна"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <пристрій>\t\t\tВикористовувати <пристрій> для вводу/виводу"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-u <gvimrc>\t\tВикористати поданий файл замість .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tРедагувати зашифровані файли"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <дисплей>\tПід'єднати vim до заданого дисплею сервера X"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tНе з'єднуватися з X сервером"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <файли>\tРедагувати <файли> на сервері Vim, якщо це можливо"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <файли>  Те саме, тільки не скаржитися на відсутність "
+#~ "сервера"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <файли>   ..., але зачекати поки усі файли будуть "
+#~ "відредаговані"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <файли>  Те саме, тільки не скаржитися, якщо сервера "
+#~ "немає"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <файли>  Так само, як --remote, але по "
+#~ "вкладці на файл"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <символи> Відіслати <символи> серверу і завершити роботу"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <вираз> Виконати <вираз> у сервері Vim і надрукувати "
+#~ "результат"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Зміни не було записано (! щоб не зважати)"
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr ""
+#~ "--serverlist\t\tПоказати список наявних серверів Vim і завершити роботу"
 
-msgid "E38: Null argument"
-msgstr "E38: Відсутній аргумент"
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <назва>\tНадіслати до/стати Vim сервером з <назвою>"
 
-msgid "E39: Number expected"
-msgstr "E39: Очікується число"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи для gvim (версія Motif)\n"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Не вдалося відкрити файл помилок %s"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи для gvim (версія neXtaw):\n"
 
-msgid "E233: cannot open display"
-msgstr "E233: Не вдалося відкрити дисплей"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи для gvim (версія Athena)\n"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Забракло пам'яті!"
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <дисплей>\tВиконати vim на заданому <дисплеї>"
 
-msgid "Pattern not found"
-msgstr "Зразок не знайдено"
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tЗапустити Vim і згорнути його вікно"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Зразок не знайдено: %s"
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <колір>\tВикористати <колір> для фону (також: -bg)"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Аргумент має бути додатний"
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <колір>\tВикористати <колір> для звичайного тексту (також: -"
+#~ "fg)"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Не вдалося перейти до попереднього каталогу"
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <шрифт>\tВикористати <шрифт> для звичайного тексту (також: -fn)"
 
-msgid "E42: No Errors"
-msgstr "E42: Жодної помилки"
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <шрифт>\tВикористати <шрифт> для жирного тексту"
 
-msgid "E776: No location list"
-msgstr "E776: Немає списку місць"
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <шрифт>\tВикористати <шрифт> для похилого тексту"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Текст збігу пошкоджено"
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <геом>\tЗадати розміри й положення (також: -geom)"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Зіпсована програма регулярних виразів"
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <товщ>\tВстановити товщину меж <товщ> (також: -bw)"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Встановлено опцію 'readonly' (! щоб не зважати)"
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <товщ>  Встановити товщину лінійки зсуву (також: -sw)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Змінна тільки для читання: «%s»"
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <висота>\tВстановити висоту меню <висота> (також: -mh)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Не можна встановити змінну у пісочниці: «%s»"
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tОбернути кольори (також: -rv)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Помилка читання файлу помилок"
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tНе обертати кольори (також: +rv)"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: На дозволено у пісочниці"
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ресурс>\t\tВстановити зазначений ресурс"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Не дозволено тут"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи gvim (версія GTK+)\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <дисплей>\tВиконати vim на <дисплеї> (також: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <роль>\tВстановити унікальну роль для ідентифікації головного вікна"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tВідкрити Vim в іншому елементі інтерфейсу GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tХай gvim надрукує ідентифікатор вікна на stdout"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <заголовок батька>\tВідкрити Vim всередині батьківського вікна"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tВідкрити Vim всередині іншого елементу win32"
+
+#~ msgid "No display"
+#~ msgstr "Немає дисплею"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Режим екрану не підтримується"
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Не вдалося відіслати.\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Некоректний розмір зсуву"
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Не вдалося відіслати. Спроба виконати на місці\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Опція 'shell' порожня"
+#~ msgid "%d of %d edited"
+#~ msgstr "відредаговано %d з %d"
 
-# msgstr "E254: "
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Не можна зчитати дані напису!"
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Немає дисплею: Відіслати вираз не вдалося.\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Помилка під час закриття файлу обміну"
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Відіслати вираз не вдалося.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Некоректна кодова сторінка"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Не вдалося встановити значення контексту вводу"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Не вдалося створити контекст вводу"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Не вдалося створити метод вводу"
+
+# msgstr "E286: "
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Застереження: Не вдалося встановити в методі вводу подію знищення"
+
+# msgstr "E287: "
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Метод вводу не підтримує стилі"
 
-msgid "E73: tag stack empty"
-msgstr "E73: Стек теґів порожній"
+# msgstr "E288: "
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: Метод вводу не підтримує відредаговані типи"
 
-msgid "E74: Command too complex"
-msgstr "E74: Занадто складна команда"
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Помилка поновлення шифрування файлу обміну"
 
-msgid "E75: Name too long"
-msgstr "E75: Задовге ім'я"
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s зашифровано, а ця версія Vim не підтримує шифрування"
 
-msgid "E76: Too many ["
-msgstr "E76: Забагато '['"
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Файл обміну зашифрований: «%s»"
 
-msgid "E77: Too many file names"
-msgstr "E77: Забагато назв файлів"
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Якщо ви задали новий ключ шифру, але не записали текстовий файл,"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Надлишкові символи"
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "введіть новий ключ шифру."
 
-msgid "E78: Unknown mark"
-msgstr "E78: Невідома помітка"
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Якщо ви записали текстовий файл після зміни ключа шифру, натисніть enter"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Не вдалося розкрити шаблон"
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "щоб використати однаковий ключ для текстового файлу та файлу обміну"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' не може бути меншим за 'winminheight'"
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "Для текстового файлу використовується ключ шифру з файлу обміну.\n"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' не може бути меншим за 'winminwidth'"
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [не придатний для цієї версії Vim]"
 
-# msgstr "E79: "
-msgid "E80: Error while writing"
-msgstr "E80: Помилка під час запису"
+#~ msgid "Tear off this menu"
+#~ msgstr "Відірвати це меню"
 
-msgid "Zero count"
-msgstr "Нульова кількість"
+#~ msgid "Select Directory dialog"
+#~ msgstr "Вибрати каталог"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> використовується не в контексті скрипту"
+#~ msgid "Save File dialog"
+#~ msgstr "Запам'ятати файл"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Отримано некоректний вираз"
+#~ msgid "Open File dialog"
+#~ msgstr "Відкрити файл"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Не можна змінити захищений регіон"
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Вибачте, але в консолі немає діалогу вибору файлу"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans не дозволяє змінювати захищені від запису файли"
+#~ msgid "ERROR: "
+#~ msgstr "ПОМИЛКА: "
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Внутрішня помилка: %s"
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[байт]  всього розм/знищ. %<PRIu64>/%<PRIu64>, викор. %<PRIu64>, макс. "
+#~ "%<PRIu64>\n"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Зразок використовує більше, ніж 'maxmempattern', пам'яті"
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[виклики] усього re/malloc() - %<PRIu64>, усього free() - %<PRIu64>\n"
+#~ "\n"
 
-msgid "E749: empty buffer"
-msgstr "E749: Порожній буфер"
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Рядок стає занадто довгим"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Некоректний зразок для пошуку чи роздільник"
+# msgstr "E340: "
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Файл уже завантажено в інший буфер"
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Неправильний вигляд миші"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Вкажіть ключ шифру: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Повторіть ключ: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Ключі не однакові!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Не вдалося з'єднатися із Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Не вдалося з'єднатися із Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Неправильний режим доступу до файлу інформації про з'єднання з "
+#~ "NetBenans: «%s»"
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "читається з сокета Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Втрачено зв'язок із NetBeans для буфера %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans не підтримується з цим GUI"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans вже під'єднано"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s тільки для читання (! щоб не зважати)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Можливість eval недоступна"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "Звільнено рядків: %<PRId64>"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Не вдалося змінити term в GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Застосуйте «:gui» для запуску GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Не можна змінити в GUI GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Некоректний(і) шрифт(и)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Не вдалося вибрати набір шрифтів"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Неправильний набір шрифтів"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Не вдалося використати розширений шрифт"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Некоректний розширений шрифт"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Миша не підтримується"
+
+# msgstr "E358: "
+#~ msgid "cannot open "
+#~ msgstr "не вдалося відкрити "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Не вдалося відкрити вікно!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Потрібна Amigados 2.04 або пізніша\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Потрібно %s версії %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Не вдалося відкрити NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Не вдалося створити "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim завершує роботу з %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "не можу змінити режим консолі ?!\n"
+
+# msgstr "E359: "
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: не консоль??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Не вдалося запустити оболонку з опцією -f"
+
+# msgstr "E360: "
+#~ msgid "Cannot execute "
+#~ msgstr "Не вдалося виконати "
+
+#~ msgid "shell "
+#~ msgstr "оболонку "
+
+#~ msgid " returned\n"
+#~ msgstr " повернуто\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE замалий"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "Помилка вводу/виводу"
+
+#~ msgid "Message"
+#~ msgstr "Повідомлення"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' не 80, не можна виконувати зовнішні команди"
+
+# msgstr "E364: "
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Не вдалося вибрати принтер"
+
+#~ msgid "to %s on %s"
+#~ msgstr "на %s з %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Невідомий шрифт принтера: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Помилка друку: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Друкується '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Некоректна назва набору символів «%s» у назві шрифту «%s»"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Помилковий символ %c в назві шрифту «%s»"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "На відкриття дисплею X пішло %<PRId64> мілісекунд"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Помилка X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Дисплей Х не пройшов перевірку"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Сплив час очікування відкриття дисплею Х"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Не вдалося запустити оболонку `sh'\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Не можна створити канали\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Не вдалося роздвоїтися\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Команда закінчила виконання\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP втратив з'єднання ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Не вдалося відкрити дисплей X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP обробляється запит 'збережи себе'"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP відкривається з'єднання"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP спостереження за з'єднанням з ICE не вдалося"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP не вдалося SmcOpenConnection: %s"
+
+#~ msgid "At line"
+#~ msgstr "Рядок:"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Не вдалося завантажити vim32.dll"
+
+#~ msgid "VIM Error"
+#~ msgstr "Помилка VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Не вдалося виправити вказівники на функції DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "оболонка повернула %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Виявлено подію %s\n"
+
+#~ msgid "close"
+#~ msgstr "close"
+
+#~ msgid "logoff"
+#~ msgstr "logoff"
+
+#~ msgid "shutdown"
+#~ msgstr "shutdown"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Команду не знайдено"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "Файл VIMRUN.EXE не знайдено у шляху пошуку.\n"
+#~ "Зовнішні команди не будуть призупинені після виконання.\n"
+#~ "Гляньте  :help win32-vimrun щоб отримати подробиці."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Застереження Vim"
+
+# msgstr "E231: "
+#~ msgid "Error file"
+#~ msgstr "Файл помилок"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: Не вдалося побудувати NFA з класом еквівалентності!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) Не вдалося отримати пам’ять для обходу гілок!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Застереження: Не вдалося знайти список слів «%s_%s.spl» чи «%s_ascii.spl»"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Перетворення у %s не підтримується"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: Недостатньо пам’яті, список слів буде неповним"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Шлях файлу теґів скорочено до %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "запущено нову оболонку\n"
+
+# msgstr "E242: "
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Використано CUT_BUFFER0 замість порожнього виділення"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Скасування буде неможливе, все одно продовжити"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Незашифрований файл має зашифрований файл історії: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Не вдалося розшифрувати файл історії: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Файл історії зашифрований: %s"
+
+# msgstr "E440: "
+# ---------------------------------------
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія з GUI для 16/32-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія з GUI для 64-розрядної MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія з GUI для 32-розрядної Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " в режимі Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " з підтримкою OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольна версія для 64-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольна версія для 32-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для 16-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для 32-розрядної MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для 16-розрядної MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Велика версія "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Нормальна версія "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Мала версія "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Крихітна версія "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "з GUI GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "з GUI GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "з GUI X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "з GUI X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "з GUI X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "з GUI Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "з GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "з GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "з GUI Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "з (класичним) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  системний gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    gvimrc користувача: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "другий gvimrc користувача: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "третій gvimrc користувача: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    системне меню: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Компілятор: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "меню  Help->Orphans       подальша інформація      "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Без режимів, текст що набрано вставляється"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "меню  Edit->Global Settings->Toggle Insert Mode    "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                          для двох режимів         "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "меню  Edit->Global Settings->Toggle Vi Compatible  "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "              щоб починати в режимі сумісності з Vi"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ЗАСТЕРЕЖЕННЯ: Ви користуєтеся Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr ":help windows95<Enter>    інформація про це        "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Не вдалося завантажити бібліотеку %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Вибачте, ця команда вимкнена, бібліотека Perl не може бути завантажена."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Обчислення виразів Perl заборонене у пісочниці без модуля Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Редагувати у (&m)різних Vim"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Редагувати у одному &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Порівняти з допомогою Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Редагувати за допомогою &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Редагувати у вже запущеному Vim - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Редагує вибрані файли з допомогою Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Помилка створення процесу, перевірте чи є gvim у шляху пошуку!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "помилка gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Шлях занадто довгий!"
+
+# msgstr "E233: "
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Невідомий набір шрифтів: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Невідомий шрифт: %s"
 
 # msgstr "E235: "
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Опція '%s' не встановлена"
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Шрифт «%s» не моноширинний"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Неправильна назва регістру"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Не вдалося завантажити бібліотечну функцію %s"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Пошук дійшов до ПОЧАТКУ, продовжується з КІНЦЯ"
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Не можна використати іврит: Не ввімкнено під час компіляції\n"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Пошук дійшов до КІНЦЯ, продовжується з ПОЧАТКУ"
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Не можна використати фарсі: Не ввімкнено під час компіляції\n"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Для «%s» потрібен ключ: "
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Не можна використати арабську мову: Не ввімкнено під час "
+#~ "компіляції\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Немає зареєстрованих серверів з назвою «%s»"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Не вдалося відкрити дисплей"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Отримано некоректний вираз"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Не можна змінити захищений регіон"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans не дозволяє змінювати захищені від запису файли"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Для «%s» потрібен ключ: "
 
 # msgstr "E406: "
-msgid "empty keys are not allowed"
-msgstr "порожні ключі не дозволені"
+#~ msgid "empty keys are not allowed"
+#~ msgstr "порожні ключі не дозволені"
 
-msgid "dictionary is locked"
-msgstr "словник заблоковано"
+#~ msgid "dictionary is locked"
+#~ msgstr "словник заблоковано"
 
-msgid "list is locked"
-msgstr "список заблоковано"
+#~ msgid "list is locked"
+#~ msgstr "список заблоковано"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "не вдалося додати ключ '%s' до словника"
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "не вдалося додати ключ '%s' до словника"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "індекс має бути цілий чи зріз, не %s"
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "індекс має бути цілий чи зріз, не %s"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "очікувався екземпляр str() чи unicode(), але отримано %s"
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "очікувався екземпляр str() чи unicode(), але отримано %s"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "очікувався екземпляр bytes() чи str(), але отримано %s"
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "очікувався екземпляр bytes() чи str(), але отримано %s"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr ""
-"очікувався int(), long() чи щось, що може бути вміщене long(), але отримано %s"
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "очікувався int(), long() чи щось, що може бути вміщене long(), але "
+#~ "отримано %s"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "очікувався int() чи щось, що може бути вміщене int(), але отримано %s"
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr ""
+#~ "очікувався int() чи щось, що може бути вміщене int(), але отримано %s"
 
-msgid "value is too large to fit into C int type"
-msgstr "значення завелике, щоб вміститися у тип C int"
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "значення завелике, щоб вміститися у тип C int"
 
-msgid "value is too small to fit into C int type"
-msgstr "значення замале, щоб вміститися у тип C int"
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "значення замале, щоб вміститися у тип C int"
 
-msgid "number must be greater then zero"
-msgstr "число має бути більше, ніж нуль"
+#~ msgid "number must be greater then zero"
+#~ msgstr "число має бути більше, ніж нуль"
 
-msgid "number must be greater or equal to zero"
-msgstr "число має бути не менше, ніж нуль"
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "число має бути не менше, ніж нуль"
 
-msgid "can't delete OutputObject attributes"
-msgstr "не вдалося знищити атрибути OutputObject"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "не вдалося знищити атрибути OutputObject"
 
 # msgstr "E180: "
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "неправильний атрибут: %s"
+#~ msgid "invalid attribute: %s"
+#~ msgstr "неправильний атрибут: %s"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Помилка ініціалізації об'єктів вводу/виводу"
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Помилка ініціалізації об'єктів вводу/виводу"
 
-msgid "failed to change directory"
-msgstr "не вдалося змінити директорію"
+#~ msgid "failed to change directory"
+#~ msgstr "не вдалося змінити директорію"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %s"
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %s"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %d"
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %d"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "внутрішня помилка: imp.find_module повернула кортеж з NULL"
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "внутрішня помилка: imp.find_module повернула кортеж з NULL"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "не вдалося знищити атрибути vim.Dictionary"
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "не вдалося знищити атрибути vim.Dictionary"
 
-msgid "cannot modify fixed dictionary"
-msgstr "не можна змінити фіксований словник"
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "не можна змінити фіксований словник"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "не можна встановити атрибут %s"
+#~ msgid "cannot set attribute %s"
+#~ msgstr "не можна встановити атрибут %s"
 
-msgid "hashtab changed during iteration"
-msgstr "хеш-таблиця змінилася під час перебирання"
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "хеш-таблиця змінилася під час перебирання"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "очікувалась послідовність розміром 2, але отримано послідовність розміру %d"
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "очікувалась послідовність розміром 2, але отримано послідовність розміру "
+#~ "%d"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "списковий конструктор не приймає іменовані аргументи"
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "списковий конструктор не приймає іменовані аргументи"
 
-msgid "list index out of range"
-msgstr "індекс списку за межами"
+#~ msgid "list index out of range"
+#~ msgstr "індекс списку за межами"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "внутрішня помилка: не вдалося отримати елемент списку vim %d"
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "внутрішня помилка: не вдалося отримати елемент списку vim %d"
 
-msgid "failed to add item to list"
-msgstr "не вдалося додати елемент до списку"
+#~ msgid "failed to add item to list"
+#~ msgstr "не вдалося додати елемент до списку"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "внутрішня помилка: немає елемента списку vim %d"
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "внутрішня помилка: немає елемента списку vim %d"
 
-msgid "internal error: failed to add item to list"
-msgstr "внутрішня помилка: не вдалося додати елемент до списку"
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "внутрішня помилка: не вдалося додати елемент до списку"
 
-msgid "cannot delete vim.List attributes"
-msgstr "не вдалося знищити атрибути vim.List"
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "не вдалося знищити атрибути vim.List"
 
-msgid "cannot modify fixed list"
-msgstr "не можна змінити фіксований список"
+#~ msgid "cannot modify fixed list"
+#~ msgstr "не можна змінити фіксований список"
 
 # msgstr "E428: "
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "безіменної функції %s не існує"
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "безіменної функції %s не існує"
 
 # msgstr "E428: "
-#, c-format
-msgid "function %s does not exist"
-msgstr "функції %s не існує"
+#~ msgid "function %s does not exist"
+#~ msgstr "функції %s не існує"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "конструктор функції не приймає іменовані аргументи"
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "конструктор функції не приймає іменовані аргументи"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "не вдалося виконати функцію %s"
+#~ msgid "failed to run function %s"
+#~ msgstr "не вдалося виконати функцію %s"
 
-msgid "unable to get option value"
-msgstr "не вдалося отримати значення опції"
+#~ msgid "problem while switching windows"
+#~ msgstr "не вдалося перемкнути вікна"
 
-msgid "internal error: unknown option type"
-msgstr "внутрішня помилка: невідомий тип опції"
+#~ msgid "unable to unset global option %s"
+#~ msgstr "не вдалося скинути глобальну опцію %s"
 
-msgid "problem while switching windows"
-msgstr "не вдалося перемкнути вікна"
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "не вдалося скинути опцію %s, яка не має глобального значення"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "не вдалося скинути глобальну опцію %s"
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "спроба звернення до знищеної вкладки"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "не вдалося скинути опцію %s, яка не має глобального значення"
+#~ msgid "no such tab page"
+#~ msgstr "такої вкладки немає"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "спроба звернення до знищеної вкладки"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "спроба звернутися до знищеного вікна"
 
-msgid "no such tab page"
-msgstr "такої вкладки немає"
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "атрибут лише для читання: буфер"
 
-msgid "attempt to refer to deleted window"
-msgstr "спроба звернутися до знищеного вікна"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "курсор за межами буфера"
 
-msgid "readonly attribute: buffer"
-msgstr "атрибут лише для читання: буфер"
+#~ msgid "no such window"
+#~ msgstr "такого вікна немає"
 
-msgid "cursor position outside buffer"
-msgstr "курсор за межами буфера"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "спроба звернення до знищеного буфера"
 
-msgid "no such window"
-msgstr "такого вікна немає"
+#~ msgid "failed to rename buffer"
+#~ msgstr "не вдалося перейменувати буфер"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "спроба звернення до знищеного буфера"
+#~ msgid "mark name must be a single character"
+#~ msgstr "назвою мітки має бути один символ"
 
-msgid "failed to rename buffer"
-msgstr "не вдалося перейменувати буфер"
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "очікувався об’єкт vim.Buffer, але отримано %s"
 
-msgid "mark name must be a single character"
-msgstr "назвою мітки має бути один символ"
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "не вдалося перемкнутися до буфера %d"
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "очікувався об’єкт vim.Buffer, але отримано %s"
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "очікувався об’єкт vim.Window, але отримано %s"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "не вдалося перемкнутися до буфера %d"
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "не вдалося знайти вікно у поточній вкладці"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "очікувався об’єкт vim.Window, але отримано %s"
+#~ msgid "did not switch to the specified window"
+#~ msgstr "не перемкнувся до вказаного вікна"
 
-msgid "failed to find window in the current tab page"
-msgstr "не вдалося знайти вікно у поточній вкладці"
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "очікувався об’єкт vim.TabPage, але отримано %s"
 
-msgid "did not switch to the specified window"
-msgstr "не перемкнувся до вказаного вікна"
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "не перемкнувся до вказаної вкладки"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "очікувався об’єкт vim.TabPage, але отримано %s"
+#~ msgid "failed to run the code"
+#~ msgstr "не вдалося виконати код"
 
-msgid "did not switch to the specified tab page"
-msgstr "не перемкнувся до вказаної вкладки"
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval не повернув дійсний об’єкт python"
 
-msgid "failed to run the code"
-msgstr "не вдалося виконати код"
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Не вдалося перетворити об’єкт python у значення vim"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval не повернув дійсний об’єкт python"
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "не вдалося перетворити %s у словник vim"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Не вдалося перетворити об’єкт python у значення vim"
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "не вдалося перетворити %s у структуру vim"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "не вдалося перетворити %s у словник vim"
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "внутрішня помилка: передано посилання NULL"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "не вдалося перетворити %s у структуру vim"
+#~ msgid "internal error: invalid value type"
+#~ msgstr "внутрішня помилка: неправильний тип значення"
 
-msgid "internal error: NULL reference passed"
-msgstr "внутрішня помилка: передано посилання NULL"
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Не вдалося встановити обробник шляху: sys.path_hooks не список\n"
+#~ "Вам слід вчинити так:\n"
+#~ "- додайте vim.path_hook до sys.path_hooks\n"
+#~ "- додайте vim.VIM_SPECIAL_PATH до sys.path\n"
 
-msgid "internal error: invalid value type"
-msgstr "внутрішня помилка: неправильний тип значення"
-
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Не вдалося встановити обробник шляху: sys.path_hooks не список\n"
-"Вам слід вчинити так:\n"
-"- додайте vim.path_hook до sys.path_hooks\n"
-"- додайте vim.VIM_SPECIAL_PATH до sys.path\n"
-
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Не вдалося встановити шлях: sys.path не список\n"
-"Вас слід додати vim.VIM_SPECIAL_PATH до sys.path"
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Не вдалося встановити шлях: sys.path не список\n"
+#~ "Вас слід додати vim.VIM_SPECIAL_PATH до sys.path"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-09-29 09:05+0300\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2010-06-18 21:53+0300\n"
 "Last-Translator: Анатолій Сахнік <sakhnik@gmail.com>\n"
 "Language-Team: Bohdan Vlasyuk <bohdan@vstu.edu.ua>\n"
@@ -21,164 +21,204 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "E831: bf_key_init() called with empty password"
-msgstr "E831: Викликано bf_key_init() з порожнім паролем"
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "не вдалося отримати значення опції"
 
-msgid "E820: sizeof(uint32_t) != 4"
-msgstr "E820: sizeof(uint32_t) != 4"
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr "внутрішня помилка: невідомий тип опції"
 
-msgid "E817: Blowfish big/little endian use wrong"
-msgstr "E817: Неправильне використання порядку байтів Blowfish (BE/LE)"
-
-msgid "E818: sha256 test failed"
-msgstr "E818: Не пройшла перевірка sha256"
-
-msgid "E819: Blowfish test failed"
-msgstr "E819: Не пройшла перевірка Blowfish"
-
+#: ../buffer.c:92
 msgid "[Location List]"
 msgstr "[Список місць]"
 
+#: ../buffer.c:93
 msgid "[Quickfix List]"
 msgstr "[Список виправлень]"
 
+#: ../buffer.c:94
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Автокоманди призвели до скасування команди"
 
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Немає можливості розмістити хоч один буфер, завершення роботи..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Немає можливості розмістити буфер, буде використано інший..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Жоден з буферів не був вивантажений"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Жоден з буферів не знищено"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Жоден з буферів не витерто"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "Вивантажено один буфер"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "Вивантажено %d буфери(ів)"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "Знищено один буфер"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "Знищено %d буфери(ів)"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "Витерто один буфер"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "Витерто %d буфери(ів)"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Не можу вивантажити останній буфер"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Жоден буфер не змінено"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: У списку немає буферів"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Буфера %<PRId64> немає"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Це вже останній буфер"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Це вже найперший буфер"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: Буфер %<PRId64> має зміни (! щоб не зважати)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Не можу вивантажити останній буфер"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Обережно: Список назв файлів переповнено"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Буфер %<PRId64> не знайдено"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Знайдено кілька збігів з %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Не знайдено буфер, схожий на %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "рядок %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер з такою назвою вже існує"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Змінено]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Не редаговано]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Новий файл]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Помилки читання]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
 msgid "[RO]"
 msgstr "[RO]"
 
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[лише читати]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "один рядок --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> рядки(ів) --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "рядок %<PRId64> з %<PRId64> --%d%%-- колонка "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[Без назви]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "допомога"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[Допомога]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Перегляд]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Усе"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Знизу"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Вгорі"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -186,9 +226,11 @@ msgstr ""
 "\n"
 "# Список буферів:\n"
 
+#: ../buffer.c:4289
 msgid "[Scratch]"
 msgstr "[З нуля]"
 
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -196,146 +238,202 @@ msgstr ""
 "\n"
 "--- Позначки ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Позначки для %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    рядок=%<PRId64>  id=%d назва=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Пропущено двокрапку"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Неправильний режим"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: Потрібна цифра"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Неправильний відсоток"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Не можна порівнювати понад %<PRId64> буфери(ів)"
 
+#: ../diff.c:753
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Не можна читати чи записувати тимчасові файли"
 
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Не вдалося створити порівняння"
 
-msgid "Patch file"
-msgstr "Латка"
-
+#: ../diff.c:966
 msgid "E816: Cannot read patch output"
 msgstr "E816: Не вдалося прочитати результат patch"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Не вдалося прочитати результат diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Цей буфер не в режимі порівняння"
 
+#: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Немає більше модифіковних буферів в режимі порівняння"
 
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Немає інших буферів в режимі порівняння"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Понад два буфери у режимі порівняння, не зрозуміло, котрий із них "
 "використати"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Не вдалося знайти буфер «%s»"
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Буфер «%s» не в режимі порівняння"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: Буфер несподівано змінився"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: У диграфах не може міститися escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Не знайдено файл розкладки"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap використано не у файлі команд"
 
+#: ../digraph.c:1821
 msgid "E791: Empty keymap entry"
 msgstr "E791: Елемент розкладки порожній"
 
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Доповнення ключових слів (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Режим ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Доповнення усього рядка (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Доповнення назви файлу (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Доповнення теґів (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Доповнення шляху за зразком (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Доповнення визначення (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Доповнення зі словника (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Доповнення з тезаурусу (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Доповнення команд (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " Користувацьке доповнення (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " Кмітливе доповнення (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Орфографічна підказка (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Доповнення місцевих ключових слів (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Трапився кінець параграфа"
 
 # msgstr "E443: "
+#: ../edit.c:101
 msgid "E839: Completion function changed window"
 msgstr "E839: Функція доповнення змінила вікно"
 
+#: ../edit.c:102
 msgid "E840: Completion function deleted text"
 msgstr "E840: Функція доповнення знищила текст"
 
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "Опція 'dictionary' порожня"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "Опція 'thesaurus' порожня"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Сканується словник: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (вставка) Прогорнути (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (заміна) Прогорнути (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Пошук у: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Пошук серед теґів."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Додається"
 
@@ -343,480 +441,598 @@ msgstr " Додається"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Пошук..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Початковий варіант"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Слово з іншого рядка"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Єдиний збіг"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "збіг %d з %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "збіг %d"
 
 # msgstr "E17: "
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неочікувані символи у :let"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: Індекс списку поза межами: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Невизначена змінна: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: Бракує ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: Аргумент у %s має бути списком"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: Аргумент у %s має бути списком чи словником"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Ключ словника не може бути порожнім"
 
 # msgstr "E396: "
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: Потрібен список"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: Потрібен словник"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: Забагато аргументів для функції: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Немає такого ключа у словнику: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Функція %s уже існує, ! щоб замінити"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Запис у словнику вже існує"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: Треба посилання на функцію"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: Не можна використати [:] зі словником"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: Неправильний тип змінної для %s="
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: Невідома функція: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: Неприпустима назва змінної: %s"
 
 # msgstr "E373: "
+#: ../eval.c:157
 msgid "E806: using Float as a String"
 msgstr "E806: Float вжито як String"
 
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: Цілей менше, ніж елементів списку"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: Цілей більше, ніж елементів списку"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "Друга ; у списку змінних"
 
 # msgstr "E235: "
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: Не можна перерахувати змінні у %s"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: Індексний доступ може бути тільки до списку чи словника"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] має бути останньою"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] вимагає список"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: Список має більше елементів, ніж ціль"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: Список має недостатньо елементів"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: Пропущено «in» після :for"
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Пропущено дужки: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Змінної немає: «%s»"
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: Змінна має забагато вкладень щоб бути за-/відкритою."
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Бракує ':' після '?'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: Список можна порівняти тільки зі списком"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: Некоректна операція над списком"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: Словник можна порівняти тільки із словником"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: Некоректна операція над словником"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: Функцію можна порівняти тільки з функцією"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: Некоректна операція над функцією"
 
+#: ../eval.c:4277
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Не можна виконати '%' над Float"
 
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Пропущено ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: Функція не має індексації"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Бракує назви опції: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Невідома опція: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Бракує лапки: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Бракує лапки: %s"
 
 # msgstr "E404: "
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Бракує коми у списку: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Немає кінцівки списку ']': %s"
 
 # msgstr "E235: "
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Бракує двокрапки у словнику: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Повторення ключа в словнику: «%s»"
 
 # msgstr "E235: "
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Бракує коми у словнику: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Немає кінцівки словника '}': %s"
 
 # msgstr "E21: "
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: У змінній забагато вкладень щоб її показати"
 
+#: ../eval.c:7188
 #, c-format
 msgid "E740: Too many arguments for function %s"
 msgstr "E740: Забагато аргументів для функції %s"
 
+#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Неправильні аргументи функції %s"
 
+#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Невідома функція: %s"
 
+#: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Замало аргументів для функції %s"
 
+#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: <SID> використовується не у контексті скрипту: %s"
 
+#: ../eval.c:7391
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
 msgstr "E725: Виклик dict-функції без словника: %s"
 
+#: ../eval.c:7453
 msgid "E808: Number or Float required"
 msgstr "E808: Треба вказати Number чи Float"
 
 # msgstr "E14: "
+#: ../eval.c:7503
 msgid "add() argument"
 msgstr "аргумент add()"
 
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: Забагато аргументів"
 
 # msgstr "E327: "
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() можна вживати тільки в режимі вставки"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&O:Гаразд"
 
 # msgstr "E226: "
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: Ключ вже існує: %s"
 
 # msgstr "E14: "
+#: ../eval.c:8692
 msgid "extend() argument"
 msgstr "аргумент extend()"
 
 # msgstr "E14: "
+#: ../eval.c:8915
 msgid "map() argument"
 msgstr "аргумент map()"
 
 # msgstr "E14: "
+#: ../eval.c:8916
 msgid "filter() argument"
 msgstr "аргумент filter()"
 
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld рядків: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: Невідома функція: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&O:Гаразд\n"
-"&C:Скасувати"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Виклики до inputrestore() частіше, ніж до inputsave()"
 
 # msgstr "E14: "
+#: ../eval.c:10771
 msgid "insert() argument"
 msgstr "аргумент insert()"
 
 # msgstr "E406: "
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: Інтервал не дозволено"
 
 # msgstr "E177: "
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: Некоректний тип для len()"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: Крок нульовий"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: Початок за кінцем"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<нічого>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: Немає з'єднання із сервером Vim"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Не вдалося відіслати до %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Не вдалося прочитати відповідь сервера"
-
 # msgstr "E14: "
+#: ../eval.c:12282
 msgid "remove() argument"
 msgstr "аргумент remove()"
 
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Забагато символьних посилань (цикл?)"
 
 # msgstr "E14: "
+#: ../eval.c:12593
 msgid "reverse() argument"
 msgstr "аргумент reverse()"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: Не вдалося надіслати клієнту"
-
 # msgstr "E14: "
+#: ../eval.c:13721
 msgid "sort() argument"
 msgstr "аргумент sort()"
 
+# msgstr "E14: "
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "аргумент add()"
+
 # msgstr "E364: "
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Помилка у функції порівняння"
 
+# msgstr "E364: "
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Помилка у функції порівняння"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Неможливо)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: Не вдалося записати тимчасовий файл"
 
+#: ../eval.c:16159
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float вжито як Number"
 
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: Funcref вжито як Number"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: List вжито як Number"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: Dictionary вжито як Number"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: Funcref вжито як String"
 
 # msgstr "E373: "
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: List вжито як String"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: Dictionary вжито як String"
 
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Неправильний тип змінної: %s"
 
+#: ../eval.c:16705
 #, c-format
 msgid "E795: Cannot delete variable %s"
 msgstr "E795: Не можна знищити змінну %s"
 
+#: ../eval.c:16724
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
 msgstr "E704: Назва змінної Funcref має починатися з великої літери: %s"
 
+#: ../eval.c:16732
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
 msgstr "E705: Назва змінної співпадає з існуючою функцією: %s"
 
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: Значення захищене: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "Невідомо"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Не можна змінити значення %s"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Змінна вкладена занадто глибоко щоб зробити її копію"
 
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Невизначена функція: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Бракує '(': %s"
 
+#: ../eval.c:17293
 msgid "E862: Cannot use g: here"
 msgstr "E862: Тут не можна використати g:"
 
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Недозволений аргумент: %s"
 
+#: ../eval.c:17323
 #, c-format
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Назва аргументу повторюється: %s"
 
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Бракує :endfunction"
 
+#: ../eval.c:17537
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
 msgstr "E707: Назва функції співпадає зі змінною: %s"
 
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Не вдалося перевизначити функцію %s: вона використовується"
 
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: Назва функції не збігається з назвою файлу скрипту: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Не вказано назву функції"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
 "E128: Назва функції має починатися з великої літери або містити двокрапку: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Назва функції має починатися з великої літери або містити двокрапку: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Не вдалося знищити функцію %s: Вона використовується"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Глибина викликів функції перевищує 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "викликається %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s припинено"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s повертає #%<PRId64>"
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s повертає %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "продовження в %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return поза межами функції"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -824,6 +1040,7 @@ msgstr ""
 "\n"
 "# глобальні змінні:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -831,216 +1048,104 @@ msgstr ""
 "\n"
 "\tВостаннє змінена у "
 
+#: ../eval.c:19272
 msgid "No old files"
 msgstr "Жодного старого файлу"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Режим налагодження.  Щоб продовжити введіть «cont»."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "рядок %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "команда: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Точка зупинки в «%s%s» рядок %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Точку зупинки не знайдено: %s"
-
-msgid "No breakpoints defined"
-msgstr "Не визначено жодної точки зупинки"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d %s %s   рядок %<PRId64>"
-
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Спочатку зробіть «:profile start {файл}»"
-
-msgid "Save As"
-msgstr "Зберегти як"
-
-#, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Зберегти зміни в «%s»?"
-
-msgid "Untitled"
-msgstr "Неназваний"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Буфер «%s» має незбережені зміни"
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr ""
-"Обережно: Несподівано опинилися у іншому буфері (перевірте автокоманди)"
-
-msgid "E163: There is only one file to edit"
-msgstr "E163: Редагується лише один файл"
-
-msgid "E164: Cannot go before first file"
-msgstr "E164: Це вже найперший файл"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Це вже останній файл"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: Компілятор не підтримується: %s"
-
-# msgstr "E195: "
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Пошук «%s» в «%s»"
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Пошук «%s»"
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "В 'runtimepath' не знайдено «%s»"
-
-msgid "Source Vim script"
-msgstr "Прочитати скрипт Vim"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Не вдалося прочитати каталог: «%s»"
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "Не вдалося виконати «%s»"
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "рядок %<PRId64>: не вдалося виконати «%s»"
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "виконується «%s»"
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "рядок %<PRId64>: виконується «%s»"
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "закінчено виконання %s"
-
-msgid "modeline"
-msgstr "modeline"
-
-# msgstr "E14: "
-msgid "--cmd argument"
-msgstr "--cmd аргумент"
-
-# msgstr "E14: "
-msgid "-c argument"
-msgstr "-c аргумент"
-
-msgid "environment variable"
-msgstr "змінна оточення"
-
-msgid "error handler"
-msgstr "обробник помилки"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Застереження: Неправильний роздільник рядків, можливо, бракує ^M"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: :scriptencoding використано поза виконуваним файлом"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: :finish використано поза виконуваним файлом"
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Мова (%s): «%s»"
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Не вдалося встановити мову «%s»"
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  шіст %02x, віс %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, шіст %04x, віс %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, шіст %08x, віс %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Неможливо перемістити рядки самі в себе"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Переміщено один рядок"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Переміщено %<PRId64> рядки(ів)"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Відфільтровано %<PRId64> рядки(ів)"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманди *Filter* не повинні змінювати поточний буфер"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Зміни не записано]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s в рядку: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Забагато помилок, решта файлу буде пропущено"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Зчитується файл viminfo: «%s»%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " інформація"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " позначки"
 
+#: ../ex_cmds.c:1462
 msgid " oldfiles"
 msgstr " старі файли"
 
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " НЕ ВДАЛОСЯ"
 
 #. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Не дозволено запис у файл viminfo: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Не вдалося записати файл viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Записується файл viminfo «%s»"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Цей файл автоматично створений Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1048,37 +1153,47 @@ msgstr ""
 "# Можете редагувати, але ОБЕРЕЖНО!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Значення 'encoding' під час створення цього файлу\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Недозволений символ на початку рядка"
 
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Записати частину файлу?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Використайте ! для запису частини буфера"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Переписати існуючий файл «%s»?"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Файл обміну «%s» існує, перезаписати?"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Файл обміну існує: %s (:silent! переважує)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Немає вхідного файлу для буфера %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не записано: запис заборонено опцією 'write'"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1087,6 +1202,7 @@ msgstr ""
 "Для «%s» встановлено 'readonly'.\n"
 "Бажаєте все одно продовжити запис?"
 
+#: ../ex_cmds.c:2439
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1097,69 +1213,84 @@ msgstr ""
 "Проте, можливо, його можна записати.\n"
 "Хочете спробувати?"
 
+#: ../ex_cmds.c:2451
 #, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "E505: «%s» тільки для читання (! щоб не зважати)"
 
-msgid "Edit File"
-msgstr "Редагувати Файл"
-
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Автокоманди несподівано знищили новий буфер %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: нечисловий аргумент для :z"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: У rvim не дозволені команди оболонки"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регулярні вирази не можна розділяти літерами"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "Замінити на %s (y/n/a/q/l/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(Перервано) "
 
 # msgstr "E31: "
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "Один збіг"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "Одна заміна"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> збіги(ів)"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> замін(и)"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " в одному рядку"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " в %<PRId64> рядках"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global не можна вживати рекурсивно"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: У global бракує зразка"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Зразок знайдено у кожному рядку: %s"
 
+#: ../ex_cmds.c:4510
 #, c-format
 msgid "Pattern not found: %s"
 msgstr "Зразок не знайдено: %s"
 
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1169,136 +1300,338 @@ msgstr ""
 "# Остання заміна:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Без паніки!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Вибачте, немає допомоги '%s' для %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Вибачте, немає допомоги для %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Вибачте, файл допомоги «%s» не знайдено"
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Не є каталогом: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Не вдалося відкрити %s для запису"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Не вдалося відкрити %s для читання"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: Мішанина кодувань файлу допомоги для мови %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Повторення теґу «%s» у файлі %s/%s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Невідома команда надпису: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Пропущено назву надпису"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Визначено забагато надписів"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Некоректний надпис: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Невідомий надпис: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Пропущено номер надпису"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Некоректна назва буфера: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Неправильний ID надпису: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (НЕ ЗНАЙДЕНО)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (не підтримується)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[Знищено]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Режим налагодження.  Щоб продовжити введіть «cont»."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "рядок %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "команда: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Точка зупинки в «%s%s» рядок %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Точку зупинки не знайдено: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Не визначено жодної точки зупинки"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d %s %s   рядок %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Спочатку зробіть «:profile start {файл}»"
+
+#: ../ex_cmds2.c:1269
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Зберегти зміни в «%s»?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Неназваний"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Буфер «%s» має незбережені зміни"
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr ""
+"Обережно: Несподівано опинилися у іншому буфері (перевірте автокоманди)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Редагується лише один файл"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Це вже найперший файл"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Це вже останній файл"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: Компілятор не підтримується: %s"
+
+# msgstr "E195: "
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Пошук «%s» в «%s»"
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Пошук «%s»"
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "В 'runtimepath' не знайдено «%s»"
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Не вдалося прочитати каталог: «%s»"
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "Не вдалося виконати «%s»"
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "рядок %<PRId64>: не вдалося виконати «%s»"
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "виконується «%s»"
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "рядок %<PRId64>: виконується «%s»"
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "закінчено виконання %s"
+
+#: ../ex_cmds2.c:2765
+msgid "modeline"
+msgstr "modeline"
+
+# msgstr "E14: "
+#: ../ex_cmds2.c:2767
+msgid "--cmd argument"
+msgstr "--cmd аргумент"
+
+# msgstr "E14: "
+#: ../ex_cmds2.c:2769
+msgid "-c argument"
+msgstr "-c аргумент"
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr "змінна оточення"
+
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr "обробник помилки"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Застереження: Неправильний роздільник рядків, можливо, бракує ^M"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: :scriptencoding використано поза виконуваним файлом"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: :finish використано поза виконуваним файлом"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Мова (%s): «%s»"
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Не вдалося встановити мову «%s»"
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "Режим Ex. Для повернення до нормального режиму виконайте «visual»"
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Кінець файлу"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Команда занадто рекурсивна"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Виняткова ситуація не оброблена: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Кінець виконуваного файлу"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Кінець функції"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Неоднозначний вжиток команди користувача"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Це не команда редактора"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Інтервал задано навиворіт"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Інтервал задано навиворіт, щоб поміняти місцями — ГАРАЗД"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Спробуйте w або w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Вибачте, цієї команди немає у цій версії"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Дозволено тільки одну назву файлу"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Залишилося відредагувати ще один файл. Все одно вийти?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Ще є %d не редагованих файлів. Все одно вийти?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: Залишилося відредагувати ще один файл"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: Залишилося %<PRId64> не редагованих файлів"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда вже існує, ! щоб замінити її"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1306,310 +1639,353 @@ msgstr ""
 "\n"
 "    Назва       Арг. Межа  Доповнення Визначення"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Не знайдено команд користувача"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Не вказано атрибутів"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Неправильна кількість аргументів"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Лічильник не може бути вказано двічі"
 
 # msgstr "E177: "
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Неправильне початкове значення лічильника"
 
 # msgstr "E178: "
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: для -complete потрібний аргумент"
 
 # msgstr "E180: "
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Неправильний атрибут: %s"
 
 # msgstr "E181: "
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Неправильна назва команди"
 
 # msgstr "E182: "
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Команди користувача повинні починатися з великої літери"
 
+#: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr ""
 "E841: Зарезервована назва, не можна використати для користувацької команди"
 
 # msgstr "E183: "
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Команду користувача не знайдено: %s"
 
 # msgstr "E179: "
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Неправильне доповнення: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Аргумент дозволений тільки для користувацького доповнення"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Користувацьке доповнення вимагає аргумент-функцію"
 
-msgid "unknown"
-msgstr "Невідомо"
-
 # msgstr "E184: "
+#: ../ex_docmd.c:5257
 #, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Не вдалося знайти схему кольорів «%s»"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Вітання, користувачу Vim!"
 
 # msgstr "E443: "
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Не можна закрити останню вкладку"
 
 # msgstr "E444: "
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "Вже й так лише одна вкладка"
 
-# msgstr "E185: "
-msgid "Edit File in new window"
-msgstr "Редагувати файл у новому вікні"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Вкладка %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Немає файлу обміну"
 
-msgid "Append File"
-msgstr "Дописати файл"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: Не вдалося змінити каталог, буфер має зміни (! щоб не зважати)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Це вже найперший каталог"
 
 # msgstr "E186: "
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Невідомо"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize вимагає два числових аргументи"
 
-# msgstr "E187: "
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Позиція вікна: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Не можна отримати позицію вікна на цій платформі"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos вимагає два числових аргументи"
 
-# msgstr "E188: "
-msgid "Save Redirection"
-msgstr "Зберегти переадресований вивід"
-
-msgid "Save View"
-msgstr "Зберегти вигляд"
-
-msgid "Save Session"
-msgstr "Зберегти сеанс"
-
-msgid "Save Setup"
-msgstr "Зберегти налаштування"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Не вдалося створити каталог: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: Файл «%s» існує (! щоб не зважати)"
 
 # msgstr "E189: "
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Не вдалося відкрити «%s» для запису"
 
 # msgstr "E190: "
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Аргумент має бути літерою, ` або '"
 
 # msgstr "E191: "
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Забагато вкладених :normal"
 
-msgid "E809: #< is not available without the +eval feature"
-msgstr "E809: #< не доступна без можливості +eval"
-
 # msgstr "E193: "
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Немає назви вторинного файлу для заміни '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Немає назви файлу автокоманди для заміни «<afile>»"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Немає номера буфера автокоманди для заміни «<abuf>»"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Немає назви збігу автокоманди для заміни «<amatch>»"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: Немає назви файлу :source для заміни «<sfile>»"
 
+#: ../ex_docmd.c:7876
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E842: немає номера рядка, щоб використати з «<sfile>»"
 
-#, no-c-format
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Назва файлу для '%' чи '#' порожня, працює лише з «:p:h»"
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Результат — порожній рядок"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Не вдалося прочитати файл viminfo"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: У цій версії немає диграфів"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Не можна викидати (:throw) винятки з префіксом 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Виняткова ситуація: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Виняток закінчено: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Виняток скинуто: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, рядок %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Спіймано виняткову ситуацію: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "Очікується %s"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "Відновлено %s"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "Скинуто %s"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Виняток"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Помилка, перервано"
 
 # msgstr "E231: "
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Помилка"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Перервано"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: Занадто багато вкладених :if"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif без :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else без :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif без :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: Не одне :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif після :else"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: Забагато вкладених :while/:for"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue без :while чи :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break без :while чи :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Вжито :endfor із :while"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Вжито :endwhile із :for"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: Забагато вкладених :try"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch без :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch після :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally без :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: Не одне :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :entry без :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction поза межами функції"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Зараз не можна редагувати інший буфер"
 
+#: ../ex_getln.c:1656
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Зараз не можна змінювати інформацію буфера"
 
 # msgstr "E197: "
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "назва теґу"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " тип файлу\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "Опція 'history' порожня"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1618,235 +1994,313 @@ msgstr ""
 "\n"
 "# Попередні %s (від найновіших):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "команди"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "шукані рядки"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "вирази"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "введені рядки"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar поза межами команди"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Активне вікно або буфер було знищено"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr "E854: шлях занадто довгий для доповнення"
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Некоректний шлях: `**[число]' повинне бути наприкінці шляху або перед "
+"'%s'."
+
+# msgstr "E343: "
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Не вдалося знайти каталог «%s» у cdpath"
+
+# msgstr "E344: "
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Не вдалося знайти файл «%s» у path"
+
+# msgstr "E345: "
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: У cdpath немає більше каталогу «%s»"
+
+# msgstr "E346: "
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: У шляху пошуку більше немає файлів «%s»"
+
+#: ../fileio.c:137
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Автокоманди змінили буфер чи його назву"
 
 # msgstr "E199: "
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Недозволена назва файлу"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "каталог"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "не файл"
 
-msgid "is a device (disabled with 'opendevice' option)"
-msgstr "є пристроєм (вимкнено опцією 'opendevice')"
-
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Новий файл]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[Новий каталог]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[Файл завеликий]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Відмовлено]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: Автокоманди *ReadPre унеможливили читання файлу"
 
 # msgstr "E200: "
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Автокоманди *ReadPre не повинні змінювати цей буфер"
 
 # msgstr "E201: "
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Читається з stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Читається з stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Конвертація унеможливила читання файлу!"
 
 # msgstr "E202: "
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[канал/сокет]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[канал]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[сокет]"
 
+#. or character special
+#: ../fileio.c:1801
 msgid "[character special]"
 msgstr "[спец. символьний]"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[Бракує CR]"
 
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[Розбито довгі рядки]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[НЕ конвертовано]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[конвертовано]"
 
-msgid "[blowfish]"
-msgstr "[blowfish]"
-
-msgid "[crypted]"
-msgstr "[зашифровано]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[ПОМИЛКА КОНВЕРТАЦІЇ у рядку %<PRId64>]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[НЕКОРЕКТНИЙ БАЙТ у рядку %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[ПОМИЛКА ЧИТАННЯ]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Не вдалося підшукати тимчасовий файл для конвертації"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Конвертація з 'charconvert' не вдалася"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "не вдалося прочитати вивід 'charconvert'"
 
-msgid "E821: File is encrypted with unknown method"
-msgstr "E821: Файл зашифровано невідомим методом"
-
 # msgstr "E217: "
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Немає відповідних автокоманд"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Автокоманда знищила або вивантажила буфер, що мав бути записаний"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Автокоманда несподіваним чином змінила кількість рядків"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans не дозволяє записувати у незмінені буфери"
-
-# msgstr "E391: "
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Часткові записи заборонені для буферів NetBeans"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "Не придатний для запису"
 
-msgid "writing to device disabled with 'opendevice' option"
-msgstr "Запис до пристрою заборонено опцією 'opendevice'"
-
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "лише для читання (! щоб не зважати)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Не вдалося записати резервний файл (! щоб не зважати)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Помилка закриття резервного файлу (! щоб не зважати)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Не вдалося прочитати файл щоб створити резервну копію (! щоб не "
 "зважати)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Не вдалося створити резервну копію (! щоб не зважати)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Не вдалося зробити резервну копію (! щоб не зважати)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Гілку ресурсів можна втратити (! щоб не зважати)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Не вдалося підшукати тимчасовий файл для запису"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Не вдалося перетворити (! щоб записати без конвертації)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Не вдалося відкрити для запису зв'язаний файл"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Не вдалося відкрити файл для запису"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Не вдалося виконати fsync"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Не вдалося закрити"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: Помилка запису, конвертація не вдалася (скиньте 'fenc')"
 
+#: ../fileio.c:3441
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Помилка запису, конвертація не вдалася у рядку %<PRId64> (скиньте 'fenc')"
+"E513: Помилка запису, конвертація не вдалася у рядку %<PRId64> (скиньте "
+"'fenc')"
 
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: Помилка запису (скінчилось вільне місце?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " ПОМИЛКА КОНВЕРТАЦІЇ"
 
+#: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
 msgstr " у рядку %<PRId64>;"
 
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Пристрій]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Новий]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr "[д]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " дописаний"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr "[з]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " записаний"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Латання: не вдалося зберегти оригінал"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Латання: не вдалося створити оригінал"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Не вдалося знищити резервний файл"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1854,106 +2308,134 @@ msgstr ""
 "\n"
 "ЗАСТЕРЕЖЕННЯ: Оригінал, мабуть, втрачений чи пошкоджений\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "Не виходьте з редактора, доки файл не записано!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[формат dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[формат mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[формат unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "один рядок, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> рядків, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "один символ"
 
-#. Explicit typecast avoids warning on Mac OS X 10.6
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> символів"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Неповний останній рядок]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ЗАСТЕРЕЖЕННЯ: Файл змінився з часу останнього читання!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Ви справді хочете його переписати??"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Помилка запису у «%s»"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Помилка закриття «%s»"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Помилка читання «%s»"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Автокоманда FileChangedShell знищила буфер"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Файл «%s» більше не досяжний"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: Застереження: Файл «%s» змінився, але й буфер у Vim також"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "Див. «:help W12» для уточнення."
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Застереження: Файл «%s» змінився після початку редагування"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "Див. «:help W11» для уточнення."
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Застереження: Режим файлу «%s» змінився після початку редагування"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "Див. «:help W16» для уточнення."
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Застереження: Файл «%s» було створено після початку редагування"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Застереження"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1961,42 +2443,51 @@ msgstr ""
 "&O:Гаразд\n"
 "&L:Завантажити"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Не вдалося підготувати «%s», щоб перечитати"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Не вдалося перечитати «%s»"
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Знищено--"
 
+#: ../fileio.c:5732
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr "Автоматичне знищення автокоманди: %s <буфер=%d>"
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Немає такої групи: «%s»"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Недозволений символ після *: %s"
 
 # msgstr "E215: "
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Немає такої події: %s"
 
 # msgstr "E215: "
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Немає такої групи чи події: %s"
 
 # msgstr "E216: "
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -2004,560 +2495,800 @@ msgstr ""
 "\n"
 "--- Автокоманди ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <буфер=%d>: некоректний номер буфера "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Не можу виконувати автокоманди для УСІХ подій"
 
 # msgstr "E217: "
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Немає відповідних автокоманд"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Забагато вкладених автокоманд"
 
 # msgstr "E218: "
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "Автокоманди %s для «%s»"
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Виконується %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "автокоманда %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Бракує {."
 
 # msgstr "E219: "
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Бракує }."
 
 # msgstr "E220: "
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Згорток не знайдено"
 
 # msgstr "E349: "
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: Не вдалося створити згортку методом 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: Не вдалося знищити згортку методом 'foldmethod'"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+-- згорнуто %3ld рядків "
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Додати до буфера читання"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: Заміна рекурсивна"
 
 # msgstr "E223: "
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Загальне скорочення для %s вже існує"
 
 # msgstr "E224: "
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Загальна заміна для %s вже існує"
 
 # msgstr "E225: "
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Вже є скорочення для %s"
 
 # msgstr "E226: "
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Вже є заміна для %s"
 
 # msgstr "E227: "
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Скорочення не знайдено"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Заміни не знайдено"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Неприпустимий режим"
 
-msgid "<cannot open> "
-msgstr "<не відкривається> "
+# msgstr "E447: "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--Жодного рядка--"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: не вдалося отримати шрифт %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Команду перервано"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: не вдалося повернутися в поточний каталог"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Необхідно вказати аргумент"
 
-msgid "Pathname:"
-msgstr "Шлях:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: За \\ має йти /, ? або &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: не вдалося отримати поточний каталог"
+# msgstr "E10: "
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Неприпустимо у вікні команд, <CR> виконує, CTRL-C виходить"
 
-msgid "OK"
-msgstr "Гаразд"
-
-msgid "Cancel"
-msgstr "Скасувати"
-
-msgid "Vim dialog"
-msgstr "Діалог Vim"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Scrollbar Widget: Не вдалося визначити розмір скороченої картинки."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Не вдалося створити BalloonEval з повідомленням і функцією"
-
-msgid "E851: Failed to create a new process for the GUI"
-msgstr "E851: Не вдалося створити новий процес для GUI"
-
-msgid "E852: The child process failed to start the GUI"
-msgstr "E852: Дочірній процес не зміг запустити GUI"
-
-# msgstr "E228: "
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Не вдалося запустити GUI"
-
-# msgstr "E229: "
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Не вдалося прочитати з «%s»"
-
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: Не вдалося запустити GUI, не знайдено шрифт"
-
-# msgstr "E230: "
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: Некоректний 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Значення 'imactivatekey' некоректне"
-
-#, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Не вдалося отримати колір %s"
-
-msgid "No match at cursor, finding next"
-msgstr "Немає над курсором, пошук триває"
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"&Y:Так\n"
-"&N:Ні\n"
-"&C:Скасувати"
+"E12: Команда не дозволена у exrc/vimrc у пошуку поточного каталогу чи теґу"
 
-msgid "Input _Methods"
-msgstr "Методи введення"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Бракує :endif"
 
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Знайти й замінити..."
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Бракує :endtry"
 
-msgid "VIM - Search..."
-msgstr "VIM - Пошук..."
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Бракує :endwhile"
 
-msgid "Find what:"
-msgstr "Знайти:"
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: Бракує :endfor"
 
-msgid "Replace with:"
-msgstr "Замінити на:"
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile без :while"
 
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Лише повне слово"
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor без :for"
 
-#. match case button
-msgid "Match case"
-msgstr "Зважати на регістр"
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Файл існує (! щоб не зважати)"
 
-msgid "Direction"
-msgstr "Напрям"
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Команда на вдалась"
 
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Вгору"
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Внутрішня помилка"
 
-msgid "Down"
-msgstr "Униз"
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Перервано"
 
-#. 'Find Next' button
-msgid "Find Next"
-msgstr "Наступне"
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Неправильна адреса"
 
-#. 'Replace' button
-msgid "Replace"
-msgstr "Замінити"
+# msgstr "E14: "
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Некоректний аргумент"
 
-#. 'Replace All' button
-msgid "Replace All"
-msgstr "Замінити усі"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Отримав запит «die» від менеджера сесій\n"
-
-msgid "Close"
-msgstr "Закрити"
-
-msgid "New tab"
-msgstr "Нова вкладка"
-
-msgid "Open Tab..."
-msgstr "Відкрити вкладку..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Несподівано знищилося головне вікно\n"
-
-msgid "&Filter"
-msgstr "&F:Фільтрувати"
-
-msgid "&Cancel"
-msgstr "&C:Скасувати"
-
-msgid "Directories"
-msgstr "Каталоги"
-
-msgid "Filter"
-msgstr "Фільтр"
-
-msgid "&Help"
-msgstr "&H:Допомога"
-
-msgid "Files"
-msgstr "Файли"
-
-msgid "&OK"
-msgstr "&O:Гаразд"
-
-msgid "Selection"
-msgstr "Виділення"
-
-msgid "Find &Next"
-msgstr "&N:Знайти далі"
-
-msgid "&Replace"
-msgstr "&R:Замінити"
-
-msgid "Replace &All"
-msgstr "&A:Замінити усі"
-
-msgid "&Undo"
-msgstr "&U:Скасувати"
-
+#: ../globals.h:1015
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Не вдалося знайти вікно «%s»"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Некоректний аргумент: %s"
 
+#: ../globals.h:1016
 #, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Аргумент не підтримується: «-%s»; користуйтесь версією з OLE."
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Неправильний вираз: %s"
 
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Не вдалося відкрити вікно всередині програми MDI"
+# msgstr "E15: "
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Неправильні межі"
 
-msgid "Close tab"
-msgstr "Закрити вкладку"
+# msgstr "E16: "
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Некоректна команда"
 
-msgid "Open tab..."
-msgstr "Відкрити вкладку..."
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: «%s» — це каталог"
 
-# msgstr "E245: "
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Знайти рядок ('\\\\' щоб знайти '\\')"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Некоректний розмір зсуву"
 
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Знайти і замінити ('\\\\' щоб знайти '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "Немає"
-
-msgid "Directory\t*.nothing\n"
-msgstr "Каталог\t*.нічого\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"Vim E458: Немає вільних комірок у палітрі, деякі кольори можуть бути "
-"неправильні"
 
+#: ../globals.h:1022
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Шрифти для цих символів відсутні у наборі %s:"
+msgid "E902: \"%s\" is not an executable"
+msgstr ""
 
-# msgstr "E250: "
+#: ../globals.h:1024
 #, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Назва набору шрифтів: %s"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Бібліотечний виклик до «%s()» не вдався"
 
-# msgstr "E252: "
+# msgstr "E18: "
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: У помітки некоректний номер рядка"
+
+# msgstr "E19: "
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Помітку не встановлено"
+
+# msgstr "E20: "
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Зміни не дозволені: вимкнено 'modifiable'"
+
+# msgstr "E21: "
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Забагато вкладених скриптів"
+
+# msgstr "E22: "
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Немає вторинного файлу"
+
+# msgstr "E23: "
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Такого скорочення немає"
+
+# msgstr "E24: "
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ! не дозволено"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Не можна використати GUI: Не ввімкнено під час компіляції"
+
+# msgstr "E25: "
+#: ../globals.h:1036
 #, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Шрифт '%s' не є моноширинним"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Немає такої групи підсвічування: %s"
 
+# msgstr "E28: "
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Текст ще не було додано"
+
+# msgstr "E29: "
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Ще не було команд"
+
+# msgstr "E30: "
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Немає такої заміни"
+
+# msgstr "E31: "
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Жодного збігу"
+
+#: ../globals.h:1041
 #, c-format
-msgid "E253: Fontset name: %s"
-msgstr "E253: Назва набору шрифтів: %s"
+msgid "E480: No match: %s"
+msgstr "E480: Жодного збігу: %s"
 
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Бракує назви файлу"
+
+# msgstr "E32: "
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Заміна зразків ще не використовувалась"
+
+# msgstr "E33: "
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Команд ще не було"
+
+# msgstr "E34: "
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Зразків пошуку ще не було"
+
+# msgstr "E35: "
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Не дозволено вказувати межі"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Місця не вистачить"
+
+# msgstr "E36: "
+#: ../globals.h:1049
 #, c-format
-msgid "Font0: %s"
-msgstr "Шрифт0: %s"
+msgid "E482: Can't create file %s"
+msgstr "E482: Не вдалося створити файл %s"
 
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Не вдалося сформувати назву тимчасового файлу"
+
+#: ../globals.h:1051
 #, c-format
-msgid "Font1: %s"
-msgstr "Шрифт1: %s"
+msgid "E484: Can't open file %s"
+msgstr "E484: Не вдалося відкрити файл %s"
 
+#: ../globals.h:1052
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0"
-msgstr "Ширина шрифту%<PRId64> не більша удвічі за ширину шрифту0"
+msgid "E485: Can't read file %s"
+msgstr "E485: Не вдалося прочитати файл %s"
 
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Зміни не було записано (! щоб не зважати)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Зміни не записано]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Відсутній аргумент"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Очікується число"
+
+#: ../globals.h:1058
 #, c-format
-msgid "Font0 width: %<PRId64>"
-msgstr "Ширина шрифту0: %<PRId64>"
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Не вдалося відкрити файл помилок %s"
 
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Забракло пам'яті!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Зразок не знайдено"
+
+#: ../globals.h:1061
 #, c-format
-msgid "Font1 width: %<PRId64>"
-msgstr "Ширина шрифту1: %<PRId64>"
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Зразок не знайдено: %s"
 
-msgid "Invalid font specification"
-msgstr "Некоректна специфікація шрифту"
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Аргумент має бути додатний"
 
-msgid "&Dismiss"
-msgstr "&D:Припинити"
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Не вдалося перейти до попереднього каталогу"
 
-msgid "no specific match"
-msgstr "немає конкретного збігу"
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Жодної помилки"
 
-# msgstr "E234: "
-msgid "Vim - Font Selector"
-msgstr "Vim - Вибір шрифту"
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: Немає списку місць"
 
-msgid "Name:"
-msgstr "Назва:"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Текст збігу пошкоджено"
 
-#. create toggle button
-msgid "Show size in Points"
-msgstr "Показати розмір у пунктах"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Зіпсована програма регулярних виразів"
 
-msgid "Encoding:"
-msgstr "Кодування:"
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Встановлено опцію 'readonly' (! щоб не зважати)"
 
-msgid "Font:"
-msgstr "Шрифт:"
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Змінна тільки для читання: «%s»"
 
-msgid "Style:"
-msgstr "Стиль:"
+#: ../globals.h:1075
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E794: Не можна встановити змінну у пісочниці: «%s»"
 
-msgid "Size:"
-msgstr "Розмір:"
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Помилка читання файлу помилок"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Помилка автомату Hangul"
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: На дозволено у пісочниці"
 
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Не дозволено тут"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Режим екрану не підтримується"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Некоректний розмір зсуву"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Опція 'shell' порожня"
+
+# msgstr "E254: "
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Не можна зчитати дані напису!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Помилка під час закриття файлу обміну"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: Стек теґів порожній"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Занадто складна команда"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Задовге ім'я"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Забагато '['"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Забагато назв файлів"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Надлишкові символи"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Невідома помітка"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Не вдалося розкрити шаблон"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' не може бути меншим за 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' не може бути меншим за 'winminwidth'"
+
+# msgstr "E79: "
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Помилка під час запису"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Нульова кількість"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> використовується не в контексті скрипту"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: Внутрішня помилка: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Зразок використовує більше, ніж 'maxmempattern', пам'яті"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: Порожній буфер"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Некоректний зразок для пошуку чи роздільник"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Файл уже завантажено в інший буфер"
+
+# msgstr "E235: "
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: Опція '%s' не встановлена"
+
+#: ../globals.h:1111
+msgid "E850: Invalid register name"
+msgstr "E850: Неправильна назва регістру"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "Пошук дійшов до ПОЧАТКУ, продовжується з КІНЦЯ"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "Пошук дійшов до КІНЦЯ, продовжується з ПОЧАТКУ"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: Пропущено двокрапку"
 
 # msgstr "E347: "
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: Некоректний компонент"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: очікується цифра"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "Сторінка %d"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "Нічого друкувати"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Друкується сторінка %d (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Копія %d з %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "Надруковано: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "Друк перервано"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Не вдалося записати вихідний файл PostScript"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Не вдалося відкрити файл «%s»"
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: Не вдалося прочитати файл ресурсів PostScript «%s»"
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: «%s» не є файлом ресурсів PostScript"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: «%s» не є підтримуваним файлом ресурсів PostScript"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: Неправильна версія файлу ресурсів «%s»"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Несумісні багатобайтове кодування й набір символів."
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr ""
 "E674: printmbcharset не може бути порожнім з багатобайтовим кодуванням."
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Не зазначено шрифт для багатобайтового друку."
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: Не вдалося відкрити файл PostScript для виводу"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Не вдалося відкрити файл «%s»"
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: Не вдалося знайти файл ресурсів PostScript «prolog.ps»"
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: Не вдалося знайти файл ресурсів PostScript «cidfont.ps»"
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: Не вдалося знайти файл ресурсів PostScript «%s.ps»"
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: Не вдалося перетворити до кодування друку «%s»"
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "Відсилається на принтер..."
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Не вдалося надрукувати файл PostScript"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "Завдання друку відіслано."
 
 # msgstr "E255: "
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Додати нову базу даних"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Запит за зразком"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Показати це повідомлення"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Знищити з'єднання"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Перезапустити усі з'єднання"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Показати з'єднання"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Використання: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Ця команда cscope не вміє ділити вікно.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Використання: cstag <ідентиф-ор>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: теґ не знайдено"
 
 # msgstr "E257: "
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) помилка: %d"
 
-msgid "E563: stat error"
-msgstr "E563: помилка stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s не є ні каталогом, ні базою даних cscope"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Додано базу даних cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Помилка читання зі з'єднання cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: Невідомий тип пошуку cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Не вдалося створити канали до cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Не вдалося розділити процес для cscope"
 
+#: ../if_cscope.c:849
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection: помилка setpgid"
 
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection: помилка під час виконання"
 
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen для to_fp не вдався"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen для fr_fp не вдався"
 
+#: ../if_cscope.c:890
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Не вдалося створити процес cscope"
 
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: жодного з'єднання із cscope"
 
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Некоректний прапорець cscopequickfix %c для %c"
 
 # msgstr "E258: "
+#: ../if_cscope.c:1058
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: Для запиту cscope %s з %s нічого не знайдено"
 
 # msgstr "E259: "
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "Команди cscope:\n"
 
+#: ../if_cscope.c:1150
 #, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %s%*s (Використання: %s)"
 
+#: ../if_cscope.c:1155
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -2579,33 +3310,32 @@ msgstr ""
 "       s: Знайти цей символ C\n"
 "       t: Знайти цей текст\n"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: Не вдалося відкрити базу даних cscope: %s"
-
-msgid "E626: cannot get cscope database information"
-msgstr "E626: Не вдалося отримати інформацію з бази даних cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: Повторна база даних cscope не додана"
 
 # msgstr "E260: "
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: З'єднання з cscope %s не знайдено"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "З'єднання з cscope %s закінчено"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Фатальна помилка в cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Теґ cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2613,365 +3343,89 @@ msgstr ""
 "\n"
 "   #   рядок"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "файл / контекст / рядок\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Помилка cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Усі бази даних cscope перезавантажено"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "Жодного з'єднання з cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    назва бази даних                    шлях\n"
 
-msgid "Lua library cannot be loaded."
-msgstr "Не вдалося завантажити бібліотеку Lua"
-
-msgid "cannot save undo information"
-msgstr "не вдалося зберегти інформацію для скасування"
-
-msgid ""
-"E815: Sorry, this command is disabled, the MzScheme libraries could not be "
-"loaded."
-msgstr ""
-"E815: Вибачте, ця команда вимкнена, бібліотеки MzScheme не можуть бути "
-"завантажені."
-
-msgid "invalid expression"
-msgstr "некоректний вираз"
-
-msgid "expressions disabled at compile time"
-msgstr "обробку виразів вимкнено під час компіляції"
-
-msgid "hidden option"
-msgstr "прихована опція"
-
-msgid "unknown option"
-msgstr "невідома опція"
-
-msgid "window index is out of range"
-msgstr "некоректний номер вікна"
-
-msgid "couldn't open buffer"
-msgstr "не вдалося відкрити буфер"
-
-msgid "cannot delete line"
-msgstr "неможливо знищити рядок"
-
-msgid "cannot replace line"
-msgstr "неможливо замінити рядок"
-
-msgid "cannot insert line"
-msgstr "не вдалося вставити рядок"
-
-msgid "string cannot contain newlines"
-msgstr "більше ніж один рядок"
-
-msgid "error converting Scheme values to Vim"
-msgstr "не вдалося перетворити значення Scheme у Vim"
-
-msgid "Vim error: ~a"
-msgstr "Помилка Vim: ~a"
-
-msgid "Vim error"
-msgstr "Помилка Vim"
-
-msgid "buffer is invalid"
-msgstr "буфер непридатний"
-
-msgid "window is invalid"
-msgstr "вікно непридатне"
-
-msgid "linenr out of range"
-msgstr "номер рядка за межами файлу"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "не дозволено у пісочниці Vim"
-
-msgid "E837: This Vim cannot execute :py3 after using :python"
-msgstr "E837: Python: Не можна використати :py і :py3 в одному сеансі"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Вибачте, ця команда вимкнена, бібліотека Python не може бути "
-"завантажена."
-
-msgid "E836: This Vim cannot execute :python after using :py3"
-msgstr "E836: Python: Не можна використати :py і :py3 в одному сеансі"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Не можна рекурсивно викликати Python"
-
-msgid "E265: $_ must be an instance of String"
-msgstr "E265: $_ має бути екземпляром String"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Вибачте, ця команда вимкнена, бібліотека Ruby не може бути завантажена."
-
-# msgstr "E414: "
-msgid "E267: unexpected return"
-msgstr "E267: несподіваний return"
-
-msgid "E268: unexpected next"
-msgstr "E268: несподіваний next"
-
-msgid "E269: unexpected break"
-msgstr "E269: несподіваний break"
-
-msgid "E270: unexpected redo"
-msgstr "E270: несподіваний redo"
-
-msgid "E271: retry outside of rescue clause"
-msgstr "E271: retry поза rescue"
-
-msgid "E272: unhandled exception"
-msgstr "E272: Необроблений виняток"
-
-# msgstr "E233: "
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: Невідомий статус longjmp: %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Перемкнути реалізацію/визначення"
-
-msgid "Show base class of"
-msgstr "Знайти базовий клас"
-
-msgid "Show overridden member function"
-msgstr "Показати замінені функції-члени"
-
-msgid "Retrieve from file"
-msgstr "Прочитати з файлу"
-
-msgid "Retrieve from project"
-msgstr "Отримати з проекту"
-
-msgid "Retrieve from all projects"
-msgstr "Отримати з усіх проектів"
-
-msgid "Retrieve"
-msgstr "Отримати"
-
-msgid "Show source of"
-msgstr "Джерело"
-
-msgid "Find symbol"
-msgstr "Знайти символ"
-
-msgid "Browse class"
-msgstr "Переглянути клас"
-
-msgid "Show class in hierarchy"
-msgstr "Показати клас в ієрархії"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Показати клас в обмеженій ієрархії"
-
-msgid "Xref refers to"
-msgstr "Xref вказує на"
-
-msgid "Xref referred by"
-msgstr "На Xref вказано з"
-
-msgid "Xref has a"
-msgstr "Xref має"
-
-msgid "Xref used by"
-msgstr "Xref використано"
-
-msgid "Show docu of"
-msgstr "Показати docu"
-
-msgid "Generate docu for"
-msgstr "Створити docu для"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Не вдалося з'єднатися зі SNiFF+. Перевірте оточення (sniffemacs має бути у "
-"$PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Помилка під час читання. Від'єднано"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ зараз "
-
-msgid "not "
-msgstr "не "
-
-msgid "connected"
-msgstr "під'єднаний"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: Невідомий запит до SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Помилка з'єднання до SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ не під'єднано"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Не є буфером SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Помилка запису. Від'єднано"
-
-msgid "invalid buffer number"
-msgstr "неправильна назва буфера"
-
-msgid "not implemented yet"
-msgstr "ще не реалізовано"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "не вдалося встановити рядки"
-
-msgid "invalid mark name"
-msgstr "неправильна назва позначки"
-
-# msgstr "E19: "
-msgid "mark not set"
-msgstr "помітку не вказано"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "рядок %d колонка %d"
-
-msgid "cannot insert/append line"
-msgstr "Не вдалося вставити/додати рядок"
-
-msgid "line number out of range"
-msgstr "номер рядка за межами файлу"
-
-msgid "unknown flag: "
-msgstr "невідомий прапорець: "
-
-msgid "unknown vimOption"
-msgstr "Невідома vimOption"
-
-msgid "keyboard interrupt"
-msgstr "перервано з клавіатури"
-
-msgid "vim error"
-msgstr "помилка Vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "не вдалося створити команду вікна/буфера: об'єкт знищується"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "Не вдалося зареєструвати подію: буфер/вікно уже знищується"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: ФАТАЛЬНА ПОМИЛКА TCL: можливо пошкоджено список посилань!? Будь ласка, "
-"повідомте у vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"Не вдалося зареєструвати команду події: посилання на буфер/вікно не знайдено"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Вибачте, ця команда вимкнена, бібліотека Tcl не може бути завантажена."
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: Код виходу %d"
-
-msgid "cannot get line"
-msgstr "не вдалося дістати рядок"
-
-msgid "Unable to register a command server name"
-msgstr "Не вдалося зареєструвати назву сервера команд"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Не вдалося відіслати команду до програми-цілі"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Використано некоректний ідентифікатор сервера: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Реквізит реєстру зразку VIM сформований неправильно.  Знищено!"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "Невідомий аргумент опції"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Забагато аргументів"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Пропущено аргумент після"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "Сміття після аргументу опції"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Забагато аргументів у «+команда», «-c команда» або «--cmd команда»"
 
 # msgstr "E14: "
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Неправильний аргумент у"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d файли(ів)\n"
 
-msgid "netbeans is not supported with this GUI\n"
-msgstr "netbeans не підтримується з цим GUI\n"
-
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Ця версія Vim не була скомпільована з підтримкою порівняння."
-
-msgid "'-nb' cannot be used: not enabled at compile time\n"
-msgstr "Не можна використати '-nb': не дозволено під час компіляції\n"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "Спроба повторно відкрити скрипт: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "Не вдалося прочитати: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "Не вдалося відкрити як вихідний файл: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: Помилка: Не вдалося запустити gvim для NetBeans\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Застереження: Вивід не у термінал\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Застереження: Уведення не з терміналу\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "команди перед vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Не вдалося прочитати з «%s»"
 
 # msgstr "E282: "
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2979,18 +3433,23 @@ msgstr ""
 "\n"
 "Дізнайтеся більше: «vim -h»\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[файл ..]       редагувати вказані файли"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               читати текст з stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t помітка      перейти до теґу"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [файл]       перейти до першої помилки"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -3000,9 +3459,11 @@ msgstr ""
 "\n"
 "Вжиток:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [аргументи] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -3010,14 +3471,7 @@ msgstr ""
 "\n"
 "   або:"
 
-msgid ""
-"\n"
-"Where case is ignored prepend / to make flag upper case"
-msgstr ""
-"\n"
-"Якщо регістр ігнорується, додайте / спереду щоб прапорець був у верхньому "
-"регістрі."
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -3027,325 +3481,192 @@ msgstr ""
 "\n"
 "Аргументи:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tЛише назви файлів після цього"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tНе розкривати шаблони"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tЗареєструвати цей gvim для OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tСкасувати реєстрацію цього gvim для OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tЗапустити GUI (ніби «gvim»)"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  чи  --nofork\tПередній план: тримати термінал після запуску GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tРежим Vi (ніби «vi»)"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tРежим Ex (ніби «ex»)"
 
+#: ../main.c:2203
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tПокращений режим Ex"
 
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tМовчазний (пакетний) режим (лише для «ex»)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tРежим порівняння (ніби «vimdiff»)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tПростий режим (ніби «evim», без режимів)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tРежим перегляду (ніби «view»)"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tОбмежений режим (ніби «rvim»)"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tЗміни (запис файлів) не дозволено"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tЗміни в тексті файлів не дозволено"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tДвійковий режим"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tРежим lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tСумісний з Vi режим: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tНе зовсім сумісний з Vi режим: 'nocompatible'"
 
+#: ../main.c:2215
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr "-V[N][файл]\t\tБільше повідомлень [рівень N] [файл журн. повідомлень]"
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tРежим налагодження"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tНе використовувати файл обміну, тримати усе в пам'яті"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tПоказати файли обміну і вийти"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (назва файлу)\tВідновити аварійно закінчений сеанс"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tТе саме, що й -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tНе використовувати newcli для відкриття вікна"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <пристрій>\t\t\tВикористовувати <пристрій> для вводу/виводу"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tЗапустити в режимі арабської мови"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tЗапустити в режимі івриту"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tЗапустити в режимі перської мови"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <термінал>\tВстановити тип терміналу у <термінал>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tВикористати поданий файл замість .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-u <gvimrc>\t\tВикористати поданий файл замість .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tНе вантажити скрипти доповнення"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tВідкрити N вкладок (або по одній для кожного файлу)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tВідкрити N вікон (або по одному для кожного файлу)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tНіби -o, але поділити вікна вертикально"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tРозпочати в кінці файлу"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<рядок>\t\tРозпочати у вказаному <рядку>"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <команда>\tВиконати <команду> перед завантаженням vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <команда>\t\tВиконати <команду> після завантаження першого файлу"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <сеанс>\t\tВиконати поданий файл після першого завантаженого файлу"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <скрипт>\t\tЗчитати команди нормального режиму з файлу <скрипт>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <скрипт>\t\tДописати усі набрані команди до файлу <скрипт>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-w <скрипт>\t\tЗаписати усі набрані команди у файл <скрипт>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tРедагувати зашифровані файли"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <дисплей>\tПід'єднати vim до заданого дисплею сервера X"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tНе з'єднуватися з X сервером"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <файли>\tРедагувати <файли> на сервері Vim, якщо це можливо"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-silent <файли>  Те саме, тільки не скаржитися на відсутність сервера"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr ""
-"--remote-wait <файли>   ..., але зачекати поки усі файли будуть відредаговані"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <файли>  Те саме, тільки не скаржитися, якщо сервера "
-"немає"
-
-msgid ""
-"--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
-msgstr ""
-"--remote-tab[-wait][-silent] <файли>  Так само, як --remote, але по вкладці "
-"на файл"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <символи> Відіслати <символи> серверу і завершити роботу"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <вираз> Виконати <вираз> у сервері Vim і надрукувати результат"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr ""
-"--serverlist\t\tПоказати список наявних серверів Vim і завершити роботу"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <назва>\tНадіслати до/стати Vim сервером з <назвою>"
-
+#: ../main.c:2240
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <файл>\tЗаписати запускні повідомлення з часовими відмітками "
 "до <файлу>"
 
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tВикористати <viminfo> замість .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  чи  --help\tНадрукувати це повідомлення і вийти"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tНадрукувати інформацію про версію програми і вийти"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Аргументи для gvim (версія Motif)\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Аргументи для gvim (версія neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Аргументи для gvim (версія Athena)\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <дисплей>\tВиконати vim на заданому <дисплеї>"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tЗапустити Vim і згорнути його вікно"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <колір>\tВикористати <колір> для фону (також: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <колір>\tВикористати <колір> для звичайного тексту (також: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <шрифт>\tВикористати <шрифт> для звичайного тексту (також: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <шрифт>\tВикористати <шрифт> для жирного тексту"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <шрифт>\tВикористати <шрифт> для похилого тексту"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <геом>\tЗадати розміри й положення (також: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <товщ>\tВстановити товщину меж <товщ> (також: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <товщ>  Встановити товщину лінійки зсуву (також: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <висота>\tВстановити висоту меню <висота> (також: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tОбернути кольори (також: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tНе обертати кольори (також: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <ресурс>\t\tВстановити зазначений ресурс"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Аргументи gvim (версія GTK+)\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <дисплей>\tВиконати vim на <дисплеї> (також: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr ""
-"--role <роль>\tВстановити унікальну роль для ідентифікації головного вікна"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tВідкрити Vim в іншому елементі інтерфейсу GTK"
-
-msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
-msgstr "--echo-wid\t\tХай gvim надрукує ідентифікатор вікна на stdout"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <заголовок батька>\tВідкрити Vim всередині батьківського вікна"
-
-msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tВідкрити Vim всередині іншого елементу win32"
-
-msgid "No display"
-msgstr "Немає дисплею"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Не вдалося відіслати.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Не вдалося відіслати. Спроба виконати на місці\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "відредаговано %d з %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Немає дисплею: Відіслати вираз не вдалося.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Відіслати вираз не вдалося.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Не встановлено жодної помітки"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Помітку «%s» не знайдено"
 
 # msgstr "E283: "
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3354,6 +3675,7 @@ msgstr ""
 "пом. ряд.  кол. файл/текст"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3363,6 +3685,7 @@ msgstr ""
 
 # msgstr "E283: "
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3371,6 +3694,7 @@ msgstr ""
 "змінити ряд. стовп. текст"
 
 # TODO
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3379,6 +3703,7 @@ msgstr ""
 "# Помітки:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3387,6 +3712,7 @@ msgstr ""
 "# Список переходів (від найновіших):\n"
 
 # TODO
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3394,98 +3720,90 @@ msgstr ""
 "\n"
 "# Попередні помітки в файлах (від найновіших):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Пропущено '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Некоректна кодова сторінка"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Не вдалося встановити значення контексту вводу"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Не вдалося створити контекст вводу"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Не вдалося створити метод вводу"
-
-# msgstr "E286: "
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Застереження: Не вдалося встановити в методі вводу подію знищення"
-
-# msgstr "E287: "
-msgid "E288: input method doesn't support any style"
-msgstr "E288: Метод вводу не підтримує стилі"
-
-# msgstr "E288: "
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: Метод вводу не підтримує відредаговані типи"
-
 # msgstr "E292: "
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: Блок не було зафіксовано"
 
 # msgstr "E293: "
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Помилка зміни позиції у файлі обміну"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Помилка зчитування файлу обміну"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Помилка зміни позиції під час запису у файл обміну"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Помилка запису файлу обміну"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Файл обміну вже існує (атака символьним посиланням?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Немає блоку 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Немає блоку 1?"
 
 # msgstr "E298: "
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Немає блоку 2?"
 
-msgid "E843: Error while updating swap file crypt"
-msgstr "E843: Помилка поновлення шифрування файлу обміну"
-
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ой, втрачено файл обміну!!!"
 
 # msgstr "E301: "
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Не вдалося перейменувати файлу обміну"
 
 # msgstr "E302: "
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: Не вдалося прочитати файл обміну для «%s», відновлення неможливе"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Немає блоку 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Не знайдено файлу обміну для %s"
 
 # msgstr "E305: "
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Введіть номер файлу обміну, котрий використати, (0 для виходу):"
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Не вдалося відкрити %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Не вдалося прочитати блок 0 з "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3493,22 +3811,28 @@ msgstr ""
 "\n"
 "Напевно, змін не було, або Vim не поновив файл обміну."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " не можна використати з цією версією Vim.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Знайдіть Vim 3.0\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s не схоже на файл обміну Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " не можна використати на цьому комп'ютері.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Файл було створено на "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3516,107 +3840,89 @@ msgstr ""
 ",\n"
 "або файл було пошкоджено."
 
-#, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
-msgstr "E833: %s зашифровано, а ця версія Vim не підтримує шифрування"
-
+#: ../memline.c:945
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr " пошкоджений (розмір сторінки менший мінімального значення).\n"
 
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Використовується файл обміну «%s»"
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Початковий файл «%s»"
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Застереження: Можливо, початковий файл було змінено"
 
-#, c-format
-msgid "Swap file is encrypted: \"%s\""
-msgstr "Файл обміну зашифрований: «%s»"
-
-msgid ""
-"\n"
-"If you entered a new crypt key but did not write the text file,"
-msgstr ""
-"\n"
-"Якщо ви задали новий ключ шифру, але не записали текстовий файл,"
-
-msgid ""
-"\n"
-"enter the new crypt key."
-msgstr ""
-"\n"
-"введіть новий ключ шифру."
-
-msgid ""
-"\n"
-"If you wrote the text file after changing the crypt key press enter"
-msgstr ""
-"\n"
-"Якщо ви записали текстовий файл після зміни ключа шифру, натисніть enter"
-
-msgid ""
-"\n"
-"to use the same key for text file and swap file"
-msgstr ""
-"\n"
-"щоб використати однаковий ключ для текстового файлу та файлу обміну"
-
 # msgstr "E308: "
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Не вдалося прочитати блок 1 з %s"
 
 # msgstr "E309: "
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "??? БРАКУЄ БАГАТЬОХ РЯДКІВ"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "??? НЕПРАВИЛЬНА КІЛЬКІСТЬ РЯДКІВ"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "??? ПОРОЖНІЙ БЛОК"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "??? ПРОПУЩЕНІ РЯДКИ"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Ідентифікатор блоку 1 неправильний (%s не є файлом обміну?)"
 
 # msgstr "E310: "
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "??? ПРОПУЩЕНО БЛОК"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? звідси і до `??? КІНЕЦЬ' рядки, можливо, сплутані"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? звідси і до `??? КІНЕЦЬ' рядки, можливо, були додані/знищені"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "??? КІНЕЦЬ"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Відновлення перервано"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Під час відновлення знайдено помилки. Перегляньте рядки, що "
 "починаються з ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Див. «:help E312» для уточнення."
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Відновлення закінчено, перевірте чи все гаразд."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3624,12 +3930,15 @@ msgstr ""
 "\n"
 "(Можливо, потрібно записати цей файл під іншою назвою\n"
 
+#: ../memline.c:1252
 msgid "and run diff with the original file to check for changes)"
 msgstr "і запустити diff з оригіналом щоб перевірити зміни)"
 
+#: ../memline.c:1254
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr "Відновлення закінчено. Вміст буфера співпадає зі вмістом файлу."
 
+#: ../memline.c:1255
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
@@ -3639,43 +3948,52 @@ msgstr ""
 "Можливо, тепер ви хочете знищити файл обміну .swp.\n"
 "\n"
 
-msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Для текстового файлу використовується ключ шифру з файлу обміну.\n"
-
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Знайдено файли обміну:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   В поточному каталозі:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Використовуючи вказану назву:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   У каталозі "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- жодного --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "           власник: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "   дата: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "             дата: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [від Vim 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "        [не схоже на файл обміну]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         назва файлу: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3683,12 +4001,15 @@ msgstr ""
 "\n"
 "           змінено: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "ТАК"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "ні"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3696,9 +4017,11 @@ msgstr ""
 "\n"
 "          користувач: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "   назва вузла: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3706,6 +4029,7 @@ msgstr ""
 "\n"
 "          назва вузла: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3713,16 +4037,11 @@ msgstr ""
 "\n"
 "         ID процесу: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (виконується)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [не придатний для цієї версії Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3730,84 +4049,106 @@ msgstr ""
 "\n"
 "         [непридатний на цьому комп'ютері]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [не можна прочитати]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [не можна відкрити]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Не вдалося заготовити, немає файлу обміну"
 
 # msgstr "E313: "
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Файл збережено"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Збереження не вдалося"
 
 # msgstr "E314: "
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: неправильний lnum: %<PRId64>"
 
 # msgstr "E315: "
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: не знайшов рядок %<PRId64>"
 
 # msgstr "E316: "
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Вказівник блоку помилковий 3"
 
 # msgstr "E317: "
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx має бути рівним 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Поновлено забагато блоків?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Вказівник блоку помилковий 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "блок 1 знищено?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Не вдалося знайти рядок %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: Вказівник блоку помилковий"
 
 # msgstr "E317: "
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count дорівнює 0"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: Номер рядка вийшов за межі: %<PRId64> за кінцем"
 
 # msgstr "E322: "
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Кількість рядків у блоці %<PRId64>"
 
 # msgstr "E323: "
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Розмір стеку збільшується"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Вказівник блоку помилковий 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Циклічні символьні посилання «%s»"
 
 # msgstr "E317: "
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: УВАГА"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3815,14 +4156,15 @@ msgstr ""
 "\n"
 "Знайдено файл обміну з назвою \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "При відкритті файлу \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      НОВІШИЙ за файл обміну!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3834,15 +4176,19 @@ msgstr ""
 "    будьте обережні, щоб не залишилися два різні екземпляри\n"
 "    одного й того самого файлу після змін."
 
+#: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
 msgstr "  Вийдіть або продовжуйте обережно.\n"
 
+#: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сеанс редагування цього файлу зазнав краху.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    Якщо це справді трапилося, спробуйте «:recover» або «vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3850,9 +4196,11 @@ msgstr ""
 "»\n"
 "    щоб відновити зміни (див. «:help recovery»).\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    Якщо ви вже це зробили, знищіть файл обміну «"
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3861,18 +4209,23 @@ msgstr ""
 "    щоб позбутися цього повідомлення.\n"
 "\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Файл обміну «"
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "» вже існує!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM — УВАГА"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Файл обміну вже існує!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3886,6 +4239,7 @@ msgstr ""
 "&Q:Вийти\n"
 "&A:Перервати"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3901,41 +4255,64 @@ msgstr ""
 "&Q:Вийти\n"
 "&A:Перервати"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Знайдено забагато файлів обміну"
 
+# msgstr "E341: "
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Забракло пам'яті!  (потрібно було %<PRIu64> байтів)"
+
 # msgstr "E326: "
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Частина шляху до елемента меню не є підменю"
 
 # msgstr "E327: "
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Меню може бути тільки в іншому режимі"
 
 # msgstr "E328: "
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Немає меню «%s»"
 
 #. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
 msgid "E792: Empty menu name"
 msgstr "E792: Порожня назва меню"
 
 # msgstr "E329: "
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Шлях до меню не повинен вести до підменю"
 
 # msgstr "E330: "
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Не можна додавати елементи меню просто до верхнього меню"
 
 # msgstr "E331: "
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Роздільник не може бути частиною шляху меню"
 
 # msgstr "E332: "
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3943,65 +4320,78 @@ msgstr ""
 "\n"
 "--- Меню ---"
 
-msgid "Tear off this menu"
-msgstr "Відірвати це меню"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Шлях повинен вести до елемента меню"
 
 # msgstr "E333: "
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Меню не знайдено: %s"
 
 # msgstr "E334: "
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Для режиму %s меню не визначено"
 
 # msgstr "E335: "
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Шлях повинен вести до підменю"
 
 # msgstr "E336: "
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Меню не знайдено — перевірте назву"
 
 # msgstr "E337: "
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Виявлено помилку під час виконання %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "рядок %4ld:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Неправильна назва регістру: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Українізація: Анатолій Сахнік <sakhnik@gmail.com>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Перервано: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "Натисніть ENTER або введіть команду для продовження"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s рядок %<PRId64>"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Ще --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " ПРОБІЛ/d/j: вниз на екран/сторінку/рядок, b/u/k: вгору, q: вийти "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Запитання"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -4009,6 +4399,17 @@ msgstr ""
 "&Y:Так\n"
 "&N:Ні"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Y:Так\n"
+"&N:Ні\n"
+"&C:Скасувати"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4022,275 +4423,178 @@ msgstr ""
 "&D:Жодного\n"
 "&C:Скасувати"
 
-msgid "Select Directory dialog"
-msgstr "Вибрати каталог"
-
-msgid "Save File dialog"
-msgstr "Запам'ятати файл"
-
-msgid "Open File dialog"
-msgstr "Відкрити файл"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: Вибачте, але в консолі немає діалогу вибору файлу"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Недостатньо аргументів для printf()"
 
+#: ../message.c:3119
 msgid "E807: Expected Float argument for printf()"
 msgstr "E807: Очікується аргумент Float для printf()"
 
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Забагато аргументів для printf()"
 
 # msgstr "E338: "
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Застереження: Змінюється файл призначений лише для читання"
 
+#: ../misc1.c:2537
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "Наберіть число й <Enter> чи клацніть мишкою (порожнє скасовує): "
 
+#: ../misc1.c:2539
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Наберіть число й <Enter> (порожнє скасовує): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "додано один рядок"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "знищено один рядок"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "додано рядків: %<PRId64>"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "знищено рядків: %<PRId64>"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Перервано)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Дзень!"
 
-msgid "ERROR: "
-msgstr "ПОМИЛКА: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[байт]  всього розм/знищ. %<PRIu64>/%<PRIu64>, викор. %<PRIu64>, макс. %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[виклики] усього re/malloc() - %<PRIu64>, усього free() - %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Рядок стає занадто довгим"
-
-# msgstr "E340: "
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
-
-# msgstr "E341: "
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Забракло пам'яті!  (потрібно було %<PRIu64> байтів)"
-
 # msgstr "E342: "
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Викликається оболонка щоб виконати: «%s»"
 
-msgid "E545: Missing colon"
-msgstr "E545: Пропущено двокрапку"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Неправильний режим"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Неправильний вигляд миші"
-
-msgid "E548: digit expected"
-msgstr "E548: Потрібна цифра"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Неправильний відсоток"
-
-msgid "Enter encryption key: "
-msgstr "Вкажіть ключ шифру: "
-
-msgid "Enter same key again: "
-msgstr "Повторіть ключ: "
-
-msgid "Keys don't match!"
-msgstr "Ключі не однакові!"
-
-msgid "E854: path too long for completion"
-msgstr "E854: шлях занадто довгий для доповнення"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Некоректний шлях: `**[число]' повинне бути наприкінці шляху або перед "
-"'%s'."
-
-# msgstr "E343: "
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Не вдалося знайти каталог «%s» у cdpath"
-
-# msgstr "E344: "
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Не вдалося знайти файл «%s» у path"
-
-# msgstr "E345: "
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: У cdpath немає більше каталогу «%s»"
-
-# msgstr "E346: "
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: У шляху пошуку більше немає файлів «%s»"
-
-msgid "Cannot connect to Netbeans #2"
-msgstr "Не вдалося з'єднатися із Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Не вдалося з'єднатися із Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Неправильний режим доступу до файлу інформації про з'єднання з "
-"NetBenans: «%s»"
-
-msgid "read from Netbeans socket"
-msgstr "читається з сокета Netbeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Втрачено зв'язок із NetBeans для буфера %<PRId64>"
-
-msgid "E838: netbeans is not supported with this GUI"
-msgstr "E838: netbeans не підтримується з цим GUI"
-
-msgid "E511: netbeans already connected"
-msgstr "E511: netbeans вже під'єднано"
-
-#, c-format
-msgid "E505: %s is read-only (add ! to override)"
-msgstr "E505: %s тільки для читання (! щоб не зважати)"
-
 # msgstr "E348: "
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Немає ідентифікатора над курсором"
 
+#: ../normal.c:1866
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' порожня"
 
-msgid "E775: Eval feature not available"
-msgstr "E775: Можливість eval недоступна"
-
+#: ../normal.c:2637
 msgid "Warning: terminal cannot highlight"
 msgstr "Застереження: Термінал не підтримує кольори"
 
+#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Немає рядка на курсорі"
 
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: Не вдалося знищити згортки поточним методом 'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: Список змін порожній"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Початок списку змін"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "Один рядок %s-но"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Один рядок %s-но %d разів"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> рядків %s-но"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> рядків %s-но %d разів"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "Залишилося вирівняти %<PRId64> рядків..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "Вирівняно один рядок"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "Вирівняно рядків: %<PRId64>"
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: Регістри перед цим не вживались"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "не вдалося запам'ятати; все одно знищити?"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "Один рядок змінено"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "Змінено рядків: %<PRId64>"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "Звільнено рядків: %<PRId64>"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "Запам'ятав блок з одного рядка"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "Запам'ятав один рядок"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "Запам'ятав блок із %<PRId64> рядків"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "Запам'ятав рядків: %<PRId64>"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: У регістрі %s нічого немає"
 
 # msgstr "E353: "
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4298,9 +4602,11 @@ msgstr ""
 "\n"
 "--- Регістри ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Неправильна назва регістру"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4308,163 +4614,182 @@ msgstr ""
 "\n"
 "# Регістри:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Невідомий тип регістру %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "довж.: %<PRId64>; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> з %<PRId64> байтів"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> of %<PRId64> символів; %<PRId64> з %<PRId64> "
-"байтів"
+"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; "
+"%<PRId64> з %<PRId64> байтів"
 
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; байт %<PRId64> з %<PRId64>"
-
+#: ../ops.c:5105
 #, c-format
 msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; символ %<PRId64> of %<PRId64>; байт "
-"%<PRId64> з %<PRId64>"
+"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; "
+"%<PRId64> of %<PRId64> символів; %<PRId64> з %<PRId64> байтів"
 
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; "
+"байт %<PRId64> з %<PRId64>"
+
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; "
+"символ %<PRId64> of %<PRId64>; байт %<PRId64> з %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> для BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стор. %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Дякуємо за вибір Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Невідома опція"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Опція не підтримується"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Не дозволено у modeline"
 
+#: ../option.c:2815
 msgid "E846: Key code not set"
 msgstr "E846: Код ключа не встановлено"
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Після = потрібно вказати число"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Не знайдено серед можливостей терміналів"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Недозволений символ <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Не вдалося спорожнити 'term'"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Не вдалося змінити term в GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Застосуйте «:gui» для запуску GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: Опції 'backupext' і 'patchmode' однакові"
 
+#: ../option.c:3964
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr "E834: Конфліктує із значенням 'listchars'"
 
+#: ../option.c:3966
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: Конфліктує із значенням 'fillchars'"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Не можна змінити в GUI GTK+ 2"
-
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Бракує двокрапки"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Рядок порожній"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Після <%s> бракує числа"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Бракує коми"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Потрібно вказати значення '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Містить недруковні або розширені символи"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Некоректний(і) шрифт(и)"
-
-msgid "E597: can't select fontset"
-msgstr "E597: Не вдалося вибрати набір шрифтів"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Неправильний набір шрифтів"
-
-msgid "E533: can't select wide font"
-msgstr "E533: Не вдалося використати розширений шрифт"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Некоректний розширений шрифт"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Недозволений символ після <%c>"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: Потрібна кома"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' має бути порожньою чи містити %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Миша не підтримується"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Послідовність виразів не завершено"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: Забагато елементів"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: Групи не збалансовано"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Вікно перегляду вже існує"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr ""
 "W17: Для арабської мови потрібне UTF-8, виконайте ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Потрібно щонайменше %d рядків"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Потрібно щонайменше %d стовпців"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Невідома опція: %s"
@@ -4472,11 +4797,13 @@ msgstr "E355: Невідома опція: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
+#: ../option.c:6037
 #, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Потрібно вказати Number: &%s = '%s'"
 
 # msgstr "E355: "
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4484,6 +4811,7 @@ msgstr ""
 "\n"
 "--- Коди терміналу ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4491,6 +4819,7 @@ msgstr ""
 "\n"
 "--- Значення загальних опцій ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4498,6 +4827,7 @@ msgstr ""
 "\n"
 "--- Значення локальних опцій ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4505,135 +4835,23 @@ msgstr ""
 "\n"
 "--- Опції ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: Помилка get_varp"
 
 # msgstr "E356: "
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Для символу %s немає пари"
 
 # msgstr "E357: "
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Зайві символи після `;': %s"
 
-# msgstr "E358: "
-msgid "cannot open "
-msgstr "не вдалося відкрити "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Не вдалося відкрити вікно!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Потрібна Amigados 2.04 або пізніша\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Потрібно %s версії %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Не вдалося відкрити NIL:\n"
-
-msgid "Cannot create "
-msgstr "Не вдалося створити "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim завершує роботу з %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "не можу змінити режим консолі ?!\n"
-
-# msgstr "E359: "
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: не консоль??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Не вдалося запустити оболонку з опцією -f"
-
-# msgstr "E360: "
-msgid "Cannot execute "
-msgstr "Не вдалося виконати "
-
-msgid "shell "
-msgstr "оболонку "
-
-msgid " returned\n"
-msgstr " повернуто\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE замалий"
-
-msgid "I/O ERROR"
-msgstr "Помилка вводу/виводу"
-
-msgid "Message"
-msgstr "Повідомлення"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' не 80, не можна виконувати зовнішні команди"
-
-# msgstr "E364: "
-msgid "E237: Printer selection failed"
-msgstr "E237: Не вдалося вибрати принтер"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "на %s з %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Невідомий шрифт принтера: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Помилка друку: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Друкується '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Некоректна назва набору символів «%s» у назві шрифту «%s»"
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Помилковий символ %c в назві шрифту «%s»"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "На відкриття дисплею X пішло %<PRId64> мілісекунд"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Помилка X\n"
-
-msgid "Testing the X display failed"
-msgstr "Дисплей Х не пройшов перевірку"
-
-msgid "Opening the X display timed out"
-msgstr "Сплив час очікування відкриття дисплею Х"
-
-msgid ""
-"\n"
-"Could not get security context for "
-msgstr ""
-"\n"
-"Не вдалося отримати контекст безпеки для "
-
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
-"\n"
-"Не вдалося встановити контекст безпеки для "
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4641,14 +4859,8 @@ msgstr ""
 "\n"
 "Не вдалося запустити оболонку"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Не вдалося запустити оболонку `sh'\n"
-
 # msgstr "E362: "
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4656,318 +4868,313 @@ msgstr ""
 "\n"
 "оболонка повернула: "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
 "\n"
-"Не можна створити канали\n"
+"Не вдалося отримати контекст безпеки для "
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
 "\n"
-"Не вдалося роздвоїтися\n"
+"Не вдалося встановити контекст безпеки для "
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Команда закінчила виконання\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP втратив з'єднання ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = «%s»"
 
-msgid "Opening the X display failed"
-msgstr "Не вдалося відкрити дисплей X"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP обробляється запит 'збережи себе'"
-
-msgid "XSMP opening connection"
-msgstr "XSMP відкривається з'єднання"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP спостереження за з'єднанням з ICE не вдалося"
-
+# msgstr "E446: "
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP не вдалося SmcOpenConnection: %s"
-
-msgid "At line"
-msgstr "Рядок:"
-
-msgid "Could not load vim32.dll!"
-msgstr "Не вдалося завантажити vim32.dll"
-
-msgid "VIM Error"
-msgstr "Помилка VIM"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Не вдалося виправити вказівники на функції DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "оболонка повернула %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Виявлено подію %s\n"
-
-msgid "close"
-msgstr "close"
-
-msgid "logoff"
-msgstr "logoff"
-
-msgid "shutdown"
-msgstr "shutdown"
-
-msgid "E371: Command not found"
-msgstr "E371: Команду не знайдено"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"Файл VIMRUN.EXE не знайдено у шляху пошуку.\n"
-"Зовнішні команди не будуть призупинені після виконання.\n"
-"Гляньте  :help win32-vimrun щоб отримати подробиці."
-
-msgid "Vim Warning"
-msgstr "Застереження Vim"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Файл «%s» не знайдено у шляху пошуку"
 
 # msgstr "E371: "
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Забагато %%%c у рядку формату"
 
 # msgstr "E372: "
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Неочікуваний `%%%c' у рядку формату"
 
 # msgstr "E373: "
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Пропущено ] у рядку формату"
 
 # msgstr "E374: "
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c у рядку формату не підтримується"
 
 # msgstr "E375: "
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Помилковий `%%%c' у префіксі рядку формату"
 
 # msgstr "E376: "
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Помилковий `%%%c' у рядку формату"
 
 # msgstr "E377: "
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' не містить зразок"
 
 # msgstr "E378: "
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Пропущена чи порожня назва каталогу"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Немає більше елементів"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d з %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (рядок знищено)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Дно стеку виправлень"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Вершина стеку виправлень"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "список помилок %d з %d; %d помилок"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Не можу записати, вказана опція 'buftype'"
 
-# msgstr "E231: "
-msgid "Error file"
-msgstr "Файл помилок"
-
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Пропущено назву файлу чи некоректний шаблон"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Не вдалося відкрити файл «%s»"
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Буфер не завантажено"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: Очікується String чи List"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Некоректний елемент у %s%%[]"
 
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Бракує ] після %s["
 
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Немає пари %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Немає пари %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Немає пари %s)"
 
 # msgstr "E406: "
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( тут не дозволено"
 
 # msgstr "E406: "
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 та ін. тут не дозволено"
 
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Пропущено ] після %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] порожній"
 
 # msgstr "E382: "
+#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Зразок занадто довгий"
 
+#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Забагато \\z("
 
+#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Забагато %s("
 
+#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Немає пари \\z("
 
+#: ../regexp.c:1637
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: Недозволений символ після %s@"
 
+#: ../regexp.c:1672
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Забагато складних %s{...}"
 
 # msgstr "E339: "
+#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Вкладені %s*"
 
 # msgstr "E61: "
+#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Вкладені %s%c"
 
+#: ../regexp.c:1800
 msgid "E63: invalid use of \\_"
 msgstr "E63: Некоректно вжито \\_"
 
 # msgstr "E62: "
+#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: Після %s%c нічого немає"
 
+#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Некоректне зворотнє посилання"
 
+#: ../regexp.c:1943
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Неправильний символ після \\z"
 
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Недозволений символ після %s%%[dxouU]"
 
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Недозволений символ після %s%%"
 
 # msgstr "E64: "
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Синтаксична помилка в %s{...}"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Зовнішні під-збіги:\n"
 
+#: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
-"E864: після \\%#= може бути тільки 0, 1, or 2. Буде використано автоматичний механізм "
+"E864: після \\%#= може бути тільки 0, 1, or 2. Буде використано автоматичний "
+"механізм "
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) Зарано трапився кінець регулярного виразу"
+
+#: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
 msgstr "E866: (NFA regexp) Не на місці %c"
 
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) Зарано трапився кінець регулярного виразу"
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
 
+#: ../regexp_nfa.c:1261
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr "E867: (NFA) Невідомий оператор '\\z%c'"
 
+#: ../regexp_nfa.c:1387
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA) Невідомий оператор '\\%%%c'"
 
-#. should never happen
-msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Не вдалося побудувати NFA з класом еквівалентності!"
-
+#: ../regexp_nfa.c:1802
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr "E869: (NFA) Невідомий оператор '\\@%c'"
 
+#: ../regexp_nfa.c:1831
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr "E870: (NFA regexp) Не вдалося прочитати межі повторення"
 
 #. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr "E871: (NFA regexp) Мульти не може бути за мульти!"
 
 #. Too many `('
+#: ../regexp_nfa.c:2037
 msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA regexp) Забагато '('"
 
+#: ../regexp_nfa.c:2042
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA regexp) Забагато \\z("
 
+#: ../regexp_nfa.c:2066
 msgid "E873: (NFA regexp) proper termination error"
 msgstr "E873: (NFA regexp) помилка належного припинення"
 
+#: ../regexp_nfa.c:2599
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr "E874: (NFA) Стек порожній!"
 
+#: ../regexp_nfa.c:3298
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
@@ -4975,139 +5182,178 @@ msgstr ""
 "E875: (NFA regexp) (Під час перетворення з постфікс у NFA) залишилося "
 "забагато станів у стеку"
 
+#: ../regexp_nfa.c:3302
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr "E876: (NFA regexp) Недостатньо пам’яті, щоб зберегти весь NFA "
 
-msgid "E878: (NFA) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA) Не вдалося отримати пам’ять для обходу гілок!"
-
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
-"Не вдалося відкрити тимчасовий файл журналу для запису, показується на stderr ... "
+"Не вдалося відкрити тимчасовий файл журналу для запису, показується на "
+"stderr ... "
 
+#: ../regexp_nfa.c:4840
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr "(NFA) НЕ ВДАЛОСЯ ВІДКРИТИ %s!"
 
+#: ../regexp_nfa.c:6049
 msgid "Could not open temporary log file for writing "
 msgstr "Не вдалося відкрити тимчасовий файл журналу для запису "
 
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " ВІРТ ЗАМІНА"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ЗАМІНА"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " НАВИВОРІТ"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " ВСТАВКА"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (вставка)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (заміна)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (вірт заміна)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Іврит"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Арабська"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (мова)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (клей)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ВИБІР"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " ВИБІР РЯДКІВ"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " ВИБІР БЛОКУ"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ВИДІЛЕННЯ"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ВИДІЛЕННЯ РЯДКІВ"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ВИДІЛЕННЯ БЛОКУ"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "йде запис"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Неправильний зразок для пошуку: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Пошук дійшов до ПОЧАТКУ без збігів з %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Пошук дійшов до КІНЦЯ без збігів з %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Після `;' має бути `?' або `/'"
 
 # msgstr "E386: "
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (разом з попередніми збігами)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Включені файли "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "не знайдено "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "у шляху пошуку ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (Уже у списку)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  НЕ ЗНАЙДЕНО"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Пошук у включеному файлі: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "Шукається у включеному файлі %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Збіг у поточному рядку"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Були знайдені всі включені файли"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Жодного включеного файлу"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Визначення не знайдено"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Зразок не знайдено"
 
+#: ../search.c:4668
 msgid "Substitute "
 msgstr "Заміна "
 
+#: ../search.c:4681
 #, c-format
 msgid ""
 "\n"
@@ -5118,88 +5364,100 @@ msgstr ""
 "# Ост. %sЗразок пошуку:\n"
 "~"
 
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: Помилка формату у файлі орфографії"
 
 # msgstr "E364: "
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: Обірваний файл орфографії"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Зайвий текст у %s у рядку %d: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Назва афіксу завелика у %s у рядку %d: %s"
 
 # msgstr "E430: "
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Помилка формату у файлі афіксів FOL, LOW чи UPP"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Символ у FOL, LOW чи UPP поза межами"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "Стискується дерево слів..."
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Перевірка орфографії не дозволена"
 
-#, c-format
-msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
-msgstr ""
-"Застереження: Не вдалося знайти список слів «%s_%s.spl» чи «%s_ascii.spl»"
-
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Застереження: Не вдалося знайти список слів «%s.%s.spl» чи «%s.ascii.spl»"
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Читається файл орфографії «%s»"
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Не схоже на файл орфографії"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Файл орфографії старий, треба поновити"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Файл орфографії призначений для більш нової версії Vim"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Недозволена секція у файлі орфографії"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Застереження: регіон %s не підтримується"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Читається файл афіксів %s ..."
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Помилка перетворення слова у %s у рядку %d: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Перетворення у %s не підтримується: з %s до %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "Перетворення у %s не підтримується"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Некоректне значення FLAG у %s у рядку %d: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG після використання прапорців у %s у рядку %d: %s"
 
+#: ../spell.c:4723
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5208,6 +5466,7 @@ msgstr ""
 "Визначення COMPOUNDFORBIDFLAG після елементу PFX може дати неправильний "
 "результат у %s у рядку %d"
 
+#: ../spell.c:4731
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5216,35 +5475,43 @@ msgstr ""
 "Визначення COMPOUNDPERMITFLAG після елементу PFX можу дати неправильний "
 "результат у %s у рядку %d"
 
+#: ../spell.c:4747
 #, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDRULES у %s у рядку %d: %s"
 
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDWORDMAX у %s у рядку %d: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDMIN у %s у рядку %d: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Неправильне значення COMPOUNDSYLMAX у %s у рядку %d: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Неправильне значення CHECKCOMPOUNDPATTERN у %s у рядку %d: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Інший прапорець комбінації у продовженні блоку афіксів у %s у рядку %d: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Подвійний афікс у %s у рядку %d: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5253,273 +5520,337 @@ msgstr ""
 "Афікс також використовується для BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/"
 "NOSUGGEST у %s у рядку %d: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Треба Y чи N у %s у рядку %d: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Непридатна умова у %s у рядку %d: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Треба кількість REP(SAL) у %s у рядку %d"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Треба кількість MAP у %s у рядку %d"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Повторення символу у MAP у %s у рядку %d"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Нерозпізнаний чи повторний елемент у %s у рядку %d: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Пропущено рядок FOL/LOW/UPP у %s"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "Вжито COMPOUNDSYLMAX без SYLLABLE"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "Забагато відкладених префіксів"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "Забагато складних прапорців"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Забагато відкладених префіксів і/або складних прапорців"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Пропущено рядок SOFO%s у %s"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Обидва рядки SAL і SOFO у %s"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Прапорець не є числом у %s у рядку %d: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Неправильний прапорець у %s у рядку %d: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "Значення %s відрізняється від того, що вжито у іншому файлі .aff"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Зчитується словниковий файл %s ..."
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Немає кількості слів у %s"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "рядок %6d, слово %6d - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Повторення слова у %s у рядку %d: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Перше повторення слова у %s у рядку %d: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d повторюваних слів у %s"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "Пропущено %d слів(~) із не-ASCII символами у %s"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Читається файл слів %s ..."
 
+#: ../spell.c:6155
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Повторення рядка /encoding= проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "Рядок /encoding= після слова проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Повторення рядка /regions= проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Забагато регіонів у %s у рядку %d: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "Рядок / проігноровано у %s у рядку %d: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Некоректний номер регіону у %s у рядку %d: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Нерозпізнані прапорці у %s у рядку %d: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "Проігноровано %d слів із не-ASCII символами"
 
-msgid "E845: Insufficient memory, word list will be incomplete"
-msgstr "E845: Недостатньо пам’яті, список слів буде неповним"
-
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "Стиснено %d з %d вузлів; залишилося %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "Перечитується файл орфографії..."
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "Виконується згортання звуків..."
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Кількість слів після згортання звуків: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Повна кількість слів: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Записується файл припущень %s ..."
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Оцінка споживання пам'яті: %d байт"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Вихідний файл не повинен мати назву регіону"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Підтримується тільки до восьми регіонів"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Некоректний регіон у %s"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Застереження: зазначено обидва `складні слова' і NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Записується файл орфографії %s ..."
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "Зроблено!"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' не містить %<PRId64> елементів"
 
+#: ../spell.c:8074
 #, c-format
 msgid "Word '%.*s' removed from %s"
 msgstr "Слово '%.*s' знищено з %s"
 
+#: ../spell.c:8117
 #, c-format
 msgid "Word '%.*s' added to %s"
 msgstr "Слово '%.*s' додано до %s"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Символи у слові відрізняються у файлах орфографії"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "Пробачте, немає пропозицій"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Пробачте, тільки %<PRId64> пропозицій"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Замінити «%.*s» на:"
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < «%.*s»"
 
 # msgstr "E34: "
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: Немає попередньої заміни"
 
 # msgstr "E333: "
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Не знайдено: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Не схоже на файл .sug: %s"
 
+#: ../spell.c:9282
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Застарілий файл .sug, треба поновити: %s"
 
+#: ../spell.c:9286
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: Файл .sug для більш нової версії Vim: %s"
 
+#: ../spell.c:9295
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: Файл .sug не відповідає файлу .spl: %s"
 
+#: ../spell.c:9305
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Помилка читання файлу .sug: %s"
 
 #. This should have been checked when generating the .spl
-#. * file.
+#. file.
+#: ../spell.c:11575
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Повторено символ у елементі MAP"
 
 # msgstr "E391: "
+#: ../syntax.c:266
 msgid "No Syntax items defined for this buffer"
 msgstr "Для буфера не визначено елементів синтаксису"
 
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Неправильний аргумент: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Немає такого синтаксичного кластера: %s"
 
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "синхронізується по коментарях стилю С"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "без синхронізації"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "починається синхронізація за "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " рядків перед першим рядком"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5527,6 +5858,7 @@ msgstr ""
 "\n"
 "--- Елементи синхронізації синтаксису ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5534,6 +5866,7 @@ msgstr ""
 "\n"
 "синхронізація по елементах"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5541,240 +5874,300 @@ msgstr ""
 "\n"
 "--- Елементи синтаксису ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Немає такого синтаксичного кластера: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "мінімальний "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "максимальний "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; збіг "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " розриви рядків"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: Містить неприйнятні тут аргументи"
 
 # msgstr "E14: "
+#: ../syntax.c:4096
 msgid "E844: invalid cchar value"
 msgstr "E844: Некоректне значення cchar"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]hete тут неприйнятний"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Не знайдено елемент регіону для %s"
 
 # msgstr "E396: "
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Потрібна назва файлу"
 
+#: ../syntax.c:4221
 msgid "E847: Too many syntax includes"
 msgstr "E847: Забагато синтаксичних включень"
 
+#: ../syntax.c:4303
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Пропущено ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Пропущено `=': %s"
 
 # ---------------------------------------
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Бракує аргументів: синтаксичний регіон %s"
 
+#: ../syntax.c:4870
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Забагато синтаксичних кластерів"
 
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Кластер не вказано"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Кінець зразку не знайдено: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Сміття після зразку: %s"
 
 # msgstr "E402: "
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr ""
 "E403: Синтаксична синхронізація: зразок для продовження рядка вказано двічі"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Неправильні аргументи: %s"
 
 # msgstr "E404: "
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Пропущено знак рівності: %s"
 
 # msgstr "E405: "
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Порожній аргумент: %s"
 
 # msgstr "E406: "
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s тут не дозволено"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s має бути першим рядком у списку contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Невідома назва групи: %s"
 
 # msgstr "E409: "
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Неправильна підкоманда :syntax: %s"
 
+#: ../syntax.c:5854
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 "  ВСЬОГО     К-ТЬ   СПІВП.  НАЙПОВІЛ.   СЕРЕДН.   НАЗВА              ШАБЛОН"
 
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Рекурсивний цикл читання syncolor.vim"
 
 # msgstr "E410: "
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Групу підсвічування не знайдено: %s"
 
 # msgstr "E411: "
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Недостатньо аргументів: «:highlight link %s»"
 
 # msgstr "E412: "
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Забагато аргументів: «:highlight link %s»"
 
 # msgstr "E413: "
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Грума має settings, highlight link проігноровано"
 
 # msgstr "E414: "
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Несподіваний знак рівності: %s"
 
 # msgstr "E415: "
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: Пропущено знак рівності: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Пропущено аргумент: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Неправильне значення: %s"
 
 # msgstr "E418: "
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Невідомий колір тексту"
 
 # msgstr "E419: "
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Невідомий колір фону"
 
 # msgstr "E420: "
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Нерозпізнана назва або номер кольору: %s"
 
 # msgstr "E421: "
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Занадто довгий код терміналу: %s"
 
 # msgstr "E422: "
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Неправильний аргумент: %s"
 
 # msgstr "E423: "
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Використано забагато різних атрибутів кольору"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Недруковний символ у назві групи"
 
 # msgstr "E181: "
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Некоректний символ у назві групи"
 
+#: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Забагато груп підсвічування і синтаксису"
 
 # msgstr "E424: "
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: Кінець стеку теґів"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: Вершина стеку теґів"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Це вже найперший відповідний теґ"
 
 # msgstr "E425: "
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Теґ не знайдено: %s"
 
 # msgstr "E426: "
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # прі тип теґ"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "файл\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Лише один відповідний теґ"
 
 # msgstr "E427: "
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Це вже останній відповідний теґ"
 
 # msgstr "E428: "
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Файл «%s» не існує"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "теґ %d з %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " або більше"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  Використано теґ, не розрізняючи великі й малі літери"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Файл «%s» не існує"
 
 # msgstr "E429: "
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5782,72 +6175,85 @@ msgstr ""
 "\n"
 "  # ДО теґу        З рядка  у файлі/тексті"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Шукається у файлі теґів %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Шлях файлу теґів скорочено до %s\n"
-
+#: ../tag.c:1545
 msgid "Ignoring long line in tags file"
 msgstr "Ігнорується довгий рядок у файлі з позначками"
 
 # msgstr "E430: "
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Помилка формату у файлі теґів «%s»"
 
 # msgstr "E431: "
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Перед байтом %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Файл теґів не впорядкований: %s"
 
 # msgstr "E432: "
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Немає файлу теґів"
 
 # msgstr "E433: "
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Не вдалося знайти зразок теґу"
 
 # msgstr "E434: "
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Не вдалося знайти теґ, тільки припущення!"
 
+#: ../tag.c:2797
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "Назва поля повторюється: %s"
 
 # msgstr "E435: "
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' не відомий. Вбудовані термінали:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "початково '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Не вдалося відкрити файл можливостей терміналів"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Немає інформації про термінал"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Немає інформації про можливості терміналу"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Немає запису «%s» про можливості терміналу"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Потрібна можливість терміналу «cm»"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5855,252 +6261,174 @@ msgstr ""
 "\n"
 "--- Клавіші терміналу ---"
 
-msgid "new shell started\n"
-msgstr "запущено нову оболонку\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Помилка читання вводу, робота завершується...\n"
 
-# msgstr "E242: "
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Використано CUT_BUFFER0 замість порожнього виділення"
-
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-msgid "E834: Line count changed unexpectedly"
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
 msgstr "E834: Кількість рядків несподівано змінилася"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Скасування буде неможливе, все одно продовжити"
-
+#: ../undo.c:627
 #, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Не вдалося відкрити файл історії для запису: %s"
 
+#: ../undo.c:717
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr "E825: Файл історії пошкоджено (%s): %s"
 
+#: ../undo.c:1039
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr "Не вдалося записати файл історії у жодну з директорій у 'undodir'"
 
+#: ../undo.c:1074
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr "Will not overwrite with undo file, cannot read: %s"
 
+#: ../undo.c:1092
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr "Не можна перезаписати, це не файл історії: %s"
 
+#: ../undo.c:1108
 msgid "Skipping undo file write, nothing to undo"
 msgstr "Файл історії не записується, нічого повертати"
 
+#: ../undo.c:1121
 #, c-format
 msgid "Writing undo file: %s"
 msgstr "Записується файл історії: %s"
 
+#: ../undo.c:1213
 #, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E829: Помилка запису у файлі історії: %s"
 
+#: ../undo.c:1280
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr "Файл історії прочитано не буде, власник інший: %s"
 
+#: ../undo.c:1292
 #, c-format
 msgid "Reading undo file: %s"
 msgstr "Читається файл історії: %s"
 
+#: ../undo.c:1299
 #, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E822: Не вдалося відкрити файл для читання: %s"
 
 # msgstr "E333: "
+#: ../undo.c:1308
 #, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E823: Не файл історії: %s"
 
-#, c-format
-msgid "E832: Non-encrypted file has encrypted undo file: %s"
-msgstr "E832: Незашифрований файл має зашифрований файл історії: %s"
-
-#, c-format
-msgid "E826: Undo file decryption failed: %s"
-msgstr "E826: Не вдалося розшифрувати файл історії: %s"
-
-#, c-format
-msgid "E827: Undo file is encrypted: %s"
-msgstr "E827: Файл історії зашифрований: %s"
-
+#: ../undo.c:1313
 #, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E824: Несумісний файл історії: %s"
 
+#: ../undo.c:1328
 msgid "File contents changed, cannot use undo info"
 msgstr "Вміст файлу змінився, не можна використати інформацію про історію"
 
+#: ../undo.c:1497
 #, c-format
 msgid "Finished reading undo file %s"
 msgstr "Закінчено читання файлу історії %s"
 
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "Вже на найстаршій зміні"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "Вже на найновішій зміні"
 
+#: ../undo.c:1806
 #, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "E830: Зміну %<PRId64> не знайдено в історії"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильні номери рядків"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "додано рядок"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "рядків додано"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "знищено рядок"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "рядків знищено"
 
 # msgstr "E438: "
+#: ../undo.c:2193
 msgid "change"
 msgstr "зміна"
 
 # msgstr "E438: "
+#: ../undo.c:2195
 msgid "changes"
 msgstr "змін"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "перед"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "після"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "Немає нічого скасовувати"
 
+#: ../undo.c:2330
 msgid "number changes  when               saved"
 msgstr "номер  зміни    час             збережено"
 
+#: ../undo.c:2360
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "%<PRId64> секунд тому"
 
 # msgstr "E406: "
+#: ../undo.c:2372
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: Не можна виконати undojoin після undo"
 
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: Список скасування пошкоджено"
 
 # msgstr "E439: "
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: Відсутній рядок скасування"
 
-# msgstr "E440: "
-# ---------------------------------------
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Версія з GUI для 16/32-розрядної Windows"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit GUI version"
-msgstr ""
-"\n"
-"Версія з GUI для 64-розрядної MS-Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Версія з GUI для 32-розрядної Windows"
-
-msgid " in Win32s mode"
-msgstr " в режимі Win32s"
-
-msgid " with OLE support"
-msgstr " з підтримкою OLE"
-
-msgid ""
-"\n"
-"MS-Windows 64-bit console version"
-msgstr ""
-"\n"
-"Консольна версія для 64-розрядної Windows"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Консольна версія для 32-розрядної Windows"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Версія для 16-розрядної Windows"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версія для 32-розрядної MS-DOS"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Версія для 16-розрядної MS-DOS"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Версія для MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Версія для MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Версія для MacOS"
-
-msgid ""
-"\n"
-"OpenVMS version"
-msgstr ""
-"\n"
-"Версія для OpenVMS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -6108,6 +6436,7 @@ msgstr ""
 "\n"
 "Включені латки: "
 
+#: ../version.c:627
 msgid ""
 "\n"
 "Extra patches: "
@@ -6115,9 +6444,11 @@ msgstr ""
 "\n"
 "Додаткові латки: "
 
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Змінив "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -6125,9 +6456,11 @@ msgstr ""
 "\n"
 "Скомпілював "
 
+#: ../version.c:649
 msgid "by "
 msgstr " "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6135,889 +6468,1921 @@ msgstr ""
 "\n"
 "Гігантська версія "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Велика версія "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Нормальна версія "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Мала версія "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Крихітна версія "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "без GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "з GUI GTK2-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "з GUI GTK2."
-
-msgid "with X11-Motif GUI."
-msgstr "з GUI X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "з GUI X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "з GUI X11-Athena."
-
-msgid "with Photon GUI."
-msgstr "з GUI Photon."
-
-msgid "with GUI."
-msgstr "з GUI."
-
-msgid "with Carbon GUI."
-msgstr "з GUI Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "з GUI Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "з (класичним) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Включені (+) або не включені (-) компоненти:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "   системний vimrc: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     vimrc користувача: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " другий vimrc користувача: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " третій vimrc користувача: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      exrc користувача: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  другий exrc користувача: \""
 
-msgid "  system gvimrc file: \""
-msgstr "  системний gvimrc: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    gvimrc користувача: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "другий gvimrc користувача: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "третій gvimrc користувача: \""
-
-msgid "    system menu file: \""
-msgstr "    системне меню: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "  заміна для $VIM: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr " заміна для $VIMRUNTIME: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Скомпільовано: "
 
-msgid "Compiler: "
-msgstr "Компілятор: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Скомпоновано: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  ВЕРСІЯ ДЛЯ НАЛАГОДЖЕННЯ"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Покращений Vi"
 
+#: ../version.c:769
 msgid "version "
 msgstr "версія "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "автор: Bram Moolenaar та ін."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim — це відкрита й вільно розповсюджувана програма"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Допоможіть сиротам з Уганди!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr ":help iccf<Enter>         подробиці                "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr ":q<Enter>                 вихід з Vim              "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr ":help<Enter> або <F1>     перегляд допомоги        "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr ":help version7<Enter>     інформація про версію    "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Ви працюєте в режимі сумісному з Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr ":set nocp<Enter>          режим несумісний з Vi    "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr ":help cp-default<Enter>   інформація про сумісність"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "меню  Help->Orphans       подальша інформація      "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Без режимів, текст що набрано вставляється"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "меню  Edit->Global Settings->Toggle Insert Mode    "
-
-msgid "                              for two modes      "
-msgstr "                          для двох режимів         "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "меню  Edit->Global Settings->Toggle Vi Compatible  "
-
-msgid "                              for Vim defaults   "
-msgstr "              щоб починати в режимі сумісності з Vi"
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Підтримайте розробку редактора Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Станьте зареєстрованим користувачем Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr ":help sponsor<Enter>      подальша інформація      "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr ":help register<Enter>     подальша інформація      "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "меню  Допомога->Спонсор/Реєстрація  подробиці      "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ЗАСТЕРЕЖЕННЯ: Ви користуєтеся Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr ":help windows95<Enter>    інформація про це        "
-
 # msgstr "E444: "
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "Це вже єдине вікно"
 
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Немає вікна перегляду"
 
 # msgstr "E441: "
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: Не вдалося одночасно розбити topleft і botright"
 
 # msgstr "E442: "
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Не вдалося перемістити вікно, заважають інші"
 
 # msgstr "E443: "
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Не вдалося закрити останнє вікно"
 
 # msgstr "E443: "
+#: ../window.c:1810
 msgid "E813: Cannot close autocmd window"
 msgstr "E813: Не вдалося закрити вікно autocmd"
 
 # msgstr "E443: "
+#: ../window.c:1814
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Не вдалося закрити вікно, залишилося б тільки вікно autocmd"
 
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: У іншому вікні є зміни"
 
 # msgstr "E445: "
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Немає назви файлу над курсором"
 
-# msgstr "E446: "
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Файл «%s» не знайдено у шляху пошуку"
+#~ msgid "E831: bf_key_init() called with empty password"
+#~ msgstr "E831: Викликано bf_key_init() з порожнім паролем"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Не вдалося завантажити бібліотеку %s"
+#~ msgid "E820: sizeof(uint32_t) != 4"
+#~ msgstr "E820: sizeof(uint32_t) != 4"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr ""
-"Вибачте, ця команда вимкнена, бібліотека Perl не може бути завантажена."
+#~ msgid "E817: Blowfish big/little endian use wrong"
+#~ msgstr "E817: Неправильне використання порядку байтів Blowfish (BE/LE)"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: Обчислення виразів Perl заборонене у пісочниці без модуля Safe"
+#~ msgid "E818: sha256 test failed"
+#~ msgstr "E818: Не пройшла перевірка sha256"
 
-msgid "Edit with &multiple Vims"
-msgstr "Редагувати у (&m)різних Vim"
+#~ msgid "E819: Blowfish test failed"
+#~ msgstr "E819: Не пройшла перевірка Blowfish"
 
-msgid "Edit with single &Vim"
-msgstr "Редагувати у одному &Vim"
+#~ msgid "Patch file"
+#~ msgstr "Латка"
 
-msgid "Diff with Vim"
-msgstr "Порівняти з допомогою Vim"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&O:Гаразд\n"
+#~ "&C:Скасувати"
 
-msgid "Edit with &Vim"
-msgstr "Редагувати за допомогою &Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Немає з'єднання із сервером Vim"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "Редагувати у вже запущеному Vim - "
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Не вдалося відіслати до %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Редагує вибрані файли з допомогою Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Не вдалося прочитати відповідь сервера"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Помилка створення процесу, перевірте чи є gvim у шляху пошуку!"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: Не вдалося надіслати клієнту"
 
-msgid "gvimext.dll error"
-msgstr "помилка gvimext.dll"
+#~ msgid "Save As"
+#~ msgstr "Зберегти як"
 
-msgid "Path length too long!"
-msgstr "Шлях занадто довгий!"
+#~ msgid "Source Vim script"
+#~ msgstr "Прочитати скрипт Vim"
 
-# msgstr "E447: "
-msgid "--No lines in buffer--"
-msgstr "--Жодного рядка--"
+#~ msgid "Edit File"
+#~ msgstr "Редагувати Файл"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Команду перервано"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (НЕ ЗНАЙДЕНО)"
 
-msgid "E471: Argument required"
-msgstr "E471: Необхідно вказати аргумент"
+#~ msgid "unknown"
+#~ msgstr "Невідомо"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: За \\ має йти /, ? або &"
+# msgstr "E185: "
+#~ msgid "Edit File in new window"
+#~ msgstr "Редагувати файл у новому вікні"
 
-# msgstr "E10: "
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Неприпустимо у вікні команд, <CR> виконує, CTRL-C виходить"
+#~ msgid "Append File"
+#~ msgstr "Дописати файл"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Команда не дозволена у exrc/vimrc у пошуку поточного каталогу чи теґу"
+# msgstr "E187: "
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Позиція вікна: X %d, Y %d"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Бракує :endif"
+# msgstr "E188: "
+#~ msgid "Save Redirection"
+#~ msgstr "Зберегти переадресований вивід"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Бракує :endtry"
+#~ msgid "Save View"
+#~ msgstr "Зберегти вигляд"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Бракує :endwhile"
+#~ msgid "Save Session"
+#~ msgstr "Зберегти сеанс"
 
-msgid "E170: Missing :endfor"
-msgstr "E170: Бракує :endfor"
+#~ msgid "Save Setup"
+#~ msgstr "Зберегти налаштування"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile без :while"
+#~ msgid "E809: #< is not available without the +eval feature"
+#~ msgstr "E809: #< не доступна без можливості +eval"
 
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor без :for"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: У цій версії немає диграфів"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Файл існує (! щоб не зважати)"
+#~ msgid "is a device (disabled with 'opendevice' option)"
+#~ msgstr "є пристроєм (вимкнено опцією 'opendevice')"
 
-msgid "E472: Command failed"
-msgstr "E472: Команда на вдалась"
+#~ msgid "Reading from stdin..."
+#~ msgstr "Читається з stdin..."
+
+#~ msgid "[blowfish]"
+#~ msgstr "[blowfish]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[зашифровано]"
+
+#~ msgid "E821: File is encrypted with unknown method"
+#~ msgstr "E821: Файл зашифровано невідомим методом"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans не дозволяє записувати у незмінені буфери"
+
+# msgstr "E391: "
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Часткові записи заборонені для буферів NetBeans"
+
+#~ msgid "writing to device disabled with 'opendevice' option"
+#~ msgstr "Запис до пристрою заборонено опцією 'opendevice'"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Гілку ресурсів можна втратити (! щоб не зважати)"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<не відкривається> "
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: не вдалося отримати шрифт %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: не вдалося повернутися в поточний каталог"
+
+#~ msgid "Pathname:"
+#~ msgstr "Шлях:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: не вдалося отримати поточний каталог"
+
+#~ msgid "OK"
+#~ msgstr "Гаразд"
+
+#~ msgid "Cancel"
+#~ msgstr "Скасувати"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Діалог Vim"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Scrollbar Widget: Не вдалося визначити розмір скороченої картинки."
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: Не вдалося створити BalloonEval з повідомленням і функцією"
+
+#~ msgid "E851: Failed to create a new process for the GUI"
+#~ msgstr "E851: Не вдалося створити новий процес для GUI"
+
+#~ msgid "E852: The child process failed to start the GUI"
+#~ msgstr "E852: Дочірній процес не зміг запустити GUI"
+
+# msgstr "E228: "
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Не вдалося запустити GUI"
+
+# msgstr "E229: "
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Не вдалося прочитати з «%s»"
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: Не вдалося запустити GUI, не знайдено шрифт"
+
+# msgstr "E230: "
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: Некоректний 'guifontwide'"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Значення 'imactivatekey' некоректне"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Не вдалося отримати колір %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "Немає над курсором, пошук триває"
+
+#~ msgid "Input _Methods"
+#~ msgstr "Методи введення"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Знайти й замінити..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Пошук..."
+
+#~ msgid "Find what:"
+#~ msgstr "Знайти:"
+
+#~ msgid "Replace with:"
+#~ msgstr "Замінити на:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "Лише повне слово"
+
+#~ msgid "Match case"
+#~ msgstr "Зважати на регістр"
+
+#~ msgid "Direction"
+#~ msgstr "Напрям"
+
+#~ msgid "Up"
+#~ msgstr "Вгору"
+
+#~ msgid "Down"
+#~ msgstr "Униз"
+
+#~ msgid "Find Next"
+#~ msgstr "Наступне"
+
+#~ msgid "Replace"
+#~ msgstr "Замінити"
+
+#~ msgid "Replace All"
+#~ msgstr "Замінити усі"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Отримав запит «die» від менеджера сесій\n"
+
+#~ msgid "Close"
+#~ msgstr "Закрити"
+
+#~ msgid "New tab"
+#~ msgstr "Нова вкладка"
+
+#~ msgid "Open Tab..."
+#~ msgstr "Відкрити вкладку..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Несподівано знищилося головне вікно\n"
+
+#~ msgid "&Filter"
+#~ msgstr "&F:Фільтрувати"
+
+#~ msgid "&Cancel"
+#~ msgstr "&C:Скасувати"
+
+#~ msgid "Directories"
+#~ msgstr "Каталоги"
+
+#~ msgid "Filter"
+#~ msgstr "Фільтр"
+
+#~ msgid "&Help"
+#~ msgstr "&H:Допомога"
+
+#~ msgid "Files"
+#~ msgstr "Файли"
+
+#~ msgid "&OK"
+#~ msgstr "&O:Гаразд"
+
+#~ msgid "Selection"
+#~ msgstr "Виділення"
+
+#~ msgid "Find &Next"
+#~ msgstr "&N:Знайти далі"
+
+#~ msgid "&Replace"
+#~ msgstr "&R:Замінити"
+
+#~ msgid "Replace &All"
+#~ msgstr "&A:Замінити усі"
+
+#~ msgid "&Undo"
+#~ msgstr "&U:Скасувати"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Не вдалося знайти вікно «%s»"
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: Аргумент не підтримується: «-%s»; користуйтесь версією з OLE."
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Не вдалося відкрити вікно всередині програми MDI"
+
+#~ msgid "Close tab"
+#~ msgstr "Закрити вкладку"
+
+#~ msgid "Open tab..."
+#~ msgstr "Відкрити вкладку..."
+
+# msgstr "E245: "
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Знайти рядок ('\\\\' щоб знайти '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Знайти і замінити ('\\\\' щоб знайти '\\')"
+
+#~ msgid "Not Used"
+#~ msgstr "Немає"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "Каталог\t*.нічого\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Немає вільних комірок у палітрі, деякі кольори можуть бути "
+#~ "неправильні"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Шрифти для цих символів відсутні у наборі %s:"
+
+# msgstr "E250: "
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Назва набору шрифтів: %s"
+
+# msgstr "E252: "
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Шрифт '%s' не є моноширинним"
+
+#~ msgid "E253: Fontset name: %s"
+#~ msgstr "E253: Назва набору шрифтів: %s"
+
+#~ msgid "Font0: %s"
+#~ msgstr "Шрифт0: %s"
+
+#~ msgid "Font1: %s"
+#~ msgstr "Шрифт1: %s"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0"
+#~ msgstr "Ширина шрифту%<PRId64> не більша удвічі за ширину шрифту0"
+
+#~ msgid "Font0 width: %<PRId64>"
+#~ msgstr "Ширина шрифту0: %<PRId64>"
+
+#~ msgid "Font1 width: %<PRId64>"
+#~ msgstr "Ширина шрифту1: %<PRId64>"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "Некоректна специфікація шрифту"
+
+#~ msgid "&Dismiss"
+#~ msgstr "&D:Припинити"
+
+#~ msgid "no specific match"
+#~ msgstr "немає конкретного збігу"
+
+# msgstr "E234: "
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - Вибір шрифту"
+
+#~ msgid "Name:"
+#~ msgstr "Назва:"
+
+#~ msgid "Show size in Points"
+#~ msgstr "Показати розмір у пунктах"
+
+#~ msgid "Encoding:"
+#~ msgstr "Кодування:"
+
+#~ msgid "Font:"
+#~ msgstr "Шрифт:"
+
+#~ msgid "Style:"
+#~ msgstr "Стиль:"
+
+#~ msgid "Size:"
+#~ msgstr "Розмір:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Помилка автомату Hangul"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: помилка stat"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: Не вдалося відкрити базу даних cscope: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: Не вдалося отримати інформацію з бази даних cscope"
+
+#~ msgid "Lua library cannot be loaded."
+#~ msgstr "Не вдалося завантажити бібліотеку Lua"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "не вдалося зберегти інформацію для скасування"
+
+#~ msgid ""
+#~ "E815: Sorry, this command is disabled, the MzScheme libraries could not "
+#~ "be loaded."
+#~ msgstr ""
+#~ "E815: Вибачте, ця команда вимкнена, бібліотеки MzScheme не можуть бути "
+#~ "завантажені."
+
+#~ msgid "invalid expression"
+#~ msgstr "некоректний вираз"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "обробку виразів вимкнено під час компіляції"
+
+#~ msgid "hidden option"
+#~ msgstr "прихована опція"
+
+#~ msgid "unknown option"
+#~ msgstr "невідома опція"
+
+#~ msgid "window index is out of range"
+#~ msgstr "некоректний номер вікна"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "не вдалося відкрити буфер"
+
+#~ msgid "cannot delete line"
+#~ msgstr "неможливо знищити рядок"
+
+#~ msgid "cannot replace line"
+#~ msgstr "неможливо замінити рядок"
+
+#~ msgid "cannot insert line"
+#~ msgstr "не вдалося вставити рядок"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "більше ніж один рядок"
+
+#~ msgid "error converting Scheme values to Vim"
+#~ msgstr "не вдалося перетворити значення Scheme у Vim"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Помилка Vim: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Помилка Vim"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "буфер непридатний"
+
+#~ msgid "window is invalid"
+#~ msgstr "вікно непридатне"
+
+#~ msgid "linenr out of range"
+#~ msgstr "номер рядка за межами файлу"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "не дозволено у пісочниці Vim"
+
+#~ msgid "E837: This Vim cannot execute :py3 after using :python"
+#~ msgstr "E837: Python: Не можна використати :py і :py3 в одному сеансі"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Вибачте, ця команда вимкнена, бібліотека Python не може бути "
+#~ "завантажена."
+
+#~ msgid "E836: This Vim cannot execute :python after using :py3"
+#~ msgstr "E836: Python: Не можна використати :py і :py3 в одному сеансі"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Не можна рекурсивно викликати Python"
+
+#~ msgid "E265: $_ must be an instance of String"
+#~ msgstr "E265: $_ має бути екземпляром String"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Вибачте, ця команда вимкнена, бібліотека Ruby не може бути "
+#~ "завантажена."
+
+# msgstr "E414: "
+#~ msgid "E267: unexpected return"
+#~ msgstr "E267: несподіваний return"
+
+#~ msgid "E268: unexpected next"
+#~ msgstr "E268: несподіваний next"
+
+#~ msgid "E269: unexpected break"
+#~ msgstr "E269: несподіваний break"
+
+#~ msgid "E270: unexpected redo"
+#~ msgstr "E270: несподіваний redo"
+
+#~ msgid "E271: retry outside of rescue clause"
+#~ msgstr "E271: retry поза rescue"
+
+#~ msgid "E272: unhandled exception"
+#~ msgstr "E272: Необроблений виняток"
 
 # msgstr "E233: "
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Невідомий набір шрифтів: %s"
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: Невідомий статус longjmp: %d"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Невідомий шрифт: %s"
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Перемкнути реалізацію/визначення"
 
-# msgstr "E235: "
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Шрифт «%s» не моноширинний"
+#~ msgid "Show base class of"
+#~ msgstr "Знайти базовий клас"
 
-msgid "E473: Internal error"
-msgstr "E473: Внутрішня помилка"
+#~ msgid "Show overridden member function"
+#~ msgstr "Показати замінені функції-члени"
 
-msgid "Interrupted"
-msgstr "Перервано"
+#~ msgid "Retrieve from file"
+#~ msgstr "Прочитати з файлу"
 
-msgid "E14: Invalid address"
-msgstr "E14: Неправильна адреса"
+#~ msgid "Retrieve from project"
+#~ msgstr "Отримати з проекту"
 
-# msgstr "E14: "
-msgid "E474: Invalid argument"
-msgstr "E474: Некоректний аргумент"
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Отримати з усіх проектів"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Некоректний аргумент: %s"
+#~ msgid "Retrieve"
+#~ msgstr "Отримати"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Неправильний вираз: %s"
+#~ msgid "Show source of"
+#~ msgstr "Джерело"
 
-# msgstr "E15: "
-msgid "E16: Invalid range"
-msgstr "E16: Неправильні межі"
+#~ msgid "Find symbol"
+#~ msgstr "Знайти символ"
 
-# msgstr "E16: "
-msgid "E476: Invalid command"
-msgstr "E476: Некоректна команда"
+#~ msgid "Browse class"
+#~ msgstr "Переглянути клас"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: «%s» — це каталог"
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Показати клас в ієрархії"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Бібліотечний виклик до «%s()» не вдався"
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Показати клас в обмеженій ієрархії"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Не вдалося завантажити бібліотечну функцію %s"
+#~ msgid "Xref refers to"
+#~ msgstr "Xref вказує на"
 
-# msgstr "E18: "
-msgid "E19: Mark has invalid line number"
-msgstr "E19: У помітки некоректний номер рядка"
+#~ msgid "Xref referred by"
+#~ msgstr "На Xref вказано з"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref має"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref використано"
+
+#~ msgid "Show docu of"
+#~ msgstr "Показати docu"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Створити docu для"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Не вдалося з'єднатися зі SNiFF+. Перевірте оточення (sniffemacs має бути "
+#~ "у $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Помилка під час читання. Від'єднано"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ зараз "
+
+#~ msgid "not "
+#~ msgstr "не "
+
+#~ msgid "connected"
+#~ msgstr "під'єднаний"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: Невідомий запит до SNiFF+: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Помилка з'єднання до SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ не під'єднано"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: Не є буфером SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Помилка запису. Від'єднано"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "неправильна назва буфера"
+
+#~ msgid "not implemented yet"
+#~ msgstr "ще не реалізовано"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "не вдалося встановити рядки"
+
+#~ msgid "invalid mark name"
+#~ msgstr "неправильна назва позначки"
 
 # msgstr "E19: "
-msgid "E20: Mark not set"
-msgstr "E20: Помітку не встановлено"
+#~ msgid "mark not set"
+#~ msgstr "помітку не вказано"
 
-# msgstr "E20: "
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Зміни не дозволені: вимкнено 'modifiable'"
+#~ msgid "row %d column %d"
+#~ msgstr "рядок %d колонка %d"
 
-# msgstr "E21: "
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Забагато вкладених скриптів"
+#~ msgid "cannot insert/append line"
+#~ msgstr "Не вдалося вставити/додати рядок"
 
-# msgstr "E22: "
-msgid "E23: No alternate file"
-msgstr "E23: Немає вторинного файлу"
+#~ msgid "line number out of range"
+#~ msgstr "номер рядка за межами файлу"
 
-# msgstr "E23: "
-msgid "E24: No such abbreviation"
-msgstr "E24: Такого скорочення немає"
+#~ msgid "unknown flag: "
+#~ msgstr "невідомий прапорець: "
 
-# msgstr "E24: "
-msgid "E477: No ! allowed"
-msgstr "E477: ! не дозволено"
+#~ msgid "unknown vimOption"
+#~ msgstr "Невідома vimOption"
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Не можна використати GUI: Не ввімкнено під час компіляції"
+#~ msgid "keyboard interrupt"
+#~ msgstr "перервано з клавіатури"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Не можна використати іврит: Не ввімкнено під час компіляції\n"
+#~ msgid "vim error"
+#~ msgstr "помилка Vim"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Не можна використати фарсі: Не ввімкнено під час компіляції\n"
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "не вдалося створити команду вікна/буфера: об'єкт знищується"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr ""
-"E800: Не можна використати арабську мову: Не ввімкнено під час компіляції\n"
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "Не вдалося зареєструвати подію: буфер/вікно уже знищується"
 
-# msgstr "E25: "
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Немає такої групи підсвічування: %s"
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: ФАТАЛЬНА ПОМИЛКА TCL: можливо пошкоджено список посилань!? Будь "
+#~ "ласка, повідомте у vim-dev@vim.org"
 
-# msgstr "E28: "
-msgid "E29: No inserted text yet"
-msgstr "E29: Текст ще не було додано"
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "Не вдалося зареєструвати команду події: посилання на буфер/вікно не "
+#~ "знайдено"
 
-# msgstr "E29: "
-msgid "E30: No previous command line"
-msgstr "E30: Ще не було команд"
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Вибачте, ця команда вимкнена, бібліотека Tcl не може бути "
+#~ "завантажена."
 
-# msgstr "E30: "
-msgid "E31: No such mapping"
-msgstr "E31: Немає такої заміни"
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: Код виходу %d"
 
-# msgstr "E31: "
-msgid "E479: No match"
-msgstr "E479: Жодного збігу"
+#~ msgid "cannot get line"
+#~ msgstr "не вдалося дістати рядок"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Жодного збігу: %s"
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Не вдалося зареєструвати назву сервера команд"
 
-msgid "E32: No file name"
-msgstr "E32: Бракує назви файлу"
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Не вдалося відіслати команду до програми-цілі"
 
-# msgstr "E32: "
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Заміна зразків ще не використовувалась"
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: Використано некоректний ідентифікатор сервера: %s"
 
-# msgstr "E33: "
-msgid "E34: No previous command"
-msgstr "E34: Команд ще не було"
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr ""
+#~ "E251: Реквізит реєстру зразку VIM сформований неправильно.  Знищено!"
 
-# msgstr "E34: "
-msgid "E35: No previous regular expression"
-msgstr "E35: Зразків пошуку ще не було"
+#~ msgid "netbeans is not supported with this GUI\n"
+#~ msgstr "netbeans не підтримується з цим GUI\n"
 
-# msgstr "E35: "
-msgid "E481: No range allowed"
-msgstr "E481: Не дозволено вказувати межі"
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Ця версія Vim не була скомпільована з підтримкою порівняння."
 
-msgid "E36: Not enough room"
-msgstr "E36: Місця не вистачить"
+#~ msgid "'-nb' cannot be used: not enabled at compile time\n"
+#~ msgstr "Не можна використати '-nb': не дозволено під час компіляції\n"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: Помилка: Не вдалося запустити gvim для NetBeans\n"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: Немає зареєстрованих серверів з назвою «%s»"
+#~ msgid ""
+#~ "\n"
+#~ "Where case is ignored prepend / to make flag upper case"
+#~ msgstr ""
+#~ "\n"
+#~ "Якщо регістр ігнорується, додайте / спереду щоб прапорець був у верхньому "
+#~ "регістрі."
 
-# msgstr "E36: "
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Не вдалося створити файл %s"
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tЗареєструвати цей gvim для OLE"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Не вдалося сформувати назву тимчасового файлу"
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tСкасувати реєстрацію цього gvim для OLE"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Не вдалося відкрити файл %s"
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tЗапустити GUI (ніби «gvim»)"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  чи  --nofork\tПередній план: тримати термінал після запуску GUI"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Не вдалося прочитати файл %s"
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tНе використовувати newcli для відкриття вікна"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <пристрій>\t\t\tВикористовувати <пристрій> для вводу/виводу"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-u <gvimrc>\t\tВикористати поданий файл замість .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tРедагувати зашифровані файли"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <дисплей>\tПід'єднати vim до заданого дисплею сервера X"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tНе з'єднуватися з X сервером"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr ""
+#~ "--remote <файли>\tРедагувати <файли> на сервері Vim, якщо це можливо"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <файли>  Те саме, тільки не скаржитися на відсутність "
+#~ "сервера"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr ""
+#~ "--remote-wait <файли>   ..., але зачекати поки усі файли будуть "
+#~ "відредаговані"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <файли>  Те саме, тільки не скаржитися, якщо сервера "
+#~ "немає"
+
+#~ msgid ""
+#~ "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per "
+#~ "file"
+#~ msgstr ""
+#~ "--remote-tab[-wait][-silent] <файли>  Так само, як --remote, але по "
+#~ "вкладці на файл"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr ""
+#~ "--remote-send <символи> Відіслати <символи> серверу і завершити роботу"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <вираз> Виконати <вираз> у сервері Vim і надрукувати "
+#~ "результат"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Зміни не було записано (! щоб не зважати)"
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr ""
+#~ "--serverlist\t\tПоказати список наявних серверів Vim і завершити роботу"
 
-msgid "E38: Null argument"
-msgstr "E38: Відсутній аргумент"
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <назва>\tНадіслати до/стати Vim сервером з <назвою>"
 
-msgid "E39: Number expected"
-msgstr "E39: Очікується число"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи для gvim (версія Motif)\n"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Не вдалося відкрити файл помилок %s"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи для gvim (версія neXtaw):\n"
 
-msgid "E233: cannot open display"
-msgstr "E233: Не вдалося відкрити дисплей"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи для gvim (версія Athena)\n"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Забракло пам'яті!"
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <дисплей>\tВиконати vim на заданому <дисплеї>"
 
-msgid "Pattern not found"
-msgstr "Зразок не знайдено"
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tЗапустити Vim і згорнути його вікно"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Зразок не знайдено: %s"
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <колір>\tВикористати <колір> для фону (також: -bg)"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Аргумент має бути додатний"
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <колір>\tВикористати <колір> для звичайного тексту (також: -"
+#~ "fg)"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Не вдалося перейти до попереднього каталогу"
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <шрифт>\tВикористати <шрифт> для звичайного тексту (також: -fn)"
 
-msgid "E42: No Errors"
-msgstr "E42: Жодної помилки"
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <шрифт>\tВикористати <шрифт> для жирного тексту"
 
-msgid "E776: No location list"
-msgstr "E776: Немає списку місць"
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <шрифт>\tВикористати <шрифт> для похилого тексту"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Текст збігу пошкоджено"
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <геом>\tЗадати розміри й положення (також: -geom)"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Зіпсована програма регулярних виразів"
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <товщ>\tВстановити товщину меж <товщ> (також: -bw)"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Встановлено опцію 'readonly' (! щоб не зважати)"
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <товщ>  Встановити товщину лінійки зсуву (також: -sw)"
 
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Змінна тільки для читання: «%s»"
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <висота>\tВстановити висоту меню <висота> (також: -mh)"
 
-#, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E794: Не можна встановити змінну у пісочниці: «%s»"
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tОбернути кольори (також: -rv)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Помилка читання файлу помилок"
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tНе обертати кольори (також: +rv)"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: На дозволено у пісочниці"
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <ресурс>\t\tВстановити зазначений ресурс"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Не дозволено тут"
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Аргументи gvim (версія GTK+)\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <дисплей>\tВиконати vim на <дисплеї> (також: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr ""
+#~ "--role <роль>\tВстановити унікальну роль для ідентифікації головного вікна"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tВідкрити Vim в іншому елементі інтерфейсу GTK"
+
+#~ msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
+#~ msgstr "--echo-wid\t\tХай gvim надрукує ідентифікатор вікна на stdout"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <заголовок батька>\tВідкрити Vim всередині батьківського вікна"
+
+#~ msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
+#~ msgstr "--windowid <HWND>\tВідкрити Vim всередині іншого елементу win32"
+
+#~ msgid "No display"
+#~ msgstr "Немає дисплею"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Режим екрану не підтримується"
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Не вдалося відіслати.\n"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Некоректний розмір зсуву"
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Не вдалося відіслати. Спроба виконати на місці\n"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Опція 'shell' порожня"
+#~ msgid "%d of %d edited"
+#~ msgstr "відредаговано %d з %d"
 
-# msgstr "E254: "
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Не можна зчитати дані напису!"
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Немає дисплею: Відіслати вираз не вдалося.\n"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Помилка під час закриття файлу обміну"
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Відіслати вираз не вдалося.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Некоректна кодова сторінка"
+
+#~ msgid "E284: Cannot set IC values"
+#~ msgstr "E284: Не вдалося встановити значення контексту вводу"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Не вдалося створити контекст вводу"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Не вдалося створити метод вводу"
+
+# msgstr "E286: "
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Застереження: Не вдалося встановити в методі вводу подію знищення"
+
+# msgstr "E287: "
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: Метод вводу не підтримує стилі"
 
-msgid "E73: tag stack empty"
-msgstr "E73: Стек теґів порожній"
+# msgstr "E288: "
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: Метод вводу не підтримує відредаговані типи"
 
-msgid "E74: Command too complex"
-msgstr "E74: Занадто складна команда"
+#~ msgid "E843: Error while updating swap file crypt"
+#~ msgstr "E843: Помилка поновлення шифрування файлу обміну"
 
-msgid "E75: Name too long"
-msgstr "E75: Задовге ім'я"
+#~ msgid ""
+#~ "E833: %s is encrypted and this version of Vim does not support encryption"
+#~ msgstr "E833: %s зашифровано, а ця версія Vim не підтримує шифрування"
 
-msgid "E76: Too many ["
-msgstr "E76: Забагато '['"
+#~ msgid "Swap file is encrypted: \"%s\""
+#~ msgstr "Файл обміну зашифрований: «%s»"
 
-msgid "E77: Too many file names"
-msgstr "E77: Забагато назв файлів"
+#~ msgid ""
+#~ "\n"
+#~ "If you entered a new crypt key but did not write the text file,"
+#~ msgstr ""
+#~ "\n"
+#~ "Якщо ви задали новий ключ шифру, але не записали текстовий файл,"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Надлишкові символи"
+#~ msgid ""
+#~ "\n"
+#~ "enter the new crypt key."
+#~ msgstr ""
+#~ "\n"
+#~ "введіть новий ключ шифру."
 
-msgid "E78: Unknown mark"
-msgstr "E78: Невідома помітка"
+#~ msgid ""
+#~ "\n"
+#~ "If you wrote the text file after changing the crypt key press enter"
+#~ msgstr ""
+#~ "\n"
+#~ "Якщо ви записали текстовий файл після зміни ключа шифру, натисніть enter"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Не вдалося розкрити шаблон"
+#~ msgid ""
+#~ "\n"
+#~ "to use the same key for text file and swap file"
+#~ msgstr ""
+#~ "\n"
+#~ "щоб використати однаковий ключ для текстового файлу та файлу обміну"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' не може бути меншим за 'winminheight'"
+#~ msgid "Using crypt key from swap file for the text file.\n"
+#~ msgstr "Для текстового файлу використовується ключ шифру з файлу обміну.\n"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' не може бути меншим за 'winminwidth'"
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [не придатний для цієї версії Vim]"
 
-# msgstr "E79: "
-msgid "E80: Error while writing"
-msgstr "E80: Помилка під час запису"
+#~ msgid "Tear off this menu"
+#~ msgstr "Відірвати це меню"
 
-msgid "Zero count"
-msgstr "Нульова кількість"
+#~ msgid "Select Directory dialog"
+#~ msgstr "Вибрати каталог"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> використовується не в контексті скрипту"
+#~ msgid "Save File dialog"
+#~ msgstr "Запам'ятати файл"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Отримано некоректний вираз"
+#~ msgid "Open File dialog"
+#~ msgstr "Відкрити файл"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Не можна змінити захищений регіон"
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: Вибачте, але в консолі немає діалогу вибору файлу"
 
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans не дозволяє змінювати захищені від запису файли"
+#~ msgid "ERROR: "
+#~ msgstr "ПОМИЛКА: "
 
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: Внутрішня помилка: %s"
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[байт]  всього розм/знищ. %<PRIu64>/%<PRIu64>, викор. %<PRIu64>, макс. "
+#~ "%<PRIu64>\n"
 
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: Зразок використовує більше, ніж 'maxmempattern', пам'яті"
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[виклики] усього re/malloc() - %<PRIu64>, усього free() - %<PRIu64>\n"
+#~ "\n"
 
-msgid "E749: empty buffer"
-msgstr "E749: Порожній буфер"
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Рядок стає занадто довгим"
 
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: Некоректний зразок для пошуку чи роздільник"
+# msgstr "E340: "
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
 
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Файл уже завантажено в інший буфер"
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Неправильний вигляд миші"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Вкажіть ключ шифру: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "Повторіть ключ: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Ключі не однакові!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Не вдалося з'єднатися із Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Не вдалося з'єднатися із Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Неправильний режим доступу до файлу інформації про з'єднання з "
+#~ "NetBenans: «%s»"
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "читається з сокета Netbeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Втрачено зв'язок із NetBeans для буфера %<PRId64>"
+
+#~ msgid "E838: netbeans is not supported with this GUI"
+#~ msgstr "E838: netbeans не підтримується з цим GUI"
+
+#~ msgid "E511: netbeans already connected"
+#~ msgstr "E511: netbeans вже під'єднано"
+
+#~ msgid "E505: %s is read-only (add ! to override)"
+#~ msgstr "E505: %s тільки для читання (! щоб не зважати)"
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: Можливість eval недоступна"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "Звільнено рядків: %<PRId64>"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Не вдалося змінити term в GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Застосуйте «:gui» для запуску GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Не можна змінити в GUI GTK+ 2"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: Некоректний(і) шрифт(и)"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: Не вдалося вибрати набір шрифтів"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Неправильний набір шрифтів"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: Не вдалося використати розширений шрифт"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Некоректний розширений шрифт"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Миша не підтримується"
+
+# msgstr "E358: "
+#~ msgid "cannot open "
+#~ msgstr "не вдалося відкрити "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Не вдалося відкрити вікно!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Потрібна Amigados 2.04 або пізніша\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Потрібно %s версії %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Не вдалося відкрити NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Не вдалося створити "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim завершує роботу з %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "не можу змінити режим консолі ?!\n"
+
+# msgstr "E359: "
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: не консоль??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: Не вдалося запустити оболонку з опцією -f"
+
+# msgstr "E360: "
+#~ msgid "Cannot execute "
+#~ msgstr "Не вдалося виконати "
+
+#~ msgid "shell "
+#~ msgstr "оболонку "
+
+#~ msgid " returned\n"
+#~ msgstr " повернуто\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE замалий"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "Помилка вводу/виводу"
+
+#~ msgid "Message"
+#~ msgstr "Повідомлення"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' не 80, не можна виконувати зовнішні команди"
+
+# msgstr "E364: "
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: Не вдалося вибрати принтер"
+
+#~ msgid "to %s on %s"
+#~ msgstr "на %s з %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Невідомий шрифт принтера: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Помилка друку: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Друкується '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Некоректна назва набору символів «%s» у назві шрифту «%s»"
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Помилковий символ %c в назві шрифту «%s»"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "На відкриття дисплею X пішло %<PRId64> мілісекунд"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Помилка X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Дисплей Х не пройшов перевірку"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Сплив час очікування відкриття дисплею Х"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Не вдалося запустити оболонку `sh'\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Не можна створити канали\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Не вдалося роздвоїтися\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Команда закінчила виконання\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP втратив з'єднання ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Не вдалося відкрити дисплей X"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP обробляється запит 'збережи себе'"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP відкривається з'єднання"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP спостереження за з'єднанням з ICE не вдалося"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP не вдалося SmcOpenConnection: %s"
+
+#~ msgid "At line"
+#~ msgstr "Рядок:"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Не вдалося завантажити vim32.dll"
+
+#~ msgid "VIM Error"
+#~ msgstr "Помилка VIM"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Не вдалося виправити вказівники на функції DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "оболонка повернула %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Виявлено подію %s\n"
+
+#~ msgid "close"
+#~ msgstr "close"
+
+#~ msgid "logoff"
+#~ msgstr "logoff"
+
+#~ msgid "shutdown"
+#~ msgstr "shutdown"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Команду не знайдено"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "Файл VIMRUN.EXE не знайдено у шляху пошуку.\n"
+#~ "Зовнішні команди не будуть призупинені після виконання.\n"
+#~ "Гляньте  :help win32-vimrun щоб отримати подробиці."
+
+#~ msgid "Vim Warning"
+#~ msgstr "Застереження Vim"
+
+# msgstr "E231: "
+#~ msgid "Error file"
+#~ msgstr "Файл помилок"
+
+#~ msgid "E868: Error building NFA with equivalence class!"
+#~ msgstr "E868: Не вдалося побудувати NFA з класом еквівалентності!"
+
+#~ msgid "E878: (NFA) Could not allocate memory for branch traversal!"
+#~ msgstr "E878: (NFA) Не вдалося отримати пам’ять для обходу гілок!"
+
+#~ msgid "Warning: Cannot find word list \"%s_%s.spl\" or \"%s_ascii.spl\""
+#~ msgstr ""
+#~ "Застереження: Не вдалося знайти список слів «%s_%s.spl» чи «%s_ascii.spl»"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "Перетворення у %s не підтримується"
+
+#~ msgid "E845: Insufficient memory, word list will be incomplete"
+#~ msgstr "E845: Недостатньо пам’яті, список слів буде неповним"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Шлях файлу теґів скорочено до %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "запущено нову оболонку\n"
+
+# msgstr "E242: "
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Використано CUT_BUFFER0 замість порожнього виділення"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Скасування буде неможливе, все одно продовжити"
+
+#~ msgid "E832: Non-encrypted file has encrypted undo file: %s"
+#~ msgstr "E832: Незашифрований файл має зашифрований файл історії: %s"
+
+#~ msgid "E826: Undo file decryption failed: %s"
+#~ msgstr "E826: Не вдалося розшифрувати файл історії: %s"
+
+#~ msgid "E827: Undo file is encrypted: %s"
+#~ msgstr "E827: Файл історії зашифрований: %s"
+
+# msgstr "E440: "
+# ---------------------------------------
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія з GUI для 16/32-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія з GUI для 64-розрядної MS-Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія з GUI для 32-розрядної Windows"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " в режимі Win32s"
+
+#~ msgid " with OLE support"
+#~ msgstr " з підтримкою OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 64-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольна версія для 64-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Консольна версія для 32-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для 16-розрядної Windows"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для 32-розрядної MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для 16-розрядної MS-DOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "OpenVMS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Версія для OpenVMS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Велика версія "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Нормальна версія "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Мала версія "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Крихітна версія "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "з GUI GTK2-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "з GUI GTK2."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "з GUI X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "з GUI X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "з GUI X11-Athena."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "з GUI Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "з GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "з GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "з GUI Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "з (класичним) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "  системний gvimrc: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    gvimrc користувача: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "другий gvimrc користувача: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "третій gvimrc користувача: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "    системне меню: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Компілятор: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "меню  Help->Orphans       подальша інформація      "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Без режимів, текст що набрано вставляється"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "меню  Edit->Global Settings->Toggle Insert Mode    "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                          для двох режимів         "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "меню  Edit->Global Settings->Toggle Vi Compatible  "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "              щоб починати в режимі сумісності з Vi"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ЗАСТЕРЕЖЕННЯ: Ви користуєтеся Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr ":help windows95<Enter>    інформація про це        "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Не вдалося завантажити бібліотеку %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr ""
+#~ "Вибачте, ця команда вимкнена, бібліотека Perl не може бути завантажена."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Обчислення виразів Perl заборонене у пісочниці без модуля Safe"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Редагувати у (&m)різних Vim"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Редагувати у одному &Vim"
+
+#~ msgid "Diff with Vim"
+#~ msgstr "Порівняти з допомогою Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Редагувати за допомогою &Vim"
+
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "Редагувати у вже запущеному Vim - "
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Редагує вибрані файли з допомогою Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Помилка створення процесу, перевірте чи є gvim у шляху пошуку!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "помилка gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Шлях занадто довгий!"
+
+# msgstr "E233: "
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Невідомий набір шрифтів: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Невідомий шрифт: %s"
 
 # msgstr "E235: "
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: Опція '%s' не встановлена"
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: Шрифт «%s» не моноширинний"
 
-msgid "E850: Invalid register name"
-msgstr "E850: Неправильна назва регістру"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Не вдалося завантажити бібліотечну функцію %s"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "Пошук дійшов до ПОЧАТКУ, продовжується з КІНЦЯ"
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Не можна використати іврит: Не ввімкнено під час компіляції\n"
 
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "Пошук дійшов до КІНЦЯ, продовжується з ПОЧАТКУ"
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Не можна використати фарсі: Не ввімкнено під час компіляції\n"
 
-#, c-format
-msgid "Need encryption key for \"%s\""
-msgstr "Для «%s» потрібен ключ: "
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr ""
+#~ "E800: Не можна використати арабську мову: Не ввімкнено під час "
+#~ "компіляції\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: Немає зареєстрованих серверів з назвою «%s»"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: Не вдалося відкрити дисплей"
+
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: Отримано некоректний вираз"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Не можна змінити захищений регіон"
+
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans не дозволяє змінювати захищені від запису файли"
+
+#~ msgid "Need encryption key for \"%s\""
+#~ msgstr "Для «%s» потрібен ключ: "
 
 # msgstr "E406: "
-msgid "empty keys are not allowed"
-msgstr "порожні ключі не дозволені"
+#~ msgid "empty keys are not allowed"
+#~ msgstr "порожні ключі не дозволені"
 
-msgid "dictionary is locked"
-msgstr "словник заблоковано"
+#~ msgid "dictionary is locked"
+#~ msgstr "словник заблоковано"
 
-msgid "list is locked"
-msgstr "список заблоковано"
+#~ msgid "list is locked"
+#~ msgstr "список заблоковано"
 
-#, c-format
-msgid "failed to add key '%s' to dictionary"
-msgstr "не вдалося додати ключ '%s' до словника"
+#~ msgid "failed to add key '%s' to dictionary"
+#~ msgstr "не вдалося додати ключ '%s' до словника"
 
-#, c-format
-msgid "index must be int or slice, not %s"
-msgstr "індекс має бути цілий чи зріз, не %s"
+#~ msgid "index must be int or slice, not %s"
+#~ msgstr "індекс має бути цілий чи зріз, не %s"
 
-#, c-format
-msgid "expected str() or unicode() instance, but got %s"
-msgstr "очікувався екземпляр str() чи unicode(), але отримано %s"
+#~ msgid "expected str() or unicode() instance, but got %s"
+#~ msgstr "очікувався екземпляр str() чи unicode(), але отримано %s"
 
-#, c-format
-msgid "expected bytes() or str() instance, but got %s"
-msgstr "очікувався екземпляр bytes() чи str(), але отримано %s"
+#~ msgid "expected bytes() or str() instance, but got %s"
+#~ msgstr "очікувався екземпляр bytes() чи str(), але отримано %s"
 
-#, c-format
-msgid ""
-"expected int(), long() or something supporting coercing to long(), but got %s"
-msgstr ""
-"очікувався int(), long() чи щось, що може бути вміщене long(), але отримано %s"
+#~ msgid ""
+#~ "expected int(), long() or something supporting coercing to long(), but "
+#~ "got %s"
+#~ msgstr ""
+#~ "очікувався int(), long() чи щось, що може бути вміщене long(), але "
+#~ "отримано %s"
 
-#, c-format
-msgid "expected int() or something supporting coercing to int(), but got %s"
-msgstr "очікувався int() чи щось, що може бути вміщене int(), але отримано %s"
+#~ msgid "expected int() or something supporting coercing to int(), but got %s"
+#~ msgstr ""
+#~ "очікувався int() чи щось, що може бути вміщене int(), але отримано %s"
 
-msgid "value is too large to fit into C int type"
-msgstr "значення завелике, щоб вміститися у тип C int"
+#~ msgid "value is too large to fit into C int type"
+#~ msgstr "значення завелике, щоб вміститися у тип C int"
 
-msgid "value is too small to fit into C int type"
-msgstr "значення замале, щоб вміститися у тип C int"
+#~ msgid "value is too small to fit into C int type"
+#~ msgstr "значення замале, щоб вміститися у тип C int"
 
-msgid "number must be greater then zero"
-msgstr "число має бути більше, ніж нуль"
+#~ msgid "number must be greater then zero"
+#~ msgstr "число має бути більше, ніж нуль"
 
-msgid "number must be greater or equal to zero"
-msgstr "число має бути не менше, ніж нуль"
+#~ msgid "number must be greater or equal to zero"
+#~ msgstr "число має бути не менше, ніж нуль"
 
-msgid "can't delete OutputObject attributes"
-msgstr "не вдалося знищити атрибути OutputObject"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "не вдалося знищити атрибути OutputObject"
 
 # msgstr "E180: "
-#, c-format
-msgid "invalid attribute: %s"
-msgstr "неправильний атрибут: %s"
+#~ msgid "invalid attribute: %s"
+#~ msgstr "неправильний атрибут: %s"
 
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Помилка ініціалізації об'єктів вводу/виводу"
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Помилка ініціалізації об'єктів вводу/виводу"
 
-msgid "failed to change directory"
-msgstr "не вдалося змінити директорію"
+#~ msgid "failed to change directory"
+#~ msgstr "не вдалося змінити директорію"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got %s"
-msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %s"
+#~ msgid "expected 3-tuple as imp.find_module() result, but got %s"
+#~ msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %s"
 
-#, c-format
-msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
-msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %d"
+#~ msgid ""
+#~ "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
+#~ msgstr "очікувався 3-кортеж як результат imp.find_module(), але отримано %d"
 
-msgid "internal error: imp.find_module returned tuple with NULL"
-msgstr "внутрішня помилка: imp.find_module повернула кортеж з NULL"
+#~ msgid "internal error: imp.find_module returned tuple with NULL"
+#~ msgstr "внутрішня помилка: imp.find_module повернула кортеж з NULL"
 
-msgid "cannot delete vim.Dictionary attributes"
-msgstr "не вдалося знищити атрибути vim.Dictionary"
+#~ msgid "cannot delete vim.Dictionary attributes"
+#~ msgstr "не вдалося знищити атрибути vim.Dictionary"
 
-msgid "cannot modify fixed dictionary"
-msgstr "не можна змінити фіксований словник"
+#~ msgid "cannot modify fixed dictionary"
+#~ msgstr "не можна змінити фіксований словник"
 
-#, c-format
-msgid "cannot set attribute %s"
-msgstr "не можна встановити атрибут %s"
+#~ msgid "cannot set attribute %s"
+#~ msgstr "не можна встановити атрибут %s"
 
-msgid "hashtab changed during iteration"
-msgstr "хеш-таблиця змінилася під час перебирання"
+#~ msgid "hashtab changed during iteration"
+#~ msgstr "хеш-таблиця змінилася під час перебирання"
 
-#, c-format
-msgid "expected sequence element of size 2, but got sequence of size %d"
-msgstr "очікувалась послідовність розміром 2, але отримано послідовність розміру %d"
+#~ msgid "expected sequence element of size 2, but got sequence of size %d"
+#~ msgstr ""
+#~ "очікувалась послідовність розміром 2, але отримано послідовність розміру "
+#~ "%d"
 
-msgid "list constructor does not accept keyword arguments"
-msgstr "списковий конструктор не приймає іменовані аргументи"
+#~ msgid "list constructor does not accept keyword arguments"
+#~ msgstr "списковий конструктор не приймає іменовані аргументи"
 
-msgid "list index out of range"
-msgstr "індекс списку за межами"
+#~ msgid "list index out of range"
+#~ msgstr "індекс списку за межами"
 
-#. No more suitable format specifications in python-2.3
-#, c-format
-msgid "internal error: failed to get vim list item %d"
-msgstr "внутрішня помилка: не вдалося отримати елемент списку vim %d"
+#~ msgid "internal error: failed to get vim list item %d"
+#~ msgstr "внутрішня помилка: не вдалося отримати елемент списку vim %d"
 
-msgid "failed to add item to list"
-msgstr "не вдалося додати елемент до списку"
+#~ msgid "failed to add item to list"
+#~ msgstr "не вдалося додати елемент до списку"
 
-#, c-format
-msgid "internal error: no vim list item %d"
-msgstr "внутрішня помилка: немає елемента списку vim %d"
+#~ msgid "internal error: no vim list item %d"
+#~ msgstr "внутрішня помилка: немає елемента списку vim %d"
 
-msgid "internal error: failed to add item to list"
-msgstr "внутрішня помилка: не вдалося додати елемент до списку"
+#~ msgid "internal error: failed to add item to list"
+#~ msgstr "внутрішня помилка: не вдалося додати елемент до списку"
 
-msgid "cannot delete vim.List attributes"
-msgstr "не вдалося знищити атрибути vim.List"
+#~ msgid "cannot delete vim.List attributes"
+#~ msgstr "не вдалося знищити атрибути vim.List"
 
-msgid "cannot modify fixed list"
-msgstr "не можна змінити фіксований список"
+#~ msgid "cannot modify fixed list"
+#~ msgstr "не можна змінити фіксований список"
 
 # msgstr "E428: "
-#, c-format
-msgid "unnamed function %s does not exist"
-msgstr "безіменної функції %s не існує"
+#~ msgid "unnamed function %s does not exist"
+#~ msgstr "безіменної функції %s не існує"
 
 # msgstr "E428: "
-#, c-format
-msgid "function %s does not exist"
-msgstr "функції %s не існує"
+#~ msgid "function %s does not exist"
+#~ msgstr "функції %s не існує"
 
-msgid "function constructor does not accept keyword arguments"
-msgstr "конструктор функції не приймає іменовані аргументи"
+#~ msgid "function constructor does not accept keyword arguments"
+#~ msgstr "конструктор функції не приймає іменовані аргументи"
 
-#, c-format
-msgid "failed to run function %s"
-msgstr "не вдалося виконати функцію %s"
+#~ msgid "failed to run function %s"
+#~ msgstr "не вдалося виконати функцію %s"
 
-msgid "unable to get option value"
-msgstr "не вдалося отримати значення опції"
+#~ msgid "problem while switching windows"
+#~ msgstr "не вдалося перемкнути вікна"
 
-msgid "internal error: unknown option type"
-msgstr "внутрішня помилка: невідомий тип опції"
+#~ msgid "unable to unset global option %s"
+#~ msgstr "не вдалося скинути глобальну опцію %s"
 
-msgid "problem while switching windows"
-msgstr "не вдалося перемкнути вікна"
+#~ msgid "unable to unset option %s which does not have global value"
+#~ msgstr "не вдалося скинути опцію %s, яка не має глобального значення"
 
-#, c-format
-msgid "unable to unset global option %s"
-msgstr "не вдалося скинути глобальну опцію %s"
+#~ msgid "attempt to refer to deleted tab page"
+#~ msgstr "спроба звернення до знищеної вкладки"
 
-#, c-format
-msgid "unable to unset option %s which does not have global value"
-msgstr "не вдалося скинути опцію %s, яка не має глобального значення"
+#~ msgid "no such tab page"
+#~ msgstr "такої вкладки немає"
 
-msgid "attempt to refer to deleted tab page"
-msgstr "спроба звернення до знищеної вкладки"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "спроба звернутися до знищеного вікна"
 
-msgid "no such tab page"
-msgstr "такої вкладки немає"
+#~ msgid "readonly attribute: buffer"
+#~ msgstr "атрибут лише для читання: буфер"
 
-msgid "attempt to refer to deleted window"
-msgstr "спроба звернутися до знищеного вікна"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "курсор за межами буфера"
 
-msgid "readonly attribute: buffer"
-msgstr "атрибут лише для читання: буфер"
+#~ msgid "no such window"
+#~ msgstr "такого вікна немає"
 
-msgid "cursor position outside buffer"
-msgstr "курсор за межами буфера"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "спроба звернення до знищеного буфера"
 
-msgid "no such window"
-msgstr "такого вікна немає"
+#~ msgid "failed to rename buffer"
+#~ msgstr "не вдалося перейменувати буфер"
 
-msgid "attempt to refer to deleted buffer"
-msgstr "спроба звернення до знищеного буфера"
+#~ msgid "mark name must be a single character"
+#~ msgstr "назвою мітки має бути один символ"
 
-msgid "failed to rename buffer"
-msgstr "не вдалося перейменувати буфер"
+#~ msgid "expected vim.Buffer object, but got %s"
+#~ msgstr "очікувався об’єкт vim.Buffer, але отримано %s"
 
-msgid "mark name must be a single character"
-msgstr "назвою мітки має бути один символ"
+#~ msgid "failed to switch to buffer %d"
+#~ msgstr "не вдалося перемкнутися до буфера %d"
 
-#, c-format
-msgid "expected vim.Buffer object, but got %s"
-msgstr "очікувався об’єкт vim.Buffer, але отримано %s"
+#~ msgid "expected vim.Window object, but got %s"
+#~ msgstr "очікувався об’єкт vim.Window, але отримано %s"
 
-#, c-format
-msgid "failed to switch to buffer %d"
-msgstr "не вдалося перемкнутися до буфера %d"
+#~ msgid "failed to find window in the current tab page"
+#~ msgstr "не вдалося знайти вікно у поточній вкладці"
 
-#, c-format
-msgid "expected vim.Window object, but got %s"
-msgstr "очікувався об’єкт vim.Window, але отримано %s"
+#~ msgid "did not switch to the specified window"
+#~ msgstr "не перемкнувся до вказаного вікна"
 
-msgid "failed to find window in the current tab page"
-msgstr "не вдалося знайти вікно у поточній вкладці"
+#~ msgid "expected vim.TabPage object, but got %s"
+#~ msgstr "очікувався об’єкт vim.TabPage, але отримано %s"
 
-msgid "did not switch to the specified window"
-msgstr "не перемкнувся до вказаного вікна"
+#~ msgid "did not switch to the specified tab page"
+#~ msgstr "не перемкнувся до вказаної вкладки"
 
-#, c-format
-msgid "expected vim.TabPage object, but got %s"
-msgstr "очікувався об’єкт vim.TabPage, але отримано %s"
+#~ msgid "failed to run the code"
+#~ msgstr "не вдалося виконати код"
 
-msgid "did not switch to the specified tab page"
-msgstr "не перемкнувся до вказаної вкладки"
+#~ msgid "E858: Eval did not return a valid python object"
+#~ msgstr "E858: Eval не повернув дійсний об’єкт python"
 
-msgid "failed to run the code"
-msgstr "не вдалося виконати код"
+#~ msgid "E859: Failed to convert returned python object to vim value"
+#~ msgstr "E859: Не вдалося перетворити об’єкт python у значення vim"
 
-msgid "E858: Eval did not return a valid python object"
-msgstr "E858: Eval не повернув дійсний об’єкт python"
+#~ msgid "unable to convert %s to vim dictionary"
+#~ msgstr "не вдалося перетворити %s у словник vim"
 
-msgid "E859: Failed to convert returned python object to vim value"
-msgstr "E859: Не вдалося перетворити об’єкт python у значення vim"
+#~ msgid "unable to convert %s to vim structure"
+#~ msgstr "не вдалося перетворити %s у структуру vim"
 
-#, c-format
-msgid "unable to convert %s to vim dictionary"
-msgstr "не вдалося перетворити %s у словник vim"
+#~ msgid "internal error: NULL reference passed"
+#~ msgstr "внутрішня помилка: передано посилання NULL"
 
-#, c-format
-msgid "unable to convert %s to vim structure"
-msgstr "не вдалося перетворити %s у структуру vim"
+#~ msgid "internal error: invalid value type"
+#~ msgstr "внутрішня помилка: неправильний тип значення"
 
-msgid "internal error: NULL reference passed"
-msgstr "внутрішня помилка: передано посилання NULL"
+#~ msgid ""
+#~ "Failed to set path hook: sys.path_hooks is not a list\n"
+#~ "You should now do the following:\n"
+#~ "- append vim.path_hook to sys.path_hooks\n"
+#~ "- append vim.VIM_SPECIAL_PATH to sys.path\n"
+#~ msgstr ""
+#~ "Не вдалося встановити обробник шляху: sys.path_hooks не список\n"
+#~ "Вам слід вчинити так:\n"
+#~ "- додайте vim.path_hook до sys.path_hooks\n"
+#~ "- додайте vim.VIM_SPECIAL_PATH до sys.path\n"
 
-msgid "internal error: invalid value type"
-msgstr "внутрішня помилка: неправильний тип значення"
-
-msgid ""
-"Failed to set path hook: sys.path_hooks is not a list\n"
-"You should now do the following:\n"
-"- append vim.path_hook to sys.path_hooks\n"
-"- append vim.VIM_SPECIAL_PATH to sys.path\n"
-msgstr ""
-"Не вдалося встановити обробник шляху: sys.path_hooks не список\n"
-"Вам слід вчинити так:\n"
-"- додайте vim.path_hook до sys.path_hooks\n"
-"- додайте vim.VIM_SPECIAL_PATH до sys.path\n"
-
-msgid ""
-"Failed to set path: sys.path is not a list\n"
-"You should now append vim.VIM_SPECIAL_PATH to sys.path"
-msgstr ""
-"Не вдалося встановити шлях: sys.path не список\n"
-"Вас слід додати vim.VIM_SPECIAL_PATH до sys.path"
+#~ msgid ""
+#~ "Failed to set path: sys.path is not a list\n"
+#~ "You should now append vim.VIM_SPECIAL_PATH to sys.path"
+#~ msgstr ""
+#~ "Не вдалося встановити шлях: sys.path не список\n"
+#~ "Вас слід додати vim.VIM_SPECIAL_PATH до sys.path"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -1885,10 +1885,6 @@ msgstr "%<PRId64> рядків, "
 msgid "1 character"
 msgstr "один символ"
 
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> символів"
-
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
 msgid "%<PRId64> characters"

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -6,147 +6,217 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 6.3 \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-02-25 22:51+0300\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2005-02-30 21:37+0400\n"
 "Last-Translator: Phan Vinh Thinh <teppi@vnlinux.org>\n"
 "Language-Team: Phan Vinh Thinh <teppi@vnlinux.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "E258: Không thể trả lời cho máy con"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Không thể phân chia bộ nhớ thậm chí cho một bộ đệm, thoát..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Không thể phân chia bộ nhớ cho bộ đệm, sử dụng bộ đệm khác..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Không có bộ đệm nào được bỏ nạp từ bộ nhớ"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Không có bộ đệm nào bị xóa"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Không có bộ đệm nào được làm sạch"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 bộ đệm được bỏ nạp từ bộ nhớ"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d bộ đệm được bỏ nạp từ bộ nhớ"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 bộ đệm bị xóa"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d bộ đệm được bỏ nạp"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 bộ đệm được làm sạch"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d bộ đệm được làm sạch"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Không thể bỏ nạp từ bộ nhớ bộ đệm cuối cùng"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Không tìm thấy bộ đệm có thay đổi"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Không có bộ đệm được liệt kê"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: Bộ đệm %<PRId64> không tồn tại"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Đây là bộ đệm cuối cùng"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Đây là bộ đệm đầu tiên"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Thay đổi trong bộ đệm %<PRId64> chưa được ghi lại (thêm ! để thoát ra bằng "
-"mọi giá)"
+"E89: Thay đổi trong bộ đệm %<PRId64> chưa được ghi lại (thêm ! để thoát ra "
+"bằng mọi giá)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Không thể bỏ nạp từ bộ nhớ bộ đệm cuối cùng"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Cảnh báo: Danh sách tên tập tin quá đầy"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: Bộ đệm %<PRId64> không được tìm thấy"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Tìm thấy vài tương ứng với %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Không có bộ đệm tương ứng với %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "dòng %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Đã có bộ đệm với tên như vậy"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Đã thay đổi]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Chưa soạn thảo]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Tập tin mới]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Lỗi đọc]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[Chỉ đọc]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[chỉ đọc]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 dòng --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> dòng --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "dòng %<PRId64> của %<PRId64> --%d%%-- cột "
 
-msgid "[No file]"
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+#, fuzzy
+msgid "[No Name]"
 msgstr "[Không có tập tin]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "trợ giúp"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[trợ giúp]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Xem trước]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "Tất cả"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Cuối"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "Đầu"
 
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -154,12 +224,11 @@ msgstr ""
 "\n"
 "# Danh sách bộ đệm:\n"
 
-msgid "[Error List]"
-msgstr "[Danh sách lỗi]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[No File]"
-msgstr "[Không có tập tin]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -167,116 +236,208 @@ msgstr ""
 "\n"
 "--- Ký hiệu ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Ký hiệu cho %s:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    dòng=%<PRId64>  id=%d  tên=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: Thiếu dấu hai chấm"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: Chế độ không cho phép"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: yêu cầu một số"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: Tỷ lệ phần trăm không cho phép"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
-msgstr "E96: Chỉ có thể theo dõi sự khác nhau trong nhiều nhất %<PRId64> bộ đệm"
+msgstr ""
+"E96: Chỉ có thể theo dõi sự khác nhau trong nhiều nhất %<PRId64> bộ đệm"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: Không thể mở tập tin termcap"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Không thể tạo tập tin khác biệt (diff)"
 
-msgid "Patch file"
-msgstr "Tập tin vá lỗi (patch)"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: Không thể đọc dữ liệu ra của lệnh diff"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Không thể đọc dữ liệu ra của lệnh diff"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Bộ đệm hiện thời không nằm trong chế độ khác biệt (diff)"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: Không còn bộ đệm trong chế độ khác biệt (diff) nào nữa"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Không còn bộ đệm trong chế độ khác biệt (diff) nào nữa"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr ""
 "E101: Có nhiều hơn hai bộ đệm trong chế độ khác biệt (diff), không biết chọn"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Không tìm thấy bộ đệm \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bộ đệm \"%s\" không nằm trong chế độ khác biệt (diff)"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Không cho phép dùng ký tự thoát Escape trong chữ ghép"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Không tìm thấy tập tin sơ đồ bàn phím"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Câu lệnh :loadkeymap được sử dụng ngoài tập tin script"
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Tự động kết thúc cho từ khóa (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^E^Y^L^]^F^I^K^D^V^N^P)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " Chế độ ^X (^E^Y^L^]^F^I^K^D^V^N^P)"
 
-#. Scroll has it's own msgs, in it's place there is the msg for local
-#. * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-msgid " Keyword Local completion (^N^P)"
-msgstr " Tự động kết thúc nội bộ cho từ khóa (^N^P)"
-
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " Tự động kết thúc tên tập tin (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Tự động kết thúc thẻ đánh dấu (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " Tự động kết thúc mẫu đường dẫn (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " Tự động kết thúc định nghĩa (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Tự động kết thúc theo từ điển (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Tự động kết thúc từ đồng âm (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " Tự động kết thúc dòng lệnh (^V^N^P)"
 
+#: ../edit.c:94
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
+
+#: ../edit.c:95
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " Tự động kết thúc thẻ đánh dấu (^]^N^P)"
+
+#: ../edit.c:96
+#, fuzzy
+msgid " Spelling suggestion (s^N^P)"
+msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
+
+#: ../edit.c:97
+msgid " Keyword Local completion (^N^P)"
+msgstr " Tự động kết thúc nội bộ cho từ khóa (^N^P)"
+
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "Kết thúc của đoạn văn"
 
-msgid "'thesaurus' option is empty"
-msgstr "Không đưa ra giá trị của tùy chọn 'thesaurus'"
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
 
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "Không đưa ra giá trị của tùy chọn 'dictionary'"
 
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr "Không đưa ra giá trị của tùy chọn 'thesaurus'"
+
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Quét từ điển: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (chèn) Cuộn (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (thay thế) Cuộn (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Quét: %s"
 
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Tìm kiếm trong số thẻ đánh dấu."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " Thêm"
 
@@ -284,200 +445,597 @@ msgstr " Thêm"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Tìm kiếm..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Từ ban đầu"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Từ của dòng khác"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "Tương ứng duy nhất"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "Tương ứng %d của %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "Tương ứng %d"
 
-#. Skip further arguments but do continue to
-#. * search for a trailing command.
-#, c-format
-msgid "E106: Unknown variable: \"%s\""
-msgstr "E106: Biến không biết: \"%s\""
+#: ../eval.c:137
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: Ở trước '=' có các ký tự không mong đợi"
 
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: Thiếu dấu ngoặc: %s"
+#: ../eval.c:138
+#, fuzzy, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E322: số thứ tự dòng vượt quá giới hạn : %<PRId64>"
 
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: Không có biến như vậy: \"%s\""
-
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: Thiếu ':' sau '?'"
-
-msgid "E110: Missing ')'"
-msgstr "E110: Thiếu ')'"
-
-msgid "E111: Missing ']'"
-msgstr "E111: Thiếu ']'"
-
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: Không đưa ra tên tùy chọn: %s"
-
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: Tùy chọn không biết: %s"
-
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: Thiếu ngoặc kép: %s"
-
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: Thiếu ngoặc kép: %s"
-
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
-
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: Hàm số không biết: %s"
-
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: Quá nhiều tham số cho hàm: %s"
-
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Không đủ tham số cho hàm: %s"
-
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: Sử dụng <SID> ngoài script: %s"
-
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
-msgid "&Ok"
-msgstr "&Ok"
-
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld dòng: "
-
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"&OK\n"
-"&Hủy bỏ"
-
-msgid "called inputrestore() more often than inputsave()"
-msgstr "Hàm số inputrestore() được gọi nhiều hơn hàm inputsave()"
-
-msgid "E655: Too many symbolic links (cycle?)"
-msgstr "E655: Quá nhiều liên kết tượng trưng (vòng lặp?)"
-
-msgid "E240: No connection to Vim server"
-msgstr "E240: Không có kết nối với máy chủ Vim"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: Máy chủ không trả lời"
-
-msgid "E258: Unable to send to client"
-msgstr "E258: Không thể trả lời cho máy con"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: Không thể gửi tin nhắn tới %s"
-
-msgid "(Invalid)"
-msgstr "(Không đúng)"
-
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Biến không xác định: %s"
 
-#, c-format
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: Tên biến không cho phép: %s"
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr "E111: Thiếu ']'"
 
+#: ../eval.c:141
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "E487: Tham số phải là một số dương"
+
+#: ../eval.c:143
+#, fuzzy, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E487: Tham số phải là một số dương"
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: Không tìm thấy tập tin tạm thời (temp) để ghi nhớ"
+
+#: ../eval.c:145
+#, fuzzy
+msgid "E714: List required"
+msgstr "E471: Cần chỉ ra tham số"
+
+#: ../eval.c:146
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: Cần tên hàm số"
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Quá nhiều tham số cho hàm: %s"
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: Hàm số %s đã có, hãy thêm ! để thay thế nó."
 
+#: ../eval.c:151
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: Đã có bộ đệm với tên như vậy"
+
+#: ../eval.c:152
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: Cần tên hàm số"
+
+#: ../eval.c:153
+#, fuzzy
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E360: Không chạy được shell với tùy chọn -f"
+
+#: ../eval.c:154
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr ""
+
+#: ../eval.c:155
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: Hàm số không biết: %s"
+
+#: ../eval.c:156
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: Tên biến không cho phép: %s"
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E138: Không thể ghi tập tin viminfo %s!"
+
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E69: Thiếu ] sau %s%%["
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: Thiếu dấu ngoặc: %s"
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: Không có biến như vậy: \"%s\""
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: Thiếu ':' sau '?'"
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+#, fuzzy
+msgid "E692: Invalid operation for Lists"
+msgstr "E449: Nhận được một biểu thức không cho phép"
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
+
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: Không chạy được shell với tùy chọn -f"
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr "E110: Thiếu ')'"
+
+#: ../eval.c:4609
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: Không thể bỏ nạp từ bộ nhớ bộ đệm cuối cùng"
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: Không đưa ra tên tùy chọn: %s"
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: Tùy chọn không biết: %s"
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: Thiếu ngoặc kép: %s"
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: Thiếu ngoặc kép: %s"
+
+#: ../eval.c:5084
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: Thiếu dấu bằng: %s"
+
+#: ../eval.c:5091
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: Thiếu '=': %s"
+
+#: ../eval.c:6475
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E405: Thiếu dấu bằng: %s"
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E527: Thiếu dấu phẩy"
+
+#: ../eval.c:6524
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: Thiếu lệnh :endfunction"
+
+#: ../eval.c:6555
+#, fuzzy
+msgid "E724: variable nested too deep for displaying"
+msgstr "E22: Các script lồng vào nhau quá sâu"
+
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Quá nhiều tham số cho hàm: %s"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Hàm số không biết: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Không đủ tham số cho hàm: %s"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: Sử dụng <SID> ngoài script: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Sau dấu = cần đưa ra một số"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "Tham số không được phép cho"
+
+#: ../eval.c:7907
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "Có quá nhiều tham số soạn thảo"
+
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: Trình đơn chỉ có trong chế độ khác"
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr "&Ok"
+
+#: ../eval.c:8676
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: đã có ánh xạ cho %s"
+
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr " vim [các tham số] "
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld dòng: "
+
+#: ../eval.c:9291
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: Hàm số không biết: %s"
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr "Hàm số inputrestore() được gọi nhiều hơn hàm inputsave()"
+
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "Có quá nhiều tham số soạn thảo"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E481: Không cho phép sử dụng phạm vi"
+
+#: ../eval.c:11140
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E596: Phông chữ không đúng"
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
+
+#: ../eval.c:12466
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: Quá nhiều liên kết tượng trưng (vòng lặp?)"
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "Tham số không được phép cho"
+
+#: ../eval.c:13776
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: Chọn máy in không thành công"
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr "(Không đúng)"
+
+#: ../eval.c:14590
+#, fuzzy
+msgid "E677: Error writing temp file"
+msgstr "E208: Lỗi ghi nhớ vào \"%s\""
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+#, fuzzy
+msgid "E730: using List as a String"
+msgstr "E374: Thiếu ] trong chuỗi định dạng"
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, fuzzy, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E93: Tìm thấy vài tương ứng với %s"
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
+
+#: ../eval.c:16724
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr "Không rõ"
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E284: Không đặt được giá trị nội dung nhập vào (IC)"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Hàm số không xác định: %s"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Thiếu '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Không đặt được giá trị nội dung nhập vào (IC)"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Tham số không cho phép: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: Thẻ ghi lặp lại \"%s\" trong tập tin %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Thiếu lệnh :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
+
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Không thể định nghĩa lại hàm số %s: hàm đang được sử dụng"
 
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
+
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Cần tên hàm số"
 
-#, c-format
-msgid "E128: Function name must start with a capital: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
 
-#, c-format
-msgid "E130: Undefined function: %s"
-msgstr "E130: Hàm số %s chưa xác định"
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
 
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Không thể xóa hàm số %s: Hàm đang được sử dụng"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Độ sâu của lời gọi hàm số lớn hơn giá trị 'maxfuncdepth'"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "lời gọi %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s dừng"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s trả lại #%<PRId64>"
 
-#, c-format
-msgid "%s returning \"%s\""
+#: ../eval.c:18670
+#, fuzzy, c-format
+msgid "%s returning %s"
 msgstr "%s trả lại \"%s\""
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "tiếp tục trong %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: lệnh :return ở ngoài một hàm"
 
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -485,261 +1043,114 @@ msgstr ""
 "\n"
 "# biến toàn cầu:\n"
 
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Bật chế độ sửa lỗi (Debug). Gõ \"cont\" để tiếp tục."
-
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "dòng %<PRId64>: %s"
-
-#, c-format
-msgid "cmd: %s"
-msgstr "câu lệnh: %s"
-
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Điểm dừng trên \"%s%s\" dòng %<PRId64>"
-
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Không tìm thấy điểm dừng: %s"
-
-msgid "No breakpoints defined"
-msgstr "Điểm dừng không được xác định"
-
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s dòng %<PRId64>"
-
-msgid "Save As"
-msgstr "Ghi nhớ như"
-
-#, c-format
-msgid "Save changes to \"%.*s\"?"
-msgstr "Ghi nhớ thay đổi vào \"%.*s\"?"
-
-msgid "Untitled"
-msgstr "Chưa đặt tên"
-
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Thay đổi chưa được ghi nhớ trong bộ đệm \"%s\""
-
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
 msgstr ""
-"Cảnh báo: Chuyển tới bộ đệm khác không theo ý muốn (hãy kiểm tra câu lệnh tự "
-"động)"
+"\n"
+"\tLần cuối cùng tùy chọn thay đổi vào "
 
-msgid "E163: There is only one file to edit"
-msgstr "E163: Chỉ có một tập tin để soạn thảo"
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "Không có tập tin được tính đến"
 
-msgid "E164: Cannot go before first file"
-msgstr "E164: Đây là tập tin đầu tiên"
-
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Đây là tập tin cuối cùng"
-
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: trình biên dịch không được hỗ trợ: %s"
-
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Tìm kiếm \"%s\" trong \"%s\""
-
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Tìm kiếm \"%s\""
-
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "không tìm thấy trong 'runtimepath': \"%s\""
-
-msgid "Source Vim script"
-msgstr "Thực hiện script của Vim"
-
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Không thể thực hiện một thư mục: \"%s\""
-
-#, c-format
-msgid "could not source \"%s\""
-msgstr "không thực hiện được \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "dòng %<PRId64>: không thực hiện được \"%s\""
-
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "thực hiện \"%s\""
-
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "dòng %<PRId64>: thực hiện \"%s\""
-
-#, c-format
-msgid "finished sourcing %s"
-msgstr "thực hiện xong %s"
-
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Cảnh báo: Ký tự phân cách dòng không đúng. Rất có thể thiếu ^M"
-
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: Lệnh :scriptencoding sử dụng ngoài tập tin script"
-
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: Lệnh :finish sử dụng ngoài tập tin script"
-
-#, c-format
-msgid "Page %d"
-msgstr "Trang %d"
-
-msgid "No text to be printed"
-msgstr "Không có gì để in"
-
-#, c-format
-msgid "Printing page %d (%d%%)"
-msgstr "In trang %d (%d%%)"
-
-#, c-format
-msgid " Copy %d of %d"
-msgstr " Sao chép %d của %d"
-
-#, c-format
-msgid "Printed: %s"
-msgstr "Đã in: %s"
-
-msgid "Printing aborted"
-msgstr "In bị dừng"
-
-msgid "E455: Error writing to PostScript output file"
-msgstr "E455: Lỗi ghi nhớ vào tập tin PostScript"
-
-#, c-format
-msgid "E624: Can't open file \"%s\""
-msgstr "E624: Không thể mở tập tin \"%s\""
-
-#, c-format
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: Không thể đọc tập tin tài nguyên PostScript \"%s\""
-
-#, c-format
-msgid "E618: file \"%s\" is not a PostScript resource file"
-msgstr "E618: \"%s\" không phải là tập tin tài nguyên PostScript"
-
-#, c-format
-msgid "E619: file \"%s\" is not a supported PostScript resource file"
-msgstr "E619: \"%s\" không phải là tập tin tài nguyên PostScript được hỗ trợ"
-
-#, c-format
-msgid "E621: \"%s\" resource file has wrong version"
-msgstr "E621: tập tin tài nguyên \"%s\" có phiên bản không đúng"
-
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: Không thể mở tập tin PostScript"
-
-#, c-format
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: Không thể mở tập tin \"%s\""
-
-msgid "E456: Can't find PostScript resource file \"prolog.ps\""
-msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"prolog.ps\""
-
-#, c-format
-msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"%s.ps\""
-
-#, c-format
-msgid "E620: Unable to convert from multi-byte to \"%s\" encoding"
-msgstr "E620: Không thể chuyển từ các ký tự nhiều byte thành bảng mã \"%s\""
-
-msgid "Sending to printer..."
-msgstr "Gửi tới máy in..."
-
-msgid "E365: Failed to print PostScript file"
-msgstr "E365: In tập tin PostScript không thành công"
-
-msgid "Print job sent."
-msgstr "Đã gửi công việc in."
-
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Ngôn ngữ %shiện thời: \"%s\""
-
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Không thể thay đổi ngôn ngữ thành \"%s\""
-
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Di chuyển các dòng lên chính chúng"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Đã di chuyển 1 dòng"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "Đã di chuyển %<PRId64> dòng"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "Đã lọc %<PRId64> dòng"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Các lệnh tự động *Filter* không được thay đổi bộ đệm hiện thời"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Thay đổi chưa được ghi nhớ]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s trên dòng: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Quá nhiều lỗi, phần còn lại của tập tin sẽ được bỏ qua"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Đọc tập tin viminfo \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " thông tin"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " dấu hiệu"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "Không có tập tin được tính đến"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " KHÔNG THÀNH CÔNG"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Thiếu quyền ghi lên tập tin viminfo: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Không thể ghi tập tin viminfo %s!"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Ghi tập tin viminfo \"%s\""
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tập tin viminfo này được tự động tạo bởi Vim %s.\n"
 
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -747,89 +1158,141 @@ msgstr ""
 "# Bạn có thể sửa tập tin này, nhưng hãy thận trọng!\n"
 "\n"
 
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Giá trị của tùy chọn 'encoding' vào thời điểm ghi tập tin\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Ký tự đầu tiên không cho phép"
 
-#. Overwriting a file that is loaded in another buffer is not a
-#. * good idea.
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Tập tin được nạp trong bộ đệm khác"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "Ghi nhớ một phần tập tin?"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Sử dụng ! để ghi nhớ một phần bộ đệm"
 
-#, c-format
-msgid "Overwrite existing file \"%.*s\"?"
+#: ../ex_cmds.c:2281
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
 msgstr "Ghi đè lên tập tin đã có \"%.*s\"?"
 
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: Tập tin đã tồn tại (thêm ! để ghi chèn)"
+
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Không có tên tập tin cho bộ đệm %<PRId64>"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Tập tin chưa được ghi nhớ: Ghi nhớ bị tắt bởi tùy chọn 'write'"
 
-#, c-format
+#: ../ex_cmds.c:2434
+#, fuzzy, c-format
 msgid ""
-"'readonly' option is set for \"%.*s\".\n"
+"'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "Tùy chọn 'readonly' được đặt cho \"%.*s\".\n"
 "Ghi nhớ bằng mọi giá?"
 
-msgid "Edit File"
-msgstr "Soạn thảo tập tin"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "là tập tin chỉ đọc (thêm ! để ghi nhớ bằng mọi giá)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Các lệnh tự động xóa bộ đệm mới ngoài ý muốn %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Tham số của lệnh :z phải là số"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Không cho phép sử dụng lệnh shell trong rvim."
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Không thể phân cách biểu thức chính quy bằng chữ cái"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "thay thế bằng %s? (y/n/a/q/l/^E/^Y)"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(bị dừng)"
 
+#: ../ex_cmds.c:4384
+#, fuzzy
+msgid "1 match"
+msgstr "; tương ứng "
+
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 thay thế"
 
+#: ../ex_cmds.c:4387
+#, fuzzy, c-format
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> thay đổi"
+
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> thay thế"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " trên 1 dòng"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " trên %<PRId64> dòng"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Không thực hiện được lệnh :global đệ qui"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Thiếu biểu thức chính quy trong lệnh :global"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Tìm thấy tương ứng trên mọi dòng: %s"
 
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "Không tìm thấy mẫu (pattern)"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -839,139 +1302,342 @@ msgstr ""
 "# Chuỗi thay thế cuối cùng:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Hãy bình tĩnh, đừng hoảng hốt!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Rất tiếc, không có trợ giúp '%s' cho %s"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Rất tiếc không có trợ giúp cho %s"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Xin lỗi, không tìm thấy tập tin trợ giúp \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s không phải là một thư mục"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Không thể mở %s để ghi"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Không thể mở %s để đọc"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr ""
 "E670: Tập tin trợ giúp sử dụng nhiều bảng mã khác nhau cho một ngôn ngữ: %s"
 
-#, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s"
+#: ../ex_cmds.c:5565
+#, fuzzy, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Thẻ ghi lặp lại \"%s\" trong tập tin %s"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Câu lệnh ký hiệu không biết: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Thiếu tên ký hiệu"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Định nghĩa quá nhiều ký hiệu"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Văn bản ký hiệu không thích hợp: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Ký hiệu không biết: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Thiếu số của ký hiệu"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Tên bộ đệm không đúng: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: ID của ký hiệu không đúng: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (KHÔNG TÌM THẤY)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (không được hỗ trợ)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[bị xóa]"
 
+#: ../ex_cmds2.c:139
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Bật chế độ sửa lỗi (Debug). Gõ \"cont\" để tiếp tục."
+
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "dòng %<PRId64>: %s"
+
+#: ../ex_cmds2.c:145
+#, c-format
+msgid "cmd: %s"
+msgstr "câu lệnh: %s"
+
+#: ../ex_cmds2.c:322
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Điểm dừng trên \"%s%s\" dòng %<PRId64>"
+
+#: ../ex_cmds2.c:581
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Không tìm thấy điểm dừng: %s"
+
+#: ../ex_cmds2.c:611
+msgid "No breakpoints defined"
+msgstr "Điểm dừng không được xác định"
+
+#: ../ex_cmds2.c:617
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s dòng %<PRId64>"
+
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "Ghi nhớ thay đổi vào \"%.*s\"?"
+
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+msgid "Untitled"
+msgstr "Chưa đặt tên"
+
+#: ../ex_cmds2.c:1421
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Thay đổi chưa được ghi nhớ trong bộ đệm \"%s\""
+
+#: ../ex_cmds2.c:1480
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr ""
+"Cảnh báo: Chuyển tới bộ đệm khác không theo ý muốn (hãy kiểm tra câu lệnh tự "
+"động)"
+
+#: ../ex_cmds2.c:1826
+msgid "E163: There is only one file to edit"
+msgstr "E163: Chỉ có một tập tin để soạn thảo"
+
+#: ../ex_cmds2.c:1828
+msgid "E164: Cannot go before first file"
+msgstr "E164: Đây là tập tin đầu tiên"
+
+#: ../ex_cmds2.c:1830
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Đây là tập tin cuối cùng"
+
+#: ../ex_cmds2.c:2175
+#, c-format
+msgid "E666: compiler not supported: %s"
+msgstr "E666: trình biên dịch không được hỗ trợ: %s"
+
+#: ../ex_cmds2.c:2257
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Tìm kiếm \"%s\" trong \"%s\""
+
+#: ../ex_cmds2.c:2284
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Tìm kiếm \"%s\""
+
+#: ../ex_cmds2.c:2307
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "không tìm thấy trong 'runtimepath': \"%s\""
+
+#: ../ex_cmds2.c:2472
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Không thể thực hiện một thư mục: \"%s\""
+
+#: ../ex_cmds2.c:2518
+#, c-format
+msgid "could not source \"%s\""
+msgstr "không thực hiện được \"%s\""
+
+#: ../ex_cmds2.c:2520
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "dòng %<PRId64>: không thực hiện được \"%s\""
+
+#: ../ex_cmds2.c:2535
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "thực hiện \"%s\""
+
+#: ../ex_cmds2.c:2537
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "dòng %<PRId64>: thực hiện \"%s\""
+
+#: ../ex_cmds2.c:2693
+#, c-format
+msgid "finished sourcing %s"
+msgstr "thực hiện xong %s"
+
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "Thêm 1 dòng"
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr " vim [các tham số] "
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr " vim [các tham số] "
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+#, fuzzy
+msgid "error handler"
+msgstr "Lỗi và sự gián đoạn"
+
+#: ../ex_cmds2.c:3020
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Cảnh báo: Ký tự phân cách dòng không đúng. Rất có thể thiếu ^M"
+
+#: ../ex_cmds2.c:3139
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: Lệnh :scriptencoding sử dụng ngoài tập tin script"
+
+#: ../ex_cmds2.c:3166
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: Lệnh :finish sử dụng ngoài tập tin script"
+
+#: ../ex_cmds2.c:3389
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Ngôn ngữ %shiện thời: \"%s\""
+
+#: ../ex_cmds2.c:3404
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Không thể thay đổi ngôn ngữ thành \"%s\""
+
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr ""
 "Chuyển vào chế độ Ex. Để chuyển về chế độ Thông thường hãy gõ \"visual\""
 
-#. must be at EOF
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Ở cuối tập tin"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Câu lệnh quá đệ quy"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Trường hợp đặc biệt không được xử lý: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Kết thúc tập tin script"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Kết thúc của hàm số"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Sự sử dụng không rõ ràng câu lệnh do người dùng định nghĩa"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Không phải là câu lệnh của trình soạn thảo"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Đưa ra phạm vi ngược lại"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Đưa ra phạm vi ngược lại, thay đổi vị trí hai giới hạn"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Hãy sử dụng w hoặc w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Xin lỗi, câu lệnh này không có trong phiên bản này"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Chỉ cho phép sử dụng một tên tập tin"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Còn 1 tập tin nữa cần soạn thảo. Thoát?"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Còn %d tập tin nữa chưa soạn thảo. Thoát?"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 tập tin nữa chờ soạn thảo."
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> tập tin nữa chưa soạn thảo."
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Đã có câu lệnh: Thêm ! để thay thế"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -979,251 +1645,352 @@ msgstr ""
 "\n"
 "    Tên\t\tTham_số Phạm_vi Phần_phụ Định_nghĩa"
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Không tìm thấy câu lệnh do người dùng định nghĩa"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Không có tham số được chỉ ra"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Số lượng tham số không đúng"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Số đếm không thể được chỉ ra hai lần"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Giá trị của số đếm theo mặc định không đúng"
 
-msgid "E179: argument required for complete"
+#: ../ex_docmd.c:4625
+#, fuzzy
+msgid "E179: argument required for -complete"
 msgstr "E179: yêu cầu đưa ra tham số để kết thúc"
 
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: Giá trị phần phụ không đúng: %s"
-
-msgid "E468: Completion argument only allowed for custom completion"
-msgstr ""
-"E468: Tham số tự động kết thúc chỉ cho phép sử dụng với phần phụ đặc biệt"
-
-msgid "E467: Custom completion requires a function argument"
-msgstr "E467: Phần phục đặc biệt yêu cầu một tham số của hàm"
-
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Thuộc tính không đúng: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: Tên câu lệnh không đúng"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Câu lệnh người dùng định nghĩa phải bắt đầu với một ký tự hoa"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: Sự sử dụng không rõ ràng câu lệnh do người dùng định nghĩa"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Không có câu lệnh người dùng định nghĩa như vậy: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: Giá trị phần phụ không đúng: %s"
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr ""
+"E468: Tham số tự động kết thúc chỉ cho phép sử dụng với phần phụ đặc biệt"
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr "E467: Phần phục đặc biệt yêu cầu một tham số của hàm"
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Không tin thấy sơ đồ màu sắc %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Xin chào người dùng Vim!"
 
-msgid "Edit File in new window"
-msgstr "Soạn thảo tập tin trong cửa sổ mới"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: Không được đóng cửa sổ cuối cùng"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "Chỉ có một cửa sổ"
+
+#: ../ex_docmd.c:6004
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "Trang %d"
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Không có tập tin swap"
 
-msgid "Append File"
-msgstr "Thêm tập tin"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr ""
+"E509: Không tạo được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Không có thư mục trước"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Không rõ"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: câu lệnh :winsize yêu cầu hai tham số bằng số"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "Vị trí cửa sổ: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Trên hệ thống này việc xác định vị trí cửa sổ không làm việc"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: câu lệnh :winpos yêu câu hai tham số bằng số"
 
-msgid "Save Redirection"
-msgstr "Chuyển hướng ghi nhớ"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
+msgstr "Không thể thực hiện một thư mục: \"%s\""
 
-msgid "Save View"
-msgstr "Ghi nhớ vẻ ngoài"
-
-msgid "Save Session"
-msgstr "Ghi nhớ buổi làm việc"
-
-msgid "Save Setup"
-msgstr "Ghi nhớ cấu hình"
-
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" đã có (thêm !, để ghi đè)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Không mở được \"%s\" để ghi nhớ"
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Tham số phải là một chữ cái hoặc dấu ngoặc thẳng/ngược"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Sử dụng đệ quy lệnh :normal quá sâu"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Không có tên tập tin tương đương để thay thế '#'"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Không có tên tập tin câu lệnh tự động để thay thế \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr ""
 "E496: Không có số thứ tự bộ đệm câu lệnh tự động để thay thế \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Không có tên tương ứng câu lệnh tự động để thay thế \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: không có tên tập tin :source để thay thế \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: không có tên tập tin :source để thay thế \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Tên tập tin rỗng cho '%' hoặc '#', chỉ làm việc với \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Kết quả của biểu thức là một chuỗi rỗng"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Không thể mở tập tin viminfo để đọc"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: Trong phiên bản này chữ ghép không được hỗ trợ"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr ""
 "E608: Không thể thực hiện lệnh :throw cho những ngoại lệ với tiền tố 'Vim'"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Trường hợp ngoại lệ: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Kết thúc việc xử lý trường hợp ngoại lệ: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Trường hợp ngoại lệ bị bỏ qua: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, dòng %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Xử lý trường hợp ngoại lệ: %s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s thực hiện việc chờ đợi"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s được phục hồi lại"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s bị bỏ qua"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Trường hợp ngoại lệ"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Lỗi và sự gián đoạn"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Lỗi"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Sự gián đoạn"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if xếp lồng vào nhau quá sâu"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif không có :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else không có :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif không có :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: phát hiện vài :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif sau :else"
 
-msgid "E585: :while nesting too deep"
+#: ../ex_eval.c:941
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while xếp lồng vào nhau quá sâu"
 
-msgid "E586: :continue without :while"
+#: ../ex_eval.c:1028
+#, fuzzy
+msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue không có :while"
 
-msgid "E587: :break without :while"
+#: ../ex_eval.c:1061
+#, fuzzy
+msgid "E587: :break without :while or :for"
 msgstr "E587: :break không có :while"
 
+#: ../ex_eval.c:1102
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: Thiếu câu lệnh :endwhile"
+
+#: ../ex_eval.c:1104
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: Thiếu câu lệnh :endwhile"
+
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try xếp lồng vào nhau quá sâu"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch không có :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch đứng sau :finally"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally không có :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: phát hiện vài :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry không có :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: lệnh :endfunction chỉ được sử dụng trong một hàm số"
 
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: Không cho phép trong hộp cát (sandbox)"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: Không có bộ đệm tương ứng với %s"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "tên thẻ ghi"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " loại tập tin\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "giá trị của tùy chọn 'history' bằng không"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1232,202 +1999,312 @@ msgstr ""
 "\n"
 "# %s, Lịch sử (bắt đầu từ mới nhất tới cũ nhất):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Dòng lệnh"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Chuỗi tìm kiếm"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Biểu thức"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Dòng nhập"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar lớn hơn chiều dài câu lệnh"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Cửa sổ hoặc bộ đệm hoạt động bị xóa"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Đường dẫn đưa ra không đúng: '**[số]' phải ở cuối đường dẫn hoặc theo "
+"sau bởi '%s'"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Không tìm thấy thư mục \"%s\" để chuyển thư mục"
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Không tìm thấy tập tin \"%s\" trong đường dẫn"
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Trong đường dẫn thay đổi thư mục không còn có thư mục \"%s\" nữa"
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Trong đường dẫn path không còn có tập tin \"%s\" nữa"
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: Các lệnh tự động *Filter* không được thay đổi bộ đệm hiện thời"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Tên tập tin không cho phép"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "là một thư mục"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "không phải là một tập tin"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Tập tin mới]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Truy cập bị từ chối]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr ""
 "E200: Câu lệnh tự động *ReadPre làm cho tập tin trở thành không thể đọc"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Câu lệnh tự động *ReadPre không được thay đổi bộ đệm hoạt động"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Đọc từ đầu vào tiêu chuẩn stdin...\n"
 
-msgid "Reading from stdin..."
-msgstr "Đọc từ đầu vào tiêu chuẩn stdin..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Sự biến đổi làm cho tập tin trở thành không thể đọc!"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[Chỉ đọc]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 ký tự"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[thiếu ký tự CR]"
 
-msgid "[NL found]"
-msgstr "[tìm thấy ký tự NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[dòng dài được chia nhỏ]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[KHÔNG được chuyển đổi]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[đã chuyển bảng mã]"
 
-msgid "[crypted]"
-msgstr "[đã mã hóa]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %<PRId64>]"
 
-msgid "[CONVERSION ERROR]"
-msgstr "[LỖI CHUYỂN BẢNG MÃ]"
-
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %<PRId64>]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LỖI ĐỌC]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Không tìm thấy tập tin tạm thời (temp) để chuyển bảng mã"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Chuyển đổi nhờ 'charconvert' không được thực hiện"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "không đọc được đầu ra của 'charconvert'"
 
+#: ../fileio.c:2437
+#, fuzzy
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr "Không có câu lệnh tự động tương ứng"
+
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Câu lệnh tự động đã xóa hoặc bỏ nạp bộ đệm cần ghi nhớ"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Câu lệnh tự động đã thay đổ số dòng theo cách không mong muốn"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans không cho phép ghi nhớ bộ đệm chưa có thay đổi nào"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "Ghi nhớ một phần bộ đệm NetBeans không được cho phép"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "không phải là một tập tin thay một thiết bị có thể ghi nhớ"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "là tập tin chỉ đọc (thêm ! để ghi nhớ bằng mọi giá)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Không thể ghi nhớ vào tập tin lưu trữ (thêm ! để ghi nhớ bằng mọi giá"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Lỗi đóng tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Không đọc được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Không tạo được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Không tạo được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Nhánh tài nguyên sẽ bị mất (thêm ! để bỏ qua việc kiểm tra lại)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Không tìm thấy tập tin tạm thời (temp) để ghi nhớ"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Không thể chuyển đổi bảng mã (thêm ! để ghi nhớ mà không chuyển đổi)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Không thể mở tập tin liên kết để ghi nhớ"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Không thể mở tập tin để ghi nhớ"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Không thực hiện thành công hàm số fsync()"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Thao tác đóng không thành công"
 
-msgid "E513: write error, conversion failed"
+#: ../fileio.c:3436
+#, fuzzy
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: Lỗi ghi nhớ, biến đổi không thành công"
 
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: lỗi ghi nhớ (không còn chỗ trống?)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " LỖI BIẾN ĐỔI"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "dòng %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Thiết bị]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Mới]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " đã thêm"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " đã ghi"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Chế độ vá lỗi (patch): không thể ghi nhớ tập tin gốc"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr ""
 "E206: Chế độ vá lỗi (patch): không thể thay đổi tham số của tập tin gốc "
 "trống rỗng"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Không thể xóa tập tin lưu trữ (backup)"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1435,76 +2312,97 @@ msgstr ""
 "\n"
 "CẢNH BÁO: Tập tin gốc có thể bị mất hoặc bị hỏng\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr ""
 "đừng thoát khởi trình soạn thảo, khi tập tin còn chưa được ghi nhớ thành cồng"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[định dạng dos]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[định dạng mac]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[định dạng unix]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 dòng, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> dòng, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 ký tự"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> ký tự"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Dòng cuối cùng không đầy đủ]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "CẢNH BÁO: Tập tin đã thay đổi so với thời điểm đọc!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Bạn có chắc muốn ghi nhớ vào tập tin này"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Lỗi ghi nhớ vào \"%s\""
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Lỗi đóng \"%s\""
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Lỗi đọc \"%s\""
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Bộ đệm bị xóa khi thực hiện câu lệnh tự động FileChangedShell"
 
-#, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
+#: ../fileio.c:4894
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Cảnh báo: Tập tin \"%s\" không còn truy cập được nữa"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -1513,28 +2411,44 @@ msgstr ""
 "W12: Cảnh báo: Tập tin \"%s\" và bộ đệm Vim đã thay đổi không phụ thuộc vào "
 "nhau"
 
+#: ../fileio.c:4907
+#, fuzzy
+msgid "See \":help W12\" for more info."
+msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
 "W11: Cảnh báo: Tập tin \"%s\" đã thay đổi sau khi việc soạn thảo bắt đầu"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Cảnh báo: chế độ truy cập tới tập tin \"%s\" đã thay đổi sau khi bắt "
 "đầu soạn thảo"
 
+#: ../fileio.c:4915
+#, fuzzy
+msgid "See \":help W16\" for more info."
+msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
+
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Cảnh báo: tập tin \"%s\" được tạo ra sau khi việc soạn thảo bắt đầu"
 
-msgid "See \":help W11\" for more info."
-msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
-
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Cảnh báo"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1542,35 +2456,48 @@ msgstr ""
 "&OK\n"
 "&Nạp tập tin"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Không thể chuẩn bị để nạp lại \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Không thể nạp lại \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Bị xóa--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Nhóm \"%s\" không tồn tại"
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Ký tự không cho phép sau *: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Sự kiện không có thật: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Nhóm hoặc sự kiện không có thật: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1578,397 +2505,807 @@ msgstr ""
 "\n"
 "--- Câu lệnh tự động ---"
 
+#: ../fileio.c:6293
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr "số của bộ đệm không đúng"
+
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Không thể thực hiện câu lệnh tự động cho MỌI sự kiện"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Không có câu lệnh tự động tương ứng"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: câu lệnh tự động xếp lồng vào nhau quá xâu"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s câu lệnh tự động cho \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Thực hiện %s"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "câu lệnh tự động %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Thiếu {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Thiếu }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Không tìm thấy nếp gấp"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr ""
 "E350: Không thể tạo nếp gấp với giá trị hiện thời của tùy chọn 'foldmethod'"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr ""
 "E351: Không thể xóa nếp gấp với giá trị hiện thời của tùy chọn 'foldmethod'"
 
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr "+--%3ld dòng được gấp"
+
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Thêm vào bộ đệm đang đọc"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: ánh xạ đệ quy"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: đã có sự viết tắt toàn cầu cho %s"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: đã có ánh xạ toàn cầu cho %s"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: đã có sự viết tắt cho %s"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: đã có ánh xạ cho %s"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Không tìm thấy viết tắt"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Không tìm thấy ánh xạ"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Chế độ không cho phép"
 
-msgid "<cannot open> "
-msgstr "<không thể mở> "
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "-- Không có dòng nào trong bộ đệm --"
 
-#, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: không tìm thấy phông chữ %s"
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: Câu lệnh bị dừng"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: không trở lại được thư mục hiện thời"
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: Cần chỉ ra tham số"
 
-msgid "Pathname:"
-msgstr "Đường dẫn tới tập tin:"
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: Sau \\ phải là các ký tự /, ? hoặc &"
 
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: không tìm thấy thư mục hiện thời"
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Lỗi trong cửa sổ dòng lệnh; <CR> thực hiện, CTRL-C thoát"
 
-msgid "OK"
-msgstr "Đồng ý"
-
-msgid "Cancel"
-msgstr "Hủy bỏ"
-
-msgid "Vim dialog"
-msgstr "Hộp thoại Vim"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Thanh cuộn: Không thể xác định hình học của thanh cuộn."
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: Không tạo được BalloonEval với cả thông báo và lời gọi ngược lại"
-
-msgid "E229: Cannot start the GUI"
-msgstr "E229: Không chạy được giao diện đồ họa GUI"
-
-#, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: Không đọc được từ \"%s\""
-
-msgid "E665: Cannot start GUI, no valid font found"
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E665: Không chạy được giao diện đồ họa GUI, đưa ra phông chữ không đúng"
+"E12: Câu lệnh không cho phép từ exrc/vimrc trong thư mục hiện thời hoặc "
+"trong tìm kiếm thẻ ghi"
 
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 'guifontwide' có giá trị không đúng"
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: Thiếu câu lệnh :endif"
 
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: Giá trị của 'imactivatekey' không đúng"
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: Thiếu câu lệnh :endtry"
 
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: Thiếu câu lệnh :endwhile"
+
+#: ../globals.h:1006
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: Thiếu câu lệnh :endif"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: Câu lệnh :endwhile không có lệnh :while (1 cặp)"
+
+#: ../globals.h:1008
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr "E580: :endif không có :if"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Tập tin đã tồn tại (thêm ! để ghi chèn)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: Không thực hiện thành công câu lệnh"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: Lỗi nội bộ"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "Bị gián đoạn"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: Địa chỉ không cho phép"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: Tham số không cho phép"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: Không chỉ định được màu %s"
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Tham số không cho phép: %s"
 
-msgid "Vim dialog..."
-msgstr "Hộp thoại Vim..."
+#: ../globals.h:1016
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Biểu thức không cho phép: %s"
 
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: Vùng không cho phép"
+
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: Câu lệnh không cho phép"
+
+#: ../globals.h:1019
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" là mộ thư mục"
+
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: Kích thước thanh cuộn không cho phép"
+
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Có\n"
-"&Không\n"
-"&Dừng"
 
-msgid "Input _Methods"
-msgstr "Phương pháp _nhập liệu"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - Tìm kiếm và thay thế..."
-
-msgid "VIM - Search..."
-msgstr "VIM - Tìm kiếm..."
-
-msgid "Find what:"
-msgstr "Tìm kiếm gì:"
-
-msgid "Replace with:"
-msgstr "Thay thế bởi:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "Chỉ tìm tương ứng hoàn toàn với từ"
-
-#. match case button
-msgid "Match case"
-msgstr "Có tính kiểu chữ"
-
-msgid "Direction"
-msgstr "Hướng"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "Lên"
-
-msgid "Down"
-msgstr "Xuống"
-
-msgid "Find Next"
-msgstr "Tìm tiếp"
-
-msgid "Replace"
-msgstr "Thay thế"
-
-msgid "Replace All"
-msgstr "Thay thế tất cả"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: Nhận được yêu cầu \"chết\" (dừng) từ trình quản lý màn hình\n"
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: Cửa sổ chính đã bị đóng đột ngột\n"
-
-msgid "Font Selection"
-msgstr "Chọn phông chữ"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "Sử dụng CUT_BUFFER0 thay cho lựa chọn trống rỗng"
-
-msgid "Filter"
-msgstr "Đầu lọc"
-
-msgid "Directories"
-msgstr "Thư mục"
-
-msgid "Help"
-msgstr "Trợ giúp"
-
-msgid "Files"
-msgstr "Tập tin"
-
-msgid "Selection"
-msgstr "Lựa chọn"
-
-msgid "Undo"
-msgstr "Hủy thao tác"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: Không tìm được tiêu đề cửa sổ \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Tham số không được hỗ trợ: \"-%s\"; Hãy sử dụng phiên bản OLE."
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: Không mở được cửa sổ bên trong ứng dụng MDI"
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "Tìm kiếm chuỗi (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "Tìm kiếm và Thay thế (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"Vim E458: Không chỉ định được bản ghi trong bảng màu, một vài màu có thể "
-"hiển thị không chính xác"
 
+#: ../globals.h:1024
 #, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Trong bộ phông chữ %s thiếu phông cho các bảng mã sau:"
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Gọi hàm số \"%s()\" của thư viện không thành công"
 
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Bộ phông chữ: %s"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Dấu hiệu chỉ đến một số thứ tự dòng không đúng"
 
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "Phông chữ '%s' không phải là phông có độ rộng cố định (fixed-width)"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: Dấu hiệu không được xác định"
 
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Bộ phông chữ: %s\n"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Không thể thay đổi, vì tùy chọn 'modifiable' bị tắt"
 
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Các script lồng vào nhau quá sâu"
 
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: Không có tập tin xen kẽ"
 
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: Không có chữ viết tắt như vậy"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: Không cho phép !"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Không sử dụng được giao diện đồ họa vì không chọn khi biên dịch"
+
+#: ../globals.h:1036
 #, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Nhóm chiếu sáng cú pháp %s không tồn tại"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: Tạm thời chưa có văn bản được chèn"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: Không có dòng lệnh trước"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: Không có ánh xạ (mapping) như vậy"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: Không có tương ứng"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Không có tương ứng: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: Không có tên tập tin"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Không có biểu thức chính quy trước để thay thế"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: Không có câu lệnh trước"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: Không có biểu thức chính quy trước"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: Không cho phép sử dụng phạm vi"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: Không đủ chỗ trống"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Không tạo được tập tin %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: Không nhận được tên tập tin tạm thời (temp)"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Không mở được tập tin %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Không đọc được tập tin %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Thay đổi chưa được ghi nhớ (thêm ! để bỏ qua ghi nhớ)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[Thay đổi chưa được ghi nhớ]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: Tham sô bằng 0"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: Yêu cầu một số"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Không mở được tập tin lỗi %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: Không đủ bộ nhớ!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "Không tìm thấy mẫu (pattern)"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Không tìm thấy mẫu (pattern): %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: Tham số phải là một số dương"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Không quay lại được thư mục trước đó"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: Không có lỗi"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
 msgstr ""
-"Chiều rộng phông chữ font%<PRId64> phải lớn hơn hai lần so với chiều rộng font0\n"
 
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "Chiều rộng font0: %<PRId64>\n"
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: Chuỗi tương ứng bị hỏng"
 
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Chương trình xử lý biểu thức chính quy bị hỏng"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Tùy chọn 'readonly' được bật (Hãy thêm ! để lờ đi)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Lỗi khi đọc tập tin lỗi"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Không cho phép trong hộp cát (sandbox)"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: Không cho phép ở đây"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Chế độ màn hình không được hỗ trợ"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: Kích thước thanh cuộn không cho phép"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Tùy chọn 'shell' là một chuỗi rỗng"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Không đọc được dữ liệu về ký tự!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: Lỗi đóng tập tin trao đổi (swap)"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: đống thẻ ghi rỗng"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: Câu lệnh quá phức tạp"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: Tên quá dài"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: Quá nhiều ký tự ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: Quá nhiều tên tập tin"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: Ký tự thừa ở đuôi"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: Dấu hiệu không biết"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Không thực hiện được phép thế theo wildcard"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: giá trị của 'winheight' không thể nhỏ hơn 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: giá trị của 'winwidth' không thể nhỏ hơn 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: Lỗi khi ghi nhớ"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "Giá trị của bộ đếm bằng 0"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Sử dụng <SID> ngoài phạm vi script"
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "E473: Lỗi nội bộ"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
 msgstr ""
-"Chiều rộng font1: %<PRId64>\n"
-"\n"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: LỖI máy tự động Hangual (tiếng Hàn)"
+#: ../globals.h:1105
+#, fuzzy
+msgid "E749: empty buffer"
+msgstr "E279: Đây không phải là bộ đệm SNiFF+"
 
+#: ../globals.h:1108
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: Chuỗi tìm kiếm không đúng: %s"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Tập tin được nạp trong bộ đệm khác"
+
+#: ../globals.h:1110
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: Phông chữ \"%s\" không có độ rộng cố định (fixed-width)"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "tìm kiếm sẽ được tiếp tục từ CUỐI tài liệu"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "tìm kiếm sẽ được tiếp tục từ ĐẦU tài liệu"
+
+#: ../hardcopy.c:240
+msgid "E550: Missing colon"
+msgstr "E550: Thiếu dấu hai chấm"
+
+#: ../hardcopy.c:252
+msgid "E551: Illegal component"
+msgstr "E551: Thành phần không cho phép"
+
+#: ../hardcopy.c:259
+msgid "E552: digit expected"
+msgstr "E552: Cần chỉ ra một số"
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr "Trang %d"
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr "Không có gì để in"
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "In trang %d (%d%%)"
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr " Sao chép %d của %d"
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr "Đã in: %s"
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr "In bị dừng"
+
+#: ../hardcopy.c:1365
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: Lỗi ghi nhớ vào tập tin PostScript"
+
+#: ../hardcopy.c:1747
+#, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E624: Không thể mở tập tin \"%s\""
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: Không thể đọc tập tin tài nguyên PostScript \"%s\""
+
+#: ../hardcopy.c:1772
+#, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E618: \"%s\" không phải là tập tin tài nguyên PostScript"
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr "E619: \"%s\" không phải là tập tin tài nguyên PostScript được hỗ trợ"
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr "E621: tập tin tài nguyên \"%s\" có phiên bản không đúng"
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: Không thể mở tập tin PostScript"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: Không thể mở tập tin \"%s\""
+
+#: ../hardcopy.c:2583
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"prolog.ps\""
+
+#: ../hardcopy.c:2593
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"%s.ps\""
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"%s.ps\""
+
+#: ../hardcopy.c:2654
+#, fuzzy, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr "E620: Không thể chuyển từ các ký tự nhiều byte thành bảng mã \"%s\""
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr "Gửi tới máy in..."
+
+#: ../hardcopy.c:2881
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: In tập tin PostScript không thành công"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr "Đã gửi công việc in."
+
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "Thêm một cơ sở dữ liệu mới"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "Yêu cầu theo một mẫu"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Hiển thị thông báo này"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "Hủy kết nối"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "Khởi đầu lại tất cả các kết nối"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Hiển thị kết nối"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Sử dụng: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Câu lệnh cscope này không hỗ trợ việc chia (split) cửa sổ.\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Sử dụng: cstag <tên>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: không tìm thấy thẻ ghi"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: lỗi stat(%s): %d"
 
-msgid "E563: stat error"
-msgstr "E563: lỗi stat"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr ""
 "E564: %s không phải là một thư mục hoặc một cơ sở dữ liệu cscope thích hợp"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "Đã thêm cơ sở dữ liệu cscope %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: lỗi lấy thông tin từ kết nối cscope %<PRId64>"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: không rõ loại tìm kiếm cscope"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Không tạo được đường ống (pipe) cho cscope"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Không thực hiện được fork() cho cscope"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "thực hiện cs_create_connection không thành công"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "thực hiện cs_create_connection không thành công"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Chạy tiến trình cscope không thành công"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: thực hiện fdopen cho to_fp không thành công"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: thực hiện fdopen cho fr_fp không thành công"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Chạy tiến trình cscope không thành công"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: không có kết nối với cscope"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: không tìm thấy tương ứng với yêu cầu cscope %s cho %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cờ cscopequickfix %c cho %c không chính xác"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: không tìm thấy tương ứng với yêu cầu cscope %s cho %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "các lệnh cscope:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Sử dụng: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: không mở được cơ sở dữ liệu cscope: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: không lấy được thông tin về cơ sở dữ liệu cscope"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: cơ sở dữ liệu này của cscope đã được gắn vào từ trước"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: đã đạt tới số kết nối lớn nhất cho phép với cscope"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: kết nối với cscope %s không được tìm thấy"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "kết nối %s với cscope đã bị đóng"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: lỗi nặng trong cs_manage_matches"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Thẻ ghi cscope: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -1976,336 +3313,90 @@ msgstr ""
 "\n"
 "   #   dòng"
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "tên tập tin / nội dung / dòng\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Lỗi cscope: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "Khởi động lại tất cả cơ sở dữ liệu cscope"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "không có kết nối với cscope\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    tên cơ sở dữ liệu                   đường dẫn ban đầu\n"
 
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr ""
-"E263: Rất tiếc câu lệnh này không làm việc, vì thư viện Python chưa được nạp."
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: Không thể gọi Python một cách đệ quy"
-
-msgid "can't delete OutputObject attributes"
-msgstr "Không xóa được thuộc tính OutputObject"
-
-msgid "softspace must be an integer"
-msgstr "giá trị softspace phải là một số nguyên"
-
-msgid "invalid attribute"
-msgstr "thuộc tính không đúng"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() yêu cầu một danh sách các chuỗi"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: Lỗi khi bắt đầu sử dụng vật thể I/O"
-
-msgid "invalid expression"
-msgstr "biểu thức không đúng"
-
-msgid "expressions disabled at compile time"
-msgstr "biểu thức bị tắt khi biên dịch"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "cố chỉ đến bộ đệm đã bị xóa"
-
-msgid "line number out of range"
-msgstr "số thứ tự của dòng vượt quá giới hạn"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<vật thể của bộ đệm (bị xóa) tại %8lX>"
-
-msgid "invalid mark name"
-msgstr "tên dấu hiệu không đúng"
-
-msgid "no such buffer"
-msgstr "không có bộ đệm như vậy"
-
-msgid "attempt to refer to deleted window"
-msgstr "cố chỉ đến cửa sổ đã bị đóng"
-
-msgid "readonly attribute"
-msgstr "thuộc tính chỉ đọc"
-
-msgid "cursor position outside buffer"
-msgstr "vị trí con trỏ nằm ngoài bộ đệm"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<vật thể của cửa sổ (bị xóa) tại %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<vật thể của cửa sổ (không rõ) tại %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<cửa sổ %d>"
-
-msgid "no such window"
-msgstr "không có cửa sổ như vậy"
-
-msgid "cannot save undo information"
-msgstr "không ghi được thông tin về việc hủy thao tác"
-
-msgid "cannot delete line"
-msgstr "không xóa được dòng"
-
-msgid "cannot replace line"
-msgstr "không thay thế được dòng"
-
-msgid "cannot insert line"
-msgstr "không chèn được dòng"
-
-msgid "string cannot contain newlines"
-msgstr "chuỗi không thể chứa ký tự dòng mới"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr ""
-"E266: Rất tiếc câu lệnh này không làm việc, vì thư viện Ruby chưa đượcnạp."
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: không rõ trạng thái của longjmp %d"
-
-msgid "Toggle implementation/definition"
-msgstr "Bật tắt giữa thi hành/định nghĩa"
-
-msgid "Show base class of"
-msgstr "Hiển thị hạng cơ bản của"
-
-msgid "Show overridden member function"
-msgstr "Hiển thị hàm số bị nạp đè lên"
-
-msgid "Retrieve from file"
-msgstr "Nhận từ tập tin"
-
-msgid "Retrieve from project"
-msgstr "Nhận từ dự án"
-
-msgid "Retrieve from all projects"
-msgstr "Nhận từ tất cả các dự án"
-
-msgid "Retrieve"
-msgstr "Nhận"
-
-msgid "Show source of"
-msgstr "Hiển thị mã nguồn"
-
-msgid "Find symbol"
-msgstr "Tìm ký hiệu"
-
-msgid "Browse class"
-msgstr "Duyệt hạng"
-
-msgid "Show class in hierarchy"
-msgstr "Hiển thị hạng trong hệ thống cấp bậc"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Hiển thị hạng trong hệ thống cấp bậc giới hạn"
-
-msgid "Xref refers to"
-msgstr "Xref chỉ đến"
-
-msgid "Xref referred by"
-msgstr "Liên kết đến xref từ"
-
-msgid "Xref has a"
-msgstr "Xref có một"
-
-msgid "Xref used by"
-msgstr "Xref được sử dụng bởi"
-
-msgid "Show docu of"
-msgstr "Hiển thị docu của"
-
-msgid "Generate docu for"
-msgstr "Tạo docu cho"
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr ""
-"Không kết nối được tới SNiFF+. Hãy kiểm tra cấu hình môi trường.(sniffemacs "
-"phải được chỉ ra trong biến $PATH).\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Lỗi trong thời gian đọc. Ngắt kết nối"
-
-msgid "SNiFF+ is currently "
-msgstr "Trong thời điểm hiện nay SNiFF+ "
-
-msgid "not "
-msgstr "không "
-
-msgid "connected"
-msgstr "được kết nối"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: không rõ yêu cầu của SNiFF+: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: Lỗi kết nối với SNiFF+"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: SNiFF+ chưa được kết nối"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: Đây không phải là bộ đệm SNiFF+"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: Lỗi trong thời gian ghi nhớ. Ngắt kết nối"
-
-msgid "invalid buffer number"
-msgstr "số của bộ đệm không đúng"
-
-msgid "not implemented yet"
-msgstr "tạm thời chưa được thực thi"
-
-msgid "unknown option"
-msgstr "tùy chọn không rõ"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "không thể đặt (các) dòng"
-
-msgid "mark not set"
-msgstr "dấu hiệu chưa được đặt"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "hàng %d cột %d"
-
-msgid "cannot insert/append line"
-msgstr "không thể chèn hoặc thêm dòng"
-
-msgid "unknown flag: "
-msgstr "cờ không biết: "
-
-msgid "unknown vimOption"
-msgstr "không rõ tùy chọn vimOption"
-
-msgid "keyboard interrupt"
-msgstr "sự gián đoạn của bàn phím"
-
-msgid "vim error"
-msgstr "lỗi của vim"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "không tạo được câu lệnh của bộ đệm hay của cửa sổ: vật thể đang bị xóa"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "không đăng ký được câu lệnh gọi ngược: bộ đệm hoặc cửa sổ đang bị xóa"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr ""
-"E280: LỖI NẶNG CỦA TCL: bị hỏng danh sách liên kết!? Hãy thông báo việc "
-"nàyđến danh sách thư (mailing list) vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr ""
-"không đăng ký được câu lệnh gọi ngược: không tìm thấy liên kết đến bộ đệm "
-"hoặc cửa sổ"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr ""
-"E571: Rất tiếc là câu lệnh này không làm việc, vì thư viện Tcl chưa được nạp"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr ""
-"E281: LỖI TCL: mã thoát ra không phải là một số nguyên!? Hãy thông báo điều "
-"này đến danh sách thư (mailing list) vim-dev@vim.org"
-
-msgid "cannot get line"
-msgstr "không nhận được dòng"
-
-msgid "Unable to register a command server name"
-msgstr "Không đăng ký được một tên cho máy chủ câu lệnh"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: Gửi câu lệnh vào chương trình khác không thành công"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: Sử dụng id máy chủ không đúng: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: Thuộc tính đăng ký của Vim được định dạng không đúng.  Xóa!"
-
-msgid "Unknown option"
+#: ../main.c:144
+#, fuzzy
+msgid "Unknown option argument"
 msgstr "Tùy chọn không biết"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "Có quá nhiều tham số soạn thảo"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "Thiếu tham số sau"
 
-msgid "Garbage after option"
+#: ../main.c:150
+#, fuzzy
+msgid "Garbage after option argument"
 msgstr "Rác sau tùy chọn"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr ""
 "Quá nhiều tham số \"+câu lệnh\", \"-c câu lệnh\" hoặc \"--cmd câu lệnh\""
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "Tham số không được phép cho"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "Vim không được biên dịch với tính năng hỗ trợ xem khác biệt (diff)."
-
-msgid "Attempt to open script file again: \""
-msgstr "Thử mở tập tin script một lần nữa: \""
-
-msgid "Cannot open for reading: \""
-msgstr "Không mở để đọc được: \""
-
-msgid "Cannot open for script output: \""
-msgstr "Không mở cho đầu ra script được: \""
-
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d tập tin để soạn thảo\n"
 
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr "Thử mở tập tin script một lần nữa: \""
+
+#: ../main.c:1350
+msgid "Cannot open for reading: \""
+msgstr "Không mở để đọc được: \""
+
+#: ../main.c:1393
+msgid "Cannot open for script output: \""
+msgstr "Không mở cho đầu ra script được: \""
+
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Cảnh báo: Đầu ra không hướng tới một terminal\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Cảnh báo: Đầu vào không phải đến từ một terminal\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "dòng lệnh chạy trước khi thực hiện vimrc"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Không đọc được từ \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2313,18 +3404,23 @@ msgstr ""
 "\n"
 "Xem thông tin chi tiết với: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[tập tin ..]     soạn thảo (các) tập tin chỉ ra"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-                đọc văn bản từ đầu vào stdin"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t thẻ ghi      soạn thảo tập tin từ chỗ thẻ ghi chỉ ra"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [tập tin lỗi] soạn thảo tập tin với lỗi đầu tiên"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2334,9 +3430,11 @@ msgstr ""
 "\n"
 "Sử dụng:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [các tham số] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2344,6 +3442,7 @@ msgstr ""
 "\n"
 "   hoặc:"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2353,325 +3452,191 @@ msgstr ""
 "\n"
 "Tham số:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tSau tham số chỉ đưa ra tên tập tin"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tKhông thực hiện việc mở rộng wildcard"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tĐăng ký gvim này cho OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\tBỏ đăng ký gvim này cho OLE"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\tSử dụng giao diện đồ họa GUI (giống \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr ""
-"-f  hoặc  --nofork\tTrong chương trình hoạt động: Không thực hiện fork khi "
-"chạy GUI"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tChế độ Vi (giống \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tChế độ Ex (giống \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tChế độ ít đưa thông báo (gói) (chỉ dành cho \"ex\")"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tChế độ khác biệt, diff (giống \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tChế độ đơn giản (giống \"evim\", không có chế độ)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tChế độ chỉ đọc (giống \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tChế độ hạn chế (giống \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tKhông có khả năng ghi nhớ thay đổi (ghi nhớ tập tin)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tKhông có khả năng thay đổi văn bản"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tChế độ nhị phân (binary)"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tChế độ Lisp"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tChế độ tương thích với Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tChế độ không tương thích hoàn toàn với Vi: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tMức độ chi tiết của thông báo"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tChế độ sửa lỗi (debug)"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tKhông sử dụng tập tin swap, chỉ sử dụng bộ nhớ"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tLiệt kê các tập tin swap rồi thoát"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (với tên tập tin)\tPhục hồi lần soạn thảo gặp sự cố"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tGiống với -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\tKhông sử dụng newcli để mở cửa sổ"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <thiết bị>\t\tSử dụng <thiết bị> cho I/O"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tKhởi động vào chế độ Ả Rập"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tKhởi động vào chế độ Do thái"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tKhởi động vào chế độ Farsi"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tĐặt loại terminal thành <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tSử dụng <vimrc> thay thế cho mọi .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\tSử dụng <gvimrc> thay thế cho mọi .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tKhông nạp bất kỳ script môđun nào"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\tMở N cửa sổ (theo mặc định: mỗi cửa sổ cho một tập tin)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tMở N cửa sổ (theo mặc định: mỗi cửa sổ cho một tập tin)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tGiống với -o nhưng phân chia theo đường thẳng đứng"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tBắt đầu soạn thảo từ cuối tập tin"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tBắt đầu soạn thảo từ dòng thứ <lnum> (số thứ tự của dòng)"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <câu lệnh>\tThực hiện <câu lệnh> trước khi nạp tập tin vimrc"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <câu lệnh>\t\tThực hiện <câu lệnh> sau khi nạp tập tin đầu tiên"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\tThực hiện <session> sau khi nạp tập tin đầu tiên"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr ""
 "-s <scriptin>\tĐọc các lệnh của chế độ Thông thường từ tập tin <scriptin>"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\tThêm tất cả các lệnh đã gõ vào tập tin <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\tGhi nhớ tất cả các lệnh đã gõ vào tập tin <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\tSoạn thảo tập tin đã mã hóa"
-
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <màn hình>\tKết nối vim tới máy chủ X đã chỉ ra"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\tKhông thực hiện việc kết nối tới máy chủ X"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <tập tin>\tSoạn thảo <tập tin> trên máy chủ Vim nếu có thể"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
-"--remote-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có máy chủ"
 
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <tập tin>  Cũng như --remote, nhưng chờ sự kết thúc"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr ""
-"--remote-wait-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có máy "
-"chủ"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <phím>\tGửi <phím> lên máy chủ Vim và thoát"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr ""
-"--remote-expr <biểu thức>\tTính <biểu thức> trên máy chủ Vim và in ra kết quả"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\tHiển thị danh sách máy chủ Vim và thoát"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <tên>\tGửi lên (hoặc trở thành) máy chủ Vim với <tên>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tSử dụng tập tin <viminfo> thay cho .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h hoặc --help\tHiển thị Trợ giúp (thông tin này) và thoát"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tĐưa ra thông tin về phiên bản Vim và thoát"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"Tham số cho gvim (phiên bản Motif):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"Tham số cho gvim (phiên bản neXtaw):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"Tham số cho gvim (phiên bản Athena):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <màn hình>\tChạy vim trong <màn hình> đã chỉ ra"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\tChạy vim ở dạng thu nhỏ"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <tên>\t\tSử dụng tài nguyên giống như khi vim có <tên>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (Chưa được thực thi)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <màu>\tSử dụng <màu> chỉ ra cho nền (cũng như: -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr ""
-"-foreground <màu>\tSử dụng <màu> cho văn bản thông thường (cũng như: -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr ""
-"-font <phông>\t\tSử dụng <phông> chữ cho văn bản thông thường (cũng như: -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <phông>\tSử dụng <phông> chữ cho văn bản in đậm"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <phông>\tSử dụng <phông> chữ cho văn bản in nghiêng"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <kích thước>\tSử dụng <kích thước> ban đầu (cũng như: -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr ""
-"-borderwidth <rộng>\tSử dụng đường viền có chiều <rộng> (cũng như: -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <rộng> Sử dụng thanh cuộn với chiều <rộng> (cũng như: -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr ""
-"-menuheight <cao>\tSử dụng thanh trình đơn với chiều <cao> (cũng như: -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tSử dụng chế độ video đảo ngược (cũng như: -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\tKhông sử dụng chế độ video đảo ngược (cũng như: +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <tài nguyên>\tĐặt <tài nguyên> chỉ ra"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"Tham số cho gvim (phiên bản RISC OS):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <số>\tChiều rộng ban đầu của cửa sổ tính theo số cột"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <số>\tChiều cao ban đầu của cửa sổ tính theo số dòng"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"Tham số cho gvim (phiên bản GTK+):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr ""
-"-display <màn hình>\tChạy vim trên <màn hình> chỉ ra (cũng như: --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <vai trò>\tĐặt <vai trò> duy nhất để nhận diện cửa sổ chính"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tMở Vim bên trong thành phần GTK khác"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <tiêu đề của mẹ>\tMở Vim bên trong ứng dụng mẹ"
-
-msgid "No display"
-msgstr "Không có màn hình"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": Gửi không thành công.\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": Gửi không thành công. Thử thực hiện nội bộ\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "đã soạn thảo %d từ %d"
-
-msgid "No display: Send expression failed.\n"
-msgstr "Không có màn hình: gửi biểu thức không thành công.\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": Gửi biểu thức không thành công.\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "Không có dấu hiệu nào được đặt."
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Không có dấu hiệu tương ứng với \"%s\""
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2680,6 +3645,7 @@ msgstr ""
 "nhãn dòng  cột tập tin/văn bản"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2688,6 +3654,7 @@ msgstr ""
 " bước_nhảy dòng  cột tập tin/văn bản"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -2695,6 +3662,7 @@ msgstr ""
 "\n"
 "thay_đổi dòng  cột văn_bản"
 
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2703,6 +3671,7 @@ msgstr ""
 "# Nhãn của tập tin:\n"
 
 #. Write the jumplist with -'
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -2710,6 +3679,7 @@ msgstr ""
 "\n"
 "# Danh sách bước nhảy (mới hơn đứng trước):\n"
 
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -2717,98 +3687,88 @@ msgstr ""
 "\n"
 "# Lịch sử các nhãn trong tập tin (từ mới nhất đến cũ nhất):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "Thiếu '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: Bảng mã không cho phép"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: Không đặt được giá trị nội dung nhập vào (IC)"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: Không tạo được nội dung nhập vào"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: Việc thử mở phương pháp nhập không thành công"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Cảnh báo: không đặt được sự gọi ngược hủy diệt thành phương pháp nhập"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: phương pháp nhập không hỗ trợ bất kỳ phong cách (style) nào"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: phương pháp nhập không hỗ trợ loại soạn thảo trước của Vim"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: phong cách over-the-spot yêu cầu một bộ phông chữ"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: GTK+ cũ hơn 1.2.3. Vùng chỉ trạng thái không làm việc"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: Máy chủ phương pháp nhập liệu chưa được chạy"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: khối chưa bị khóa"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Lỗi tìm kiếm khi đọc tập tin trao đổi (swap)"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: Lỗi đọc tập tin trao đổi (swap)"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Lỗi tìm kiếm khi ghi nhớ tập tin trao đổi (swap)"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr ""
 "E300: Tập tin trao đổi (swap) đã tồn tại (sử dụng liên kết mềm tấn công?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Chưa lấy khối số 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Chưa lấy khối số 12?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Chưa lấy khối số 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ối, mất tập tin trao đổi (swap)!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: Không đổi được tên tập tin trao đổi (swap)"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Không mở được tập tin trao đổi (swap) cho \"%s\", nên không thể phục "
 "hồi"
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_timestamp: Chưa lấy khối số 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Không tìm thấy tập tin trao đổi (swap) cho %s"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "Hãy nhập số của tập tin trao đổi (swap) muốn sử dụng (0 để thoát): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: Không mở được %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "Không thể đọc khối số 0 từ "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -2816,22 +3776,28 @@ msgstr ""
 "\n"
 "Chưa có thay đổi nào hoặc Vim không thể cập nhật tập tin trao đổi (swap)"
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " không thể sử dụng trong phiên bản Vim này.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "Hãy sử dụng Vim phiên bản 3.0.\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " không thể sử dụng trên máy tính này.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "Tập tin đã được tạo trên "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -2839,63 +3805,85 @@ msgstr ""
 ",\n"
 "hoặc tập tin đã bị hỏng."
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Đang sử dụng tập tin trao đổi (swap) \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Tập tin gốc \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Cảnh báo: Tập tin gốc có thể đã bị thay đổi"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Không đọc được khối số 1 từ %s"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???THIẾU NHIỀU DÒNG"
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???GIÁ TRỊ CỦA SỐ ĐẾM DÒNG BỊ SAI"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???KHỐI RỖNG"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???THIẾU DÒNG"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Khối 1 ID sai (%s không phải là tập tin .swp?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???THIẾU KHỐI"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? từ đây tới ???CUỐI, các dòng có thể đã bị hỏng"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? từ đây tới ???CUỐI, các dòng có thể đã bị chèn hoặc xóa"
 
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???CUỐI"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Việc phục hồi bị gián đoạn"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Phát hiện ra lỗi trong khi phục hồi; hãy xem những dòng bắt đầu với ???"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "Hãy xem thông tin bổ sung trong trợ giúp \":help E312\""
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Việc phục hồi đã hoàn thành. Nên kiểm tra xem mọi thứ có ổn không."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -2903,50 +3891,71 @@ msgstr ""
 "\n"
 "(Có thể ghi nhớ tập tin với tên khác và so sánh với tập\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "gốc bằng chương trình diff).\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "Sau đó hãy xóa tập tin .swp.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "Tìm thấy tập tin trao đổi (swap):"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   Trong thư mục hiện thời:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Với tên chỉ ra:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   Trong thư mục   "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- không --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "          người sở hữu: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    ngày: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              ngày: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [từ Vim phiên bản 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [không phải là tập tin trao đổi (swap) của Vim]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "         tên tập tin: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -2954,12 +3963,15 @@ msgstr ""
 "\n"
 "           thay đổi: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "CÓ"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "không"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -2967,9 +3979,11 @@ msgstr ""
 "\n"
 "      tên người dùng: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "    tên máy: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -2977,6 +3991,7 @@ msgstr ""
 "\n"
 "           tên máy: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -2984,16 +3999,11 @@ msgstr ""
 "\n"
 "     ID tiến trình: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (vẫn đang chạy)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [không sử dụng được với phiên bản này của Vim]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3001,71 +4011,97 @@ msgstr ""
 "\n"
 "         [không sử dụng được trên máy tính này]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [không đọc được]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [không mở được]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Không cập nhật được tập tin trao đổi (swap) vì không tìm thấy nó"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "Đã cập nhật tập tin trao đổi (swap)"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: Cập nhật không thành công"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: giá trị lnum không đúng: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: không tìm được dòng %<PRId64>"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Giá trị của pointer khối số 3 không đúng"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "giá trị stack_idx phải bằng 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Đã cập nhật quá nhiều khối?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Giá trị của pointer khối số 4 không đúng"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "đã xóa khối số 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Không tìm được dòng %<PRId64>"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: giá trị của pointer khối không đúng"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "giá trị pe_line_count bằng không"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: số thứ tự dòng vượt quá giới hạn : %<PRId64>"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: giá trị đếm dòng không đúng trong khối %<PRId64>"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "Kích thước của đống tăng lên"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Giá trị của cái chỉ (pointer) khối số 2 không đúng"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: CHÚ Ý"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3073,39 +4109,45 @@ msgstr ""
 "\n"
 "Tìm thấy một tập tin trao đổi (swap) với tên \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "Khi mở tập tin: \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "                    MỚI hơn so với tập tin trao đổi (swap)\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) Rất có thể một chương trình khác đang soạn thảo tập tin.\n"
 "    Nếu như vậy, hãy cẩn thận khi thay đổi, làm sao để không thu\n"
 "    được hai phương án khác nhau của cùng một tập tin.\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Thoát hoặc tiếp tục với sự cẩn thận.\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Lần soạn thảo trước của tập tin này gặp sự cố.\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr ""
 "    Trong trường hợp này, hãy sử dụng câu lệnh \":recover\" hoặc \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3113,10 +4155,12 @@ msgstr ""
 "\"\n"
 "    để phục hồi những thay đổi (hãy xem \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr ""
 "    Nếu đã thực hiện thao tác này rồi, thì hãy xóa tập tin trao đổi (swap) \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3124,18 +4168,23 @@ msgstr ""
 "\"\n"
 "    để tránh sự xuất hiện của thông báo này trong tương lai.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "Tập tin trao đổi (swap) \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" đã có rồi!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - CHÚ Ý"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "Tập tin trao đổi (swap) đã rồi!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3149,46 +4198,75 @@ msgstr ""
 "&Q Thoát\n"
 "&A Gián đoạn"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Abort\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "&O Mở chỉ để đọc\n"
 "&E Vẫn soạn thảo\n"
 "&R Phục hồi\n"
 "&Q Thoát\n"
-"&A Gián đoạn&D Xóa nó"
+"&A Gián đoạn"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: Tìm thấy quá nhiều tập tin trao đổi (swap)"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Không đủ bộ nhớ! (phân chia %<PRIu64> byte)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr ""
 "E327: Một phần của đường dẫn tới phần tử của trình đơn không phải là trình "
 "đơn con"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Trình đơn chỉ có trong chế độ khác"
 
-msgid "E329: No menu of that name"
+#: ../menu.c:64
+#, fuzzy, c-format
+msgid "E329: No menu \"%s\""
 msgstr "E329: Không có trình đơn với tên như vậy"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Đường dẫn tới trình đơn không được đưa tới trình đơn con"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr ""
 "E331: Các phần tử của trình đơn không thể thêm trực tiếp vào thanh trình đơn"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Cái phân chia không thể là một phần của đường dẫn tới trình đơn"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3196,62 +4274,75 @@ msgstr ""
 "\n"
 "--- Trình đơn ---"
 
-msgid "Tear off this menu"
-msgstr "Chia cắt trình đơn này"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Đường dẫn tới trình đơn phải đưa tới một phần tử cuả trình đơn"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Không tìm thấy trình đơn: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Trình đơn không được định nghĩa cho chế độ %s"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Đường dẫn tới trình đơn phải đưa tới một trình đơn con"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Không tìm thấy trình đơn - hãy kiểm tra tên trình đơn"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Phát hiện lỗi khi xử lý %s:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "dòng %4ld:"
 
-msgid "[string too long]"
-msgstr "[chuỗi quá dài]"
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "Bản dịch các thông báo sang tiếng Việt: Phan Vĩnh Thịnh <teppi@vnlinux.org>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "Gián đoạn: "
 
-msgid "Hit ENTER to continue"
-msgstr "Nhấn phím ENTER để tiếp tục"
-
-msgid "Hit ENTER or type command to continue"
+#: ../message.c:988
+#, fuzzy
+msgid "Press ENTER or type command to continue"
 msgstr "Nhấn phím ENTER hoặc nhập câu lệnh để tiếp tục"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, dòng %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- Còn nữa --"
 
-msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-msgstr " (RET/BS: dòng, SPACE/b: trang, d/u: nửa trang, q: thoát)"
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
-msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-msgstr " (RET: dòng, SPACE: trang, d: nửa trang, q: thoát)"
-
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "Câu hỏi"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3259,6 +4350,17 @@ msgstr ""
 "&Có\n"
 "&Không"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Có\n"
+"&Không\n"
+"&Dừng"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3271,235 +4373,181 @@ msgstr ""
 "&Vứt bỏ tất cả\n"
 "&Dừng lại"
 
-msgid "Save File dialog"
-msgstr "Ghi nhớ tập tin"
+#: ../message.c:3058
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
 
-msgid "Open File dialog"
-msgstr "Mở tập tin"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
 msgstr ""
-"E338: Xin lỗi nhưng không có trình duyệt tập tin trong chế độ kênh giao tác "
-"(console)"
 
+#: ../message.c:3873
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: Quá nhiều tham số cho hàm: %s"
+
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Cảnh báo: Thay đổi một tập tin chỉ có quyền đọc"
 
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "Thêm 1 dòng"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "Bớt 1 dòng"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "Thêm %<PRId64> dòng"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "Bớt %<PRId64> dòng"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Bị gián đoạn)"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: ghi nhớ các tập tin...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: Đã xong.\n"
-
-msgid "ERROR: "
-msgstr "LỖI: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
+#: ../misc1.c:2635
+msgid "Beep!"
 msgstr ""
-"\n"
-"[byte] tổng phân phối-còn trống %<PRIu64>-%<PRIu64>, sử dụng %<PRIu64>, píc sử dụng %<PRIu64>\n"
 
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[gọi] tổng re/malloc() %<PRIu64>, tổng free() %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: Dòng đang trở thành quá dài"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: Lỗi nội bộ: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Không đủ bộ nhớ! (phân chia %<PRIu64> byte)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Gọi shell để thực hiện: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: Thiếu dấu hai chấm"
-
-msgid "E546: Illegal mode"
-msgstr "E546: Chế độ không cho phép"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: Dạng trỏ chuột không cho phép"
-
-msgid "E548: digit expected"
-msgstr "E548: yêu cầu một số"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: Tỷ lệ phần trăm không cho phép"
-
-msgid "Enter encryption key: "
-msgstr "Nhập mật khẩu để mã hóa: "
-
-msgid "Enter same key again: "
-msgstr "      Nhập lại mật khẩu:"
-
-msgid "Keys don't match!"
-msgstr "Hai mật khẩu không trùng nhau!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Đường dẫn đưa ra không đúng: '**[số]' phải ở cuối đường dẫn hoặc theo "
-"sau bởi '%s'"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Không tìm thấy thư mục \"%s\" để chuyển thư mục"
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Không tìm thấy tập tin \"%s\" trong đường dẫn"
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Trong đường dẫn thay đổi thư mục không còn có thư mục \"%s\" nữa"
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Trong đường dẫn path không còn có tập tin \"%s\" nữa"
-
-msgid "E550: Missing colon"
-msgstr "E550: Thiếu dấu hai chấm"
-
-msgid "E551: Illegal component"
-msgstr "E551: Thành phần không cho phép"
-
-msgid "E552: digit expected"
-msgstr "E552: Cần chỉ ra một số"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "Không kết nối được với Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "Không kết nối được với NetBeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr ""
-"E668: Chế độ truy cập thông tin về liên kết với NetBeans không đúng: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "đọc từ socket NetBeans"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: Bị mất liên kết với NetBeans cho bộ đệm %<PRId64>"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "Cảnh báo: terminal không thực hiện được sự chiếu sáng"
-
-msgid "E348: No string under cursor"
-msgstr "E348: Không có chuỗi ở vị trí con trỏ"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: Không có tên ở vị trí con trỏ"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E91: Tùy chọn 'shell' là một chuỗi rỗng"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "Cảnh báo: terminal không thực hiện được sự chiếu sáng"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: Không có chuỗi ở vị trí con trỏ"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr ""
 "E352: Không thể tẩy xóa nếp gấp với giá trị hiện thời của tùy chọn "
 "'foldmethod'"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: danh sách những thay đổi trống rỗng"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Ở đầu danh sách những thay đổi"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Ở cuối danh sách những thay đổi"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Gõ :quit<Enter>  để thoát khỏi Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "Trên 1 dòng %s 1 lần"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Trên 1 dòng %s %d lần"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "Trên %<PRId64> dòng %s 1 lần"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "Trên %<PRId64> dòng %s %d lần"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "Thụt đầu %<PRId64> dòng..."
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "Đã thụt đầu 1 dòng"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> dòng đã thụt đầu"
 
+#: ../ops.c:938
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: Không có thư mục trước"
+
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "sao chép không thành công; đã xóa"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 dòng đã thay đổi"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> đã thay đổi"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "đã làm sạch %<PRId64> dòng"
+#: ../ops.c:2521
+#, fuzzy
+msgid "block of 1 line yanked"
+msgstr "đã sao chép 1 dòng"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "đã sao chép 1 dòng"
 
+#: ../ops.c:2525
+#, fuzzy, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr "đã sao chép %<PRId64> dòng"
+
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "đã sao chép %<PRId64> dòng"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Trong sổ đăng ký %s không có gì hết"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3507,9 +4555,11 @@ msgstr ""
 "\n"
 "--- Sổ đăng ký ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Tên sổ đăng ký không cho phép"
 
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3517,152 +4567,194 @@ msgstr ""
 "\n"
 "# Sổ đăng ký:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Loại sổ đăng ký không biết %d"
 
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
-
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Cột; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "Chọn %s%<PRId64> của %<PRId64> Dòng; %<PRId64> của %<PRId64> Từ; %<PRId64> của %<PRId64> Byte"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Chọn %s%<PRId64> của %<PRId64> Dòng; %<PRId64> của %<PRId64> Từ; %<PRId64> "
+"của %<PRId64> Byte"
 
+#: ../ops.c:5105
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"Chọn %s%<PRId64> của %<PRId64> Dòng; %<PRId64> của %<PRId64> Từ; %<PRId64> "
+"của %<PRId64> Byte"
+
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Cột %s của %s;  Dòng %<PRId64> của %<PRId64>; Từ %<PRId64> của %<PRId64>; Byte %<PRId64> của %<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Cột %s của %s;  Dòng %<PRId64> của %<PRId64>; Từ %<PRId64> của %<PRId64>; "
+"Byte %<PRId64> của %<PRId64>"
 
+#: ../ops.c:5133
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Cột %s của %s;  Dòng %<PRId64> của %<PRId64>; Từ %<PRId64> của %<PRId64>; "
+"Byte %<PRId64> của %<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> cho BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Trang %N"
 
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Xin cảm ơn đã sử dụng Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Tùy chọn không biết"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Tùy chọn không được hỗ trợ"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Không cho phép trên dòng chế độ (modeline)"
 
-msgid ""
-"\n"
-"\tLast set from "
+#: ../option.c:2815
+msgid "E846: Key code not set"
 msgstr ""
-"\n"
-"\tLần cuối cùng tùy chọn thay đổi vào "
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Sau dấu = cần đưa ra một số"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Không tìm thấy trong termcap"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Ký tự không cho phép <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Giá trị của tùy chọn 'term' không thể là một chuỗi trống rỗng"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: Không thể thay đổi terminal trong giao diện đồ họa GUI"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: Hãy sử dụng \":gui\" để chạy giao diện đồ họa GUI"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: giá trị của tùy chọn 'backupext' và 'patchmode' bằng nhau"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: Không thể thay đổi trong giao diện đồ họa GTK+ 2"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Thiếu dấu hai chấm"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Chuỗi có độ dài bằng không"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Thiếu một số sau <%s>"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Thiếu dấu phẩy"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Cần đưa ra một giá trị cho '"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: chứa ký tự không in ra hoặc ký tự với chiều rộng gấp đôi"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: Phông chữ không đúng"
-
-msgid "E597: can't select fontset"
-msgstr "E597: không chọn được bộ phông chữ"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: Bộ phông chữ không đúng"
-
-msgid "E533: can't select wide font"
-msgstr "E533: không chọn được phông chữ với các ký tự có chiều rộng gấp đôi"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: Phông chữ, với ký tự có chiều rộng gấp đôi, không đúng"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ký tự sau <%c> không chính xác"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: cầu có dấu phẩy"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: Giá trị của tùy chọn 'commentstring' phải rỗng hoặc chứa %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: Chuột không được hỗ trợ"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Dãy các biểu thức không đóng"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: quá nhiều phần tử"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: các nhóm không cân bằng"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Cửa sổ xem trước đã có"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Tiếng Ả Rập yêu cầu sử dụng UTF-8, hãy nhập ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Cần ít nhất %d dòng"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Cần ít nhất %d cột"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Tùy chọn không biết: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Sau dấu = cần đưa ra một số"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3670,6 +4762,7 @@ msgstr ""
 "\n"
 "--- Mã terminal ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3677,6 +4770,7 @@ msgstr ""
 "\n"
 "--- Giá trị tùy chọn toàn cầu ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3684,6 +4778,7 @@ msgstr ""
 "\n"
 "--- Giá trị tùy chọn nội bộ ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3691,128 +4786,21 @@ msgstr ""
 "\n"
 "--- Tùy chọn ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: LỖI get_varp"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Thiếu ký tự tương ứng cho %s"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Thừa ký tự sau dấu chấm phẩy: %s"
 
-msgid "cannot open "
-msgstr "không mở được "
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: Không mở được cửa sổ!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "Cần Amigados phiên bản 2.04 hoặc mới hơn\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "Cần %s phiên bản %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "Không mở được NIL:\n"
-
-msgid "Cannot create "
-msgstr "Không tạo được "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Thoát Vim với mã %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "không thay đổi được chế độ kênh giao tác (console)?!\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: không phải là kênh giao tác (console)??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: Không chạy được shell với tùy chọn -f"
-
-msgid "Cannot execute "
-msgstr "Không chạy được "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " thoát\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "Giá trị ANCHOR_BUF_SIZE quá nhỏ."
-
-msgid "I/O ERROR"
-msgstr "LỖI I/O (NHẬP/XUẤT)"
-
-msgid "...(truncated)"
-msgstr "...(bị cắt bớt)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "Tùy chọn 'columns' khác 80, chương trình ngoại trú không thể thực hiện"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: Chọn máy in không thành công"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "tới %s trên %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: Không rõ phông chữ của máy in: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: Lỗi in: %s"
-
-msgid "Unknown"
-msgstr "Không rõ"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "Đang in '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: Tên bảng mã không cho phép \"%s\" trong tên phông chữ \"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: Ký tự không cho phép '%c' trong tên phông chữ \"%s\""
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Tín hiệu đôi, thoát\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: Nhận được tín hiệu chết %s\n"
-
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: Nhận được tín hiệu chết\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "Mở màn hình X mất %<PRId64> mili giây"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: Lỗi X\n"
-
-msgid "Testing the X display failed"
-msgstr "Kiểm tra màn hình X không thành công"
-
-msgid "Opening the X display timed out"
-msgstr "Không mở được màn hình X trong thời gian cho phép (time out)"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -3820,13 +4808,7 @@ msgstr ""
 "\n"
 "Không chạy được shell "
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"Không chạy được shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -3834,386 +4816,959 @@ msgstr ""
 "\n"
 "shell dừng làm việc "
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"Không tạo được đường ống (pipe)\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"Không thực hiện được fork()\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"Câu lệnh bị gián đoạn\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP mất kết nối ICE"
-
-msgid "Opening the X display failed"
-msgstr "Mở màn hình X không thành công"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP xử lý yêu cầu tự động ghi nhớ"
-
-msgid "XSMP opening connection"
-msgstr "XSMP mở kết nối"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP mất theo dõi kết nối ICE"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP thực hiện SmcOpenConnection không thành công: %s"
-
-msgid "At line"
-msgstr "Tại dòng"
-
-msgid "Could not allocate memory for command line."
-msgstr "Không phân chia được bộ nhớ cho dòng lệnh."
-
-msgid "VIM Error"
-msgstr "Lỗi VIM"
-
-msgid "Could not load vim32.dll!"
-msgstr "Không nạp được vim32.dll!"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "Không sửa được cái chỉ (pointer) hàm số tới DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "thoát shell với mã %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: Nhận được sự kiện %s\n"
-
-msgid "close"
-msgstr "đóng"
-
-msgid "logoff"
-msgstr "thoát"
-
-msgid "shutdown"
-msgstr "tắt máy"
-
-msgid "E371: Command not found"
-msgstr "E371: Câu lệnh không tìm thấy"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
+msgid "dlerror = \"%s\""
 msgstr ""
-"Không tìm thấy VIMRUN.EXE trong $PATH.\n"
-"Lệnh ngoại trú sẽ không dừng lại sau khi hoàn thành.\n"
-"Thông tin chi tiết xem trong :help win32-vimrun"
 
-msgid "Vim Warning"
-msgstr "Cảnh báo Vim"
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Không tìm thấy tập tin \"%s\" trong đường dẫn"
 
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Quá nhiều %%%c trong chuỗi định dạng"
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Không mong đợi %%%c trong chuỗi định dạng"
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Thiếu ] trong chuỗi định dạng"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c không được hỗ trợ trong chuỗi định dạng"
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Không cho phép %%%c trong tiền tố của chuỗi định dạng"
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Không cho phép %%%c trong chuỗi định dạng"
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: Trong giá trị 'errorformat' thiếu mẫu (pattern)"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Tên thư mục không được đưa ra hoặc bằng một chuỗi rỗng"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Không còn phần tử nào nữa"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d của %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (dòng bị xóa)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Ở dưới của đống sửa nhanh"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Ở đầu của đống sửa nhanh"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "danh sách lỗi %d của %d; %d lỗi"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Không ghi nhớ được, giá trị 'buftype' không phải là chuỗi rỗng"
 
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "E624: Không thể mở tập tin \"%s\""
+
+#: ../quickfix.c:3429
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "1 bộ đệm được bỏ nạp từ bộ nhớ"
+
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E548: yêu cầu một số"
+
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: phần tử không cho phép trong %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: Mẫu (pattern) quá dài"
+#: ../regexp.c:374
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E69: Thiếu ] sau %s%%["
 
-msgid "E50: Too many \\z("
-msgstr "E50: Quá nhiều \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: Quá nhiều %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: Không có cặp cho \\z("
-
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: Không có cặp cho %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: Không có cặp cho %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: Không có cặp cho %s)"
 
-#, c-format
-msgid "E56: %s* operand could be empty"
-msgstr "E56: operand %s* không thể rỗng"
-
-#, c-format
-msgid "E57: %s+ operand could be empty"
-msgstr "E57: operand %s+ không thể rỗng"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: ký tự không cho phép sau %s@"
-
-#, c-format
-msgid "E58: %s{ operand could be empty"
-msgstr "E58: operand %s{ không thể rỗng"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: Quá nhiều cấu trúc phức tạp %s{...}"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: %s* lồng vào"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: %s%c lồng vào"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: không cho phép sử dụng \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c không theo sau gì cả"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: Không cho phép liên kết ngược lại"
-
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( không thể sử dụng ở đây"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 và tương tự không được sử dụng ở đây"
 
-msgid "E68: Invalid character after \\z"
-msgstr "E68: Ký tự không cho phép sau \\z"
-
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Thiếu ] sau %s%%["
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] rỗng"
 
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: Mẫu (pattern) quá dài"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: Quá nhiều \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: Quá nhiều %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: Không có cặp cho \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: ký tự không cho phép sau %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Quá nhiều cấu trúc phức tạp %s{...}"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: %s* lồng vào"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: %s%c lồng vào"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: không cho phép sử dụng \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c không theo sau gì cả"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: Không cho phép liên kết ngược lại"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: Ký tự không cho phép sau \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E71: Ký tự không cho phép sau %s%%"
+
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Ký tự không cho phép sau %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Lỗi cú pháp trong %s{...}"
 
-msgid "E361: Crash intercepted; regexp too complex?"
-msgstr "E361: Sự cố được ngăn chặn; biểu thức chính quy quá phức tạp?"
-
-msgid "E363: pattern caused out-of-stack error"
-msgstr "E363: sử dụng mẫu (pattern) gây ra lỗi out-of-stack"
-
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "Sự tương ứng con ngoài:\n"
 
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "+--%3ld dòng được gấp"
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: Quá nhiều \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: Không tìm thấy tập tin tạm thời (temp) để ghi nhớ"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " THAY THẾ ẢO"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " THAY THẾ"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " NGƯỢC LẠI"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " CHÈN"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (chèn)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (thay thế)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (thay thế ảo)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Do thái"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Ả rập"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (ngôn ngữ)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (dán)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " CHẾ ĐỘ VISUAL"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " DÒNG VISUAL"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " KHỐI VISUAL"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " LỰA CHỌN"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " LỰA CHỌN DÒNG"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " LỰA CHỌN KHỐI"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "đang ghi"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "tìm kiếm sẽ được tiếp tục từ CUỐI tài liệu"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "tìm kiếm sẽ được tiếp tục từ ĐẦU tài liệu"
-
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Chuỗi tìm kiếm không đúng: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: tìm kiếm kết thúc ở ĐẦU tập tin; không tìm thấy %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: tìm kiếm kết thúc ở CUỐI tập tin; không tìm thấy %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Mong đợi nhập '?' hoặc '/' sau ';'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (gồm cả những tương ứng đã liệt kê trước đây)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Tập tin tính đến "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "không tìm thấy "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "trong đường dẫn ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Đã liệt kê)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " KHÔNG TÌM THẤY"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Quét trong tập tin được tính đến: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "Quét trong tập tin được tính đến: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Tương ứng nằm trên dòng hiện tại"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Tìm thấy tất cả các tập tin được tính đến"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "Không có tập tin được tính đến"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Không tìm thấy định nghĩa"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Không tìm thấy mẫu (pattern)"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 thay thế"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+#, fuzzy
+msgid "E759: Format error in spell file"
+msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:955
+#, fuzzy
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E431: Lỗi định dạng trong tập tin thẻ ghi \"%s\""
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "Đang sử dụng tập tin trao đổi (swap) \"%s\""
+
+#: ../spell.c:2496
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
+
+#: ../spell.c:3762
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "E519: Tùy chọn không được hỗ trợ"
+
+#: ../spell.c:4550
+#, fuzzy, c-format
+msgid "Reading affix file %s ..."
+msgstr "Tìm kiếm tập tin thẻ ghi %s"
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: Thẻ ghi lặp lại \"%s\" trong tập tin %s"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "Có quá nhiều tham số soạn thảo"
+
+#: ../spell.c:5238
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "Có quá nhiều tham số soạn thảo"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, fuzzy, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "Quét từ điển: %s"
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "Tìm thấy tương ứng trên mọi dòng: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, fuzzy, c-format
+msgid "Reading word file %s ..."
+msgstr "Đọc từ đầu vào tiêu chuẩn stdin..."
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "E573: Sử dụng id máy chủ không đúng: %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "Ghi tập tin viminfo \"%s\""
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+#, fuzzy
+msgid "E754: Only up to 8 regions supported"
+msgstr "E519: Tùy chọn không được hỗ trợ"
+
+#: ../spell.c:7846
+#, fuzzy, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E15: Biểu thức không cho phép: %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, fuzzy, c-format
+msgid "Writing spell file %s ..."
+msgstr "Ghi tập tin viminfo \"%s\""
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, fuzzy, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr " trên %<PRId64> dòng"
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, fuzzy, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "Ghi nhớ thay đổi vào \"%.*s\"?"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: Không có biểu thức chính quy trước"
+
+#: ../spell.c:8925
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: Không tìm thấy trình đơn: %s"
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Lỗi khi đọc tập tin lỗi"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "Không có phần tử cú pháp nào được định nghĩa cho bộ đệm này"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Tham số không cho phép: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Không có cụm cú pháp như vậy: %s"
 
-msgid "No Syntax items defined for this buffer"
-msgstr "Không có phần tử cú pháp nào được định nghĩa cho bộ đệm này"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "Đồng bộ hóa theo chú thích kiểu C"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "không đồng bộ hóa"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "đồng bộ hóa bắt đầu "
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " dòng trước dòng đầu tiên"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -4221,6 +5776,7 @@ msgstr ""
 "\n"
 "--- Phần tử đồng bộ hóa cú pháp ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -4228,6 +5784,7 @@ msgstr ""
 "\n"
 "đồng bộ hóa theo phần tử"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -4235,200 +5792,274 @@ msgstr ""
 "\n"
 "--- Phần tử cú pháp ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Không có cụm cú pháp như vậy: %s"
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "nhỏ nhất "
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "lớn nhất "
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; tương ứng "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " chuyển dòng"
 
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: không được sử dụng tham số contains ở đây"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: Tham số không cho phép"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: không được sử dụng group[t]here ở đây"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Phần tử vùng cho %s không tìm thấy"
 
-msgid "E395: contains argument not accepted here"
-msgstr "E395: không được sử dụng tham số contains ở đây"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: không được sử dụng tham số containedin ở đây"
-
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: Yêu cầu tên tập tin"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: Quá nhiều tên tập tin"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: Thiếu '=': %s"
+
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Thiếu '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Không đủ tham số: vùng cú pháp %s"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: Không có cụm cú pháp như vậy: %s"
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Chưa chỉ ra cụm"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Không tìm thấy ký tự phân chia mẫu (pattern): %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Rác ở sau mẫu (pattern): %s"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: đồng bộ hóa cú pháp: mẫu tiếp tục của dòng chỉ ra hai lần"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Tham số không cho phép: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Thiếu dấu bằng: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Tham số trống rỗng: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s không được cho phép ở đây"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s phải là đầu tiên trong danh sách contains"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Tên nhóm không biết: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Câu lệnh con :syntax không đúng: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: không tìm thấy nhóm chiếu sáng cú pháp: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Không đủ tham số: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Quá nhiều tham số: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: nhóm có thiết lập riêng, chiếu sáng liên kết bị bỏ qua"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: dấu bằng không được mong đợi: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: thiếu dấu bằng: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: thiếu tham số: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Giá trị không cho phép: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Không rõ màu văn bản (FG)"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Không rõ màu nền sau (BG)"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Tên hoặc số của màu không được nhận ra: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: mã terminal quá dài: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Tham số không cho phép: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Sử dụng quá nhiều thuộc tính chiếu sáng cú pháp"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ký tự không thể tin ra trong tên nhóm"
 
-#. This is an error, but since there previously was no check only
-#. * give a warning.
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: Ký tự không cho phép trong tên nhóm"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: ở cuối đống thẻ ghi"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: ở đầu đống thẻ ghi"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Không chuyển được tới vị trí ở trước thẻ ghi tương ứng đầu tiên"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: không tìm thấy thẻ ghi: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri loại thẻ ghi"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "tập tin\n"
 
-#.
-#. * Ask to select a tag from the list.
-#. * When using ":silent" assume that <CR> was entered.
-#.
-msgid "Enter nr of choice (<CR> to abort): "
-msgstr "Hãy chọn số cần thiết (<CR> để dừng):"
-
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: Chỉ có một thẻ ghi tương ứng"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Không chuyển được tới vị trí ở sau thẻ ghi tương ứng cuối cùng"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Tập tin \"%s\" không tồn tại"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "thẻ ghi %d của %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " và hơn nữa"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Đang sử dụng thẻ ghi với kiểu chữ khác!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Tập tin \"%s\" không tồn tại"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -4436,59 +6067,79 @@ msgstr ""
 "\n"
 "  # TỚI thẻ ghi        TỪ   dòng  trong tập tin/văn bản"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Tìm kiếm tập tin thẻ ghi %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Đường dẫn tới tập tin thẻ ghi bị cắt bớt cho %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Lỗi định dạng trong tập tin thẻ ghi \"%s\""
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Trước byte %<PRId64>"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tập tin thẻ ghi chưa được sắp xếp: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Không có tập tin thẻ ghi"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Không tìm thấy mẫu thẻ ghi"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Không tìm thấy thẻ ghi, đang thử đoán!"
 
+#: ../tag.c:2797
+#, c-format
+msgid "Duplicate field name: %s"
+msgstr ""
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' không rõ. Có các terminal gắn sẵn (builtin) sau:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "theo mặc định '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Không thể mở tập tin termcap"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Trong terminfo không có bản ghi nào về terminal này"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Trong termcap không có bản ghi nào về terminal này"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Trong termcap không có bản ghi \"%s\""
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: cần khả năng của terminal \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -4496,109 +6147,176 @@ msgstr ""
 "\n"
 "--- Phím terminal ---"
 
-msgid "new shell started\n"
-msgstr "đã chạy shell mới\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Lỗi đọc dữ liệu nhập, thoát...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "Không thể hủy thao tác; tiếp tục thực hiện"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: Không thể mở tập tin để ghi nhớ"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "Ghi tập tin viminfo \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Đọc tập tin viminfo \"%s\"%s%s%s"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: Không thể mở tập tin viminfo để đọc"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E484: Không mở được tập tin %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: Không mở được tập tin %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "thực hiện xong %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: Bộ đệm %<PRId64> không được tìm thấy"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: số thứ tự dòng không đúng"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "Thêm 1 dòng"
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "Thêm 1 dòng"
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "Bớt 1 dòng"
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "Bớt %<PRId64> dòng"
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "duy nhất 1 thay đổi"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "%<PRId64> thay đổi"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "duy nhất 1 thay đổi"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "Trên %<PRId64> dòng %s %d lần"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "Không tìm thấy ánh xạ"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> Cột; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s không được cho phép ở đây"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: danh sách hủy thao tác (undo) bị hỏng"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: bị mất dòng hủy thao tác"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"Phiên bản với giao diện đồ họa GUI cho MS-Windows 16/32 bit"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"Phiên bản với giao diện đồ họa GUI cho MS-Windows 32 bit"
-
-msgid " in Win32s mode"
-msgstr " trong chế độ Win32"
-
-msgid " with OLE support"
-msgstr " với hỗ trợ OLE"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"Phiên bản console cho MS-Windows 32 bit"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"Phiên bản cho MS-Windows 16 bit"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"Phiên bản cho MS-DOS 32 bit"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"Phiên bản cho MS-DOS 16 bit"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"Phiên bản cho MacOS X (unix)"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"Phiên bản cho MacOS X"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"Phiên bản cho MacOS"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"Phiên bản cho RISC OS"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -4606,9 +6324,18 @@ msgstr ""
 "\n"
 "Bao gồm các bản vá lỗi: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "Sự tương ứng con ngoài:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Với các thay đổi bởi "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -4616,9 +6343,11 @@ msgstr ""
 "\n"
 "Được biên dịch "
 
+#: ../version.c:649
 msgid "by "
 msgstr "bởi "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -4626,571 +6355,1521 @@ msgstr ""
 "\n"
 "Phiên bản khổng lồ "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"Phiên bản lớn "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"Phiên bản thông thường "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Phiên bản nhỏ "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"Phiên bản \"tí hon\" "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "không có giao diện đồ họa GUI."
 
-msgid "with GTK2-GNOME GUI."
-msgstr "với giao diện đồ họa GUI GTK2-GNOME."
-
-msgid "with GTK-GNOME GUI."
-msgstr "với giao diện đồ họa GUI GTK-GNOME."
-
-msgid "with GTK2 GUI."
-msgstr "với giao diện đồ họa GUI GTK2."
-
-msgid "with GTK GUI."
-msgstr "với giao diện đồ họa GUI GTK."
-
-msgid "with X11-Motif GUI."
-msgstr "với giao diện đồ họa GUI X11-Motif."
-
-msgid "with X11-neXtaw GUI."
-msgstr "với giao diện đồ họa GUI X11-neXtaw."
-
-msgid "with X11-Athena GUI."
-msgstr "với giao diện đồ họa GUI X11-Athena."
-
-msgid "with BeOS GUI."
-msgstr "với giao diện đồ họa GUI BeOS."
-
-msgid "with Photon GUI."
-msgstr "với giao diện đồ họa GUI Photon."
-
-msgid "with GUI."
-msgstr "với giao diện đồ họa GUI."
-
-msgid "with Carbon GUI."
-msgstr "với giao diện đồ họa GUI Carbon."
-
-msgid "with Cocoa GUI."
-msgstr "với giao diện đồ họa GUI Cocoa."
-
-msgid "with (classic) GUI."
-msgstr "với giao diện đồ họa (cổ điển) GUI."
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Tính năng có (+) hoặc không (-):\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "            tập tin vimrc chung cho hệ thống: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "         tập tin vimrc của người dùng: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  tập tin vimrc thứ hai của người dùng: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  tập tin vimrc thứ ba của người dùng: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         tập tin exrc của người dùng: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  tập tin exrc thứ hai của người dùng: \""
 
-msgid "  system gvimrc file: \""
-msgstr "            tập tin gvimrc chung cho hệ thống: \""
-
-msgid "    user gvimrc file: \""
-msgstr "         tập tin gvimrc của người dùng: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "  tập tin gvimrc thứ hai của người dùng: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "  tập tin gvimrc thứ ba của người dùng: \""
-
-msgid "    system menu file: \""
-msgstr "             tập tin trình đơn chung cho hệ thống: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "          giá trị $VIM theo mặc định: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "   giá trị $VIMRUNTIME theo mặc định: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "Tham số biên dịch: "
 
-msgid "Compiler: "
-msgstr "Trình biên dịch: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Liên kết: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  BIÊN DỊCH SỬA LỖI (DEBUG)"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM ::: Vi IMproved (Vi cải tiến) ::: Phiên bản tiếng Việt"
 
+#: ../version.c:769
 msgid "version "
 msgstr "phiên bản "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Do Bram Moolenaar và những người khác thực hiện"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim là chương trình mã nguồn mở và phân phối tự do"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Hãy giúp đỡ trẻ em nghèo Uganda!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "hãy gõ :help iccf<Enter>       để biết thêm thông tin"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "    hãy gõ :q<Enter>               để thoát khỏi chương trình     "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr " hãy gõ :help<Enter> hoặc <F1>  để có được trợ giúp        "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "hãy gõ :help version7<Enter>   để biết về phiên bản này  "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Làm việc trong chế độ tương thích với Vi"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "hãy gõ :set nocp<Enter>        để chuyển vào chế độ Vim     "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "hãy gõ :help cp-default<Enter> để có thêm thông tin về điều này"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "trình đơn Trợ giúp->Mồ côi             để có thêm thông tin     "
-
-msgid "Running modeless, typed text is inserted"
-msgstr "Không chế độ, văn bản nhập vào sẽ được chèn"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "trình đơn Soạn thảo->Thiết lập chung->Chế độ chèn                     "
-
-msgid "                              for two modes      "
-msgstr "                                 cho hai chế độ               "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr ""
-"trình đơn Soạn thảo->Thiết lập chung->Tương thích với Vi                "
-
-msgid "                              for Vim defaults   "
-msgstr ""
-"                                 để chuyển vào chế độ Vim mặc định       "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "Hãy giúp đỡ phát triển Vim!"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Hãy trở thành người dùng đăng ký của Vim!"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "hãy gõ :help sponsor<Enter>    để biết thêm thông tin "
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "hãy gõ :help register<Enter>   để biết thêm thông tin "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "trình đơn Trợ giúp->Giúp đỡ/Đăng ký để biết thêm thông tin    "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "CẢNH BÁO: nhận ra Windows 95/98/ME"
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "Chỉ có một cửa sổ"
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "hãy gõ :help windows95<Enter>  để biết thêm thông tin     "
-
+#: ../window.c:224
 msgid "E441: There is no preview window"
 msgstr "E441: Không có cửa sổ xem trước"
 
+#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr ""
 "E442: Cửa sổ không thể đồng thời ở bên trái phía trên và bên phải phía dưới"
 
+#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Không đổi được chỗ khi cửa sổ khác được chia"
 
+#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Không được đóng cửa sổ cuối cùng"
 
-msgid "Already only one window"
-msgstr "Chỉ có một cửa sổ"
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: Không được đóng cửa sổ cuối cùng"
 
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: Không được đóng cửa sổ cuối cùng"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Cửa sổ khác có thay đổi chưa được ghi nhớ"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Không có tên tập tin tại vị trí con trỏ"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Không tìm thấy tập tin \"%s\" trong đường dẫn"
+#~ msgid "[Error List]"
+#~ msgstr "[Danh sách lỗi]"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: Không nạp được thư viện %s"
+#~ msgid "[No File]"
+#~ msgstr "[Không có tập tin]"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "Xin lỗi, câu lệnh này bị tắt: không nạp được thư viện Perl."
+#~ msgid "Patch file"
+#~ msgstr "Tập tin vá lỗi (patch)"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr ""
-"E299: Không cho phép sự tính toán Perl trong hộp cát mà không có môđun An "
-"toàn"
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: Biến không biết: \"%s\""
 
-msgid "Edit with &multiple Vims"
-msgstr "Soạn thảo trong nhiều Vi&m"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "&OK\n"
+#~ "&Hủy bỏ"
 
-msgid "Edit with single &Vim"
-msgstr "Soạn thảo trong một &Vim"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: Không có kết nối với máy chủ Vim"
 
-msgid "&Diff with Vim"
-msgstr "&So sánh (diff) qua Vim"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: Máy chủ không trả lời"
 
-msgid "Edit with &Vim"
-msgstr "Soạn thảo trong &Vim"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: Không thể gửi tin nhắn tới %s"
 
-#. Now concatenate
-msgid "Edit with existing Vim - &"
-msgstr "Soạn thảo trong Vim đã chạy - &"
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: Hàm số %s chưa xác định"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "Soạn thảo (các) tập tin đã chọn trong Vim"
+#~ msgid "Save As"
+#~ msgstr "Ghi nhớ như"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Lỗi tạo tiến trình: Hãy kiểm tra xem gvim có trong đường dẫn không!"
+#~ msgid "Source Vim script"
+#~ msgstr "Thực hiện script của Vim"
 
-msgid "gvimext.dll error"
-msgstr "lỗi gvimext.dll"
+#~ msgid "Edit File"
+#~ msgstr "Soạn thảo tập tin"
 
-msgid "Path length too long!"
-msgstr "Đường dẫn quá dài!"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (KHÔNG TÌM THẤY)"
 
-msgid "--No lines in buffer--"
-msgstr "-- Không có dòng nào trong bộ đệm --"
+#~ msgid "Edit File in new window"
+#~ msgstr "Soạn thảo tập tin trong cửa sổ mới"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: Câu lệnh bị dừng"
+#~ msgid "Append File"
+#~ msgstr "Thêm tập tin"
 
-msgid "E471: Argument required"
-msgstr "E471: Cần chỉ ra tham số"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "Vị trí cửa sổ: X %d, Y %d"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: Sau \\ phải là các ký tự /, ? hoặc &"
+#~ msgid "Save Redirection"
+#~ msgstr "Chuyển hướng ghi nhớ"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Lỗi trong cửa sổ dòng lệnh; <CR> thực hiện, CTRL-C thoát"
+#~ msgid "Save View"
+#~ msgstr "Ghi nhớ vẻ ngoài"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Câu lệnh không cho phép từ exrc/vimrc trong thư mục hiện thời hoặc "
-"trong tìm kiếm thẻ ghi"
+#~ msgid "Save Session"
+#~ msgstr "Ghi nhớ buổi làm việc"
 
-msgid "E171: Missing :endif"
-msgstr "E171: Thiếu câu lệnh :endif"
+#~ msgid "Save Setup"
+#~ msgstr "Ghi nhớ cấu hình"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: Thiếu câu lệnh :endtry"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: Trong phiên bản này chữ ghép không được hỗ trợ"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: Thiếu câu lệnh :endwhile"
+#~ msgid "[NL found]"
+#~ msgstr "[tìm thấy ký tự NL]"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: Câu lệnh :endwhile không có lệnh :while (1 cặp)"
+#~ msgid "[crypted]"
+#~ msgstr "[đã mã hóa]"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Tập tin đã tồn tại (thêm ! để ghi chèn)"
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "[LỖI CHUYỂN BẢNG MÃ]"
 
-msgid "E472: Command failed"
-msgstr "E472: Không thực hiện thành công câu lệnh"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans không cho phép ghi nhớ bộ đệm chưa có thay đổi nào"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: Không rõ bộ phông chữ: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "Ghi nhớ một phần bộ đệm NetBeans không được cho phép"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: Không rõ phông chữ: %s"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr ""
+#~ "E460: Nhánh tài nguyên sẽ bị mất (thêm ! để bỏ qua việc kiểm tra lại)"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: Phông chữ \"%s\" không có độ rộng cố định (fixed-width)"
+#~ msgid "<cannot open> "
+#~ msgstr "<không thể mở> "
 
-msgid "E473: Internal error"
-msgstr "E473: Lỗi nội bộ"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: không tìm thấy phông chữ %s"
 
-msgid "Interrupted"
-msgstr "Bị gián đoạn"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: không trở lại được thư mục hiện thời"
 
-msgid "E14: Invalid address"
-msgstr "E14: Địa chỉ không cho phép"
+#~ msgid "Pathname:"
+#~ msgstr "Đường dẫn tới tập tin:"
 
-msgid "E474: Invalid argument"
-msgstr "E474: Tham số không cho phép"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: không tìm thấy thư mục hiện thời"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Tham số không cho phép: %s"
+#~ msgid "OK"
+#~ msgstr "Đồng ý"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Biểu thức không cho phép: %s"
+#~ msgid "Cancel"
+#~ msgstr "Hủy bỏ"
 
-msgid "E16: Invalid range"
-msgstr "E16: Vùng không cho phép"
+#~ msgid "Vim dialog"
+#~ msgstr "Hộp thoại Vim"
 
-msgid "E476: Invalid command"
-msgstr "E476: Câu lệnh không cho phép"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "Thanh cuộn: Không thể xác định hình học của thanh cuộn."
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" là mộ thư mục"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr ""
+#~ "E232: Không tạo được BalloonEval với cả thông báo và lời gọi ngược lại"
 
-msgid "E18: Unexpected characters before '='"
-msgstr "E18: Ở trước '=' có các ký tự không mong đợi"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: Không chạy được giao diện đồ họa GUI"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Gọi hàm số \"%s()\" của thư viện không thành công"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: Không đọc được từ \"%s\""
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: Nạp hàm số %s của thư viện không thành công"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr ""
+#~ "E665: Không chạy được giao diện đồ họa GUI, đưa ra phông chữ không đúng"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Dấu hiệu chỉ đến một số thứ tự dòng không đúng"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 'guifontwide' có giá trị không đúng"
 
-msgid "E20: Mark not set"
-msgstr "E20: Dấu hiệu không được xác định"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: Giá trị của 'imactivatekey' không đúng"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Không thể thay đổi, vì tùy chọn 'modifiable' bị tắt"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: Không chỉ định được màu %s"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Các script lồng vào nhau quá sâu"
+#~ msgid "Vim dialog..."
+#~ msgstr "Hộp thoại Vim..."
 
-msgid "E23: No alternate file"
-msgstr "E23: Không có tập tin xen kẽ"
+#~ msgid "Input _Methods"
+#~ msgstr "Phương pháp _nhập liệu"
 
-msgid "E24: No such abbreviation"
-msgstr "E24: Không có chữ viết tắt như vậy"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - Tìm kiếm và thay thế..."
 
-msgid "E477: No ! allowed"
-msgstr "E477: Không cho phép !"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - Tìm kiếm..."
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: Không sử dụng được giao diện đồ họa vì không chọn khi biên dịch"
+#~ msgid "Find what:"
+#~ msgstr "Tìm kiếm gì:"
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: Tiếng Do thái không được chọn khi biên dịch\n"
+#~ msgid "Replace with:"
+#~ msgstr "Thay thế bởi:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: Tiếng Farsi không được chọn khi biên dịch\n"
+#~ msgid "Match whole word only"
+#~ msgstr "Chỉ tìm tương ứng hoàn toàn với từ"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: Tiếng Ả Rập không được chọn khi biên dịch\n"
+#~ msgid "Match case"
+#~ msgstr "Có tính kiểu chữ"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Nhóm chiếu sáng cú pháp %s không tồn tại"
+#~ msgid "Direction"
+#~ msgstr "Hướng"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: Tạm thời chưa có văn bản được chèn"
+#~ msgid "Up"
+#~ msgstr "Lên"
 
-msgid "E30: No previous command line"
-msgstr "E30: Không có dòng lệnh trước"
+#~ msgid "Down"
+#~ msgstr "Xuống"
 
-msgid "E31: No such mapping"
-msgstr "E31: Không có ánh xạ (mapping) như vậy"
+#~ msgid "Find Next"
+#~ msgstr "Tìm tiếp"
 
-msgid "E479: No match"
-msgstr "E479: Không có tương ứng"
+#~ msgid "Replace"
+#~ msgstr "Thay thế"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Không có tương ứng: %s"
+#~ msgid "Replace All"
+#~ msgstr "Thay thế tất cả"
 
-msgid "E32: No file name"
-msgstr "E32: Không có tên tập tin"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: Nhận được yêu cầu \"chết\" (dừng) từ trình quản lý màn hình\n"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Không có biểu thức chính quy trước để thay thế"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: Cửa sổ chính đã bị đóng đột ngột\n"
 
-msgid "E34: No previous command"
-msgstr "E34: Không có câu lệnh trước"
+#~ msgid "Font Selection"
+#~ msgstr "Chọn phông chữ"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: Không có biểu thức chính quy trước"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "Sử dụng CUT_BUFFER0 thay cho lựa chọn trống rỗng"
 
-msgid "E481: No range allowed"
-msgstr "E481: Không cho phép sử dụng phạm vi"
+#~ msgid "Filter"
+#~ msgstr "Đầu lọc"
 
-msgid "E36: Not enough room"
-msgstr "E36: Không đủ chỗ trống"
+#~ msgid "Directories"
+#~ msgstr "Thư mục"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: máy chủ \"%s\" chưa đăng ký"
+#~ msgid "Help"
+#~ msgstr "Trợ giúp"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Không tạo được tập tin %s"
+#~ msgid "Files"
+#~ msgstr "Tập tin"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: Không nhận được tên tập tin tạm thời (temp)"
+#~ msgid "Selection"
+#~ msgstr "Lựa chọn"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Không mở được tập tin %s"
+#~ msgid "Undo"
+#~ msgstr "Hủy thao tác"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Không đọc được tập tin %s"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: Không tìm được tiêu đề cửa sổ \"%s\""
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Thay đổi chưa được ghi nhớ (thêm ! để bỏ qua ghi nhớ)"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr ""
+#~ "E243: Tham số không được hỗ trợ: \"-%s\"; Hãy sử dụng phiên bản OLE."
 
-msgid "E38: Null argument"
-msgstr "E38: Tham sô bằng 0"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: Không mở được cửa sổ bên trong ứng dụng MDI"
 
-msgid "E39: Number expected"
-msgstr "E39: Yêu cầu một số"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "Tìm kiếm chuỗi (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Không mở được tập tin lỗi %s"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "Tìm kiếm và Thay thế (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
 
-msgid "E233: cannot open display"
-msgstr "E233: không mở được màn hình"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr ""
+#~ "Vim E458: Không chỉ định được bản ghi trong bảng màu, một vài màu có thể "
+#~ "hiển thị không chính xác"
 
-msgid "E41: Out of memory!"
-msgstr "E41: Không đủ bộ nhớ!"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Trong bộ phông chữ %s thiếu phông cho các bảng mã sau:"
 
-msgid "Pattern not found"
-msgstr "Không tìm thấy mẫu (pattern)"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Bộ phông chữ: %s"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Không tìm thấy mẫu (pattern): %s"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "Phông chữ '%s' không phải là phông có độ rộng cố định (fixed-width)"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: Tham số phải là một số dương"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Bộ phông chữ: %s\n"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Không quay lại được thư mục trước đó"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E42: No Errors"
-msgstr "E42: Không có lỗi"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: Chuỗi tương ứng bị hỏng"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr ""
+#~ "Chiều rộng phông chữ font%<PRId64> phải lớn hơn hai lần so với chiều rộng "
+#~ "font0\n"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Chương trình xử lý biểu thức chính quy bị hỏng"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "Chiều rộng font0: %<PRId64>\n"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Tùy chọn 'readonly' được bật (Hãy thêm ! để lờ đi)"
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Chiều rộng font1: %<PRId64>\n"
+#~ "\n"
 
-#, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: LỖI máy tự động Hangual (tiếng Hàn)"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Lỗi khi đọc tập tin lỗi"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: lỗi stat"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Không cho phép trong hộp cát (sandbox)"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: không mở được cơ sở dữ liệu cscope: %s"
 
-msgid "E523: Not allowed here"
-msgstr "E523: Không cho phép ở đây"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: không lấy được thông tin về cơ sở dữ liệu cscope"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Chế độ màn hình không được hỗ trợ"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: đã đạt tới số kết nối lớn nhất cho phép với cscope"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: Kích thước thanh cuộn không cho phép"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E263: Rất tiếc câu lệnh này không làm việc, vì thư viện Python chưa được "
+#~ "nạp."
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Tùy chọn 'shell' là một chuỗi rỗng"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: Không thể gọi Python một cách đệ quy"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Không đọc được dữ liệu về ký tự!"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "Không xóa được thuộc tính OutputObject"
 
-msgid "E72: Close error on swap file"
-msgstr "E72: Lỗi đóng tập tin trao đổi (swap)"
+#~ msgid "softspace must be an integer"
+#~ msgstr "giá trị softspace phải là một số nguyên"
 
-msgid "E73: tag stack empty"
-msgstr "E73: đống thẻ ghi rỗng"
+#~ msgid "invalid attribute"
+#~ msgstr "thuộc tính không đúng"
 
-msgid "E74: Command too complex"
-msgstr "E74: Câu lệnh quá phức tạp"
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() yêu cầu một danh sách các chuỗi"
 
-msgid "E75: Name too long"
-msgstr "E75: Tên quá dài"
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: Lỗi khi bắt đầu sử dụng vật thể I/O"
 
-msgid "E76: Too many ["
-msgstr "E76: Quá nhiều ký tự ["
+#~ msgid "invalid expression"
+#~ msgstr "biểu thức không đúng"
 
-msgid "E77: Too many file names"
-msgstr "E77: Quá nhiều tên tập tin"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "biểu thức bị tắt khi biên dịch"
 
-msgid "E488: Trailing characters"
-msgstr "E488: Ký tự thừa ở đuôi"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "cố chỉ đến bộ đệm đã bị xóa"
 
-msgid "E78: Unknown mark"
-msgstr "E78: Dấu hiệu không biết"
+#~ msgid "line number out of range"
+#~ msgstr "số thứ tự của dòng vượt quá giới hạn"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Không thực hiện được phép thế theo wildcard"
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<vật thể của bộ đệm (bị xóa) tại %8lX>"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: giá trị của 'winheight' không thể nhỏ hơn 'winminheight'"
+#~ msgid "invalid mark name"
+#~ msgstr "tên dấu hiệu không đúng"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: giá trị của 'winwidth' không thể nhỏ hơn 'winminwidth'"
+#~ msgid "no such buffer"
+#~ msgstr "không có bộ đệm như vậy"
 
-msgid "E80: Error while writing"
-msgstr "E80: Lỗi khi ghi nhớ"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "cố chỉ đến cửa sổ đã bị đóng"
 
-msgid "Zero count"
-msgstr "Giá trị của bộ đếm bằng 0"
+#~ msgid "readonly attribute"
+#~ msgstr "thuộc tính chỉ đọc"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Sử dụng <SID> ngoài phạm vi script"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "vị trí con trỏ nằm ngoài bộ đệm"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: Nhận được một biểu thức không cho phép"
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<vật thể của cửa sổ (bị xóa) tại %.8lX>"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: Không thể thay đổi vùng đã được bảo vệ"
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<vật thể của cửa sổ (không rõ) tại %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<cửa sổ %d>"
+
+#~ msgid "no such window"
+#~ msgstr "không có cửa sổ như vậy"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "không ghi được thông tin về việc hủy thao tác"
+
+#~ msgid "cannot delete line"
+#~ msgstr "không xóa được dòng"
+
+#~ msgid "cannot replace line"
+#~ msgstr "không thay thế được dòng"
+
+#~ msgid "cannot insert line"
+#~ msgstr "không chèn được dòng"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "chuỗi không thể chứa ký tự dòng mới"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E266: Rất tiếc câu lệnh này không làm việc, vì thư viện Ruby chưa đượcnạp."
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: không rõ trạng thái của longjmp %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "Bật tắt giữa thi hành/định nghĩa"
+
+#~ msgid "Show base class of"
+#~ msgstr "Hiển thị hạng cơ bản của"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Hiển thị hàm số bị nạp đè lên"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Nhận từ tập tin"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Nhận từ dự án"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Nhận từ tất cả các dự án"
+
+#~ msgid "Retrieve"
+#~ msgstr "Nhận"
+
+#~ msgid "Show source of"
+#~ msgstr "Hiển thị mã nguồn"
+
+#~ msgid "Find symbol"
+#~ msgstr "Tìm ký hiệu"
+
+#~ msgid "Browse class"
+#~ msgstr "Duyệt hạng"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Hiển thị hạng trong hệ thống cấp bậc"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Hiển thị hạng trong hệ thống cấp bậc giới hạn"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref chỉ đến"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Liên kết đến xref từ"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref có một"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref được sử dụng bởi"
+
+#~ msgid "Show docu of"
+#~ msgstr "Hiển thị docu của"
+
+#~ msgid "Generate docu for"
+#~ msgstr "Tạo docu cho"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "Không kết nối được tới SNiFF+. Hãy kiểm tra cấu hình môi trường."
+#~ "(sniffemacs phải được chỉ ra trong biến $PATH).\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Lỗi trong thời gian đọc. Ngắt kết nối"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "Trong thời điểm hiện nay SNiFF+ "
+
+#~ msgid "not "
+#~ msgstr "không "
+
+#~ msgid "connected"
+#~ msgstr "được kết nối"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: không rõ yêu cầu của SNiFF+: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: Lỗi kết nối với SNiFF+"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: SNiFF+ chưa được kết nối"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: Lỗi trong thời gian ghi nhớ. Ngắt kết nối"
+
+#~ msgid "not implemented yet"
+#~ msgstr "tạm thời chưa được thực thi"
+
+#~ msgid "unknown option"
+#~ msgstr "tùy chọn không rõ"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "không thể đặt (các) dòng"
+
+#~ msgid "mark not set"
+#~ msgstr "dấu hiệu chưa được đặt"
+
+#~ msgid "row %d column %d"
+#~ msgstr "hàng %d cột %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "không thể chèn hoặc thêm dòng"
+
+#~ msgid "unknown flag: "
+#~ msgstr "cờ không biết: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "không rõ tùy chọn vimOption"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "sự gián đoạn của bàn phím"
+
+#~ msgid "vim error"
+#~ msgstr "lỗi của vim"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr ""
+#~ "không tạo được câu lệnh của bộ đệm hay của cửa sổ: vật thể đang bị xóa"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr ""
+#~ "không đăng ký được câu lệnh gọi ngược: bộ đệm hoặc cửa sổ đang bị xóa"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr ""
+#~ "E280: LỖI NẶNG CỦA TCL: bị hỏng danh sách liên kết!? Hãy thông báo việc "
+#~ "nàyđến danh sách thư (mailing list) vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr ""
+#~ "không đăng ký được câu lệnh gọi ngược: không tìm thấy liên kết đến bộ đệm "
+#~ "hoặc cửa sổ"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr ""
+#~ "E571: Rất tiếc là câu lệnh này không làm việc, vì thư viện Tcl chưa được "
+#~ "nạp"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr ""
+#~ "E281: LỖI TCL: mã thoát ra không phải là một số nguyên!? Hãy thông báo "
+#~ "điều này đến danh sách thư (mailing list) vim-dev@vim.org"
+
+#~ msgid "cannot get line"
+#~ msgstr "không nhận được dòng"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "Không đăng ký được một tên cho máy chủ câu lệnh"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: Gửi câu lệnh vào chương trình khác không thành công"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: Thuộc tính đăng ký của Vim được định dạng không đúng.  Xóa!"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "Vim không được biên dịch với tính năng hỗ trợ xem khác biệt (diff)."
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tĐăng ký gvim này cho OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\tBỏ đăng ký gvim này cho OLE"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\tSử dụng giao diện đồ họa GUI (giống \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr ""
+#~ "-f  hoặc  --nofork\tTrong chương trình hoạt động: Không thực hiện fork "
+#~ "khi chạy GUI"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tMức độ chi tiết của thông báo"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\tKhông sử dụng newcli để mở cửa sổ"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <thiết bị>\t\tSử dụng <thiết bị> cho I/O"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\tSử dụng <gvimrc> thay thế cho mọi .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\tSoạn thảo tập tin đã mã hóa"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <màn hình>\tKết nối vim tới máy chủ X đã chỉ ra"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\tKhông thực hiện việc kết nối tới máy chủ X"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <tập tin>\tSoạn thảo <tập tin> trên máy chủ Vim nếu có thể"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có máy "
+#~ "chủ"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <tập tin>  Cũng như --remote, nhưng chờ sự kết thúc"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr ""
+#~ "--remote-wait-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có "
+#~ "máy chủ"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <phím>\tGửi <phím> lên máy chủ Vim và thoát"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr ""
+#~ "--remote-expr <biểu thức>\tTính <biểu thức> trên máy chủ Vim và in ra kết "
+#~ "quả"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\tHiển thị danh sách máy chủ Vim và thoát"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <tên>\tGửi lên (hoặc trở thành) máy chủ Vim với <tên>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Tham số cho gvim (phiên bản Motif):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Tham số cho gvim (phiên bản neXtaw):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Tham số cho gvim (phiên bản Athena):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <màn hình>\tChạy vim trong <màn hình> đã chỉ ra"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\tChạy vim ở dạng thu nhỏ"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <tên>\t\tSử dụng tài nguyên giống như khi vim có <tên>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (Chưa được thực thi)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <màu>\tSử dụng <màu> chỉ ra cho nền (cũng như: -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr ""
+#~ "-foreground <màu>\tSử dụng <màu> cho văn bản thông thường (cũng như: -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr ""
+#~ "-font <phông>\t\tSử dụng <phông> chữ cho văn bản thông thường (cũng như: -"
+#~ "fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <phông>\tSử dụng <phông> chữ cho văn bản in đậm"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <phông>\tSử dụng <phông> chữ cho văn bản in nghiêng"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr ""
+#~ "-geometry <kích thước>\tSử dụng <kích thước> ban đầu (cũng như: -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr ""
+#~ "-borderwidth <rộng>\tSử dụng đường viền có chiều <rộng> (cũng như: -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr ""
+#~ "-scrollbarwidth <rộng> Sử dụng thanh cuộn với chiều <rộng> (cũng như: -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr ""
+#~ "-menuheight <cao>\tSử dụng thanh trình đơn với chiều <cao> (cũng như: -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\tSử dụng chế độ video đảo ngược (cũng như: -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\tKhông sử dụng chế độ video đảo ngược (cũng như: +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <tài nguyên>\tĐặt <tài nguyên> chỉ ra"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Tham số cho gvim (phiên bản RISC OS):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <số>\tChiều rộng ban đầu của cửa sổ tính theo số cột"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <số>\tChiều cao ban đầu của cửa sổ tính theo số dòng"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Tham số cho gvim (phiên bản GTK+):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr ""
+#~ "-display <màn hình>\tChạy vim trên <màn hình> chỉ ra (cũng như: --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <vai trò>\tĐặt <vai trò> duy nhất để nhận diện cửa sổ chính"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\tMở Vim bên trong thành phần GTK khác"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <tiêu đề của mẹ>\tMở Vim bên trong ứng dụng mẹ"
+
+#~ msgid "No display"
+#~ msgstr "Không có màn hình"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": Gửi không thành công.\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": Gửi không thành công. Thử thực hiện nội bộ\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "đã soạn thảo %d từ %d"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "Không có màn hình: gửi biểu thức không thành công.\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": Gửi biểu thức không thành công.\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: Bảng mã không cho phép"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: Không tạo được nội dung nhập vào"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: Việc thử mở phương pháp nhập không thành công"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr ""
+#~ "E287: Cảnh báo: không đặt được sự gọi ngược hủy diệt thành phương pháp "
+#~ "nhập"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: phương pháp nhập không hỗ trợ bất kỳ phong cách (style) nào"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: phương pháp nhập không hỗ trợ loại soạn thảo trước của Vim"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: phong cách over-the-spot yêu cầu một bộ phông chữ"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: GTK+ cũ hơn 1.2.3. Vùng chỉ trạng thái không làm việc"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: Máy chủ phương pháp nhập liệu chưa được chạy"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [không sử dụng được với phiên bản này của Vim]"
+
+#~ msgid ""
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
+#~ msgstr ""
+#~ "&O Mở chỉ để đọc\n"
+#~ "&E Vẫn soạn thảo\n"
+#~ "&R Phục hồi\n"
+#~ "&Q Thoát\n"
+#~ "&A Gián đoạn&D Xóa nó"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "Chia cắt trình đơn này"
+
+#~ msgid "[string too long]"
+#~ msgstr "[chuỗi quá dài]"
+
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "Nhấn phím ENTER để tiếp tục"
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: dòng, SPACE/b: trang, d/u: nửa trang, q: thoát)"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: dòng, SPACE: trang, d: nửa trang, q: thoát)"
+
+#~ msgid "Save File dialog"
+#~ msgstr "Ghi nhớ tập tin"
+
+#~ msgid "Open File dialog"
+#~ msgstr "Mở tập tin"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr ""
+#~ "E338: Xin lỗi nhưng không có trình duyệt tập tin trong chế độ kênh giao "
+#~ "tác (console)"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: ghi nhớ các tập tin...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: Đã xong.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "LỖI: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[byte] tổng phân phối-còn trống %<PRIu64>-%<PRIu64>, sử dụng %<PRIu64>, "
+#~ "píc sử dụng %<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[gọi] tổng re/malloc() %<PRIu64>, tổng free() %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: Dòng đang trở thành quá dài"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: Lỗi nội bộ: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: Dạng trỏ chuột không cho phép"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "Nhập mật khẩu để mã hóa: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "      Nhập lại mật khẩu:"
+
+#~ msgid "Keys don't match!"
+#~ msgstr "Hai mật khẩu không trùng nhau!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "Không kết nối được với Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "Không kết nối được với NetBeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr ""
+#~ "E668: Chế độ truy cập thông tin về liên kết với NetBeans không đúng: \"%s"
+#~ "\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "đọc từ socket NetBeans"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: Bị mất liên kết với NetBeans cho bộ đệm %<PRId64>"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "đã làm sạch %<PRId64> dòng"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: Không thể thay đổi terminal trong giao diện đồ họa GUI"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: Hãy sử dụng \":gui\" để chạy giao diện đồ họa GUI"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: Không thể thay đổi trong giao diện đồ họa GTK+ 2"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: không chọn được bộ phông chữ"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: Bộ phông chữ không đúng"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: không chọn được phông chữ với các ký tự có chiều rộng gấp đôi"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: Phông chữ, với ký tự có chiều rộng gấp đôi, không đúng"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: Chuột không được hỗ trợ"
+
+#~ msgid "cannot open "
+#~ msgstr "không mở được "
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: Không mở được cửa sổ!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "Cần Amigados phiên bản 2.04 hoặc mới hơn\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "Cần %s phiên bản %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "Không mở được NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "Không tạo được "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Thoát Vim với mã %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "không thay đổi được chế độ kênh giao tác (console)?!\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: không phải là kênh giao tác (console)??\n"
+
+#~ msgid "Cannot execute "
+#~ msgstr "Không chạy được "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " thoát\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "Giá trị ANCHOR_BUF_SIZE quá nhỏ."
+
+#~ msgid "I/O ERROR"
+#~ msgstr "LỖI I/O (NHẬP/XUẤT)"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(bị cắt bớt)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr ""
+#~ "Tùy chọn 'columns' khác 80, chương trình ngoại trú không thể thực hiện"
+
+#~ msgid "to %s on %s"
+#~ msgstr "tới %s trên %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: Không rõ phông chữ của máy in: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: Lỗi in: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "Đang in '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: Tên bảng mã không cho phép \"%s\" trong tên phông chữ \"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: Ký tự không cho phép '%c' trong tên phông chữ \"%s\""
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Tín hiệu đôi, thoát\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: Nhận được tín hiệu chết %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: Nhận được tín hiệu chết\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "Mở màn hình X mất %<PRId64> mili giây"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: Lỗi X\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "Kiểm tra màn hình X không thành công"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "Không mở được màn hình X trong thời gian cho phép (time out)"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Không chạy được shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Không tạo được đường ống (pipe)\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Không thực hiện được fork()\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Câu lệnh bị gián đoạn\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP mất kết nối ICE"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "Mở màn hình X không thành công"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP xử lý yêu cầu tự động ghi nhớ"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP mở kết nối"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP mất theo dõi kết nối ICE"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP thực hiện SmcOpenConnection không thành công: %s"
+
+#~ msgid "At line"
+#~ msgstr "Tại dòng"
+
+#~ msgid "Could not allocate memory for command line."
+#~ msgstr "Không phân chia được bộ nhớ cho dòng lệnh."
+
+#~ msgid "VIM Error"
+#~ msgstr "Lỗi VIM"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "Không nạp được vim32.dll!"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "Không sửa được cái chỉ (pointer) hàm số tới DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "thoát shell với mã %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: Nhận được sự kiện %s\n"
+
+#~ msgid "close"
+#~ msgstr "đóng"
+
+#~ msgid "logoff"
+#~ msgstr "thoát"
+
+#~ msgid "shutdown"
+#~ msgstr "tắt máy"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: Câu lệnh không tìm thấy"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "Không tìm thấy VIMRUN.EXE trong $PATH.\n"
+#~ "Lệnh ngoại trú sẽ không dừng lại sau khi hoàn thành.\n"
+#~ "Thông tin chi tiết xem trong :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Cảnh báo Vim"
+
+#~ msgid "E56: %s* operand could be empty"
+#~ msgstr "E56: operand %s* không thể rỗng"
+
+#~ msgid "E57: %s+ operand could be empty"
+#~ msgstr "E57: operand %s+ không thể rỗng"
+
+#~ msgid "E58: %s{ operand could be empty"
+#~ msgstr "E58: operand %s{ không thể rỗng"
+
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr "E361: Sự cố được ngăn chặn; biểu thức chính quy quá phức tạp?"
+
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: sử dụng mẫu (pattern) gây ra lỗi out-of-stack"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: không được sử dụng tham số containedin ở đây"
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "Hãy chọn số cần thiết (<CR> để dừng):"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Đường dẫn tới tập tin thẻ ghi bị cắt bớt cho %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "đã chạy shell mới\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "Không thể hủy thao tác; tiếp tục thực hiện"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản với giao diện đồ họa GUI cho MS-Windows 16/32 bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản với giao diện đồ họa GUI cho MS-Windows 32 bit"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " trong chế độ Win32"
+
+#~ msgid " with OLE support"
+#~ msgstr " với hỗ trợ OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản console cho MS-Windows 32 bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho MS-Windows 16 bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho MS-DOS 32 bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho MS-DOS 16 bit"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho MacOS X (unix)"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho MacOS X"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho MacOS"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản cho RISC OS"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản lớn "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản thông thường "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản nhỏ "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "Phiên bản \"tí hon\" "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "với giao diện đồ họa GUI GTK2-GNOME."
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "với giao diện đồ họa GUI GTK-GNOME."
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "với giao diện đồ họa GUI GTK2."
+
+#~ msgid "with GTK GUI."
+#~ msgstr "với giao diện đồ họa GUI GTK."
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "với giao diện đồ họa GUI X11-Motif."
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "với giao diện đồ họa GUI X11-neXtaw."
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "với giao diện đồ họa GUI X11-Athena."
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "với giao diện đồ họa GUI BeOS."
+
+#~ msgid "with Photon GUI."
+#~ msgstr "với giao diện đồ họa GUI Photon."
+
+#~ msgid "with GUI."
+#~ msgstr "với giao diện đồ họa GUI."
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "với giao diện đồ họa GUI Carbon."
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "với giao diện đồ họa GUI Cocoa."
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "với giao diện đồ họa (cổ điển) GUI."
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "            tập tin gvimrc chung cho hệ thống: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "         tập tin gvimrc của người dùng: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "  tập tin gvimrc thứ hai của người dùng: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "  tập tin gvimrc thứ ba của người dùng: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "             tập tin trình đơn chung cho hệ thống: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "Trình biên dịch: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "trình đơn Trợ giúp->Mồ côi             để có thêm thông tin     "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "Không chế độ, văn bản nhập vào sẽ được chèn"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr ""
+#~ "trình đơn Soạn thảo->Thiết lập chung->Chế độ chèn                     "
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                                 cho hai chế độ               "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr ""
+#~ "trình đơn Soạn thảo->Thiết lập chung->Tương thích với Vi                "
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr ""
+#~ "                                 để chuyển vào chế độ Vim mặc định       "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "CẢNH BÁO: nhận ra Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "hãy gõ :help windows95<Enter>  để biết thêm thông tin     "
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: Không nạp được thư viện %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "Xin lỗi, câu lệnh này bị tắt: không nạp được thư viện Perl."
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr ""
+#~ "E299: Không cho phép sự tính toán Perl trong hộp cát mà không có môđun An "
+#~ "toàn"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "Soạn thảo trong nhiều Vi&m"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "Soạn thảo trong một &Vim"
+
+#~ msgid "&Diff with Vim"
+#~ msgstr "&So sánh (diff) qua Vim"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "Soạn thảo trong &Vim"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "Soạn thảo trong Vim đã chạy - &"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "Soạn thảo (các) tập tin đã chọn trong Vim"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "Lỗi tạo tiến trình: Hãy kiểm tra xem gvim có trong đường dẫn không!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "lỗi gvimext.dll"
+
+#~ msgid "Path length too long!"
+#~ msgstr "Đường dẫn quá dài!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: Không rõ bộ phông chữ: %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: Không rõ phông chữ: %s"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: Nạp hàm số %s của thư viện không thành công"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: Tiếng Do thái không được chọn khi biên dịch\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: Tiếng Farsi không được chọn khi biên dịch\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: Tiếng Ả Rập không được chọn khi biên dịch\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: máy chủ \"%s\" chưa đăng ký"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: không mở được màn hình"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: Không thể thay đổi vùng đã được bảo vệ"

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -4,7 +4,7 @@
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
 # FIRST AUTHOR  Wang Jun <junw@turbolinux.com.cn>
-# 
+#
 # TRANSLATORS
 #   Edyfox <edyfox@gmail.com>
 #   Yuheng Xie <elephant@linux.net.cn>
@@ -15,146 +15,213 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Simplified Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-04-21 15:16+0800\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2006-04-21 14:00+0800\n"
 "Last-Translator: Yuheng Xie <elephant@linux.net.cn>\n"
 "Language-Team: Simplified Chinese <i18n-translation@lists.linux.net.cn>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "选项参数后的内容无效"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Location 列表]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Quickfix 列表]"
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: 无法分配任何缓冲区，退出程序..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: 无法分配缓冲区，使用另一个缓冲区..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 没有释放任何缓冲区"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 没有删除任何缓冲区"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 没有清除任何缓冲区"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "释放了 1 个缓冲区"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "释放了 %d 个缓冲区"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "删除了 1 个缓冲区"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "删除了 %d 个缓冲区"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "清除了 1 个缓冲区"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "清除了 %d 个缓冲区"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 无法释放最后一个缓冲区"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 没有修改过的缓冲区"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: 没有可列出的缓冲区"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: 缓冲区 %<PRId64> 不存在"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 无法切换，已是最后一个缓冲区"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 无法切换，已是第一个缓冲区"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: 缓冲区 %<PRId64> 已修改但尚未保存 (请加 ! 强制执行)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 无法释放最后一个缓冲区"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 文件名过多"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: 找不到缓冲区 %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: 找到不止一个 %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: 没有匹配的缓冲区 %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "第 %<PRId64> 行"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有缓冲区使用该名称"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [已修改]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未编辑]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新文件]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[读错误]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[只读]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[只读]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 行 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64> / %<PRId64> --%d%%-- 列 "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[未命名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "帮助"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[帮助]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[预览]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全部"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "底端"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "顶端"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -162,12 +229,11 @@ msgstr ""
 "\n"
 "# 缓冲区列表:\n"
 
-msgid "[Location List]"
-msgstr "[Location 列表]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[Quickfix List]"
-msgstr "[Quickfix 列表]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -175,126 +241,202 @@ msgstr ""
 "\n"
 "--- Signs ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s 的 Signs:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  id=%d  名称=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: 缺少冒号"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 无效的模式"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 此处需要数字"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 无效的百分比"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: 不能比较(diff) %<PRId64> 个以上的缓冲区"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: 无法打开 termcap 文件"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 无法创建 diff"
 
-msgid "Patch file"
-msgstr "Patch 文件"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: 无法读取 diff 的输出"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: 无法读取 diff 的输出"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 当前缓冲区不在 diff 模式"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: 没有其它处于 diff 模式的缓冲区"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 没有其它处于 diff 模式的缓冲区"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: 有两个以上的缓冲区处于 diff 模式，不能决定用哪一个"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: 找不到缓冲区 \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: 缓冲区 \"%s\" 不在 diff 模式"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 意外地改变了缓冲区"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 复合字符(digraph)中不能使用 Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: 找不到 Keymap 文件"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: 不是在脚本文件中使用 :loadkeymap "
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " 关键字补全 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X 模式 (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 整行补全 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " 文件名补全 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Tag 补全 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " 头文件模式补全 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定义补全 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dictionary 补全 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus 补全 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " 命令行补全 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " 用户自定义补全 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 拼写建议 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 关键字局部补全 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "已到段落结尾"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "选项 'dictionary' 为空"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "选项 'thesaurus' 为空"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "正在扫描 dictionary: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (插入) Scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (替换) Scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "正在扫描: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "扫描标签."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 增加"
 
@@ -302,375 +444,585 @@ msgstr " 增加"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 查找中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "回到起点"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "另一行的词"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "唯一匹配"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "匹配 %d / %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "匹配 %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: :let 中出现异常字符"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: List 索引超出范围: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 未定义的变量: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: 缺少 ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s 的参数必须是 List"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s 的参数必须是 List 或者 Dictionary"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Dictionary 的键不能为空"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: 需要 List"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: 需要 Dictionary"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 函数的参数过多: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Dictionary 中不存在键: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 函数 %s 已存在，请加 ! 强制替换"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Dictionary 项已存在"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: 需要 Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: 不能对 Dictionary 使用 [:]"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: %s= 的变量类型不正确"
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 未知的函数: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 无效的变量名: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: 将 List 作 String 使用"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: 目标比 List 项数少"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: 目标比 List 项数多"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "变量列表中出现两个 ;"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: 无法列出 %s 的变量"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: 只能索引 List 或 Dictionary"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] 必须在最后"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] 需要一个 List 值"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: List 值的项比目标多"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: List 值没有足够多的项"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for 后缺少 \"in\""
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: 缺少括号: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: 无此变量: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: (un)lock 的变量嵌套过深"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' 后缺少 ':'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: 只能比较 List 和 List"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: 对 List 无效的操作"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: 只能比较 Dictionary 和 Dictionary"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: 对 Dictionary 无效的操作"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: 只能比较 Funcref 和 Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: 对 Funcrefs 无效的操作"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: 不能对 Dictionary 使用 [:]"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: 缺少 ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: 不能索引一个 Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: 缺少选项名称: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 未知的选项: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 缺少引号: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 缺少引号: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: List 中缺少逗号: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: List 缺少结束符 ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Dictionary 中缺少冒号: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Dictionary 中出现重复的键: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Dictionary 中缺少逗号: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Dictionary 缺少结束符 '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 变量嵌套过深无法显示"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: 函数的参数过多: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: 函数的参数过多: %s"
+
+#: ../eval.c:7377
+#, fuzzy, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E130: 未知的函数: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: 函数 %s 的参数太少"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> 不能在 script 上下文外使用: %s"
+
+#: ../eval.c:7391
+#, fuzzy, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E720: Dictionary 中缺少冒号: %s"
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: = 后面需要数字"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 参数过多"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() 只能在插入模式中使用"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "确定(&O)"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: 键已存在: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd 参数"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 行: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 未知的函数: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"确定(&O)\n"
-"取消(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() 的调用次数多于 inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 不允许的范围"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len() 的类型无效"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: 步长为零"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 起始值在终止值后"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<空>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: 没有到 Vim 服务器的连接"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd 参数"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: 无法发送到 %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: 无法读取服务器响应"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: 符号连接过多(循环？)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: 无法发送到客户端"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c 参数"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Sort 比较函数失败"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Sort 比较函数失败"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(无效)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 写临时文件出错"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: 将 List 作数字使用"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: 将 Funcref 作数字使用"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: 将 List 作数字使用"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 将 Dictionary 作数字使用"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: 将 Funcref 作 String 使用"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: 将 List 作 String 使用"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: 将 Dictionary 作 String 使用"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funcref 变量名必须以大写字母开头: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: 变量名与已有函数名冲突: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 变量类型不匹配: %s"
 
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: 无法列出 %s 的变量"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funcref 变量名必须以大写字母开头: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: 变量名与已有函数名冲突: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 值已锁定: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "未知"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: 无法改变 %s 的值"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: 变量嵌套过深无法复制"
 
+#: ../eval.c:17249
+#, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E123: 函数 %s 尚未定义"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: 缺少 '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: 不能设定 IC 值"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 无效的参数: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: 无效的参数: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: 缺少 :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: 函数名与脚本文件名不匹配: %s"
+
+#: ../eval.c:17549
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E127: 函数 %s 正在使用中，不能重新定义"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 函数名与脚本文件名不匹配: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 需要函数名"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 函数名必须以大写字母开头或者包含冒号: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 函数名必须以大写字母开头或者包含冒号: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 无法删除函数 %s: 正在使用中"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 函数调用深度超出 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "调用 %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s 已中止"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s 返回 #%<PRId64> "
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s 返回 %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "在 %s 中继续"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return 不在函数中"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -678,6 +1030,7 @@ msgstr ""
 "\n"
 "# 全局变量:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -685,79 +1038,110 @@ msgstr ""
 "\n"
 "\t最近修改于 "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "没有包含文件"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  十六进制 %02x,  八进制 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 十六进制 %04x, 八进制 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 十六进制 %08x, 八进制 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 把行移动到自已中"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "移动了 1 行"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "移动了 %<PRId64> 行"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "过滤了 %<PRId64> 行"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[已修改但尚未保存]\n"
 
 # bad to translate
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 位于行: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: 错误过多，忽略文件的剩余部分"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "读取 viminfo 文件 \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 信息"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " 标记"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "没有包含文件"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失败"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo 文件不可写入: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: 无法写入 viminfo 文件 %s！"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "写入 viminfo 文件 \"%s\""
 
 # do not translate to avoid writing Chinese in files
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, fuzzy, c-format
-#~ msgid "# This viminfo file was generated by Vim %s.\n"
-#~ msgstr "# 这个 viminfo 文件是由 Vim %s 生成的。\n"
+msgid "# This viminfo file was generated by Vim %s.\n"
+msgstr "# 这个 viminfo 文件是由 Vim %s 生成的。\n"
 
 # do not translate to avoid writing Chinese in files
-#, fuzzy, c-format
+#: ../ex_cmds.c:1722
+#, fuzzy
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -766,41 +1150,48 @@ msgstr ""
 "\n"
 
 # do not translate to avoid writing Chinese in files
-#, fuzzy, c-format
-#~ msgid "# Value of 'encoding' when this file was written\n"
-#~ msgstr "# 'encoding' 在此文件建立时的值\n"
+#: ../ex_cmds.c:1723
+#, fuzzy
+msgid "# Value of 'encoding' when this file was written\n"
+msgstr "# 'encoding' 在此文件建立时的值\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "无效的启动字符"
 
-msgid "Save As"
-msgstr "另存为"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "要写入部分文件吗？"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: 请使用 ! 来写入部分缓冲区"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "覆盖已存在的文件 \"%s\" 吗？"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "交换文件 \"%s\" 已存在，确实要覆盖吗？"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 交换文件已存在: %s (:silent! 强制执行)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: 缓冲区 %<PRId64> 没有文件名"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 文件未写入: 写入被 'write' 选项禁用"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -809,62 +1200,93 @@ msgstr ""
 "\"%s\" 已设定 'readonly' 选项。\n"
 "确实要覆盖吗？"
 
-msgid "Edit File"
-msgstr "编辑文件"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "只读 (请加 ! 强制执行)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: 自动命令意外地删除了新缓冲区 %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z 不接受非数字的参数"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim 中禁止使用 shell 命令"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正则表达式不能用字母作分界"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "替换为 %s (y/n/a/q/l/^E/^Y)？"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(已中断) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 个匹配，"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 次替换，"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> 个匹配，"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> 次替换，"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr "共 1 行"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr "共 %<PRId64> 行"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 不能递归执行"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: global 缺少正则表达式"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "每行都匹配表达式: %s"
 
-# do not translate to avoid writing Chinese in files
+#: ../ex_cmds.c:4510
 #, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "找不到模式"
+
+# do not translate to avoid writing Chinese in files
+#: ../ex_cmds.c:4587
+#, fuzzy
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -874,263 +1296,335 @@ msgstr ""
 "# 最近的替换字符串:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 不要慌！"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 抱歉，没有 '%s' 的 %s 的说明"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 抱歉，没有 %s 的说明"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "抱歉，找不到帮助文件 \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: 不是目录: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 无法打开并写入 %s"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 无法打开并读取 %s"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 在一种语言中混合了多种帮助文件编码: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Tag \"%s\" 在文件 %s/%s 中重复出现"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未知的 sign 命令: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: 缺少 sign 名称"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Signs 定义过多"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 无效的 sign 文字: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 未知的 sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: 缺少 sign 号"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 无效的缓冲区名: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 无效的 sign ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (找不到)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (不支持)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[已删除]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "进入调试模式。输入 \"cont\" 继续运行。"
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "第 %<PRId64> 行: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "命令: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "断点 \"%s%s\" 第 %<PRId64> 行"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 找不到断点: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "没有定义断点"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  第 %<PRId64> 行"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 请先使用 :profile start <fname>"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "将改变保存到 \"%s\" 吗？"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "未命名"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: 缓冲区 \"%s\" 已修改但尚未保存"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "警告: 意外地进入了其它缓冲区 (请检查自动命令)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 只有一个文件可编辑"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 无法切换，已是第一个文件"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 无法切换，已是最后一个文件"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: 不支持编译器: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "正在查找 \"%s\"，在 \"%s\" 中"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "正在查找 \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "在 'runtimepath' 中找不到 \"%s\""
 
-msgid "Source Vim script"
-msgstr "执行 Vim 脚本"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "不能执行目录: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "不能执行 \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "第 %<PRId64> 行: 不能执行 \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "执行 \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "第 %<PRId64> 行: 执行 \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "结束执行 %s"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modeline"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 参数"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 参数"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "环境变量"
 
-#~ msgid "error handler"
-#~ msgstr ""
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr ""
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 警告: 错误的行分隔符，可能是少了 ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: 在脚本文件外使用了 :scriptencoding"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: 在脚本文件外使用了 :finish"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "当前的 %s语言: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 不能设定语言为 \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "进入 Ex 模式。输入 \"visual\" 回到正常模式。"
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: 已到文件末尾"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: 命令递归层数过多"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 异常没有被捕获: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "脚本文件结束"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "函数结束"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: 不确定的用户自定义命令"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: 不是编辑器的命令"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 使用了逆向的范围"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "使用了逆向的范围，确定交换吗"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: 请使用 w 或 w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: 抱歉，命令在此版本中不可用"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: 只允许一个文件名"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "还有 1 个文件未编辑。确实要退出吗？"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "还有 %d 个文件未编辑。确实要退出吗？"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 还有 1 个文件未编辑"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 还有 %<PRId64> 个文件未编辑"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已存在: 请加 ! 强制替换"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1138,275 +1632,339 @@ msgstr ""
 "\n"
 "    名称        参数 范围  补全      定义      "
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "找不到用户自定义命令"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 没有指定属性"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 无效的参数个数"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: 不能指定两次计数"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: 无效的计数默认值"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete 需要参数"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 无效的属性: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 无效的命令名"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: 用户自定义命令必须以大写字母开头"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: 不确定的用户自定义命令"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: 没有这个用户自定义命令: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 无效的补全类型: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 只有 custom 补全才允许参数"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Custom 补全需要一个函数参数"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: 找不到配色方案 %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "您好，Vim 用户！"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 不能关闭最后一个 tab 页"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "已经只剩一个 tab 页了"
 
-msgid "Edit File in new window"
-msgstr "在新窗口编辑文件"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Tab 页 %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "无交换文件"
 
-msgid "Append File"
-msgstr "追加文件"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: 不能改变目录，缓冲区已修改 (请加 ! 强制执行)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 前一个目录不存在"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize 需要两个数字参数"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "窗口位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: 在此平台上不能获得窗口位置"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos 需要两个数字参数"
 
-msgid "Save Redirection"
-msgstr "保存重定向"
-
-msgid "Save View"
-msgstr "保存视图"
-
-msgid "Save Session"
-msgstr "保存会话"
-
-msgid "Save Setup"
-msgstr "保存设定"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: 无法创建目录: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" 已存在 (请加 ! 强制执行)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: 无法打开并写入 \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 参数必须是一个字母或者正/反引号"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal 递归层数过深"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: 没有用于替换 '#' 的交替文件名"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: 没有用于替换 \"<afile>\" 的自动命令文件名"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: 没有用于替换 \"<abuf>\" 的自动命令缓冲区号"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: 没有用于替换 \"<amatch>\" 的自动命令匹配名"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: 没有用于替换 \"<sfile>\" 的 :source 文件名"
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: 没有用于替换 \"<sfile>\" 的 :source 文件名"
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%' 或 '#' 为空文件名，只能用于 \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 结果为空字符串"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: 无法打开并读取 viminfo 文件"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: 此版本无复合字符(digraph)"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 不能 :throw 前缀为 'Vim' 的异常"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "抛出异常: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "完成异常: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "丢弃异常: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s，第 %<PRId64> 行"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "捕获异常: %s"
 
+#: ../ex_eval.c:676
 #, c-format
-#~ msgid "%s made pending"
-#~ msgstr ""
+msgid "%s made pending"
+msgstr ""
 
+#: ../ex_eval.c:679
 #, fuzzy, c-format
-#~ msgid "%s resumed"
-#~ msgstr " 已返回\n"
+msgid "%s resumed"
+msgstr " 已返回\n"
 
+#: ../ex_eval.c:683
 #, c-format
-#~ msgid "%s discarded"
-#~ msgstr ""
+msgid "%s discarded"
+msgstr ""
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "异常"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "错误和中断"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "错误"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "中断"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if 嵌套层数过深"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif 缺少对应的 :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else 缺少对应的 :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif 缺少对应的 :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 多个 :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif 在 :else 后面"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for 嵌套层数过深"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue 缺少对应的 :while 或 :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break 缺少对应的 :while 或 :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :while 以 :endfor 结尾"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :for 以 :endwhile 结尾"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try 嵌套层数过深"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch 缺少对应的 :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch 在 :finally 后面"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally 缺少对应的 :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 多个 :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry 缺少对应的 :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction 不在函数内"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 目前不允许编辑别的缓冲区"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: 目前不允许编辑别的缓冲区"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "tag 名"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " 类型 文件\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "选项 'history' 为零"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5046
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -1416,211 +1974,307 @@ msgstr ""
 "# %s 历史记录 (从新到旧):\n"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5047
 #, fuzzy
-#~ msgid "Command Line"
-#~ msgstr "命令行"
+msgid "Command Line"
+msgstr "命令行"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5048
 #, fuzzy
-#~ msgid "Search String"
-#~ msgstr "查找字符串"
+msgid "Search String"
+msgstr "查找字符串"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5049
 #, fuzzy
-#~ msgid "Expression"
-#~ msgstr "表达式"
+msgid "Expression"
+msgstr "表达式"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5050
 #, fuzzy
-#~ msgid "Input Line"
-#~ msgstr "输入行"
+msgid "Input Line"
+msgstr "输入行"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar 超过命令长度"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: 活动窗口或缓冲区已被删除"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr "E343: 无效的路径: '**[number]' 必须在路径末尾或者后面接 '%s'。"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath 中找不到目录 \"%s\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: 在路径中找不到文件 \"%s\""
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: 在路径中找不到更多的文件 \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: 在路径中找不到更多的文件 \"%s\""
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "无效的文件名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "是目录"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "不是文件"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[新文件]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[新目录]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[文件过大]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[权限不足]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre 自动命令导致文件不可读"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre 自动命令不允许改变当前缓冲区"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 从标准输入读取...\n"
 
-msgid "Reading from stdin..."
-msgstr "从标准输入读取..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 转换导致文件不可读"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[只读]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 个字符"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[缺少 CR]'"
 
-msgid "[NL found]"
-msgstr "[找到 NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[长行分割]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未转换]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[已转换]"
 
-msgid "[crypted]"
-msgstr "[已加密]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[第 %<PRId64> 行转换错误]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[第 %<PRId64> 行无效字符]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[读错误]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "找不到用于转换的临时文件"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert' 转换失败"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "无法读取 'charconvert' 的输出"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: 找不到 acwrite 缓冲区对应的自动命令"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 自动命令删除或释放了要写入的缓冲区"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: 自动命令意外地改变了行数"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans 不允许未修改的缓冲区写入"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeans 不允许缓冲区部分写入"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "不是文件或可写的设备"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "只读 (请加 ! 强制执行)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: 无法写入备份文件 (请加 ! 强制执行)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: 关闭备份文件出错 (请加 ! 强制执行)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: 无法读取文件以供备份 (请加 ! 强制执行)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: 无法创建备份文件 (请加 ! 强制执行)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: 无法生成备份文件 (请加 ! 强制执行)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Resource fork 会丢失 (请加 ! 强制执行)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 找不到用于写入的临时文件"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 无法转换 (请加 ! 强制不转换写入)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: 无法打开并写入链接文件"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 无法打开并写入文件"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: 同步失败"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 关闭失败"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 写入错误，转换失败 (请将 'fenc' 置空以强制执行)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr "E513: 写入错误，转换失败 (请将 'fenc' 置空以强制执行)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 写入错误 (文件系统已满？)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 转换错误"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "第 %<PRId64> 行"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[设备]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 已追加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 已写入"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: 无法保存原始文件"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Patchmode: 无法生成空的原始文件"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: 无法删除备份文件"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1628,105 +2282,134 @@ msgstr ""
 "\n"
 "警告: 原始文件可能已丢失或损坏\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "在文件正确写入前请勿退出编辑器！"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos 格式]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac 格式]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix 格式]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行，"
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行，"
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 个字符"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 个字符"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[最后一行不完整]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 此文件自读入后已发生变动！！！"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "确实要写入吗"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: 写入文件 \"%s\" 出错"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: 关闭文件 \"%s\" 出错"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: 读取文件 \"%s\" 出错"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell 自动命令删除了缓冲区"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: 文件 \"%s\" 已经不存在"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: 文件 \"%s\" 已变动，并且在 Vim 中的缓冲区也已变动"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "进一步说明请见 \":help W12\""
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: 编辑开始后，文件 \"%s\" 已变动"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "进一步说明请见 \":help W11\""
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: 编辑开始后，文件 \"%s\" 的模式已变动"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "进一步说明请见 \":help W16\""
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: 编辑开始后，文件 \"%s\" 已被创建"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1734,39 +2417,48 @@ msgstr ""
 "确定(&O)\n"
 "加载文件(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: 无法为重新加载 \"%s\" 做准备"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: 无法重新加载 \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--已删除--"
 
+#: ../fileio.c:5732
 #, c-format
-#~ msgid "auto-removing autocommand: %s <buffer=%d>"
-#~ msgstr ""
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: 无此组: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * 后面有无效字符: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: 无此事件: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: 无此组或事件: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1774,565 +2466,797 @@ msgstr ""
 "\n"
 "--- 自动命令 ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: 无效的缓冲区号 "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 不能对所有事件执行自动命令"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "没有匹配的自动命令"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: 自动命令嵌套层数过深"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s 自动命令 \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "执行 %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "自动命令 %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: 缺少 {。"
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: 缺少 }。"
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 找不到折叠"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 不能在当前的 'foldmethod' 下创建折叠"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 不能在当前的 'foldmethod' 下删除折叠"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--已折叠 %3ld 行"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 添加到已读缓冲区中"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 递归映射"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: 全局缩写 %s 已存在"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: 全局映射 %s 已存在"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: 缩写 %s 已存在"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: 映射 %s 已存在"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "找不到缩写"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "找不到映射"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 无效的模式"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: 无法启动图形界面"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--缓冲区无内容--"
 
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: 命令被中止"
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 需要参数"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ 后面应该跟有 /、? 或 &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"
+
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: 缺少 :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: 缺少 :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: 缺少 :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: 缺少 :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile 缺少对应的 :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor 缺少对应的 :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 文件已存在 (请加 ! 强制执行)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: 命令执行失败"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 内部错误"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "已中断"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 无效的地址"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 无效的参数"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: 无法读取文件 \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 无效的参数: %s"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 无法启动图形界面，找不到有效的字体"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 无效的 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' 的值无效"
-
+#: ../globals.h:1016
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: 无法分配颜色 %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 无效的表达式: %s"
 
-msgid "No match at cursor, finding next"
-msgstr "在光标处没有匹配，查找下一个"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 无效的范围"
 
-msgid "<cannot open> "
-msgstr "<无法打开>"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 无效的命令"
 
+#: ../globals.h:1019
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: 无法获取字体 %s"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" 是目录"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 无法返回当前目录"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 无效的滚动大小"
 
-msgid "Pathname:"
-msgstr "路径:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 无法获取当前目录"
-
-msgid "OK"
-msgstr "确定"
-
-msgid "Cancel"
-msgstr "取消"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "滚动条部件: 无法获取滑块图像的几何大小"
-
-msgid "Vim dialog"
-msgstr "Vim 对话框"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: 不能同时使用消息和回调函数来创建 BalloonEval"
-
-msgid "Vim dialog..."
-msgstr "Vim 对话框..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"是(&Y)\n"
-"否(&N)\n"
-"取消(&C)"
 
-msgid "Input _Methods"
-msgstr "输入法(_M)"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 查找和替换..."
-
-msgid "VIM - Search..."
-msgstr "VIM - 查找..."
-
-msgid "Find what:"
-msgstr "查找内容:"
-
-msgid "Replace with:"
-msgstr "替换为:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "匹配完整的词"
-
-#. match case button
-msgid "Match case"
-msgstr "匹配大小写"
-
-msgid "Direction"
-msgstr "方向"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "向上"
-
-msgid "Down"
-msgstr "向下"
-
-msgid "Find Next"
-msgstr "查找下一个"
-
-msgid "Replace"
-msgstr "替换"
-
-msgid "Replace All"
-msgstr "全部替换"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: 从会话管理器收到 \"die\" 请求\n"
-
-msgid "Close"
-msgstr "关闭"
-
-msgid "New tab"
-msgstr "新建标签"
-
-msgid "Open Tab..."
-msgstr "打开标签..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: 主窗口被意外地摧毁\n"
-
-msgid "Font Selection"
-msgstr "选择字体"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "使用 CUT_BUFFER0 来取代空选择"
-
-msgid "&Filter"
-msgstr "过滤(&F)"
-
-msgid "&Cancel"
-msgstr "取消(&C)"
-
-msgid "Directories"
-msgstr "目录"
-
-msgid "Filter"
-msgstr "过滤器"
-
-msgid "&Help"
-msgstr "帮助(&H)"
-
-msgid "Files"
-msgstr "文件"
-
-msgid "&OK"
-msgstr "确定(&O)"
-
-msgid "Selection"
-msgstr "选择"
-
-msgid "Find &Next"
-msgstr "查找下一个(&N)"
-
-msgid "&Replace"
-msgstr "替换(&R)"
-
-msgid "Replace &All"
-msgstr "全部替换(&A)"
-
-msgid "&Undo"
-msgstr "撤销(&U)"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: 找不到窗口标题 \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 不支持的参数: \"-%s\"；请使用 OLE 版本。"
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: 无法在 MDI 应用程序中打开窗口"
-
-msgid "Close tab"
-msgstr "关闭标签"
-
-msgid "Open tab..."
-msgstr "打开标签..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "查找字符串 (使用 '\\\\' 来查找 '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "查找和替换字符串 (使用 '\\\\' 来查找 '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "未使用"
-
-msgid "Directory\t*.nothing\n"
-msgstr "目录\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 无法分配颜色表项，某些颜色可能不正确"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Fontset %s 缺少下列字符集的字体:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Fontset 名称: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "'%s' 不是固定宽度的字体"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Fontset 名称: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "字体0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "字体1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "字体0的宽度：%<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"字体1的宽度: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "指定了无效的字体"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 调用函数库 \"%s()\" 失败"
 
-msgid "&Dismiss"
-msgstr "取消(&D)"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 标记的行号无效"
 
-msgid "no specific match"
-msgstr "找不到匹配的项"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 没有设定标记"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - 字体选择器"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 不能修改，因为选项 'modifiable' 是关的"
 
-msgid "Name:"
-msgstr "名称:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 脚本嵌套过深"
 
-#. create toggle button
-#~ msgid "Show size in Points"
-#~ msgstr ""
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 没有交替文件"
 
-msgid "Encoding:"
-msgstr "编码:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: 没有这个缩写"
 
-msgid "Font:"
-msgstr "字体:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: 不能使用 \"!\""
 
-msgid "Style:"
-msgstr "风格:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: 无法使用图形界面: 编译时没有启用"
 
-msgid "Size:"
-msgstr "尺寸:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 没有这个高亮群组名: %s"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul automata 错误"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: 没有插入过文字"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 没有前一个命令行"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: 没有这个映射"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 没有匹配"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 没有匹配: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: 没有文件名"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 没有前一个替换正则表达式"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: 没有前一个命令"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 没有前一个正则表达式"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 不能使用范围"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: 没有足够的空间"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: 无法创建文件 %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 无法获取临时文件名"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: 无法打开文件 %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: 无法读取文件 %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 已修改但尚未保存 (可用 ! 强制执行)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[已修改但尚未保存]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 空的参数"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 此处需要数字"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 无法打开错误文件 %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: 内存不足！"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "找不到模式"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 找不到模式: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 参数必须是正数"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 无法回到前一个目录"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: 没有错误"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 没有 location 列表"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 已损坏的匹配字符串"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 已损坏的正则表达式程序"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 已设定选项 'readonly' (请加 ! 强制执行)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 不能改变只读变量 \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: 不能在 sandbox 中设定变量: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 读取错误文件失败"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: 不允许在 sandbox 中使用"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: 不允许在此使用"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 不支持设定屏幕模式"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 无效的滚动大小"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 选项 'shell' 为空"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: 无法读取 sign 数据！"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: 交换文件关闭错误"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tag 堆栈为空"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: 命令过复杂"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名字过长"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [ 过多"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: 文件名过多"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 多余的尾部字符"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 未知的标记"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 无法扩展通配符"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' 不能小于 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' 不能小于 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 写入出错"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "计数为零"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: 在脚本环境外使用了 <SID>"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 内部错误: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: 表达式的内存使用超出 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: 空的缓冲区"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 无效的搜索表达式或分隔符"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 文件已在另一个缓冲区中被加载"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: 没有设定选项 '%s'"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 无效的寄存器名: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "已查找到文件开头，再从结尾继续查找"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "已查找到文件结尾，再从开头继续查找"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: 缺少冒号"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 无效的部分"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 应该要有数字"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "第 %d 页"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "没有要打印的文字"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "正在打印第 %d 页 (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr "复制 %d / %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "已打印: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "打印中止"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: 写入 PostScript 输出文件出错"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: 无法打开文件 \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: 无法读取 PostScript 资源文件 \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: 文件 \"%s\" 不是 PostScript 资源文件"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: 文件 \"%s\" 不是已支持的 PostScript 资源文件"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" 资源文件版本不正确"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 不兼容的多字节编码和字符集。"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset 在多字节编码下不能为空。"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: 没有指定多字节打印的默认字体。"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: 无法打开 PostScript 输出文件"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: 无法打开文件 \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: 无法转换至打印编码 \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "发送到打印机……"
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: 无法打印 PostScript 文件"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "打印任务已被发送。"
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "添加一个新的数据库"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "查询一个模式"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "显示此信息"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "结束一个连接"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "重置所有连接"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "显示连接"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 用法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "这个 cscope 命令不支持分割窗口。\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 用法: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: 找不到 tag"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) 错误: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat 错误"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s 不是目录或有效的 cscope 数据库"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "添加了 cscope 数据库 %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: 读取 cscope 连接 %<PRId64> 出错"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 查找类型"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: 无法创建 cscope 管道"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: 无法对 cscope 进行 fork"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection 执行失败"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection 执行失败"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: 无法生成 cscope 进程"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen to_fp 失败"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen fr_fp 失败"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: 无法生成 cscope 进程"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: 没有 cscope 连接"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: cscope 查询 %s %s 没有找到匹配的结果"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cscopequickfix 标志 %c 对 %c 无效"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: cscope 查询 %s %s 没有找到匹配的结果"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope 命令:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (用法: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: 无法打开 cscope 数据库: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: 无法获取 cscope 数据库信息"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重复的 cscope 数据库未被加入"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: 已达到 cscope 的最大连接数"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: 找不到 cscope 连接 %s"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope 连接 %s 已关闭"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches 严重错误"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2340,363 +3264,87 @@ msgstr ""
 "\n"
 "   #   行  "
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "文件名 / 上下文 / 行\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope 错误: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "所有 cscope 数据库已被重置"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "没有 cscope 连接\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    数据库名                            prepend path\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr "???: 抱歉，此命令不可用，无法加载 MzScheme 库"
-
-msgid "invalid expression"
-msgstr "无效的表达式"
-
-msgid "expressions disabled at compile time"
-msgstr "编译时没有启用表达式"
-
-msgid "hidden option"
-msgstr "隐藏的选项"
-
-msgid "unknown option"
-msgstr "未知的选项"
-
-msgid "window index is out of range"
-msgstr "窗口索引超出范围"
-
-msgid "couldn't open buffer"
-msgstr "无法打开缓冲区"
-
-msgid "cannot save undo information"
-msgstr "无法保存撤销信息"
-
-msgid "cannot delete line"
-msgstr "无法删除行"
-
-msgid "cannot replace line"
-msgstr "无法替换行"
-
-msgid "cannot insert line"
-msgstr "无法插入行"
-
-msgid "string cannot contain newlines"
-msgstr "字符串不能包含换行(NL)"
-
-msgid "Vim error: ~a"
-msgstr "Vim 错误: ~a"
-
-msgid "Vim error"
-msgstr "Vim 错误"
-
-msgid "buffer is invalid"
-msgstr "缓冲区无效"
-
-msgid "window is invalid"
-msgstr "窗口无效"
-
-msgid "linenr out of range"
-msgstr "行号超出范围"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "不允许在 sandbox 中使用"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr "E263: 抱歉，此命令不可用，无法加载 Python 库。"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: 不能递归调用 Python"
-
-msgid "can't delete OutputObject attributes"
-msgstr "不能删除 OutputObject 属性"
-
-msgid "softspace must be an integer"
-msgstr "softspace 必须是整数"
-
-msgid "invalid attribute"
-msgstr "无效的属性"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() 需要字符串列表作参数"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: 初始化 I/O 对象出错"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "试图引用已被删除的缓冲区"
-
-msgid "line number out of range"
-msgstr "行号超出范围"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<缓冲区对象(已删除): %8lX>"
-
-msgid "invalid mark name"
-msgstr "无效的标记名称"
-
-msgid "no such buffer"
-msgstr "无此缓冲区"
-
-msgid "attempt to refer to deleted window"
-msgstr "试图引用已被删除的窗口"
-
-msgid "readonly attribute"
-msgstr "只读属性"
-
-msgid "cursor position outside buffer"
-msgstr "光标位置在缓冲区外"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<窗口对象(已删除): %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<窗口对象(未知): %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<窗口 %d>"
-
-msgid "no such window"
-msgstr "无此窗口"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: 抱歉，此命令不可用，无法加载 Ruby 库"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知的 longjmp 状态 %d"
-
-msgid "Toggle implementation/definition"
-msgstr "切换实现/定义"
-
-msgid "Show base class of"
-msgstr "显示 base class of:"
-
-msgid "Show overridden member function"
-msgstr "显示被覆盖的成员函数"
-
-msgid "Retrieve from file"
-msgstr "恢复: 从文件"
-
-msgid "Retrieve from project"
-msgstr "恢复: 从对象"
-
-msgid "Retrieve from all projects"
-msgstr "恢复: 从所有项目"
-
-msgid "Retrieve"
-msgstr "恢复"
-
-msgid "Show source of"
-msgstr "显示源代码: "
-
-msgid "Find symbol"
-msgstr "查找 symbol"
-
-msgid "Browse class"
-msgstr "浏览 class"
-
-msgid "Show class in hierarchy"
-msgstr "显示层次关系的类"
-
-msgid "Show class in restricted hierarchy"
-msgstr "显示 restricted 层次关系的 class"
-
-msgid "Xref refers to"
-msgstr "Xref 参考到"
-
-msgid "Xref referred by"
-msgstr "Xref 被谁参考:"
-
-msgid "Xref has a"
-msgstr "Xref 有"
-
-msgid "Xref used by"
-msgstr "Xref 被谁使用:"
-
-msgid "Show docu of"
-msgstr "显示文件: "
-
-msgid "Generate docu for"
-msgstr "产生文件: "
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr "不能连接到 SNiFF+。请检查环境变量 ($PATH 里必需可以找到 sniffemacs)\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 读取错误. 取消连接"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ 目前"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "连接中"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 不正确的 SNiff+ 调用: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: 连接到 SNiFF+ 失败"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: 未连接到 SNiFF+"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: 不是 SNiFF+ 的缓冲区"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 写入错误。结束连接"
-
-msgid "invalid buffer number"
-msgstr "无效的缓冲区号"
-
-msgid "not implemented yet"
-msgstr "尚未实现"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "无法设定行"
-
-msgid "mark not set"
-msgstr "没有设定标记"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "第 %d 行 第 %d 列"
-
-msgid "cannot insert/append line"
-msgstr "无法插入/追加行"
-
-msgid "unknown flag: "
-msgstr "未知的标志: "
-
-msgid "unknown vimOption"
-msgstr "未知的 vim 选项"
-
-msgid "keyboard interrupt"
-msgstr "键盘中断"
-
-msgid "vim error"
-msgstr "vim 错误"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "无法创建缓冲区/窗口命令: 对象将被删除"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "无法注册回调命令: 缓冲区/窗口已被删除"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr "E280: TCL 严重错误: reflist 损坏！？请报告给 vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "无法注册回调命令: 找不到缓冲区/窗口引用"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: 抱歉，此命令不可用，无法加载 Tcl 库"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: TCL 错误: 退出返回值不是整数！？请报告给 vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 退出返回值 %d"
-
-msgid "cannot get line"
-msgstr "无法获取行"
-
-msgid "Unable to register a command server name"
-msgstr "无法注册命令服务器名"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248:  无法发送命令到目的程序"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 使用了无效的服务器 id: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 实例注册属性有误。已删除！"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "未知的选项参数"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "编辑参数过多"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "缺少必要的参数"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "选项参数后的内容无效"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "\"+command\"、\"-c command\" 或 \"--cmd command\" 参数过多"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "无效的参数"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "还有 %d 个文件等待编辑\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "此 Vim 编译时没有加入 diff 功能"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "试图再次打开脚本文件: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "无法打开并读取: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "无法打开并输出脚本: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: 错误: 无法从 NetBeans 中启动 gvim\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 输出不是到终端(屏幕)\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 警告: 输入不是来自终端(键盘)\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc 命令行"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: 无法读取 \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2704,18 +3352,23 @@ msgstr ""
 "\n"
 "更多信息请见: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[文件 ..]       编辑指定的文件"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               从标准输入(stdin)读取文本"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          编辑 tag 定义处的文件"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  编辑第一个出错处的文件"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2725,9 +3378,11 @@ msgstr ""
 "\n"
 "用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [参数] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2735,9 +3390,7 @@ msgstr ""
 "\n"
 "  或:"
 
-#~ msgid "where case is ignored prepend / to make flag upper case"
-#~ msgstr ""
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2747,318 +3400,189 @@ msgstr ""
 "\n"
 "参数:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t在这以后只有文件名"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t不扩展通配符"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\t注册此 gvim 到 OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\t取消 OLE 中的 gvim 注册"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\t使用图形界面 (同 \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  或  --nofork\t前台: 启动图形界面时不 fork"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi 模式 (同 \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx 模式 (同 \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t安静(批处理)模式 (只能与 \"ex\" 一起使用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff 模式 (同 \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\t容易模式 (同 \"evim\"，无模式)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t只读模式 (同 \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t限制模式 (同 \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t不可修改(写入文件)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t文本不可修改"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t二进制模式"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp 模式"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\t兼容传统的 Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\t不完全兼容传统的 Vi: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tVerbose 等级"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t调试模式"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t不使用交换文件，只使用内存"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t列出交换文件并退出"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (跟文件名)\t\t恢复崩溃的会话"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t同 -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t不使用 newcli 来打开窗口"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\t使用 <device> 进行输入输出"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\t以 Arabic 模式启动"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\t以 Hebrew 模式启动"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\t以 Farsi 模式启动"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t设定终端类型为 <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t使用 <vimrc> 替代任何 .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t使用 <gvimrc> 替代任何 .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t不加载 plugin 脚本"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-P[N]\t\t打开 N 个标签页 (默认值: 每个文件一个)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\t打开 N 个窗口 (默认值: 每个文件一个)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t同 -o 但垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t启动后跳到文件末尾"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t启动后跳到第 <lnum> 行"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\t加载任何 vimrc 文件前执行 <command>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t加载第一个文件后执行 <command>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t加载第一个文件后执行文件 <session>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t从文件 <scriptin> 读入正常模式的命令"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t将所有输入的命令追加到文件 <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t将所有输入的命令写入到文件 <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t编辑加密的文件"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
 
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t将 vim 与指定的 X-server 连接"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\t不连接到 X Server"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  同 --remote 但会等待文件完成编辑"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  同上，找不到服务器时不抱怨"
-
-msgid "--remote-tab <files>  As --remote but open tab page for each file"
-msgstr "--remote-tab <files>  同 --remote 但对每个文件打开一个标签页"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 服务器并退出"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t在 Vim 服务器上求 <expr> 的值并打印结果"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t列出可用的 Vim 服务器名称并退出"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t发送到或成为 Vim 服务器 <name>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 取代 .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  或  --help\t打印帮助(本信息)并退出"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t打印版本信息并退出"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim (Motif 版本) 可识别的参数:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim (neXtaw 版本) 可识别的参数:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim (Athena 版本) 可识别的参数:\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t在 <display> 上运行 vim"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t启动后最小化"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\t读取 Resource 时把 vim 视为 <name>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (尚未实现)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t使用 <color> 作为背景色 (也可用 -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t使用 <color> 作为一般文字颜色 (也可用 -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t使用 <font> 作为一般字体 (也可用 -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t使用 <font> 作为粗体字体"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t使用 <font> 作为斜体字体"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t使用 <geom> 作为初始位置 (也可用 -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t设定边框宽度为 <width> (也可用 -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width> 设定滚动条宽度为 <width> (也可用 -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t设定菜单栏高度为 <height> (也可用 -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t使用反显 (也可用 -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t不使用反显 (也可用 +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t设定指定的资源"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim (RISC OS 版本) 可识别的参数:\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <number>\t窗口初始宽度"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <number>\t窗口初始高度"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim (GTK+ 版本) 可识别的参数:\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t在 <display> 上运行 vim (也可用 --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t设置用于区分主窗口的窗口角色名"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t在另一个 GTK 部件中打开 Vim"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\t在父应用程序中打开 Vim"
-
-msgid "No display"
-msgstr "没有 display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 发送失败。\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 发送失败。尝试本地执行\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d 中 %d 已编辑"
-
-msgid "No display: Send expression failed.\n"
-msgstr "没有 display: 发送表达式失败。\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 发送表达式失败。\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "没有设定标记"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: 没有匹配 \"%s\" 的标记"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3067,6 +3591,7 @@ msgstr ""
 "标记   行   列 文件/文本"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3075,6 +3600,7 @@ msgstr ""
 " 跳转   行   列 文件/文本"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3082,7 +3608,7 @@ msgstr ""
 "\n"
 "  改变   行   列 文本"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3091,7 +3617,7 @@ msgstr ""
 "# 文件标记:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3099,7 +3625,7 @@ msgstr ""
 "\n"
 "# 跳转列表 (从新到旧):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3107,94 +3633,84 @@ msgstr ""
 "\n"
 "# 文件内的标记历史记录 (从新到旧):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "缺少 '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 无效的代码页"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: 不能设定 IC 值"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: 无法创建输入上下文"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: 无法打开输入法"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: 无法设定输入法的释放回调函数"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 输入法不支持任何风格"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 输入法不支持我的预编辑类型"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: over-the-spot 风格需要 Fontset"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: 你的 GTK+ 比 1.2.3 旧。状态区不可用。"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: 输入法服务器未运行"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: 块未被锁定"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: 交换文件读取定位错误"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: 交换文件读取错误"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: 交换文件写入定位错误"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: 交换文件写入错误"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: 交换文件已存在 (符号连接攻击？)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: 找不到块 0？"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: 找不到块 1？"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: 找不到块 2？"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: 噢，交换文件不见了！！！"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: 无法重命名交换文件"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: 无法打开 \"%s\" 的交换文件，恢复将不可能"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): 找不到块 0？"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: 找不到 %s 的交换文件"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "请输入要使用的交换文件编号 (0 退出): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: 无法打开 %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "无法读取块 0: "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3202,22 +3718,28 @@ msgstr ""
 "\n"
 "可能你没做过任何修改或是 Vim 还来不及更新交换文件。"
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " 不能在该版本的 Vim 中使用。\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "使用 Vim 3.0。\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s 看起来不像是 Vim 交换文件"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " 不能在这台电脑上使用。\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "此文件创建于 "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3225,78 +3747,100 @@ msgstr ""
 "，\n"
 "或是此文件已损坏。"
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "使用交换文件 \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原始文件 \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原始文件可能已被修改"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: 无法从 %s 读取块 1"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1065
 #, fuzzy
-#~ msgid "???MANY LINES MISSING"
-#~ msgstr "???缺少了太多行"
+msgid "???MANY LINES MISSING"
+msgstr "???缺少了太多行"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1076
 #, fuzzy
-#~ msgid "???LINE COUNT WRONG"
-#~ msgstr "???行数错误"
+msgid "???LINE COUNT WRONG"
+msgstr "???行数错误"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1082
 #, fuzzy
-#~ msgid "???EMPTY BLOCK"
-#~ msgstr "???空的块"
+msgid "???EMPTY BLOCK"
+msgstr "???空的块"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1103
 #, fuzzy
-#~ msgid "???LINES MISSING"
-#~ msgstr "???缺少了一些行"
+msgid "???LINES MISSING"
+msgstr "???缺少了一些行"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: 块 1 ID 错误 (%s 不是交换文件？)"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1133
 #, fuzzy
-#~ msgid "???BLOCK MISSING"
-#~ msgstr "???缺少块"
+msgid "???BLOCK MISSING"
+msgstr "???缺少块"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1147
 #, fuzzy
-#~ msgid "??? from here until ???END lines may be messed up"
-#~ msgstr "??? 从这里到 ???END 的行可能已混乱"
+msgid "??? from here until ???END lines may be messed up"
+msgstr "??? 从这里到 ???END 的行可能已混乱"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1164
 #, fuzzy
-#~ msgid "??? from here until ???END lines may have been inserted/deleted"
-#~ msgstr "??? 从这里到 ???END 的行可能已被插入/删除过"
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr "??? 从这里到 ???END 的行可能已被插入/删除过"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1181
 #, fuzzy
-#~ msgid "???END"
-#~ msgstr "???END"
+msgid "???END"
+msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: 恢复已被中断"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: 恢复时发生错误；请注意开头为 ??? 的行"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "更多信息请见 \":help E312\""
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "恢复完毕。请确定一切正常。"
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3304,50 +3848,71 @@ msgstr ""
 "\n"
 "(你可能想要将这个文件另存为别的文件名\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "再运行 diff 与原文件比较以检查是否有改变)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "然后把 .swp 文件删掉。\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "找到交换文件:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   位于当前目录:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   使用指定的名字:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   位于目录 "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- 无 --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            所有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    日期: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              日期: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [来自 Vim 版本 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [不像是 Vim 交换文件]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "            文件名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3355,12 +3920,15 @@ msgstr ""
 "\n"
 "            修改过: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "是"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "否"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3368,9 +3936,11 @@ msgstr ""
 "\n"
 "            用户名: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "      主机名: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3378,6 +3948,7 @@ msgstr ""
 "\n"
 "            主机名: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3385,16 +3956,11 @@ msgstr ""
 "\n"
 "           进程 ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (仍在运行)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [不能在该版本的 Vim 上使用]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3402,75 +3968,97 @@ msgstr ""
 "\n"
 "         [不能在本机上使用]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [无法读取]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [无法打开]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: 无法保留，没有交换文件"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "文件已保留"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 保留失败"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 无效的 lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 找不到第 %<PRId64> 行"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指针块 id 错误 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx 应该是 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新了太多的块？"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: 指针块 id 错误 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "删除了块 1？"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 找不到第 %<PRId64> 行"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指针块 id 错误"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count 为零"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行号超出范围: %<PRId64> 超出结尾"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: 块 %<PRId64> 行数错误"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "堆栈大小增加"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: 指针块 id 错误 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: \"%s\" 符号连接出现循环"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3478,38 +4066,44 @@ msgstr ""
 "\n"
 "发现交换文件 \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "正在打开文件 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      比交换文件新！\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 另一个程序可能也在编辑同一个文件。\n"
 "    如果是这样，修改时请注意避免同一个文件产生两个不同的版本。\n"
 "\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    退出，或小心地继续。\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 上次编辑此文件时崩溃。\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    如果是这样，请用 \":recover\" 或 \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3517,9 +4111,11 @@ msgstr ""
 "\"\n"
 "    恢复修改的内容 (请见 \":help recovery\")。\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    如果你已经进行了恢复，请删除交换文件 \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3527,18 +4123,23 @@ msgstr ""
 "\"\n"
 "    以避免再看到此消息。\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "交换文件 \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" 已存在！"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "交换文件已存在！"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3552,6 +4153,7 @@ msgstr ""
 "退出(&Q)\n"
 "中止(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3567,30 +4169,57 @@ msgstr ""
 "退出(&Q)\n"
 "中止(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: 找到太多交换文件"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: 菜单项的某部分路径不是子菜单"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: 菜单只在其它模式中存在"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: 没有菜单 \"%s\""
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+#, fuzzy
+msgid "E792: Empty menu name"
+msgstr "E749: 空的缓冲区"
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: 菜单路径不能指向子菜单"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: 不能把菜单项直接加到菜单栏中"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 分隔线不能是菜单路径的一部分"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3598,60 +4227,73 @@ msgstr ""
 "\n"
 "--- 菜单 ---"
 
-msgid "Tear off this menu"
-msgstr "撕下此菜单"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: 菜单路径必须指向菜单项"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: 找不到菜单: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s 模式中菜单未定义"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: 菜单路径必须指向子菜单"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: 找不到菜单 - 请检查菜单名称"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "处理 %s 时发生错误:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "第 %4ld 行:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 无效的寄存器名: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "简体中文消息维护者: Yuheng Xie <elephant@linux.net.cn>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "已中断: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "请按 ENTER 或其它命令继续"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 第 %<PRId64> 行"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 更多 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " 空格/d/j: 屏幕/页/行 下翻，b/u/k: 上翻，q: 退出 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "问题"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3659,6 +4301,17 @@ msgstr ""
 "是(&Y)\n"
 "否(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"是(&Y)\n"
+"否(&N)\n"
+"取消(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3672,257 +4325,177 @@ msgstr ""
 "全部丢弃(&D)\n"
 "取消(&C)"
 
-msgid "Select Directory dialog"
-msgstr "选择目录对话框"
-
-msgid "Save File dialog"
-msgstr "保存文件对话框"
-
-msgid "Open File dialog"
-msgstr "打开文件对话框"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: 抱歉，控制台模式下没有文件浏览器"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() 的参数不足"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: printf() 的参数不足"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf() 的参数过多"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 警告: 正在修改一个只读文件"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "请输入数字或点击鼠标 (<Enter> 取消): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "请选择数字 (<Enter> 取消): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "多了 1 行"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "少了 1 行"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "多了 %<PRId64> 行"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "少了 %<PRId64> 行"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (已中断)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Beep!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: 正在保留文件……\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 结束。\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "错误: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 此行过长"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "调用 shell 执行: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: 缺少冒号"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 无效的模式"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 无效的鼠标形状"
-
-msgid "E548: digit expected"
-msgstr "E548: 此处需要数字"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 无效的百分比"
-
-msgid "Enter encryption key: "
-msgstr "输入密码: "
-
-msgid "Enter same key again: "
-msgstr "请再输入一次: "
-
-msgid "Keys don't match!"
-msgstr "两次密码不匹配！"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr "E343: 无效的路径: '**[number]' 必须在路径末尾或者后面接 '%s'。"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath 中找不到目录 \"%s\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: 在路径中找不到文件 \"%s\""
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: 在路径中找不到更多的文件 \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: 在路径中找不到更多的文件 \"%s\""
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "无法连接到 Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "无法连接到 Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans 连接信息文件中错误的访问模式: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "从 Netbeans 套接字读取"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' 为空"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: 求值功能不可用"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "警告: 你的终端不能显示高亮"
-
-msgid "E348: No string under cursor"
-msgstr "E348: 光标处没有字符串"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: 光标处没有识别字"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' 为空"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "警告: 你的终端不能显示高亮"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: 光标处没有字符串"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 不能在当前的 'foldmethod' 下删除 fold"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 改变列表为空"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 已在改变列表的开始处"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "输入  :quit<Enter>  退出 Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 行 %s 了 1 次"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 行 %s 了 %d 次"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行 %s 了 1 次"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行 %s 了 %d 次"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "缩进 %<PRId64> 行…… "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "缩进了 1 行 "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "缩进了 %<PRId64> 行 "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: 没有前一个使用的寄存器"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "无法复制；改为删除"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "改变了 1 行"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "改变了 %<PRId64> 行"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "释放了 %<PRId64> 行"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "复制了 1 行的块"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "复制了 1 行"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "复制了 %<PRId64> 行的块"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "复制了 %<PRId64> 行"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: 寄存器 %s 里没有东西"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3930,10 +4503,11 @@ msgstr ""
 "\n"
 "--- 寄存器 ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "无效的寄存器名"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3941,155 +4515,194 @@ msgstr ""
 "\n"
 "# 寄存器:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的寄存器类型 %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 列; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字节"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字节"
-
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个"
-"字节"
+"选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/"
+"%<PRId64> 个字节"
 
+#: ../ops.c:5105
 #, c-format
-#~ msgid "(+%<PRId64> for BOM)"
-#~ msgstr ""
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/"
+"%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
 
-#~ msgid "%<%f%h%m%=Page %N"
-#~ msgstr ""
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 "
+"%<PRId64>/%<PRId64> 个字节"
 
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 "
+"%<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个字节"
+
+#: ../ops.c:5146
+#, c-format
+msgid "(+%<PRId64> for BOM)"
+msgstr ""
+
+#: ../option.c:1238
+msgid "%<%f%h%m%=Page %N"
+msgstr ""
+
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "感谢您选择 Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 未知的选项"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: 不支持该选项"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: 不允许在 modeline 中使用"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = 后面需要数字"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Termcap 里面找不到"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 无效的字符 <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 不能设定 'term' 为空字符串"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: 在图形界面中不能改变终端"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: 请用 \":gui\" 启动图形界面"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' 和 'patchmode' 相等"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: 在 GTK+ 2 图形界面中不能更改"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: 缺少冒号"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 字符串长度为零"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> 后面缺少数字"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: 缺少逗号"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: 必须指定一个 ' 值"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 包含不可显示字符或宽字符"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 无效的字体"
-
-msgid "E597: can't select fontset"
-msgstr "E597: 无法选择 Fontset"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 无效的 Fontset"
-
-msgid "E533: can't select wide font"
-msgstr "E533: 无法选择宽字体"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 无效的宽字体"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> 后面有无效的字符"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: 需要逗号"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' 必须为空或包含 %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: 不支持鼠标"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 没有结束的表达式序列"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 项目过多"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: 错乱的组"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: 预览窗口已存在"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic 需要 UTF-8，请执行 ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 至少需要 %d 行"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 至少需要 %d 列"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 未知的选项: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: = 后面需要数字"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4097,6 +4710,7 @@ msgstr ""
 "\n"
 "--- 终端编码 ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4104,6 +4718,7 @@ msgstr ""
 "\n"
 "--- 全局选项值 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4111,6 +4726,7 @@ msgstr ""
 "\n"
 "--- 局部选项值 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4118,126 +4734,21 @@ msgstr ""
 "\n"
 "--- 选项 ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp 错误"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': 找不到 %s 对应的字符"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': 分号后有多余的字符: %s"
 
-msgid "cannot open "
-msgstr "不能打开"
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: 不能打开窗口!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "需要 Amigados 版本 2.04 以上\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "需要 %s 版本 %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "不能打开 NIL:\n"
-
-msgid "Cannot create "
-msgstr "不能创建 "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim 返回值: %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "不能切换主控台(console)模式 !?\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: 不是主控台(console)??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: 不能用 -f 选项执行 shell"
-
-msgid "Cannot execute "
-msgstr "不能执行 "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " 已返回\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE 太小"
-
-msgid "I/O ERROR"
-msgstr "I/O 错误"
-
-msgid "Message"
-msgstr "消息"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' 不是 80, 不能执行外部命令"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: 选择打印机失败"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "从 %s 到 %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 未知的打印机字体: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 打印错误: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "打印 '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 字符集 \"%s\" 不能对应字体\"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 双重信号，退出中\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: 拦截到致命信号(deadly signal) %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 拦截到致命信号(deadly signal)\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "打开 X display 用时 %<PRId64> 秒"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X 错误\n"
-
-msgid "Testing the X display failed"
-msgstr "测试 X display 失败"
-
-msgid "Opening the X display timed out"
-msgstr "打开 X display 超时"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4245,13 +4756,7 @@ msgstr ""
 "\n"
 "无法执行 shell"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"无法执行 shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4259,472 +4764,616 @@ msgstr ""
 "\n"
 "Shell 已返回"
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"无法建立管道\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"无法 fork\n"
-
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"命令已结束\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP 丢失了到 ICE 的连接"
 
 # do not translate
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "打开 X display 失败"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP 处理 save-yourself 请求"
-
-msgid "XSMP opening connection"
-msgstr "XSMP 打开连接"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE 连接监视失败"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection 调用失败: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: 在路径中找不到文件 \"%s\""
 
-msgid "At line"
-msgstr "在行号 "
-
-msgid "Could not load vim32.dll!"
-msgstr "无法加载 vim32.dll！"
-
-msgid "VIM Error"
-msgstr "VIM 错误"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "无法修正到 DLL 的函数指针!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "Shell 返回 %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: 拦截到 %s 事件\n"
-
-msgid "close"
-msgstr "关闭"
-
-msgid "logoff"
-msgstr "注消"
-
-msgid "shutdown"
-msgstr "关机"
-
-msgid "E371: Command not found"
-msgstr "E371: 找不到命令"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"在你的 $PATH 中找不到 VIMRUN.EXE。\n"
-"外部命令执行完毕后将不会暂停。\n"
-"进一步说明请见 :help win32-vimrun"
-
-msgid "Vim Warning"
-msgstr "Vim 警告"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: 格式化字符串里有太多 %%%c "
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: 格式化字符串不应该出现 %%%c "
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: 格式化字符串里少了 ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: 格式化字符串里有不支持的 %%%c "
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: 格式化字符串开头里有不正确的 %%%c "
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: 格式化字符串里有不正确的 %%%c "
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' 未设定"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: 找不到目录名称或是空的目录名称"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 没有更多的项"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d / %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行已删除)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Quickfix 堆栈底端"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Quickfix 堆栈顶端"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "错误列表 %d / %d；共 %d 个错误"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 无法写入，已设定选项 'buftype'"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: 缺少文件名或模式无效"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "无法打开文件 \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: 缓冲区未加载"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: 此处需要 String 或者 List"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: %s%%[] 中有无效的项"
 
-msgid "E339: Pattern too long"
-msgstr "E339: 模式太长"
-
-msgid "E50: Too many \\z("
-msgstr "E50: 太多 \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: 太多 %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: 不匹配的 \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: 不匹配的 %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: 不匹配的 %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: 不匹配的 %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: %s@ 后面有无效的字符"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: 太多复杂的 %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: 嵌套的 %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: 嵌套的 %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: 不正确地使用 \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 前面无内容"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: 无效的回引"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: 此处不允许 \\z("
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: 此处不允许 \\z1 等"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: \\z 后面有无效的字符"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: %s%%[ 后缺少 ]"
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: 空的 %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: %s%%[dxouU] 后面有无效的字符"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: %s%% 后面有无效的字符"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ 后缺少 ]"
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: 不匹配的 %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: 不匹配的 %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: 不匹配的 %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: 此处不允许 \\z("
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: 此处不允许 \\z1 等"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ 后缺少 ]"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: 空的 %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: 模式太长"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: 太多 %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: 不匹配的 \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: %s@ 后面有无效的字符"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: 太多复杂的 %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: 嵌套的 %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: 嵌套的 %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: 不正确地使用 \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 前面无内容"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: 无效的回引"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: \\z 后面有无效的字符"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: %s%%[dxouU] 后面有无效的字符"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: %s%% 后面有无效的字符"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...} 中语法错误"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部符合:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: 找不到用于写入的临时文件"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-替换"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 替换"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反向"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 插入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (插入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (替换)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (V-替换)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrew"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabic"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (语言)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (粘帖)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " 可视"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " 可视 行"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " 可视 块"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " 选择"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 选择 行"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 选择 块"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "记录中"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 无效的查找字符串: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 已查找到文件开头仍找不到 %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 已查找到文件结尾仍找不到 %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: 在 ';' 后面应该有 '?' 或 '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (包括上次列出符合项)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- 包含文件 "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "找不到 "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "在路径 ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (已列出)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  找不到"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "查找包含文件: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "查找包含的文件 %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 当前行匹配"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "所有包含文件都已找到"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "没有包含文件"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 找不到定义"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: 找不到 pattern"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 次替换，"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: 拼写文件格式错误"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: 已截断的拼写文件"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "%s 第 %d 行，多余的后续字符: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "%s 第 %d 行，附加项名字太长: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: 附加文件 FOL、LOW 或 UPP 中格式错误"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL、LOW 或 UPP 中字符超出范围"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "压缩单词树……"
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: 拼写检查未启用"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "警告: 找不到单词列表 \"%s.%s.spl\" or \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "读取拼写文件 \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: 这看起来不像是拼写文件"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 旧版本的拼写文件，需要更新"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: 为更高版本的 Vim 所用的拼写文件"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: 拼写文件中存在不支持的节"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "警告: 区域 %s 不支持"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "读取附加文件 %s ……"
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "单词 %s 转换失败，第 %d 行: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "不支持 %s 中的转换: 从 %s 到 %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "不支持 %s 中的转换"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 第 %d 行，FLAG 的值无效: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 第 %d 行，在使用标志后出现 FLAG: %s"
 
+#: ../spell.c:4723
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDWORDMAX 值: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDSYLMAX 值: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 CHECKCOMPOUNDPATTERN 值: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "%s 第 %d 行，在连续的附加块中出现不同的组合标志: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的附加项: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -4733,266 +5382,334 @@ msgstr ""
 "%s 第 %d 行，附加项被 BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST 使"
 "用: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s 第 %d 行，此处需要 Y 或 N: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的条件: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s 第 %d 行，此处需要 REP(SAL) 计数"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s 第 %d 行，此处需要 MAP 计数"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s 第 %d 行，MAP 中存在重复的字符"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s 第 %d 行，无法识别或重复的项: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s 中缺少 FOL/LOW/UPP 行"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "在没有 SYLLABLE 的情况下使用了 COMPOUNDSYLMAX"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "太多延迟前缀"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "太多组合标志"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "太多延迟前缀和/或组合标志"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "%s 中缺少 SOFO%s 行"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "%s 同时出现 SQL 和 SOFO 行"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s 第 %d 行，标志不是数字: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s 第 %d 行，无效的标志: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s 的值与另一个 .aff 文件中使用的值不相同"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "读取字典文件 %s ……"
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s 中没有单词计数"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "第 %6d 行，第 %6d 个单词 - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的单词: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "%s 第 %d 行，首次重复的单词: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "存在 %d 个重复的单词，在 %s 中"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "忽略了含有非 ASCII 字符的 %d 个单词，在 %s 中"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "读取单词文件 %s ……"
 
+#: ../spell.c:6155
 #, c-format
-#~ msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，单词后的 /encoding= 行已被忽略: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的 /regions= 行已被忽略: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s 第 %d 行，太多区域: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，/ 行已被忽略: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s 第 %d 行，无效的区域号: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s 第 %d 行，不可识别的标志: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "忽略了含有非 ASCII 字符的 %d 个单词"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "压缩了 %d/%d 个节点；剩余 %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "读取拼写文件……"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "正在 soundfolding……"
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "soundfolding 后的单词数: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "单词总数: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "写入建议文件 %s ……"
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "估计运行时内存用量: %d 字节"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 输出文件名不能含有区域名"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 最多只支持 8 个区域"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: %s 出现无效的范围"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "警告: 同时指定了 compounding 和 NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "写入拼写文件 %s ……"
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "完成！"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' 没有 %<PRId64> 项"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "从 %s 中删除了单词"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "向 %s 中添加了单词"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 拼写文件之间的字符不相同"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "抱歉，没有建议"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "抱歉，只有 %<PRId64> 条建议"
 
+#. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "将 \"%.*s\" 改为："
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: 之前没有拼写替换"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 找不到: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: 看起来不像是 .sug 文件: %s"
 
+#: ../spell.c:9282
 #, c-format
-#~ msgid "E779: Old .sug file, needs to be updated: %s"
-#~ msgstr ""
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
 
+#: ../spell.c:9286
 #, c-format
-#~ msgid "E780: .sug file is for newer version of Vim: %s"
-#~ msgstr ""
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
 
+#: ../spell.c:9295
 #, c-format
-#~ msgid "E781: .sug file doesn't match .spl file: %s"
-#~ msgstr ""
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
 
+#: ../spell.c:9305
 #, fuzzy, c-format
-#~ msgid "E782: error while reading .sug file: %s"
-#~ msgstr "E47: 读取错误文件失败"
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: 读取错误文件失败"
 
 #. This should have been checked when generating the .spl
-#. * file.
-#~ msgid "E783: duplicate char in MAP entry"
-#~ msgstr ""
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "这个缓冲区没有定义任何语法项"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 无效的参数: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 无此语法 cluster: \"%s\""
 
-msgid "No Syntax items defined for this buffer"
-msgstr "这个缓冲区没有定义任何语法项"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C风格注释同步中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "没有同步"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同步开始"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr "行号超出范围"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5000,6 +5717,7 @@ msgstr ""
 "\n"
 "--- 语法同步项目 (Syntax sync items) ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5007,6 +5725,7 @@ msgstr ""
 "\n"
 "同步中:"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5014,200 +5733,276 @@ msgstr ""
 "\n"
 "--- 语法项目 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 无此语法 cluster: \"%s\""
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "最小"
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "最大"
 
+#: ../syntax.c:3513
 #, fuzzy
-#~ msgid "; match "
-#~ msgstr "匹配 %d"
+msgid "; match "
+msgstr "匹配 %d"
 
+#: ../syntax.c:3515
 #, fuzzy
-#~ msgid " line breaks"
-#~ msgstr "少于一行"
+msgid " line breaks"
+msgstr "少于一行"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: 使用了不正确的参数"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: 使用了不正确的参数"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: 无效的参数"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: 使用了不正确的参数"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: 找不到 %s 的 region item"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: 需要文件名称"
 
-#, c-format
-msgid "E747: Missing ']': %s"
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 文件名过多"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
 msgstr "E747: 缺少 ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: 缺少 '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: syntax region %s 的参数太少"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 无此语法 cluster: \"%s\""
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: 没有指定的属性"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: 找不到分隔符号: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: '%s' 后面的东西不能识别"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 语法同步: 连接行符号指定了两次"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 无效的参数: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 缺少等号: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空的参数: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s 不能在此出现"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s 必须是列表里的第一个"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 不正确的组名: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 不正确的 :syntax 子命令: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: 加载 syncolor.vim 时出现嵌套循环"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: 找不到 highlight group: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 参数太少: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 参数过多: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: 已设定组, 忽略 highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 不该有的等号: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 缺少等号: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 缺少参数: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不合法的值: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 错误的前景颜色"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 错误的背景颜色"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: 错误的颜色名称或数值: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 终端编码太长: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 无效的参数: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 使用了太多不同的高亮度属性"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 组名中存在不可显示字符"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: 组名中含有无效字符"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: 已在 tag 堆栈底部"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: 已在 tag 堆栈顶部"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 已到第一个匹配的 tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: 找不到 tag: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "文件\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 只有一个匹配的 tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 己到最后一个匹配的 tag"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "文件 \"%s\" 不存在"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "找到 tag: %d / %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " 或更多"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  以不同大小写来使用 tag！"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: 文件 \"%s\" 不存在"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5215,59 +6010,79 @@ msgstr ""
 "\n"
 "  # 到 tag         从   行    在 文件/文本"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "查找 tag 文件 %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tag 文件路径被截断为 %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 文件 \"%s\" 格式错误"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "在第 %<PRId64> 字节之前"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag 文件未排序: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: 没有 tag 文件"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: 找不到 tag 模式"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: 找不到 tag，试着猜！"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "%s 第 %d 行，重复的附加项: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' 未知。可用的内建终端有:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "默认值为: '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: 无法打开 termcap 文件"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: 在 terminfo 中找不到终端项"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: 在 termcap 中找不到终端项"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap 中没有 \"%s\" 项"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 终端需要能力 \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5275,146 +6090,170 @@ msgstr ""
 "\n"
 "--- 终端按键 ---"
 
-msgid "new shell started\n"
-msgstr "启动新 shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 读错误，退出中...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "无法撤销；仍然继续"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: 意外地改变了缓冲区"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: 无法打开并写入文件"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "写入 viminfo 文件 \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: 交换文件写入错误"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "读取单词文件 %s ……"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: 无法打开并读取 viminfo 文件"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: 找不到: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: 无法打开文件 %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "结束执行 %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "已位于最旧的改变"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "已位于最新的改变"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "找不到撤销号 %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行号错误"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "行被加入"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "行被加入"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "行被去掉"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "行被去掉"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "行发生改变"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "行发生改变"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s；%s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "before"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "after"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "无可撤销"
 
-msgid "number changes  time"
-msgstr "  编号    改变  时间"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 列; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s 不能在此出现"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: 撤销列表损坏"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: 找不到要撤销的行"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 位图形界面版本"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 位图形界面版本"
-
-msgid " in Win32s mode"
-msgstr " Win32s 模式"
-
-msgid " with OLE support"
-msgstr " 带 OLE 支持"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 位控制台版本"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 位控制台版本"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 位 MS-DOS 版本"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 位 MS-DOS 版本"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版本"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版本"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版本"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS 版本"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5422,9 +6261,18 @@ msgstr ""
 "\n"
 "包含补丁: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "外部符合:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "修改者 "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5432,9 +6280,11 @@ msgstr ""
 "\n"
 "编译"
 
+#: ../version.c:649
 msgid "by "
 msgstr "者 "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5442,605 +6292,1559 @@ msgstr ""
 "\n"
 "巨型版本 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"大型版本 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"正常版本 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"小型版本 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"微型版本 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "无图形界面。"
 
-msgid "with GTK2-GNOME GUI."
-msgstr "带 GTK2-GNOME 图形界面。"
-
-msgid "with GTK-GNOME GUI."
-msgstr "带 GTK-GNOME 图形界面。"
-
-msgid "with GTK2 GUI."
-msgstr "带 GTK2 图形界面。"
-
-msgid "with GTK GUI."
-msgstr "带 GTK 图形界面。"
-
-msgid "with X11-Motif GUI."
-msgstr "带 X11-Motif 图形界面。"
-
-msgid "with X11-neXtaw GUI."
-msgstr "带 X11-neXtaw 图形界面。"
-
-msgid "with X11-Athena GUI."
-msgstr "带 X11-Athena 图形界面。"
-
-msgid "with Photon GUI."
-msgstr "带 Photon 图形界面。"
-
-msgid "with GUI."
-msgstr "带图形界面。"
-
-msgid "with Carbon GUI."
-msgstr "带 Carbon 图形界面。"
-
-msgid "with Cocoa GUI."
-msgstr "带 Cocoa 图形界面。"
-
-msgid "with (classic) GUI."
-msgstr "带(传统)图形界面。"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  可使用(+)与不可使用(-)的功能:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "     系统 vimrc 文件: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     用户 vimrc 文件: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 第二用户 vimrc 文件: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 第三用户 vimrc 文件: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      用户 exrc 文件: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  第二用户 exrc 文件: \""
 
-msgid "  system gvimrc file: \""
-msgstr "    系统 gvimrc 文件: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    用户 gvimrc 文件: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "第二用户 gvimrc 文件: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "第三用户 gvimrc 文件: \""
-
-msgid "    system menu file: \""
-msgstr "        系统菜单文件: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "         $VIM 预设值: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "  $VIMRUNTIME 预设值: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "编译方式: "
 
-msgid "Compiler: "
-msgstr "编译器: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "链接方式: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  调试版本"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "版本 "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "维护人 Bram Moolenaar 等"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim 是可自由分发的开放源代码软件"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "帮助乌干达的可怜儿童！"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "输入  :help iccf<Enter>       查看说明        "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "输入  :q<Enter>               退出            "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "输入  :help version7<Enter>   查看版本信息    "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "运行于 Vi 兼容模式"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "输入  :set nocp<Enter>        恢复默认的 Vim  "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "输入  :help cp-default<Enter> 查看相关说明    "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "菜单  帮助->孤儿           查看说明           "
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr "赞助 Vim 的开发！"
 
-msgid "Running modeless, typed text is inserted"
-msgstr "无模式运行，输入文字即插入"
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr "成为 Vim 的注册用户！"
 
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "菜单  编辑->全局设定->开/关插入模式  "
+#: ../version.c:831
+msgid "type  :help sponsor<Enter>    for information "
+msgstr "输入  :help sponsor<Enter>    查看说明        "
+
+#: ../version.c:832
+msgid "type  :help register<Enter>   for information "
+msgstr "输入  :help register<Enter>   查看说明        "
+
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr "菜单  Help->Sponsor/Register  查看说明           "
+
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "已经只剩一个窗口了"
+
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: 没有预览窗口"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: 不能同时进行 topleft 和 botright 分割"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: 有其它分割窗口时不能旋转"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:2717
+msgid "E445: Other window contains changes"
+msgstr "E445: 其它窗口有改变的内容"
+
+#: ../window.c:4805
+msgid "E446: No file name under cursor"
+msgstr "E446: 光标处没有文件名"
+
+#~ msgid "Patch file"
+#~ msgstr "Patch 文件"
+
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "确定(&O)\n"
+#~ "取消(&C)"
+
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: 没有到 Vim 服务器的连接"
+
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: 无法发送到 %s"
+
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 无法读取服务器响应"
+
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 无法发送到客户端"
+
+#~ msgid "Save As"
+#~ msgstr "另存为"
+
+#~ msgid "Edit File"
+#~ msgstr "编辑文件"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (找不到)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "执行 Vim 脚本"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "在新窗口编辑文件"
+
+#~ msgid "Append File"
+#~ msgstr "追加文件"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "窗口位置: X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "保存重定向"
+
+#~ msgid "Save View"
+#~ msgstr "保存视图"
+
+#~ msgid "Save Session"
+#~ msgstr "保存会话"
+
+#~ msgid "Save Setup"
+#~ msgstr "保存设定"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 此版本无复合字符(digraph)"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "从标准输入读取..."
+
+#~ msgid "[NL found]"
+#~ msgstr "[找到 NL]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[已加密]"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans 不允许未修改的缓冲区写入"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeans 不允许缓冲区部分写入"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resource fork 会丢失 (请加 ! 强制执行)"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: 无法启动图形界面"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: 无法读取文件 \"%s\""
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 无法启动图形界面，找不到有效的字体"
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 无效的 'guifontwide'"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 的值无效"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: 无法分配颜色 %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "在光标处没有匹配，查找下一个"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<无法打开>"
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 无法获取字体 %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 无法返回当前目录"
+
+#~ msgid "Pathname:"
+#~ msgstr "路径:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 无法获取当前目录"
+
+#~ msgid "OK"
+#~ msgstr "确定"
+
+#~ msgid "Cancel"
+#~ msgstr "取消"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "滚动条部件: 无法获取滑块图像的几何大小"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Vim 对话框"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: 不能同时使用消息和回调函数来创建 BalloonEval"
+
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim 对话框..."
+
+#~ msgid "Input _Methods"
+#~ msgstr "输入法(_M)"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 查找和替换..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 查找..."
+
+#~ msgid "Find what:"
+#~ msgstr "查找内容:"
+
+#~ msgid "Replace with:"
+#~ msgstr "替换为:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "匹配完整的词"
+
+#~ msgid "Match case"
+#~ msgstr "匹配大小写"
+
+#~ msgid "Direction"
+#~ msgstr "方向"
+
+#~ msgid "Up"
+#~ msgstr "向上"
+
+#~ msgid "Down"
+#~ msgstr "向下"
+
+#~ msgid "Find Next"
+#~ msgstr "查找下一个"
+
+#~ msgid "Replace"
+#~ msgstr "替换"
+
+#~ msgid "Replace All"
+#~ msgstr "全部替换"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: 从会话管理器收到 \"die\" 请求\n"
+
+#~ msgid "Close"
+#~ msgstr "关闭"
+
+#~ msgid "New tab"
+#~ msgstr "新建标签"
+
+#~ msgid "Open Tab..."
+#~ msgstr "打开标签..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: 主窗口被意外地摧毁\n"
+
+#~ msgid "Font Selection"
+#~ msgstr "选择字体"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "使用 CUT_BUFFER0 来取代空选择"
+
+#~ msgid "&Filter"
+#~ msgstr "过滤(&F)"
+
+#~ msgid "&Cancel"
+#~ msgstr "取消(&C)"
+
+#~ msgid "Directories"
+#~ msgstr "目录"
+
+#~ msgid "Filter"
+#~ msgstr "过滤器"
+
+#~ msgid "&Help"
+#~ msgstr "帮助(&H)"
+
+#~ msgid "Files"
+#~ msgstr "文件"
+
+#~ msgid "&OK"
+#~ msgstr "确定(&O)"
+
+#~ msgid "Selection"
+#~ msgstr "选择"
+
+#~ msgid "Find &Next"
+#~ msgstr "查找下一个(&N)"
+
+#~ msgid "&Replace"
+#~ msgstr "替换(&R)"
+
+#~ msgid "Replace &All"
+#~ msgstr "全部替换(&A)"
+
+#~ msgid "&Undo"
+#~ msgstr "撤销(&U)"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: 找不到窗口标题 \"%s\""
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 不支持的参数: \"-%s\"；请使用 OLE 版本。"
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: 无法在 MDI 应用程序中打开窗口"
+
+#~ msgid "Close tab"
+#~ msgstr "关闭标签"
+
+#~ msgid "Open tab..."
+#~ msgstr "打开标签..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "查找字符串 (使用 '\\\\' 来查找 '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "查找和替换字符串 (使用 '\\\\' 来查找 '\\')"
+
+#~ msgid "Not Used"
+#~ msgstr "未使用"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "目录\t*.nothing\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 无法分配颜色表项，某些颜色可能不正确"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Fontset %s 缺少下列字符集的字体:"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Fontset 名称: %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "'%s' 不是固定宽度的字体"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Fontset 名称: %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "字体0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "字体1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "字体0的宽度：%<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "字体1的宽度: %<PRId64>\n"
+#~ "\n"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "指定了无效的字体"
+
+#~ msgid "&Dismiss"
+#~ msgstr "取消(&D)"
+
+#~ msgid "no specific match"
+#~ msgstr "找不到匹配的项"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - 字体选择器"
+
+#~ msgid "Name:"
+#~ msgstr "名称:"
+
+#~ msgid "Encoding:"
+#~ msgstr "编码:"
+
+#~ msgid "Font:"
+#~ msgstr "字体:"
+
+#~ msgid "Style:"
+#~ msgstr "风格:"
+
+#~ msgid "Size:"
+#~ msgstr "尺寸:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata 错误"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 错误"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: 无法打开 cscope 数据库: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: 无法获取 cscope 数据库信息"
+
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: 已达到 cscope 的最大连接数"
+
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr "???: 抱歉，此命令不可用，无法加载 MzScheme 库"
+
+#~ msgid "invalid expression"
+#~ msgstr "无效的表达式"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "编译时没有启用表达式"
+
+#~ msgid "hidden option"
+#~ msgstr "隐藏的选项"
+
+#~ msgid "unknown option"
+#~ msgstr "未知的选项"
+
+#~ msgid "window index is out of range"
+#~ msgstr "窗口索引超出范围"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "无法打开缓冲区"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "无法保存撤销信息"
+
+#~ msgid "cannot delete line"
+#~ msgstr "无法删除行"
+
+#~ msgid "cannot replace line"
+#~ msgstr "无法替换行"
+
+#~ msgid "cannot insert line"
+#~ msgstr "无法插入行"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "字符串不能包含换行(NL)"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim 错误: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim 错误"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "缓冲区无效"
+
+#~ msgid "window is invalid"
+#~ msgstr "窗口无效"
+
+#~ msgid "linenr out of range"
+#~ msgstr "行号超出范围"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "不允许在 sandbox 中使用"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr "E263: 抱歉，此命令不可用，无法加载 Python 库。"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: 不能递归调用 Python"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "不能删除 OutputObject 属性"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace 必须是整数"
+
+#~ msgid "invalid attribute"
+#~ msgstr "无效的属性"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() 需要字符串列表作参数"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: 初始化 I/O 对象出错"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "试图引用已被删除的缓冲区"
+
+#~ msgid "line number out of range"
+#~ msgstr "行号超出范围"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<缓冲区对象(已删除): %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "无效的标记名称"
+
+#~ msgid "no such buffer"
+#~ msgstr "无此缓冲区"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "试图引用已被删除的窗口"
+
+#~ msgid "readonly attribute"
+#~ msgstr "只读属性"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "光标位置在缓冲区外"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<窗口对象(已删除): %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<窗口对象(未知): %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<窗口 %d>"
+
+#~ msgid "no such window"
+#~ msgstr "无此窗口"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: 抱歉，此命令不可用，无法加载 Ruby 库"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知的 longjmp 状态 %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "切换实现/定义"
+
+#~ msgid "Show base class of"
+#~ msgstr "显示 base class of:"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "显示被覆盖的成员函数"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "恢复: 从文件"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "恢复: 从对象"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "恢复: 从所有项目"
+
+#~ msgid "Retrieve"
+#~ msgstr "恢复"
+
+#~ msgid "Show source of"
+#~ msgstr "显示源代码: "
+
+#~ msgid "Find symbol"
+#~ msgstr "查找 symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "浏览 class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "显示层次关系的类"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "显示 restricted 层次关系的 class"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref 参考到"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref 被谁参考:"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref 有"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref 被谁使用:"
+
+#~ msgid "Show docu of"
+#~ msgstr "显示文件: "
+
+#~ msgid "Generate docu for"
+#~ msgstr "产生文件: "
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "不能连接到 SNiFF+。请检查环境变量 ($PATH 里必需可以找到 sniffemacs)\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 读取错误. 取消连接"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ 目前"
+
+#~ msgid "not "
+#~ msgstr "未"
+
+#~ msgid "connected"
+#~ msgstr "连接中"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 不正确的 SNiff+ 调用: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: 连接到 SNiFF+ 失败"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: 未连接到 SNiFF+"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: 不是 SNiFF+ 的缓冲区"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 写入错误。结束连接"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "无效的缓冲区号"
+
+#~ msgid "not implemented yet"
+#~ msgstr "尚未实现"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "无法设定行"
+
+#~ msgid "mark not set"
+#~ msgstr "没有设定标记"
+
+#~ msgid "row %d column %d"
+#~ msgstr "第 %d 行 第 %d 列"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "无法插入/追加行"
+
+#~ msgid "unknown flag: "
+#~ msgstr "未知的标志: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "未知的 vim 选项"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "键盘中断"
+
+#~ msgid "vim error"
+#~ msgstr "vim 错误"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "无法创建缓冲区/窗口命令: 对象将被删除"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "无法注册回调命令: 缓冲区/窗口已被删除"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E280: TCL 严重错误: reflist 损坏！？请报告给 vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "无法注册回调命令: 找不到缓冲区/窗口引用"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: 抱歉，此命令不可用，无法加载 Tcl 库"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr "E281: TCL 错误: 退出返回值不是整数！？请报告给 vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 退出返回值 %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "无法获取行"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "无法注册命令服务器名"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248:  无法发送命令到目的程序"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 使用了无效的服务器 id: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 实例注册属性有误。已删除！"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "此 Vim 编译时没有加入 diff 功能"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: 错误: 无法从 NetBeans 中启动 gvim\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t注册此 gvim 到 OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\t取消 OLE 中的 gvim 注册"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\t使用图形界面 (同 \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  或  --nofork\t前台: 启动图形界面时不 fork"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose 等级"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t不使用 newcli 来打开窗口"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\t使用 <device> 进行输入输出"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t使用 <gvimrc> 替代任何 .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t编辑加密的文件"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t将 vim 与指定的 X-server 连接"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\t不连接到 X Server"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  同 --remote 但会等待文件完成编辑"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  同上，找不到服务器时不抱怨"
+
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr "--remote-tab <files>  同 --remote 但对每个文件打开一个标签页"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 服务器并退出"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t在 Vim 服务器上求 <expr> 的值并打印结果"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t列出可用的 Vim 服务器名称并退出"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t发送到或成为 Vim 服务器 <name>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (Motif 版本) 可识别的参数:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (neXtaw 版本) 可识别的参数:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (Athena 版本) 可识别的参数:\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t在 <display> 上运行 vim"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t启动后最小化"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\t读取 Resource 时把 vim 视为 <name>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (尚未实现)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t使用 <color> 作为背景色 (也可用 -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t使用 <color> 作为一般文字颜色 (也可用 -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t使用 <font> 作为一般字体 (也可用 -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t使用 <font> 作为粗体字体"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t使用 <font> 作为斜体字体"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t使用 <geom> 作为初始位置 (也可用 -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t设定边框宽度为 <width> (也可用 -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width> 设定滚动条宽度为 <width> (也可用 -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t设定菜单栏高度为 <height> (也可用 -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t使用反显 (也可用 -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t不使用反显 (也可用 +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t设定指定的资源"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (RISC OS 版本) 可识别的参数:\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <number>\t窗口初始宽度"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <number>\t窗口初始高度"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (GTK+ 版本) 可识别的参数:\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t在 <display> 上运行 vim (也可用 --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t设置用于区分主窗口的窗口角色名"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t在另一个 GTK 部件中打开 Vim"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\t在父应用程序中打开 Vim"
+
+#~ msgid "No display"
+#~ msgstr "没有 display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 发送失败。\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 发送失败。尝试本地执行\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d 中 %d 已编辑"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "没有 display: 发送表达式失败。\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 发送表达式失败。\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 无效的代码页"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: 无法创建输入上下文"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: 无法打开输入法"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: 无法设定输入法的释放回调函数"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 输入法不支持任何风格"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 输入法不支持我的预编辑类型"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: over-the-spot 风格需要 Fontset"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: 你的 GTK+ 比 1.2.3 旧。状态区不可用。"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: 输入法服务器未运行"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [不能在该版本的 Vim 上使用]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "撕下此菜单"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "选择目录对话框"
+
+#~ msgid "Save File dialog"
+#~ msgstr "保存文件对话框"
+
+#~ msgid "Open File dialog"
+#~ msgstr "打开文件对话框"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: 抱歉，控制台模式下没有文件浏览器"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: 正在保留文件……\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 结束。\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "错误: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 此行过长"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 无效的鼠标形状"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "输入密码: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "请再输入一次: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "两次密码不匹配！"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "无法连接到 Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "无法连接到 Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 连接信息文件中错误的访问模式: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "从 Netbeans 套接字读取"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: 求值功能不可用"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "释放了 %<PRId64> 行"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: 在图形界面中不能改变终端"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: 请用 \":gui\" 启动图形界面"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: 在 GTK+ 2 图形界面中不能更改"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 无效的字体"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 无法选择 Fontset"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 无效的 Fontset"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: 无法选择宽字体"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 无效的宽字体"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: 不支持鼠标"
+
+#~ msgid "cannot open "
+#~ msgstr "不能打开"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: 不能打开窗口!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "需要 Amigados 版本 2.04 以上\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "需要 %s 版本 %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "不能打开 NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "不能创建 "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim 返回值: %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "不能切换主控台(console)模式 !?\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 不是主控台(console)??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: 不能用 -f 选项执行 shell"
+
+#~ msgid "Cannot execute "
+#~ msgstr "不能执行 "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " 已返回\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE 太小"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 错误"
+
+#~ msgid "Message"
+#~ msgstr "消息"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' 不是 80, 不能执行外部命令"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: 选择打印机失败"
+
+#~ msgid "to %s on %s"
+#~ msgstr "从 %s 到 %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 未知的打印机字体: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 打印错误: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "打印 '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 字符集 \"%s\" 不能对应字体\"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 双重信号，退出中\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: 拦截到致命信号(deadly signal) %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 拦截到致命信号(deadly signal)\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "打开 X display 用时 %<PRId64> 秒"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X 错误\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "测试 X display 失败"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "打开 X display 超时"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法执行 shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法建立管道\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法 fork\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "命令已结束\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP 丢失了到 ICE 的连接"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "打开 X display 失败"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP 处理 save-yourself 请求"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP 打开连接"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE 连接监视失败"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection 调用失败: %s"
+
+#~ msgid "At line"
+#~ msgstr "在行号 "
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "无法加载 vim32.dll！"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM 错误"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "无法修正到 DLL 的函数指针!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "Shell 返回 %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: 拦截到 %s 事件\n"
+
+#~ msgid "close"
+#~ msgstr "关闭"
+
+#~ msgid "logoff"
+#~ msgstr "注消"
+
+#~ msgid "shutdown"
+#~ msgstr "关机"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 找不到命令"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "在你的 $PATH 中找不到 VIMRUN.EXE。\n"
+#~ "外部命令执行完毕后将不会暂停。\n"
+#~ "进一步说明请见 :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim 警告"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "不支持 %s 中的转换"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: 使用了不正确的参数"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag 文件路径被截断为 %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "启动新 shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "无法撤销；仍然继续"
+
+#~ msgid "number changes  time"
+#~ msgstr "  编号    改变  时间"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 位图形界面版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 位图形界面版本"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " Win32s 模式"
+
+#~ msgid " with OLE support"
+#~ msgstr " 带 OLE 支持"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 位控制台版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 位控制台版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 位 MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 位 MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "大型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "正常版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "小型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "微型版本 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "带 GTK2-GNOME 图形界面。"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "带 GTK-GNOME 图形界面。"
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "带 GTK2 图形界面。"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "带 GTK 图形界面。"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "带 X11-Motif 图形界面。"
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "带 X11-neXtaw 图形界面。"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "带 X11-Athena 图形界面。"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "带 Photon 图形界面。"
+
+#~ msgid "with GUI."
+#~ msgstr "带图形界面。"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "带 Carbon 图形界面。"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "带 Cocoa 图形界面。"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "带(传统)图形界面。"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "    系统 gvimrc 文件: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    用户 gvimrc 文件: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "第二用户 gvimrc 文件: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "第三用户 gvimrc 文件: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "        系统菜单文件: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "编译器: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "菜单  帮助->孤儿           查看说明           "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "无模式运行，输入文字即插入"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "菜单  编辑->全局设定->开/关插入模式  "
 
 #, fuzzy
 #~ msgid "                              for two modes      "
 #~ msgstr " # pid    数据库名称                          prepend path\n"
 
-#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-#~ msgstr ""
-
 #, fuzzy
 #~ msgid "                              for Vim defaults   "
 #~ msgstr " # pid    数据库名称                          prepend path\n"
 
-msgid "Sponsor Vim development!"
-msgstr "赞助 Vim 的开发！"
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "警告: 检测到 Windows 95/98/ME"
 
-msgid "Become a registered Vim user!"
-msgstr "成为 Vim 的注册用户！"
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "输入  :help windows95<Enter>  查看相关说明    "
 
-msgid "type  :help sponsor<Enter>    for information "
-msgstr "输入  :help sponsor<Enter>    查看说明        "
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: 无法加载库 %s"
 
-msgid "type  :help register<Enter>   for information "
-msgstr "输入  :help register<Enter>   查看说明        "
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "抱歉，此命令不可用: 无法加载 Perl 库。"
 
-msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "菜单  Help->Sponsor/Register  查看说明           "
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "用多个 Vim 编辑(&M)"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "警告: 检测到 Windows 95/98/ME"
+#~ msgid "Edit with single &Vim"
+#~ msgstr "用单个 Vim 编辑(&V)"
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "输入  :help windows95<Enter>  查看相关说明    "
+#~ msgid "Diff with Vim"
+#~ msgstr "用 Vim 比较(diff)"
 
-msgid "Already only one window"
-msgstr "已经只剩一个窗口了"
+#~ msgid "Edit with &Vim"
+#~ msgstr "用 Vim 编辑(&V)"
 
-msgid "E441: There is no preview window"
-msgstr "E441: 没有预览窗口"
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "用当前的 Vim 编辑 - "
 
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: 不能同时进行 topleft 和 botright 分割"
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "用 Vim 编辑选中的文件"
 
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: 有其它分割窗口时不能旋转"
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "创建进程失败: 请检查 gvim 是否在路径中！"
 
-msgid "E444: Cannot close last window"
-msgstr "E444: 不能关闭最后一个窗口"
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 错误"
 
-msgid "E445: Other window contains changes"
-msgstr "E445: 其它窗口有改变的内容"
+#~ msgid "Path length too long!"
+#~ msgstr "路径太长！"
 
-msgid "E446: No file name under cursor"
-msgstr "E446: 光标处没有文件名"
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 未知的 Fontset: %s"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: 在路径中找不到文件 \"%s\""
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 未知的字体: %s"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: 无法加载库 %s"
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: 字体 \"%s\" 不是等宽字体"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "抱歉，此命令不可用: 无法加载 Perl 库。"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: 无法加载库函数 %s"
 
-#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-#~ msgstr ""
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: 无法使用 Hebrew: 编译时没有启用\n"
 
-msgid "Edit with &multiple Vims"
-msgstr "用多个 Vim 编辑(&M)"
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: 无法使用 Farsi: 编译时没有启用\n"
 
-msgid "Edit with single &Vim"
-msgstr "用单个 Vim 编辑(&V)"
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: 无法使用 Arabic: 编译时没有启用\n"
 
-msgid "Diff with Vim"
-msgstr "用 Vim 比较(diff)"
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
 
-msgid "Edit with &Vim"
-msgstr "用 Vim 编辑(&V)"
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: 无法打开 display"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "用当前的 Vim 编辑 - "
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 收到无效的表达式"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "用 Vim 编辑选中的文件"
-
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "创建进程失败: 请检查 gvim 是否在路径中！"
-
-msgid "gvimext.dll error"
-msgstr "gvimext.dll 错误"
-
-msgid "Path length too long!"
-msgstr "路径太长！"
-
-msgid "--No lines in buffer--"
-msgstr "--缓冲区无内容--"
-
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: 命令被中止"
-
-msgid "E471: Argument required"
-msgstr "E471: 需要参数"
-
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ 后面应该跟有 /、? 或 &"
-
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
-
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"
-
-msgid "E171: Missing :endif"
-msgstr "E171: 缺少 :endif"
-
-msgid "E600: Missing :endtry"
-msgstr "E600: 缺少 :endtry"
-
-msgid "E170: Missing :endwhile"
-msgstr "E170: 缺少 :endwhile"
-
-msgid "E170: Missing :endfor"
-msgstr "E170: 缺少 :endfor"
-
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile 缺少对应的 :while"
-
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor 缺少对应的 :for"
-
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 文件已存在 (请加 ! 强制执行)"
-
-msgid "E472: Command failed"
-msgstr "E472: 命令执行失败"
-
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 未知的 Fontset: %s"
-
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 未知的字体: %s"
-
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: 字体 \"%s\" 不是等宽字体"
-
-msgid "E473: Internal error"
-msgstr "E473: 内部错误"
-
-msgid "Interrupted"
-msgstr "已中断"
-
-msgid "E14: Invalid address"
-msgstr "E14: 无效的地址"
-
-msgid "E474: Invalid argument"
-msgstr "E474: 无效的参数"
-
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 无效的参数: %s"
-
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 无效的表达式: %s"
-
-msgid "E16: Invalid range"
-msgstr "E16: 无效的范围"
-
-msgid "E476: Invalid command"
-msgstr "E476: 无效的命令"
-
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" 是目录"
-
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 调用函数库 \"%s()\" 失败"
-
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: 无法加载库函数 %s"
-
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 标记的行号无效"
-
-msgid "E20: Mark not set"
-msgstr "E20: 没有设定标记"
-
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 不能修改，因为选项 'modifiable' 是关的"
-
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 脚本嵌套过深"
-
-msgid "E23: No alternate file"
-msgstr "E23: 没有交替文件"
-
-msgid "E24: No such abbreviation"
-msgstr "E24: 没有这个缩写"
-
-msgid "E477: No ! allowed"
-msgstr "E477: 不能使用 \"!\""
-
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: 无法使用图形界面: 编译时没有启用"
-
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: 无法使用 Hebrew: 编译时没有启用\n"
-
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: 无法使用 Farsi: 编译时没有启用\n"
-
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: 无法使用 Arabic: 编译时没有启用\n"
-
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 没有这个高亮群组名: %s"
-
-msgid "E29: No inserted text yet"
-msgstr "E29: 没有插入过文字"
-
-msgid "E30: No previous command line"
-msgstr "E30: 没有前一个命令行"
-
-msgid "E31: No such mapping"
-msgstr "E31: 没有这个映射"
-
-msgid "E479: No match"
-msgstr "E479: 没有匹配"
-
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 没有匹配: %s"
-
-msgid "E32: No file name"
-msgstr "E32: 没有文件名"
-
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 没有前一个替换正则表达式"
-
-msgid "E34: No previous command"
-msgstr "E34: 没有前一个命令"
-
-msgid "E35: No previous regular expression"
-msgstr "E35: 没有前一个正则表达式"
-
-msgid "E481: No range allowed"
-msgstr "E481: 不能使用范围"
-
-msgid "E36: Not enough room"
-msgstr "E36: 没有足够的空间"
-
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
-
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: 无法创建文件 %s"
-
-msgid "E483: Can't get temp file name"
-msgstr "E483: 无法获取临时文件名"
-
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: 无法打开文件 %s"
-
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: 无法读取文件 %s"
-
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 已修改但尚未保存 (可用 ! 强制执行)"
-
-msgid "E38: Null argument"
-msgstr "E38: 空的参数"
-
-msgid "E39: Number expected"
-msgstr "E39: 此处需要数字"
-
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 无法打开错误文件 %s"
-
-msgid "E233: cannot open display"
-msgstr "E233: 无法打开 display"
-
-msgid "E41: Out of memory!"
-msgstr "E41: 内存不足！"
-
-msgid "Pattern not found"
-msgstr "找不到模式"
-
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 找不到模式: %s"
-
-msgid "E487: Argument must be positive"
-msgstr "E487: 参数必须是正数"
-
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 无法回到前一个目录"
-
-msgid "E42: No Errors"
-msgstr "E42: 没有错误"
-
-msgid "E776: No location list"
-msgstr "E776: 没有 location 列表"
-
-msgid "E43: Damaged match string"
-msgstr "E43: 已损坏的匹配字符串"
-
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 已损坏的正则表达式程序"
-
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 已设定选项 'readonly' (请加 ! 强制执行)"
-
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 不能改变只读变量 \"%s\""
-
-#, c-format
-msgid "E46: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: 不能在 sandbox 中设定变量: \"%s\""
-
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 读取错误文件失败"
-
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: 不允许在 sandbox 中使用"
-
-msgid "E523: Not allowed here"
-msgstr "E523: 不允许在此使用"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 不支持设定屏幕模式"
-
-msgid "E49: Invalid scroll size"
-msgstr "E49: 无效的滚动大小"
-
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 选项 'shell' 为空"
-
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: 无法读取 sign 数据！"
-
-msgid "E72: Close error on swap file"
-msgstr "E72: 交换文件关闭错误"
-
-msgid "E73: tag stack empty"
-msgstr "E73: tag 堆栈为空"
-
-msgid "E74: Command too complex"
-msgstr "E74: 命令过复杂"
-
-msgid "E75: Name too long"
-msgstr "E75: 名字过长"
-
-msgid "E76: Too many ["
-msgstr "E76: [ 过多"
-
-msgid "E77: Too many file names"
-msgstr "E77: 文件名过多"
-
-msgid "E488: Trailing characters"
-msgstr "E488: 多余的尾部字符"
-
-msgid "E78: Unknown mark"
-msgstr "E78: 未知的标记"
-
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 无法扩展通配符"
-
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' 不能小于 'winminheight'"
-
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' 不能小于 'winminwidth'"
-
-msgid "E80: Error while writing"
-msgstr "E80: 写入出错"
-
-msgid "Zero count"
-msgstr "计数为零"
-
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: 在脚本环境外使用了 <SID>"
-
-msgid "E449: Invalid expression received"
-msgstr "E449: 收到无效的表达式"
-
-#~ msgid "E463: Region is guarded, cannot modify"
-#~ msgstr ""
-
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans 不允许改变只读文件"
-
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 内部错误: %s"
-
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: 表达式的内存使用超出 'maxmempattern'"
-
-msgid "E749: empty buffer"
-msgstr "E749: 空的缓冲区"
-
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 无效的搜索表达式或分隔符"
-
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 文件已在另一个缓冲区中被加载"
-
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: 没有设定选项 '%s'"
-
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "已查找到文件开头，再从结尾继续查找"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "已查找到文件结尾，再从开头继续查找"
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans 不允许改变只读文件"
 
 #~ msgid "Affix flags ignored when PFXPOSTPONE used in %s line %d: %s"
 #~ msgstr "%s 第 %d 行，使用 PFXPOSTPONE 时附加标志被忽略: %s"
@@ -6053,18 +7857,6 @@ msgstr "已查找到文件结尾，再从开头继续查找"
 
 #~ msgid "E106: Unknown variable: \"%s\""
 #~ msgstr "E106: 未定义的变量: \"%s\""
-
-#~ msgid "E119: Not enough arguments for function: %s"
-#~ msgstr "E119: 函数 %s 的参数太少"
-
-#~ msgid "E120: Using <SID> not in a script context: %s"
-#~ msgstr "E120: <SID> 不能在 script 上下文外使用: %s"
-
-#~ msgid "E123: Undefined function: %s"
-#~ msgstr "E123: 函数 %s 尚未定义"
-
-#~ msgid "E127: Cannot redefine function %s: It is in use"
-#~ msgstr "E127: 函数 %s 正在使用中，不能重新定义"
 
 #~ msgid "function "
 #~ msgstr "函数 "

--- a/src/nvim/po/zh_CN.cp936.po
+++ b/src/nvim/po/zh_CN.cp936.po
@@ -4,7 +4,7 @@
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
 # FIRST AUTHOR  Wang Jun <junw@turbolinux.com.cn>
-# 
+#
 # TRANSLATORS
 #   Edyfox <edyfox@gmail.com>
 #   Yuheng Xie <elephant@linux.net.cn>
@@ -15,146 +15,213 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Simplified Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-04-21 15:16+0800\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2006-04-21 14:00+0800\n"
 "Last-Translator: Yuheng Xie <elephant@linux.net.cn>\n"
 "Language-Team: Simplified Chinese <i18n-translation@lists.linux.net.cn>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=gbk\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "选项参数后的内容无效"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Location 列表]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Quickfix 列表]"
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: 无法分配任何缓冲区，退出程序..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: 无法分配缓冲区，使用另一个缓冲区..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 没有释放任何缓冲区"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 没有删除任何缓冲区"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 没有清除任何缓冲区"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "释放了 1 个缓冲区"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "释放了 %d 个缓冲区"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "删除了 1 个缓冲区"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "删除了 %d 个缓冲区"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "清除了 1 个缓冲区"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "清除了 %d 个缓冲区"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 无法释放最后一个缓冲区"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 没有修改过的缓冲区"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: 没有可列出的缓冲区"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: 缓冲区 %<PRId64> 不存在"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 无法切换，已是最后一个缓冲区"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 无法切换，已是第一个缓冲区"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: 缓冲区 %<PRId64> 已修改但尚未保存 (请加 ! 强制执行)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 无法释放最后一个缓冲区"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 文件名过多"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: 找不到缓冲区 %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: 找到不止一个 %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: 没有匹配的缓冲区 %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "第 %<PRId64> 行"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有缓冲区使用该名称"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [已修改]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未编辑]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新文件]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[读错误]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[只读]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[只读]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 行 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64> / %<PRId64> --%d%%-- 列 "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[未命名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "帮助"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[帮助]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[预览]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全部"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "底端"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "顶端"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -162,12 +229,11 @@ msgstr ""
 "\n"
 "# 缓冲区列表:\n"
 
-msgid "[Location List]"
-msgstr "[Location 列表]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[Quickfix List]"
-msgstr "[Quickfix 列表]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -175,127 +241,203 @@ msgstr ""
 "\n"
 "--- Signs ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s 的 Signs:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  id=%d  名称=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: 缺少冒号"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 无效的模式"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 此处需要数字"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 无效的百分比"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: 不能比较(diff) %<PRId64> 个以上的缓冲区"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: 无法打开 termcap 文件"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 无法创建 diff"
 
-msgid "Patch file"
-msgstr "Patch 文件"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: 无法读取 diff 的输出"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: 无法读取 diff 的输出"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 当前缓冲区不在 diff 模式"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: 没有其它处于 diff 模式的缓冲区"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 没有其它处于 diff 模式的缓冲区"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: 有两个以上的缓冲区处于 diff 模式，不能决定用哪一个"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: 找不到缓冲区 \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: 缓冲区 \"%s\" 不在 diff 模式"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 意外地改变了缓冲区"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 复合字符(digraph)中不能使用 Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: 找不到 Keymap 文件"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: 不是在脚本文件中使用 :loadkeymap "
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " 关键字补全 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X 模式 (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 整行补全 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " 文件名补全 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Tag 补全 (^]^N^P)"
 
+#: ../edit.c:88
 #, fuzzy
-#~ msgid " Path pattern completion (^N^P)"
-#~ msgstr " 路径模式补全 (^N^P)"
+msgid " Path pattern completion (^N^P)"
+msgstr " 路径模式补全 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定义补全 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dictionary 补全 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus 补全 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " 命令行补全 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " 用户自定义补全 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 拼写建议 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 关键字局部补全 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "已到段落结尾"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "选项 'dictionary' 为空"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "选项 'thesaurus' 为空"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "正在扫描 dictionary: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (插入) Scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (替换) Scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "正在扫描: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "扫描标签."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 增加"
 
@@ -303,375 +445,585 @@ msgstr " 增加"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 查找中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "回到起点"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "另一行的词"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "唯一匹配"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "匹配 %d / %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "匹配 %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: :let 中出现异常字符"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: List 索引超出范围: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 未定义的变量: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: 缺少 ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s 的参数必须是 List"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s 的参数必须是 List 或者 Dictionary"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Dictionary 的键不能为空"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: 需要 List"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: 需要 Dictionary"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 函数的参数过多: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Dictionary 中不存在键: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 函数 %s 已存在，请加 ! 强制替换"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Dictionary 项已存在"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: 需要 Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: 不能对 Dictionary 使用 [:]"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: %s= 的变量类型不正确"
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 未知的函数: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 无效的变量名: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: 将 List 作 String 使用"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: 目标比 List 项数少"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: 目标比 List 项数多"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "变量列表中出现两个 ;"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: 无法列出 %s 的变量"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: 只能索引 List 或 Dictionary"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] 必须在最后"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] 需要一个 List 值"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: List 值的项比目标多"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: List 值没有足够多的项"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for 后缺少 \"in\""
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: 缺少括号: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: 无此变量: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: (un)lock 的变量嵌套过深"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' 后缺少 ':'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: 只能比较 List 和 List"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: 对 List 无效的操作"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: 只能比较 Dictionary 和 Dictionary"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: 对 Dictionary 无效的操作"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: 只能比较 Funcref 和 Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: 对 Funcrefs 无效的操作"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: 不能对 Dictionary 使用 [:]"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: 缺少 ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: 不能索引一个 Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: 缺少选项名称: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 未知的选项: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 缺少引号: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 缺少引号: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: List 中缺少逗号: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: List 缺少结束符 ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Dictionary 中缺少冒号: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Dictionary 中出现重复的键: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Dictionary 中缺少逗号: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Dictionary 缺少结束符 '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 变量嵌套过深无法显示"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: 函数的参数过多: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: 函数的参数过多: %s"
+
+#: ../eval.c:7377
+#, fuzzy, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E130: 未知的函数: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: 函数 %s 的参数太少"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> 不能在 script 上下文外使用: %s"
+
+#: ../eval.c:7391
+#, fuzzy, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E720: Dictionary 中缺少冒号: %s"
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: = 后面需要数字"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 参数过多"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() 只能在插入模式中使用"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "确定(&O)"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: 键已存在: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd 参数"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 行: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 未知的函数: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"确定(&O)\n"
-"取消(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() 的调用次数多于 inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 不允许的范围"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len() 的类型无效"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: 步长为零"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 起始值在终止值后"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<空>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: 没有到 Vim 服务器的连接"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd 参数"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: 无法发送到 %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: 无法读取服务器响应"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: 符号连接过多(循环？)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: 无法发送到客户端"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c 参数"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Sort 比较函数失败"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Sort 比较函数失败"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(无效)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 写临时文件出错"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: 将 List 作数字使用"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: 将 Funcref 作数字使用"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: 将 List 作数字使用"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 将 Dictionary 作数字使用"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: 将 Funcref 作 String 使用"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: 将 List 作 String 使用"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: 将 Dictionary 作 String 使用"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funcref 变量名必须以大写字母开头: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: 变量名与已有函数名冲突: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 变量类型不匹配: %s"
 
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: 无法列出 %s 的变量"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funcref 变量名必须以大写字母开头: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: 变量名与已有函数名冲突: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 值已锁定: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "未知"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: 无法改变 %s 的值"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: 变量嵌套过深无法复制"
 
+#: ../eval.c:17249
+#, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E123: 函数 %s 尚未定义"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: 缺少 '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: 不能设定 IC 值"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 无效的参数: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: 无效的参数: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: 缺少 :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: 函数名与脚本文件名不匹配: %s"
+
+#: ../eval.c:17549
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E127: 函数 %s 正在使用中，不能重新定义"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 函数名与脚本文件名不匹配: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 需要函数名"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 函数名必须以大写字母开头或者包含冒号: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 函数名必须以大写字母开头或者包含冒号: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 无法删除函数 %s: 正在使用中"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 函数调用深度超出 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "调用 %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s 已中止"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s 返回 #%<PRId64> "
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s 返回 %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "在 %s 中继续"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return 不在函数中"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -679,6 +1031,7 @@ msgstr ""
 "\n"
 "# 全局变量:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -686,79 +1039,110 @@ msgstr ""
 "\n"
 "\t最近修改于 "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "没有包含文件"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  十六进制 %02x,  八进制 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 十六进制 %04x, 八进制 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 十六进制 %08x, 八进制 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 把行移动到自已中"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "移动了 1 行"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "移动了 %<PRId64> 行"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "过滤了 %<PRId64> 行"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[已修改但尚未保存]\n"
 
 # bad to translate
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 位于行: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: 错误过多，忽略文件的剩余部分"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "读取 viminfo 文件 \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 信息"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " 标记"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "没有包含文件"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失败"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo 文件不可写入: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: 无法写入 viminfo 文件 %s！"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "写入 viminfo 文件 \"%s\""
 
 # do not translate to avoid writing Chinese in files
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, fuzzy, c-format
-#~ msgid "# This viminfo file was generated by Vim %s.\n"
-#~ msgstr "# 这个 viminfo 文件是由 Vim %s 生成的。\n"
+msgid "# This viminfo file was generated by Vim %s.\n"
+msgstr "# 这个 viminfo 文件是由 Vim %s 生成的。\n"
 
 # do not translate to avoid writing Chinese in files
-#, fuzzy, c-format
+#: ../ex_cmds.c:1722
+#, fuzzy
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -767,41 +1151,48 @@ msgstr ""
 "\n"
 
 # do not translate to avoid writing Chinese in files
-#, fuzzy, c-format
-#~ msgid "# Value of 'encoding' when this file was written\n"
-#~ msgstr "# 'encoding' 在此文件建立时的值\n"
+#: ../ex_cmds.c:1723
+#, fuzzy
+msgid "# Value of 'encoding' when this file was written\n"
+msgstr "# 'encoding' 在此文件建立时的值\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "无效的启动字符"
 
-msgid "Save As"
-msgstr "另存为"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "要写入部分文件吗？"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: 请使用 ! 来写入部分缓冲区"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "覆盖已存在的文件 \"%s\" 吗？"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "交换文件 \"%s\" 已存在，确实要覆盖吗？"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 交换文件已存在: %s (:silent! 强制执行)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: 缓冲区 %<PRId64> 没有文件名"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 文件未写入: 写入被 'write' 选项禁用"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -810,62 +1201,93 @@ msgstr ""
 "\"%s\" 已设定 'readonly' 选项。\n"
 "确实要覆盖吗？"
 
-msgid "Edit File"
-msgstr "编辑文件"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "只读 (请加 ! 强制执行)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: 自动命令意外地删除了新缓冲区 %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z 不接受非数字的参数"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim 中禁止使用 shell 命令"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正则表达式不能用字母作分界"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "替换为 %s (y/n/a/q/l/^E/^Y)？"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(已中断) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 个匹配，"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 次替换，"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> 个匹配，"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> 次替换，"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr "共 1 行"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr "共 %<PRId64> 行"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 不能递归执行"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: global 缺少正则表达式"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "每行都匹配表达式: %s"
 
-# do not translate to avoid writing Chinese in files
+#: ../ex_cmds.c:4510
 #, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "找不到模式"
+
+# do not translate to avoid writing Chinese in files
+#: ../ex_cmds.c:4587
+#, fuzzy
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -875,263 +1297,335 @@ msgstr ""
 "# 最近的替换字符串:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 不要慌！"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 抱歉，没有 '%s' 的 %s 的说明"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 抱歉，没有 %s 的说明"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "抱歉，找不到帮助文件 \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: 不是目录: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 无法打开并写入 %s"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 无法打开并读取 %s"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 在一种语言中混合了多种帮助文件编码: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Tag \"%s\" 在文件 %s/%s 中重复出现"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未知的 sign 命令: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: 缺少 sign 名称"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Signs 定义过多"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 无效的 sign 文字: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 未知的 sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: 缺少 sign 号"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 无效的缓冲区名: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 无效的 sign ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (找不到)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (不支持)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[已删除]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "进入调试模式。输入 \"cont\" 继续运行。"
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "第 %<PRId64> 行: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "命令: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "断点 \"%s%s\" 第 %<PRId64> 行"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 找不到断点: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "没有定义断点"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  第 %<PRId64> 行"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 请先使用 :profile start <fname>"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "将改变保存到 \"%s\" 吗？"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "未命名"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: 缓冲区 \"%s\" 已修改但尚未保存"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "警告: 意外地进入了其它缓冲区 (请检查自动命令)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 只有一个文件可编辑"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 无法切换，已是第一个文件"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 无法切换，已是最后一个文件"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: 不支持编译器: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "正在查找 \"%s\"，在 \"%s\" 中"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "正在查找 \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "在 'runtimepath' 中找不到 \"%s\""
 
-msgid "Source Vim script"
-msgstr "执行 Vim 脚本"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "不能执行目录: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "不能执行 \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "第 %<PRId64> 行: 不能执行 \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "执行 \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "第 %<PRId64> 行: 执行 \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "结束执行 %s"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modeline"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 参数"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 参数"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "环境变量"
 
-#~ msgid "error handler"
-#~ msgstr ""
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr ""
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 警告: 错误的行分隔符，可能是少了 ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: 在脚本文件外使用了 :scriptencoding"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: 在脚本文件外使用了 :finish"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "当前的 %s语言: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 不能设定语言为 \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "进入 Ex 模式。输入 \"visual\" 回到正常模式。"
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: 已到文件末尾"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: 命令递归层数过多"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 异常没有被捕获: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "脚本文件结束"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "函数结束"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: 不确定的用户自定义命令"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: 不是编辑器的命令"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 使用了逆向的范围"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "使用了逆向的范围，确定交换吗"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: 请使用 w 或 w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: 抱歉，命令在此版本中不可用"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: 只允许一个文件名"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "还有 1 个文件未编辑。确实要退出吗？"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "还有 %d 个文件未编辑。确实要退出吗？"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 还有 1 个文件未编辑"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 还有 %<PRId64> 个文件未编辑"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已存在: 请加 ! 强制替换"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1139,275 +1633,339 @@ msgstr ""
 "\n"
 "    名称        参数 范围  补全      定义      "
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "找不到用户自定义命令"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 没有指定属性"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 无效的参数个数"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: 不能指定两次计数"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: 无效的计数默认值"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete 需要参数"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 无效的属性: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 无效的命令名"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: 用户自定义命令必须以大写字母开头"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: 不确定的用户自定义命令"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: 没有这个用户自定义命令: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 无效的补全类型: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 只有 custom 补全才允许参数"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Custom 补全需要一个函数参数"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: 找不到配色方案 %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "您好，Vim 用户！"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 不能关闭最后一个 tab 页"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "已经只剩一个 tab 页了"
 
-msgid "Edit File in new window"
-msgstr "在新窗口编辑文件"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Tab 页 %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "无交换文件"
 
-msgid "Append File"
-msgstr "追加文件"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: 不能改变目录，缓冲区已修改 (请加 ! 强制执行)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 前一个目录不存在"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize 需要两个数字参数"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "窗口位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: 在此平台上不能获得窗口位置"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos 需要两个数字参数"
 
-msgid "Save Redirection"
-msgstr "保存重定向"
-
-msgid "Save View"
-msgstr "保存视图"
-
-msgid "Save Session"
-msgstr "保存会话"
-
-msgid "Save Setup"
-msgstr "保存设定"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: 无法创建目录: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" 已存在 (请加 ! 强制执行)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: 无法打开并写入 \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 参数必须是一个字母或者正/反引号"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal 递归层数过深"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: 没有用于替换 '#' 的交替文件名"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: 没有用于替换 \"<afile>\" 的自动命令文件名"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: 没有用于替换 \"<abuf>\" 的自动命令缓冲区号"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: 没有用于替换 \"<amatch>\" 的自动命令匹配名"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: 没有用于替换 \"<sfile>\" 的 :source 文件名"
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: 没有用于替换 \"<sfile>\" 的 :source 文件名"
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%' 或 '#' 为空文件名，只能用于 \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 结果为空字符串"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: 无法打开并读取 viminfo 文件"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: 此版本无复合字符(digraph)"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 不能 :throw 前缀为 'Vim' 的异常"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "抛出异常: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "完成异常: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "丢弃异常: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s，第 %<PRId64> 行"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "捕获异常: %s"
 
+#: ../ex_eval.c:676
 #, c-format
-#~ msgid "%s made pending"
-#~ msgstr ""
+msgid "%s made pending"
+msgstr ""
 
+#: ../ex_eval.c:679
 #, fuzzy, c-format
-#~ msgid "%s resumed"
-#~ msgstr " 已返回\n"
+msgid "%s resumed"
+msgstr " 已返回\n"
 
+#: ../ex_eval.c:683
 #, c-format
-#~ msgid "%s discarded"
-#~ msgstr ""
+msgid "%s discarded"
+msgstr ""
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "异常"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "错误和中断"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "错误"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "中断"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if 嵌套层数过深"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif 缺少对应的 :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else 缺少对应的 :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif 缺少对应的 :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 多个 :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif 在 :else 后面"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for 嵌套层数过深"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue 缺少对应的 :while 或 :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break 缺少对应的 :while 或 :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :while 以 :endfor 结尾"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :for 以 :endwhile 结尾"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try 嵌套层数过深"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch 缺少对应的 :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch 在 :finally 后面"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally 缺少对应的 :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 多个 :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry 缺少对应的 :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction 不在函数内"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 目前不允许编辑别的缓冲区"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: 目前不允许编辑别的缓冲区"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "tag 名"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " 类型 文件\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "选项 'history' 为零"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5046
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -1417,211 +1975,307 @@ msgstr ""
 "# %s 历史记录 (从新到旧):\n"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5047
 #, fuzzy
-#~ msgid "Command Line"
-#~ msgstr "命令行"
+msgid "Command Line"
+msgstr "命令行"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5048
 #, fuzzy
-#~ msgid "Search String"
-#~ msgstr "查找字符串"
+msgid "Search String"
+msgstr "查找字符串"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5049
 #, fuzzy
-#~ msgid "Expression"
-#~ msgstr "表达式"
+msgid "Expression"
+msgstr "表达式"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5050
 #, fuzzy
-#~ msgid "Input Line"
-#~ msgstr "输入行"
+msgid "Input Line"
+msgstr "输入行"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar 超过命令长度"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: 活动窗口或缓冲区已被删除"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr "E343: 无效的路径: '**[number]' 必须在路径末尾或者后面接 '%s'。"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath 中找不到目录 \"%s\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: 在路径中找不到文件 \"%s\""
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: 在路径中找不到更多的文件 \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: 在路径中找不到更多的文件 \"%s\""
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "无效的文件名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "是目录"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "不是文件"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[新文件]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[新目录]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[文件过大]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[权限不足]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre 自动命令导致文件不可读"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre 自动命令不允许改变当前缓冲区"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 从标准输入读取...\n"
 
-msgid "Reading from stdin..."
-msgstr "从标准输入读取..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 转换导致文件不可读"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[只读]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 个字符"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[缺少 CR]'"
 
-msgid "[NL found]"
-msgstr "[找到 NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[长行分割]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未转换]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[已转换]"
 
-msgid "[crypted]"
-msgstr "[已加密]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[第 %<PRId64> 行转换错误]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[第 %<PRId64> 行无效字符]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[读错误]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "找不到用于转换的临时文件"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert' 转换失败"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "无法读取 'charconvert' 的输出"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: 找不到 acwrite 缓冲区对应的自动命令"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 自动命令删除或释放了要写入的缓冲区"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: 自动命令意外地改变了行数"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans 不允许未修改的缓冲区写入"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeans 不允许缓冲区部分写入"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "不是文件或可写的设备"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "只读 (请加 ! 强制执行)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: 无法写入备份文件 (请加 ! 强制执行)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: 关闭备份文件出错 (请加 ! 强制执行)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: 无法读取文件以供备份 (请加 ! 强制执行)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: 无法创建备份文件 (请加 ! 强制执行)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: 无法生成备份文件 (请加 ! 强制执行)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Resource fork 会丢失 (请加 ! 强制执行)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 找不到用于写入的临时文件"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 无法转换 (请加 ! 强制不转换写入)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: 无法打开并写入链接文件"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 无法打开并写入文件"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: 同步失败"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 关闭失败"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 写入错误，转换失败 (请将 'fenc' 置空以强制执行)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr "E513: 写入错误，转换失败 (请将 'fenc' 置空以强制执行)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 写入错误 (文件系统已满？)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 转换错误"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "第 %<PRId64> 行"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[设备]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 已追加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 已写入"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: 无法保存原始文件"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Patchmode: 无法生成空的原始文件"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: 无法删除备份文件"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1629,105 +2283,134 @@ msgstr ""
 "\n"
 "警告: 原始文件可能已丢失或损坏\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "在文件正确写入前请勿退出编辑器！"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos 格式]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac 格式]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix 格式]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行，"
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行，"
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 个字符"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 个字符"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[最后一行不完整]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 此文件自读入后已发生变动！！！"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "确实要写入吗"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: 写入文件 \"%s\" 出错"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: 关闭文件 \"%s\" 出错"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: 读取文件 \"%s\" 出错"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell 自动命令删除了缓冲区"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: 文件 \"%s\" 已经不存在"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: 文件 \"%s\" 已变动，并且在 Vim 中的缓冲区也已变动"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "进一步说明请见 \":help W12\""
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: 编辑开始后，文件 \"%s\" 已变动"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "进一步说明请见 \":help W11\""
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: 编辑开始后，文件 \"%s\" 的模式已变动"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "进一步说明请见 \":help W16\""
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: 编辑开始后，文件 \"%s\" 已被创建"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1735,39 +2418,48 @@ msgstr ""
 "确定(&O)\n"
 "加载文件(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: 无法为重新加载 \"%s\" 做准备"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: 无法重新加载 \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--已删除--"
 
+#: ../fileio.c:5732
 #, c-format
-#~ msgid "auto-removing autocommand: %s <buffer=%d>"
-#~ msgstr ""
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: 无此组: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * 后面有无效字符: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: 无此事件: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: 无此组或事件: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1775,565 +2467,797 @@ msgstr ""
 "\n"
 "--- 自动命令 ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: 无效的缓冲区号 "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 不能对所有事件执行自动命令"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "没有匹配的自动命令"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: 自动命令嵌套层数过深"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s 自动命令 \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "执行 %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "自动命令 %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: 缺少 {。"
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: 缺少 }。"
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 找不到折叠"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 不能在当前的 'foldmethod' 下创建折叠"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 不能在当前的 'foldmethod' 下删除折叠"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--已折叠 %3ld 行"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 添加到已读缓冲区中"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 递归映射"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: 全局缩写 %s 已存在"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: 全局映射 %s 已存在"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: 缩写 %s 已存在"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: 映射 %s 已存在"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "找不到缩写"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "找不到映射"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 无效的模式"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: 无法启动图形界面"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--缓冲区无内容--"
 
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: 命令被中止"
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 需要参数"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ 后面应该跟有 /、? 或 &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"
+
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: 缺少 :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: 缺少 :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: 缺少 :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: 缺少 :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile 缺少对应的 :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor 缺少对应的 :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 文件已存在 (请加 ! 强制执行)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: 命令执行失败"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 内部错误"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "已中断"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 无效的地址"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 无效的参数"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: 无法读取文件 \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 无效的参数: %s"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 无法启动图形界面，找不到有效的字体"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 无效的 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' 的值无效"
-
+#: ../globals.h:1016
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: 无法分配颜色 %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 无效的表达式: %s"
 
-msgid "No match at cursor, finding next"
-msgstr "在光标处没有匹配，查找下一个"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 无效的范围"
 
-msgid "<cannot open> "
-msgstr "<无法打开>"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 无效的命令"
 
+#: ../globals.h:1019
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: 无法获取字体 %s"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" 是目录"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 无法返回当前目录"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 无效的滚动大小"
 
-msgid "Pathname:"
-msgstr "路径:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 无法获取当前目录"
-
-msgid "OK"
-msgstr "确定"
-
-msgid "Cancel"
-msgstr "取消"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "滚动条部件: 无法获取滑块图像的几何大小"
-
-msgid "Vim dialog"
-msgstr "Vim 对话框"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: 不能同时使用消息和回调函数来创建 BalloonEval"
-
-msgid "Vim dialog..."
-msgstr "Vim 对话框..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"是(&Y)\n"
-"否(&N)\n"
-"取消(&C)"
 
-msgid "Input _Methods"
-msgstr "输入法(_M)"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 查找和替换..."
-
-msgid "VIM - Search..."
-msgstr "VIM - 查找..."
-
-msgid "Find what:"
-msgstr "查找内容:"
-
-msgid "Replace with:"
-msgstr "替换为:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "匹配完整的词"
-
-#. match case button
-msgid "Match case"
-msgstr "匹配大小写"
-
-msgid "Direction"
-msgstr "方向"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "向上"
-
-msgid "Down"
-msgstr "向下"
-
-msgid "Find Next"
-msgstr "查找下一个"
-
-msgid "Replace"
-msgstr "替换"
-
-msgid "Replace All"
-msgstr "全部替换"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: 从会话管理器收到 \"die\" 请求\n"
-
-msgid "Close"
-msgstr "关闭"
-
-msgid "New tab"
-msgstr "新建标签"
-
-msgid "Open Tab..."
-msgstr "打开标签..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: 主窗口被意外地摧毁\n"
-
-msgid "Font Selection"
-msgstr "选择字体"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "使用 CUT_BUFFER0 来取代空选择"
-
-msgid "&Filter"
-msgstr "过滤(&F)"
-
-msgid "&Cancel"
-msgstr "取消(&C)"
-
-msgid "Directories"
-msgstr "目录"
-
-msgid "Filter"
-msgstr "过滤器"
-
-msgid "&Help"
-msgstr "帮助(&H)"
-
-msgid "Files"
-msgstr "文件"
-
-msgid "&OK"
-msgstr "确定(&O)"
-
-msgid "Selection"
-msgstr "选择"
-
-msgid "Find &Next"
-msgstr "查找下一个(&N)"
-
-msgid "&Replace"
-msgstr "替换(&R)"
-
-msgid "Replace &All"
-msgstr "全部替换(&A)"
-
-msgid "&Undo"
-msgstr "撤销(&U)"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: 找不到窗口标题 \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 不支持的参数: \"-%s\"；请使用 OLE 版本。"
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: 无法在 MDI 应用程序中打开窗口"
-
-msgid "Close tab"
-msgstr "关闭标签"
-
-msgid "Open tab..."
-msgstr "打开标签..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "查找字符串 (使用 '\\\\' 来查找 '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "查找和替换字符串 (使用 '\\\\' 来查找 '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "未使用"
-
-msgid "Directory\t*.nothing\n"
-msgstr "目录\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 无法分配颜色表项，某些颜色可能不正确"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Fontset %s 缺少下列字符集的字体:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Fontset 名称: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "'%s' 不是固定宽度的字体"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Fontset 名称: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "字体0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "字体1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "字体0的宽度：%<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"字体1的宽度: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "指定了无效的字体"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 调用函数库 \"%s()\" 失败"
 
-msgid "&Dismiss"
-msgstr "取消(&D)"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 标记的行号无效"
 
-msgid "no specific match"
-msgstr "找不到匹配的项"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 没有设定标记"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - 字体选择器"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 不能修改，因为选项 'modifiable' 是关的"
 
-msgid "Name:"
-msgstr "名称:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 脚本嵌套过深"
 
-#. create toggle button
-#~ msgid "Show size in Points"
-#~ msgstr ""
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 没有交替文件"
 
-msgid "Encoding:"
-msgstr "编码:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: 没有这个缩写"
 
-msgid "Font:"
-msgstr "字体:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: 不能使用 \"!\""
 
-msgid "Style:"
-msgstr "风格:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: 无法使用图形界面: 编译时没有启用"
 
-msgid "Size:"
-msgstr "尺寸:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 没有这个高亮群组名: %s"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul automata 错误"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: 没有插入过文字"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 没有前一个命令行"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: 没有这个映射"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 没有匹配"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 没有匹配: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: 没有文件名"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 没有前一个替换正则表达式"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: 没有前一个命令"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 没有前一个正则表达式"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 不能使用范围"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: 没有足够的空间"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: 无法创建文件 %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 无法获取临时文件名"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: 无法打开文件 %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: 无法读取文件 %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 已修改但尚未保存 (可用 ! 强制执行)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[已修改但尚未保存]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 空的参数"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 此处需要数字"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 无法打开错误文件 %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: 内存不足！"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "找不到模式"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 找不到模式: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 参数必须是正数"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 无法回到前一个目录"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: 没有错误"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 没有 location 列表"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 已损坏的匹配字符串"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 已损坏的正则表达式程序"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 已设定选项 'readonly' (请加 ! 强制执行)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 不能改变只读变量 \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: 不能在 sandbox 中设定变量: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 读取错误文件失败"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: 不允许在 sandbox 中使用"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: 不允许在此使用"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 不支持设定屏幕模式"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 无效的滚动大小"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 选项 'shell' 为空"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: 无法读取 sign 数据！"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: 交换文件关闭错误"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tag 堆栈为空"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: 命令过复杂"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名字过长"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [ 过多"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: 文件名过多"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 多余的尾部字符"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 未知的标记"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 无法扩展通配符"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' 不能小于 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' 不能小于 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 写入出错"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "计数为零"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: 在脚本环境外使用了 <SID>"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 内部错误: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: 表达式的内存使用超出 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: 空的缓冲区"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 无效的搜索表达式或分隔符"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 文件已在另一个缓冲区中被加载"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: 没有设定选项 '%s'"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 无效的寄存器名: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "已查找到文件开头，再从结尾继续查找"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "已查找到文件结尾，再从开头继续查找"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: 缺少冒号"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 无效的部分"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 应该要有数字"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "第 %d 页"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "没有要打印的文字"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "正在打印第 %d 页 (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr "复制 %d / %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "已打印: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "打印中止"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: 写入 PostScript 输出文件出错"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: 无法打开文件 \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: 无法读取 PostScript 资源文件 \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: 文件 \"%s\" 不是 PostScript 资源文件"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: 文件 \"%s\" 不是已支持的 PostScript 资源文件"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" 资源文件版本不正确"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 不兼容的多字节编码和字符集。"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset 在多字节编码下不能为空。"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: 没有指定多字节打印的默认字体。"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: 无法打开 PostScript 输出文件"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: 无法打开文件 \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: 无法转换至打印编码 \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "发送到打印机……"
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: 无法打印 PostScript 文件"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "打印任务已被发送。"
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "添加一个新的数据库"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "查询一个模式"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "显示此信息"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "结束一个连接"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "重置所有连接"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "显示连接"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 用法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "这个 cscope 命令不支持分割窗口。\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 用法: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: 找不到 tag"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) 错误: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat 错误"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s 不是目录或有效的 cscope 数据库"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "添加了 cscope 数据库 %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: 读取 cscope 连接 %<PRId64> 出错"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 查找类型"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: 无法创建 cscope 管道"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: 无法对 cscope 进行 fork"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection 执行失败"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection 执行失败"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: 无法生成 cscope 进程"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen to_fp 失败"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen fr_fp 失败"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: 无法生成 cscope 进程"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: 没有 cscope 连接"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: cscope 查询 %s %s 没有找到匹配的结果"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cscopequickfix 标志 %c 对 %c 无效"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: cscope 查询 %s %s 没有找到匹配的结果"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope 命令:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (用法: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: 无法打开 cscope 数据库: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: 无法获取 cscope 数据库信息"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重复的 cscope 数据库未被加入"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: 已达到 cscope 的最大连接数"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: 找不到 cscope 连接 %s"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope 连接 %s 已关闭"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches 严重错误"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2341,363 +3265,87 @@ msgstr ""
 "\n"
 "   #   行  "
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "文件名 / 上下文 / 行\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope 错误: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "所有 cscope 数据库已被重置"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "没有 cscope 连接\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    数据库名                            prepend path\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr "???: 抱歉，此命令不可用，无法加载 MzScheme 库"
-
-msgid "invalid expression"
-msgstr "无效的表达式"
-
-msgid "expressions disabled at compile time"
-msgstr "编译时没有启用表达式"
-
-msgid "hidden option"
-msgstr "隐藏的选项"
-
-msgid "unknown option"
-msgstr "未知的选项"
-
-msgid "window index is out of range"
-msgstr "窗口索引超出范围"
-
-msgid "couldn't open buffer"
-msgstr "无法打开缓冲区"
-
-msgid "cannot save undo information"
-msgstr "无法保存撤销信息"
-
-msgid "cannot delete line"
-msgstr "无法删除行"
-
-msgid "cannot replace line"
-msgstr "无法替换行"
-
-msgid "cannot insert line"
-msgstr "无法插入行"
-
-msgid "string cannot contain newlines"
-msgstr "字符串不能包含换行(NL)"
-
-msgid "Vim error: ~a"
-msgstr "Vim 错误: ~a"
-
-msgid "Vim error"
-msgstr "Vim 错误"
-
-msgid "buffer is invalid"
-msgstr "缓冲区无效"
-
-msgid "window is invalid"
-msgstr "窗口无效"
-
-msgid "linenr out of range"
-msgstr "行号超出范围"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "不允许在 sandbox 中使用"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr "E263: 抱歉，此命令不可用，无法加载 Python 库。"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: 不能递归调用 Python"
-
-msgid "can't delete OutputObject attributes"
-msgstr "不能删除 OutputObject 属性"
-
-msgid "softspace must be an integer"
-msgstr "softspace 必须是整数"
-
-msgid "invalid attribute"
-msgstr "无效的属性"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() 需要字符串列表作参数"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: 初始化 I/O 对象出错"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "试图引用已被删除的缓冲区"
-
-msgid "line number out of range"
-msgstr "行号超出范围"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<缓冲区对象(已删除): %8lX>"
-
-msgid "invalid mark name"
-msgstr "无效的标记名称"
-
-msgid "no such buffer"
-msgstr "无此缓冲区"
-
-msgid "attempt to refer to deleted window"
-msgstr "试图引用已被删除的窗口"
-
-msgid "readonly attribute"
-msgstr "只读属性"
-
-msgid "cursor position outside buffer"
-msgstr "光标位置在缓冲区外"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<窗口对象(已删除): %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<窗口对象(未知): %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<窗口 %d>"
-
-msgid "no such window"
-msgstr "无此窗口"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: 抱歉，此命令不可用，无法加载 Ruby 库"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知的 longjmp 状态 %d"
-
-msgid "Toggle implementation/definition"
-msgstr "切换实现/定义"
-
-msgid "Show base class of"
-msgstr "显示 base class of:"
-
-msgid "Show overridden member function"
-msgstr "显示被覆盖的成员函数"
-
-msgid "Retrieve from file"
-msgstr "恢复: 从文件"
-
-msgid "Retrieve from project"
-msgstr "恢复: 从对象"
-
-msgid "Retrieve from all projects"
-msgstr "恢复: 从所有项目"
-
-msgid "Retrieve"
-msgstr "恢复"
-
-msgid "Show source of"
-msgstr "显示源代码: "
-
-msgid "Find symbol"
-msgstr "查找 symbol"
-
-msgid "Browse class"
-msgstr "浏览 class"
-
-msgid "Show class in hierarchy"
-msgstr "显示层次关系的类"
-
-msgid "Show class in restricted hierarchy"
-msgstr "显示 restricted 层次关系的 class"
-
-msgid "Xref refers to"
-msgstr "Xref 参考到"
-
-msgid "Xref referred by"
-msgstr "Xref 被谁参考:"
-
-msgid "Xref has a"
-msgstr "Xref 有"
-
-msgid "Xref used by"
-msgstr "Xref 被谁使用:"
-
-msgid "Show docu of"
-msgstr "显示文件: "
-
-msgid "Generate docu for"
-msgstr "产生文件: "
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr "不能连接到 SNiFF+。请检查环境变量 ($PATH 里必需可以找到 sniffemacs)\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 读取错误. 取消连接"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ 目前"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "连接中"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 不正确的 SNiff+ 调用: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: 连接到 SNiFF+ 失败"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: 未连接到 SNiFF+"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: 不是 SNiFF+ 的缓冲区"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 写入错误。结束连接"
-
-msgid "invalid buffer number"
-msgstr "无效的缓冲区号"
-
-msgid "not implemented yet"
-msgstr "尚未实现"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "无法设定行"
-
-msgid "mark not set"
-msgstr "没有设定标记"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "第 %d 行 第 %d 列"
-
-msgid "cannot insert/append line"
-msgstr "无法插入/追加行"
-
-msgid "unknown flag: "
-msgstr "未知的标志: "
-
-msgid "unknown vimOption"
-msgstr "未知的 vim 选项"
-
-msgid "keyboard interrupt"
-msgstr "键盘中断"
-
-msgid "vim error"
-msgstr "vim 错误"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "无法创建缓冲区/窗口命令: 对象将被删除"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "无法注册回调命令: 缓冲区/窗口已被删除"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr "E280: TCL 严重错误: reflist 损坏！？请报告给 vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "无法注册回调命令: 找不到缓冲区/窗口引用"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: 抱歉，此命令不可用，无法加载 Tcl 库"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: TCL 错误: 退出返回值不是整数！？请报告给 vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 退出返回值 %d"
-
-msgid "cannot get line"
-msgstr "无法获取行"
-
-msgid "Unable to register a command server name"
-msgstr "无法注册命令服务器名"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248:  无法发送命令到目的程序"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 使用了无效的服务器 id: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 实例注册属性有误。已删除！"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "未知的选项参数"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "编辑参数过多"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "缺少必要的参数"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "选项参数后的内容无效"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "\"+command\"、\"-c command\" 或 \"--cmd command\" 参数过多"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "无效的参数"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "还有 %d 个文件等待编辑\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "此 Vim 编译时没有加入 diff 功能"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "试图再次打开脚本文件: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "无法打开并读取: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "无法打开并输出脚本: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: 错误: 无法从 NetBeans 中启动 gvim\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 输出不是到终端(屏幕)\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 警告: 输入不是来自终端(键盘)\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc 命令行"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: 无法读取 \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2705,18 +3353,23 @@ msgstr ""
 "\n"
 "更多信息请见: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[文件 ..]       编辑指定的文件"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               从标准输入(stdin)读取文本"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          编辑 tag 定义处的文件"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  编辑第一个出错处的文件"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2726,9 +3379,11 @@ msgstr ""
 "\n"
 "用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [参数] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2736,9 +3391,7 @@ msgstr ""
 "\n"
 "  或:"
 
-#~ msgid "where case is ignored prepend / to make flag upper case"
-#~ msgstr ""
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2748,318 +3401,189 @@ msgstr ""
 "\n"
 "参数:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t在这以后只有文件名"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t不扩展通配符"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\t注册此 gvim 到 OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\t取消 OLE 中的 gvim 注册"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\t使用图形界面 (同 \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  或  --nofork\t前台: 启动图形界面时不 fork"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi 模式 (同 \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx 模式 (同 \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t安静(批处理)模式 (只能与 \"ex\" 一起使用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff 模式 (同 \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\t容易模式 (同 \"evim\"，无模式)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t只读模式 (同 \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t限制模式 (同 \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t不可修改(写入文件)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t文本不可修改"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t二进制模式"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp 模式"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\t兼容传统的 Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\t不完全兼容传统的 Vi: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tVerbose 等级"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t调试模式"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t不使用交换文件，只使用内存"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t列出交换文件并退出"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (跟文件名)\t\t恢复崩溃的会话"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t同 -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t不使用 newcli 来打开窗口"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\t使用 <device> 进行输入输出"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\t以 Arabic 模式启动"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\t以 Hebrew 模式启动"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\t以 Farsi 模式启动"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t设定终端类型为 <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t使用 <vimrc> 替代任何 .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t使用 <gvimrc> 替代任何 .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t不加载 plugin 脚本"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-P[N]\t\t打开 N 个标签页 (默认值: 每个文件一个)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\t打开 N 个窗口 (默认值: 每个文件一个)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t同 -o 但垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t启动后跳到文件末尾"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t启动后跳到第 <lnum> 行"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\t加载任何 vimrc 文件前执行 <command>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t加载第一个文件后执行 <command>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t加载第一个文件后执行文件 <session>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t从文件 <scriptin> 读入正常模式的命令"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t将所有输入的命令追加到文件 <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t将所有输入的命令写入到文件 <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t编辑加密的文件"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
 
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t将 vim 与指定的 X-server 连接"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\t不连接到 X Server"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  同 --remote 但会等待文件完成编辑"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  同上，找不到服务器时不抱怨"
-
-msgid "--remote-tab <files>  As --remote but open tab page for each file"
-msgstr "--remote-tab <files>  同 --remote 但对每个文件打开一个标签页"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 服务器并退出"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t在 Vim 服务器上求 <expr> 的值并打印结果"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t列出可用的 Vim 服务器名称并退出"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t发送到或成为 Vim 服务器 <name>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 取代 .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  或  --help\t打印帮助(本信息)并退出"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t打印版本信息并退出"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim (Motif 版本) 可识别的参数:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim (neXtaw 版本) 可识别的参数:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim (Athena 版本) 可识别的参数:\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t在 <display> 上运行 vim"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t启动后最小化"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\t读取 Resource 时把 vim 视为 <name>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (尚未实现)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t使用 <color> 作为背景色 (也可用 -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t使用 <color> 作为一般文字颜色 (也可用 -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t使用 <font> 作为一般字体 (也可用 -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t使用 <font> 作为粗体字体"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t使用 <font> 作为斜体字体"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t使用 <geom> 作为初始位置 (也可用 -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t设定边框宽度为 <width> (也可用 -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width> 设定滚动条宽度为 <width> (也可用 -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t设定菜单栏高度为 <height> (也可用 -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t使用反显 (也可用 -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t不使用反显 (也可用 +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t设定指定的资源"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim (RISC OS 版本) 可识别的参数:\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <number>\t窗口初始宽度"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <number>\t窗口初始高度"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim (GTK+ 版本) 可识别的参数:\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t在 <display> 上运行 vim (也可用 --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t设置用于区分主窗口的窗口角色名"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t在另一个 GTK 部件中打开 Vim"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\t在父应用程序中打开 Vim"
-
-msgid "No display"
-msgstr "没有 display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 发送失败。\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 发送失败。尝试本地执行\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d 中 %d 已编辑"
-
-msgid "No display: Send expression failed.\n"
-msgstr "没有 display: 发送表达式失败。\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 发送表达式失败。\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "没有设定标记"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: 没有匹配 \"%s\" 的标记"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3068,6 +3592,7 @@ msgstr ""
 "标记   行   列 文件/文本"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3076,6 +3601,7 @@ msgstr ""
 " 跳转   行   列 文件/文本"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3083,7 +3609,7 @@ msgstr ""
 "\n"
 "  改变   行   列 文本"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3092,7 +3618,7 @@ msgstr ""
 "# 文件标记:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3100,7 +3626,7 @@ msgstr ""
 "\n"
 "# 跳转列表 (从新到旧):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3108,94 +3634,84 @@ msgstr ""
 "\n"
 "# 文件内的标记历史记录 (从新到旧):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "缺少 '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 无效的代码页"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: 不能设定 IC 值"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: 无法创建输入上下文"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: 无法打开输入法"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: 无法设定输入法的释放回调函数"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 输入法不支持任何风格"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 输入法不支持我的预编辑类型"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: over-the-spot 风格需要 Fontset"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: 你的 GTK+ 比 1.2.3 旧。状态区不可用。"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: 输入法服务器未运行"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: 块未被锁定"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: 交换文件读取定位错误"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: 交换文件读取错误"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: 交换文件写入定位错误"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: 交换文件写入错误"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: 交换文件已存在 (符号连接攻击？)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: 找不到块 0？"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: 找不到块 1？"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: 找不到块 2？"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: 噢，交换文件不见了！！！"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: 无法重命名交换文件"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: 无法打开 \"%s\" 的交换文件，恢复将不可能"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): 找不到块 0？"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: 找不到 %s 的交换文件"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "请输入要使用的交换文件编号 (0 退出): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: 无法打开 %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "无法读取块 0: "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3203,22 +3719,28 @@ msgstr ""
 "\n"
 "可能你没做过任何修改或是 Vim 还来不及更新交换文件。"
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " 不能在该版本的 Vim 中使用。\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "使用 Vim 3.0。\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s 看起来不像是 Vim 交换文件"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " 不能在这台电脑上使用。\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "此文件创建于 "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3226,78 +3748,100 @@ msgstr ""
 "，\n"
 "或是此文件已损坏。"
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "使用交换文件 \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原始文件 \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原始文件可能已被修改"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: 无法从 %s 读取块 1"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1065
 #, fuzzy
-#~ msgid "???MANY LINES MISSING"
-#~ msgstr "???缺少了太多行"
+msgid "???MANY LINES MISSING"
+msgstr "???缺少了太多行"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1076
 #, fuzzy
-#~ msgid "???LINE COUNT WRONG"
-#~ msgstr "???行数错误"
+msgid "???LINE COUNT WRONG"
+msgstr "???行数错误"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1082
 #, fuzzy
-#~ msgid "???EMPTY BLOCK"
-#~ msgstr "???空的块"
+msgid "???EMPTY BLOCK"
+msgstr "???空的块"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1103
 #, fuzzy
-#~ msgid "???LINES MISSING"
-#~ msgstr "???缺少了一些行"
+msgid "???LINES MISSING"
+msgstr "???缺少了一些行"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: 块 1 ID 错误 (%s 不是交换文件？)"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1133
 #, fuzzy
-#~ msgid "???BLOCK MISSING"
-#~ msgstr "???缺少块"
+msgid "???BLOCK MISSING"
+msgstr "???缺少块"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1147
 #, fuzzy
-#~ msgid "??? from here until ???END lines may be messed up"
-#~ msgstr "??? 从这里到 ???END 的行可能已混乱"
+msgid "??? from here until ???END lines may be messed up"
+msgstr "??? 从这里到 ???END 的行可能已混乱"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1164
 #, fuzzy
-#~ msgid "??? from here until ???END lines may have been inserted/deleted"
-#~ msgstr "??? 从这里到 ???END 的行可能已被插入/删除过"
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr "??? 从这里到 ???END 的行可能已被插入/删除过"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1181
 #, fuzzy
-#~ msgid "???END"
-#~ msgstr "???END"
+msgid "???END"
+msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: 恢复已被中断"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: 恢复时发生错误；请注意开头为 ??? 的行"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "更多信息请见 \":help E312\""
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "恢复完毕。请确定一切正常。"
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3305,50 +3849,71 @@ msgstr ""
 "\n"
 "(你可能想要将这个文件另存为别的文件名\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "再运行 diff 与原文件比较以检查是否有改变)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "然后把 .swp 文件删掉。\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "找到交换文件:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   位于当前目录:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   使用指定的名字:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   位于目录 "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- 无 --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            所有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    日期: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              日期: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [来自 Vim 版本 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [不像是 Vim 交换文件]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "            文件名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3356,12 +3921,15 @@ msgstr ""
 "\n"
 "            修改过: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "是"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "否"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3369,9 +3937,11 @@ msgstr ""
 "\n"
 "            用户名: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "      主机名: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3379,6 +3949,7 @@ msgstr ""
 "\n"
 "            主机名: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3386,16 +3957,11 @@ msgstr ""
 "\n"
 "           进程 ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (仍在运行)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [不能在该版本的 Vim 上使用]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3403,75 +3969,97 @@ msgstr ""
 "\n"
 "         [不能在本机上使用]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [无法读取]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [无法打开]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: 无法保留，没有交换文件"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "文件已保留"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 保留失败"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 无效的 lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 找不到第 %<PRId64> 行"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指针块 id 错误 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx 应该是 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新了太多的块？"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: 指针块 id 错误 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "删除了块 1？"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 找不到第 %<PRId64> 行"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指针块 id 错误"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count 为零"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行号超出范围: %<PRId64> 超出结尾"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: 块 %<PRId64> 行数错误"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "堆栈大小增加"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: 指针块 id 错误 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: \"%s\" 符号连接出现循环"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3479,38 +4067,44 @@ msgstr ""
 "\n"
 "发现交换文件 \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "正在打开文件 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      比交换文件新！\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 另一个程序可能也在编辑同一个文件。\n"
 "    如果是这样，修改时请注意避免同一个文件产生两个不同的版本。\n"
 "\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    退出，或小心地继续。\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 上次编辑此文件时崩溃。\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    如果是这样，请用 \":recover\" 或 \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3518,9 +4112,11 @@ msgstr ""
 "\"\n"
 "    恢复修改的内容 (请见 \":help recovery\")。\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    如果你已经进行了恢复，请删除交换文件 \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3528,18 +4124,23 @@ msgstr ""
 "\"\n"
 "    以避免再看到此消息。\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "交换文件 \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" 已存在！"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "交换文件已存在！"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3553,6 +4154,7 @@ msgstr ""
 "退出(&Q)\n"
 "中止(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3568,30 +4170,57 @@ msgstr ""
 "退出(&Q)\n"
 "中止(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: 找到太多交换文件"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: 菜单项的某部分路径不是子菜单"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: 菜单只在其它模式中存在"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: 没有菜单 \"%s\""
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+#, fuzzy
+msgid "E792: Empty menu name"
+msgstr "E749: 空的缓冲区"
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: 菜单路径不能指向子菜单"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: 不能把菜单项直接加到菜单栏中"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 分隔线不能是菜单路径的一部分"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3599,60 +4228,73 @@ msgstr ""
 "\n"
 "--- 菜单 ---"
 
-msgid "Tear off this menu"
-msgstr "撕下此菜单"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: 菜单路径必须指向菜单项"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: 找不到菜单: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s 模式中菜单未定义"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: 菜单路径必须指向子菜单"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: 找不到菜单 - 请检查菜单名称"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "处理 %s 时发生错误:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "第 %4ld 行:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 无效的寄存器名: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "简体中文消息维护者: Yuheng Xie <elephant@linux.net.cn>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "已中断: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "请按 ENTER 或其它命令继续"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 第 %<PRId64> 行"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 更多 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " 空格/d/j: 屏幕/页/行 下翻，b/u/k: 上翻，q: 退出 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "问题"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3660,6 +4302,17 @@ msgstr ""
 "是(&Y)\n"
 "否(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"是(&Y)\n"
+"否(&N)\n"
+"取消(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3673,257 +4326,177 @@ msgstr ""
 "全部丢弃(&D)\n"
 "取消(&C)"
 
-msgid "Select Directory dialog"
-msgstr "选择目录对话框"
-
-msgid "Save File dialog"
-msgstr "保存文件对话框"
-
-msgid "Open File dialog"
-msgstr "打开文件对话框"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: 抱歉，控制台模式下没有文件浏览器"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() 的参数不足"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: printf() 的参数不足"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf() 的参数过多"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 警告: 正在修改一个只读文件"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "请输入数字或点击鼠标 (<Enter> 取消): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "请选择数字 (<Enter> 取消): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "多了 1 行"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "少了 1 行"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "多了 %<PRId64> 行"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "少了 %<PRId64> 行"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (已中断)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Beep!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: 正在保留文件……\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 结束。\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "错误: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 此行过长"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "调用 shell 执行: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: 缺少冒号"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 无效的模式"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 无效的鼠标形状"
-
-msgid "E548: digit expected"
-msgstr "E548: 此处需要数字"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 无效的百分比"
-
-msgid "Enter encryption key: "
-msgstr "输入密码: "
-
-msgid "Enter same key again: "
-msgstr "请再输入一次: "
-
-msgid "Keys don't match!"
-msgstr "两次密码不匹配！"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr "E343: 无效的路径: '**[number]' 必须在路径末尾或者后面接 '%s'。"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath 中找不到目录 \"%s\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: 在路径中找不到文件 \"%s\""
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: 在路径中找不到更多的文件 \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: 在路径中找不到更多的文件 \"%s\""
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "无法连接到 Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "无法连接到 Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans 连接信息文件中错误的访问模式: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "从 Netbeans 套接字读取"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' 为空"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: 求值功能不可用"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "警告: 你的终端不能显示高亮"
-
-msgid "E348: No string under cursor"
-msgstr "E348: 光标处没有字符串"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: 光标处没有识别字"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' 为空"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "警告: 你的终端不能显示高亮"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: 光标处没有字符串"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 不能在当前的 'foldmethod' 下删除 fold"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 改变列表为空"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 已在改变列表的开始处"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "输入  :quit<Enter>  退出 Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 行 %s 了 1 次"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 行 %s 了 %d 次"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行 %s 了 1 次"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行 %s 了 %d 次"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "缩进 %<PRId64> 行…… "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "缩进了 1 行 "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "缩进了 %<PRId64> 行 "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: 没有前一个使用的寄存器"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "无法复制；改为删除"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "改变了 1 行"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "改变了 %<PRId64> 行"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "释放了 %<PRId64> 行"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "复制了 1 行的块"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "复制了 1 行"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "复制了 %<PRId64> 行的块"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "复制了 %<PRId64> 行"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: 寄存器 %s 里没有东西"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3931,10 +4504,11 @@ msgstr ""
 "\n"
 "--- 寄存器 ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "无效的寄存器名"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3942,155 +4516,194 @@ msgstr ""
 "\n"
 "# 寄存器:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的寄存器类型 %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 列; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字节"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字节"
-
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个"
-"字节"
+"选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/"
+"%<PRId64> 个字节"
 
+#: ../ops.c:5105
 #, c-format
-#~ msgid "(+%<PRId64> for BOM)"
-#~ msgstr ""
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/"
+"%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
 
-#~ msgid "%<%f%h%m%=Page %N"
-#~ msgstr ""
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 "
+"%<PRId64>/%<PRId64> 个字节"
 
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 "
+"%<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个字节"
+
+#: ../ops.c:5146
+#, c-format
+msgid "(+%<PRId64> for BOM)"
+msgstr ""
+
+#: ../option.c:1238
+msgid "%<%f%h%m%=Page %N"
+msgstr ""
+
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "感谢您选择 Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 未知的选项"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: 不支持该选项"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: 不允许在 modeline 中使用"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = 后面需要数字"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Termcap 里面找不到"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 无效的字符 <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 不能设定 'term' 为空字符串"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: 在图形界面中不能改变终端"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: 请用 \":gui\" 启动图形界面"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' 和 'patchmode' 相等"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: 在 GTK+ 2 图形界面中不能更改"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: 缺少冒号"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 字符串长度为零"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> 后面缺少数字"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: 缺少逗号"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: 必须指定一个 ' 值"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 包含不可显示字符或宽字符"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 无效的字体"
-
-msgid "E597: can't select fontset"
-msgstr "E597: 无法选择 Fontset"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 无效的 Fontset"
-
-msgid "E533: can't select wide font"
-msgstr "E533: 无法选择宽字体"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 无效的宽字体"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> 后面有无效的字符"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: 需要逗号"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' 必须为空或包含 %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: 不支持鼠标"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 没有结束的表达式序列"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 项目过多"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: 错乱的组"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: 预览窗口已存在"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic 需要 UTF-8，请执行 ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 至少需要 %d 行"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 至少需要 %d 列"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 未知的选项: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: = 后面需要数字"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4098,6 +4711,7 @@ msgstr ""
 "\n"
 "--- 终端编码 ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4105,6 +4719,7 @@ msgstr ""
 "\n"
 "--- 全局选项值 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4112,6 +4727,7 @@ msgstr ""
 "\n"
 "--- 局部选项值 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4119,126 +4735,21 @@ msgstr ""
 "\n"
 "--- 选项 ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp 错误"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': 找不到 %s 对应的字符"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': 分号后有多余的字符: %s"
 
-msgid "cannot open "
-msgstr "不能打开"
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: 不能打开窗口!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "需要 Amigados 版本 2.04 以上\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "需要 %s 版本 %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "不能打开 NIL:\n"
-
-msgid "Cannot create "
-msgstr "不能创建 "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim 返回值: %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "不能切换主控台(console)模式 !?\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: 不是主控台(console)??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: 不能用 -f 选项执行 shell"
-
-msgid "Cannot execute "
-msgstr "不能执行 "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " 已返回\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE 太小"
-
-msgid "I/O ERROR"
-msgstr "I/O 错误"
-
-msgid "Message"
-msgstr "消息"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' 不是 80, 不能执行外部命令"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: 选择打印机失败"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "从 %s 到 %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 未知的打印机字体: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 打印错误: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "打印 '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 字符集 \"%s\" 不能对应字体\"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 双重信号，退出中\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: 拦截到致命信号(deadly signal) %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 拦截到致命信号(deadly signal)\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "打开 X display 用时 %<PRId64> 秒"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X 错误\n"
-
-msgid "Testing the X display failed"
-msgstr "测试 X display 失败"
-
-msgid "Opening the X display timed out"
-msgstr "打开 X display 超时"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4246,13 +4757,7 @@ msgstr ""
 "\n"
 "无法执行 shell"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"无法执行 shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4260,472 +4765,616 @@ msgstr ""
 "\n"
 "Shell 已返回"
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"无法建立管道\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"无法 fork\n"
-
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"命令已结束\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP 丢失了到 ICE 的连接"
 
 # do not translate
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "打开 X display 失败"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP 处理 save-yourself 请求"
-
-msgid "XSMP opening connection"
-msgstr "XSMP 打开连接"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE 连接监视失败"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection 调用失败: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: 在路径中找不到文件 \"%s\""
 
-msgid "At line"
-msgstr "在行号 "
-
-msgid "Could not load vim32.dll!"
-msgstr "无法加载 vim32.dll！"
-
-msgid "VIM Error"
-msgstr "VIM 错误"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "无法修正到 DLL 的函数指针!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "Shell 返回 %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: 拦截到 %s 事件\n"
-
-msgid "close"
-msgstr "关闭"
-
-msgid "logoff"
-msgstr "注消"
-
-msgid "shutdown"
-msgstr "关机"
-
-msgid "E371: Command not found"
-msgstr "E371: 找不到命令"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"在你的 $PATH 中找不到 VIMRUN.EXE。\n"
-"外部命令执行完毕后将不会暂停。\n"
-"进一步说明请见 :help win32-vimrun"
-
-msgid "Vim Warning"
-msgstr "Vim 警告"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: 格式化字符串里有太多 %%%c "
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: 格式化字符串不应该出现 %%%c "
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: 格式化字符串里少了 ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: 格式化字符串里有不支持的 %%%c "
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: 格式化字符串开头里有不正确的 %%%c "
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: 格式化字符串里有不正确的 %%%c "
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' 未设定"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: 找不到目录名称或是空的目录名称"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 没有更多的项"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d / %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行已删除)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Quickfix 堆栈底端"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Quickfix 堆栈顶端"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "错误列表 %d / %d；共 %d 个错误"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 无法写入，已设定选项 'buftype'"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: 缺少文件名或模式无效"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "无法打开文件 \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: 缓冲区未加载"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: 此处需要 String 或者 List"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: %s%%[] 中有无效的项"
 
-msgid "E339: Pattern too long"
-msgstr "E339: 模式太长"
-
-msgid "E50: Too many \\z("
-msgstr "E50: 太多 \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: 太多 %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: 不匹配的 \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: 不匹配的 %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: 不匹配的 %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: 不匹配的 %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: %s@ 后面有无效的字符"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: 太多复杂的 %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: 嵌套的 %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: 嵌套的 %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: 不正确地使用 \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 前面无内容"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: 无效的回引"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: 此处不允许 \\z("
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: 此处不允许 \\z1 等"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: \\z 后面有无效的字符"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: %s%%[ 后缺少 ]"
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: 空的 %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: %s%%[dxouU] 后面有无效的字符"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: %s%% 后面有无效的字符"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ 后缺少 ]"
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: 不匹配的 %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: 不匹配的 %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: 不匹配的 %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: 此处不允许 \\z("
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: 此处不允许 \\z1 等"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ 后缺少 ]"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: 空的 %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: 模式太长"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: 太多 %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: 不匹配的 \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: %s@ 后面有无效的字符"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: 太多复杂的 %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: 嵌套的 %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: 嵌套的 %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: 不正确地使用 \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 前面无内容"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: 无效的回引"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: \\z 后面有无效的字符"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: %s%%[dxouU] 后面有无效的字符"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: %s%% 后面有无效的字符"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...} 中语法错误"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部符合:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: 找不到用于写入的临时文件"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-替换"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 替换"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反向"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 插入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (插入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (替换)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (V-替换)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrew"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabic"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (语言)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (粘帖)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " 可视"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " 可视 行"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " 可视 块"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " 选择"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 选择 行"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 选择 块"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "记录中"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 无效的查找字符串: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 已查找到文件开头仍找不到 %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 已查找到文件结尾仍找不到 %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: 在 ';' 后面应该有 '?' 或 '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (包括上次列出符合项)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- 包含文件 "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "找不到 "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "在路径 ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (已列出)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  找不到"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "查找包含文件: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "查找包含的文件 %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 当前行匹配"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "所有包含文件都已找到"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "没有包含文件"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 找不到定义"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: 找不到 pattern"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 次替换，"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: 拼写文件格式错误"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: 已截断的拼写文件"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "%s 第 %d 行，多余的后续字符: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "%s 第 %d 行，附加项名字太长: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: 附加文件 FOL、LOW 或 UPP 中格式错误"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL、LOW 或 UPP 中字符超出范围"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "压缩单词树……"
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: 拼写检查未启用"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "警告: 找不到单词列表 \"%s.%s.spl\" or \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "读取拼写文件 \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: 这看起来不像是拼写文件"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 旧版本的拼写文件，需要更新"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: 为更高版本的 Vim 所用的拼写文件"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: 拼写文件中存在不支持的节"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "警告: 区域 %s 不支持"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "读取附加文件 %s ……"
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "单词 %s 转换失败，第 %d 行: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "不支持 %s 中的转换: 从 %s 到 %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "不支持 %s 中的转换"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 第 %d 行，FLAG 的值无效: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 第 %d 行，在使用标志后出现 FLAG: %s"
 
+#: ../spell.c:4723
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDWORDMAX 值: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDSYLMAX 值: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 CHECKCOMPOUNDPATTERN 值: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "%s 第 %d 行，在连续的附加块中出现不同的组合标志: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的附加项: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -4734,266 +5383,334 @@ msgstr ""
 "%s 第 %d 行，附加项被 BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST 使"
 "用: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s 第 %d 行，此处需要 Y 或 N: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的条件: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s 第 %d 行，此处需要 REP(SAL) 计数"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s 第 %d 行，此处需要 MAP 计数"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s 第 %d 行，MAP 中存在重复的字符"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s 第 %d 行，无法识别或重复的项: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s 中缺少 FOL/LOW/UPP 行"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "在没有 SYLLABLE 的情况下使用了 COMPOUNDSYLMAX"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "太多延迟前缀"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "太多组合标志"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "太多延迟前缀和/或组合标志"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "%s 中缺少 SOFO%s 行"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "%s 同时出现 SQL 和 SOFO 行"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s 第 %d 行，标志不是数字: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s 第 %d 行，无效的标志: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s 的值与另一个 .aff 文件中使用的值不相同"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "读取字典文件 %s ……"
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s 中没有单词计数"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "第 %6d 行，第 %6d 个单词 - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的单词: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "%s 第 %d 行，首次重复的单词: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "存在 %d 个重复的单词，在 %s 中"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "忽略了含有非 ASCII 字符的 %d 个单词，在 %s 中"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "读取单词文件 %s ……"
 
+#: ../spell.c:6155
 #, c-format
-#~ msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，单词后的 /encoding= 行已被忽略: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的 /regions= 行已被忽略: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s 第 %d 行，太多区域: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，/ 行已被忽略: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s 第 %d 行，无效的区域号: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s 第 %d 行，不可识别的标志: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "忽略了含有非 ASCII 字符的 %d 个单词"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "压缩了 %d/%d 个节点；剩余 %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "读取拼写文件……"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "正在 soundfolding……"
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "soundfolding 后的单词数: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "单词总数: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "写入建议文件 %s ……"
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "估计运行时内存用量: %d 字节"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 输出文件名不能含有区域名"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 最多只支持 8 个区域"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: %s 出现无效的范围"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "警告: 同时指定了 compounding 和 NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "写入拼写文件 %s ……"
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "完成！"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' 没有 %<PRId64> 项"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "从 %s 中删除了单词"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "向 %s 中添加了单词"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 拼写文件之间的字符不相同"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "抱歉，没有建议"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "抱歉，只有 %<PRId64> 条建议"
 
+#. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "将 \"%.*s\" 改为："
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: 之前没有拼写替换"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 找不到: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: 看起来不像是 .sug 文件: %s"
 
+#: ../spell.c:9282
 #, c-format
-#~ msgid "E779: Old .sug file, needs to be updated: %s"
-#~ msgstr ""
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
 
+#: ../spell.c:9286
 #, c-format
-#~ msgid "E780: .sug file is for newer version of Vim: %s"
-#~ msgstr ""
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
 
+#: ../spell.c:9295
 #, c-format
-#~ msgid "E781: .sug file doesn't match .spl file: %s"
-#~ msgstr ""
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
 
+#: ../spell.c:9305
 #, fuzzy, c-format
-#~ msgid "E782: error while reading .sug file: %s"
-#~ msgstr "E47: 读取错误文件失败"
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: 读取错误文件失败"
 
 #. This should have been checked when generating the .spl
-#. * file.
-#~ msgid "E783: duplicate char in MAP entry"
-#~ msgstr ""
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "这个缓冲区没有定义任何语法项"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 无效的参数: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 无此语法 cluster: \"%s\""
 
-msgid "No Syntax items defined for this buffer"
-msgstr "这个缓冲区没有定义任何语法项"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C风格注释同步中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "没有同步"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同步开始"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr "行号超出范围"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5001,6 +5718,7 @@ msgstr ""
 "\n"
 "--- 语法同步项目 (Syntax sync items) ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5008,6 +5726,7 @@ msgstr ""
 "\n"
 "同步中:"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5015,200 +5734,276 @@ msgstr ""
 "\n"
 "--- 语法项目 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 无此语法 cluster: \"%s\""
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "最小"
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "最大"
 
+#: ../syntax.c:3513
 #, fuzzy
-#~ msgid "; match "
-#~ msgstr "匹配 %d"
+msgid "; match "
+msgstr "匹配 %d"
 
+#: ../syntax.c:3515
 #, fuzzy
-#~ msgid " line breaks"
-#~ msgstr "少于一行"
+msgid " line breaks"
+msgstr "少于一行"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: 使用了不正确的参数"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: 使用了不正确的参数"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: 无效的参数"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: 使用了不正确的参数"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: 找不到 %s 的 region item"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: 需要文件名称"
 
-#, c-format
-msgid "E747: Missing ']': %s"
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 文件名过多"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
 msgstr "E747: 缺少 ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: 缺少 '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: syntax region %s 的参数太少"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 无此语法 cluster: \"%s\""
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: 没有指定的属性"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: 找不到分隔符号: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: '%s' 后面的东西不能识别"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 语法同步: 连接行符号指定了两次"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 无效的参数: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 缺少等号: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空的参数: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s 不能在此出现"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s 必须是列表里的第一个"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 不正确的组名: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 不正确的 :syntax 子命令: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: 加载 syncolor.vim 时出现嵌套循环"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: 找不到 highlight group: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 参数太少: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 参数过多: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: 已设定组, 忽略 highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 不该有的等号: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 缺少等号: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 缺少参数: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不合法的值: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 错误的前景颜色"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 错误的背景颜色"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: 错误的颜色名称或数值: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 终端编码太长: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 无效的参数: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 使用了太多不同的高亮度属性"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 组名中存在不可显示字符"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: 组名中含有无效字符"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: 已在 tag 堆栈底部"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: 已在 tag 堆栈顶部"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 已到第一个匹配的 tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: 找不到 tag: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "文件\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 只有一个匹配的 tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 己到最后一个匹配的 tag"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "文件 \"%s\" 不存在"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "找到 tag: %d / %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " 或更多"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  以不同大小写来使用 tag！"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: 文件 \"%s\" 不存在"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5216,59 +6011,79 @@ msgstr ""
 "\n"
 "  # 到 tag         从   行    在 文件/文本"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "查找 tag 文件 %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tag 文件路径被截断为 %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 文件 \"%s\" 格式错误"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "在第 %<PRId64> 字节之前"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag 文件未排序: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: 没有 tag 文件"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: 找不到 tag 模式"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: 找不到 tag，试着猜！"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "%s 第 %d 行，重复的附加项: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' 未知。可用的内建终端有:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "默认值为: '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: 无法打开 termcap 文件"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: 在 terminfo 中找不到终端项"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: 在 termcap 中找不到终端项"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap 中没有 \"%s\" 项"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 终端需要能力 \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5276,146 +6091,170 @@ msgstr ""
 "\n"
 "--- 终端按键 ---"
 
-msgid "new shell started\n"
-msgstr "启动新 shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 读错误，退出中...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "无法撤销；请继续"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: 意外地改变了缓冲区"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: 无法打开并写入文件"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "写入 viminfo 文件 \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: 交换文件写入错误"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "读取单词文件 %s ……"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: 无法打开并读取 viminfo 文件"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: 找不到: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: 无法打开文件 %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "结束执行 %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "已位于最旧的改变"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "已位于最新的改变"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "找不到撤销号 %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行号错误"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "行被加入"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "行被加入"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "行被去掉"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "行被去掉"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "行发生改变"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "行发生改变"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s；%s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "before"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "after"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "无可撤销"
 
-msgid "number changes  time"
-msgstr "  编号    改变  时间"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 列; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s 不能在此出现"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: 撤销列表损坏"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: 找不到要撤销的行"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 位图形界面版本"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 位图形界面版本"
-
-msgid " in Win32s mode"
-msgstr " Win32s 模式"
-
-msgid " with OLE support"
-msgstr " 带 OLE 支持"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 位控制台版本"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 位控制台版本"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 位 MS-DOS 版本"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 位 MS-DOS 版本"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版本"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版本"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版本"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS 版本"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5423,9 +6262,18 @@ msgstr ""
 "\n"
 "包含补丁: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "外部符合:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "修改者 "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5433,9 +6281,11 @@ msgstr ""
 "\n"
 "编译"
 
+#: ../version.c:649
 msgid "by "
 msgstr "者 "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5443,605 +6293,1559 @@ msgstr ""
 "\n"
 "巨型版本 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"大型版本 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"正常版本 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"小型版本 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"微型版本 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "无图形界面。"
 
-msgid "with GTK2-GNOME GUI."
-msgstr "带 GTK2-GNOME 图形界面。"
-
-msgid "with GTK-GNOME GUI."
-msgstr "带 GTK-GNOME 图形界面。"
-
-msgid "with GTK2 GUI."
-msgstr "带 GTK2 图形界面。"
-
-msgid "with GTK GUI."
-msgstr "带 GTK 图形界面。"
-
-msgid "with X11-Motif GUI."
-msgstr "带 X11-Motif 图形界面。"
-
-msgid "with X11-neXtaw GUI."
-msgstr "带 X11-neXtaw 图形界面。"
-
-msgid "with X11-Athena GUI."
-msgstr "带 X11-Athena 图形界面。"
-
-msgid "with Photon GUI."
-msgstr "带 Photon 图形界面。"
-
-msgid "with GUI."
-msgstr "带图形界面。"
-
-msgid "with Carbon GUI."
-msgstr "带 Carbon 图形界面。"
-
-msgid "with Cocoa GUI."
-msgstr "带 Cocoa 图形界面。"
-
-msgid "with (classic) GUI."
-msgstr "带(传统)图形界面。"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  可使用(+)与不可使用(-)的功能:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "     系统 vimrc 文件: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     用户 vimrc 文件: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 第二用户 vimrc 文件: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 第三用户 vimrc 文件: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      用户 exrc 文件: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  第二用户 exrc 文件: \""
 
-msgid "  system gvimrc file: \""
-msgstr "    系统 gvimrc 文件: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    用户 gvimrc 文件: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "第二用户 gvimrc 文件: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "第三用户 gvimrc 文件: \""
-
-msgid "    system menu file: \""
-msgstr "        系统菜单文件: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "         $VIM 预设值: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "  $VIMRUNTIME 预设值: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "编译方式: "
 
-msgid "Compiler: "
-msgstr "编译器: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "链接方式: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  调试版本"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "版本 "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "维护人 Bram Moolenaar 等"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim 是可自由分发的开放源代码软件"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "帮助乌干达的可怜儿童！"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "输入  :help iccf<Enter>       查看说明        "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "输入  :q<Enter>               退出            "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "输入  :help version7<Enter>   查看版本信息    "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "运行于 Vi 兼容模式"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "输入  :set nocp<Enter>        恢复默认的 Vim  "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "输入  :help cp-default<Enter> 查看相关说明    "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "菜单  Help->Orphans           查看说明           "
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr "赞助 Vim 的开发！"
 
-msgid "Running modeless, typed text is inserted"
-msgstr "无模式运行，输入文字即插入"
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr "成为 Vim 的注册用户！"
 
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "菜单  Edit->Global Settings->Toggle Insert Mode  "
+#: ../version.c:831
+msgid "type  :help sponsor<Enter>    for information "
+msgstr "输入  :help sponsor<Enter>    查看说明        "
+
+#: ../version.c:832
+msgid "type  :help register<Enter>   for information "
+msgstr "输入  :help register<Enter>   查看说明        "
+
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr "菜单  Help->Sponsor/Register  查看说明           "
+
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "已经只剩一个窗口了"
+
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: 没有预览窗口"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: 不能同时进行 topleft 和 botright 分割"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: 有其它分割窗口时不能旋转"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:2717
+msgid "E445: Other window contains changes"
+msgstr "E445: 其它窗口有改变的内容"
+
+#: ../window.c:4805
+msgid "E446: No file name under cursor"
+msgstr "E446: 光标处没有文件名"
+
+#~ msgid "Patch file"
+#~ msgstr "Patch 文件"
+
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "确定(&O)\n"
+#~ "取消(&C)"
+
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: 没有到 Vim 服务器的连接"
+
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: 无法发送到 %s"
+
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 无法读取服务器响应"
+
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 无法发送到客户端"
+
+#~ msgid "Save As"
+#~ msgstr "另存为"
+
+#~ msgid "Edit File"
+#~ msgstr "编辑文件"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (找不到)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "执行 Vim 脚本"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "在新窗口编辑文件"
+
+#~ msgid "Append File"
+#~ msgstr "追加文件"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "窗口位置: X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "保存重定向"
+
+#~ msgid "Save View"
+#~ msgstr "保存视图"
+
+#~ msgid "Save Session"
+#~ msgstr "保存会话"
+
+#~ msgid "Save Setup"
+#~ msgstr "保存设定"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 此版本无复合字符(digraph)"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "从标准输入读取..."
+
+#~ msgid "[NL found]"
+#~ msgstr "[找到 NL]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[已加密]"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans 不允许未修改的缓冲区写入"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeans 不允许缓冲区部分写入"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resource fork 会丢失 (请加 ! 强制执行)"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: 无法启动图形界面"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: 无法读取文件 \"%s\""
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 无法启动图形界面，找不到有效的字体"
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 无效的 'guifontwide'"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 的值无效"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: 无法分配颜色 %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "在光标处没有匹配，查找下一个"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<无法打开>"
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 无法获取字体 %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 无法返回当前目录"
+
+#~ msgid "Pathname:"
+#~ msgstr "路径:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 无法获取当前目录"
+
+#~ msgid "OK"
+#~ msgstr "确定"
+
+#~ msgid "Cancel"
+#~ msgstr "取消"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "滚动条部件: 无法获取滑块图像的几何大小"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Vim 对话框"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: 不能同时使用消息和回调函数来创建 BalloonEval"
+
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim 对话框..."
+
+#~ msgid "Input _Methods"
+#~ msgstr "输入法(_M)"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 查找和替换..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 查找..."
+
+#~ msgid "Find what:"
+#~ msgstr "查找内容:"
+
+#~ msgid "Replace with:"
+#~ msgstr "替换为:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "匹配完整的词"
+
+#~ msgid "Match case"
+#~ msgstr "匹配大小写"
+
+#~ msgid "Direction"
+#~ msgstr "方向"
+
+#~ msgid "Up"
+#~ msgstr "向上"
+
+#~ msgid "Down"
+#~ msgstr "向下"
+
+#~ msgid "Find Next"
+#~ msgstr "查找下一个"
+
+#~ msgid "Replace"
+#~ msgstr "替换"
+
+#~ msgid "Replace All"
+#~ msgstr "全部替换"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: 从会话管理器收到 \"die\" 请求\n"
+
+#~ msgid "Close"
+#~ msgstr "关闭"
+
+#~ msgid "New tab"
+#~ msgstr "新建标签"
+
+#~ msgid "Open Tab..."
+#~ msgstr "打开标签..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: 主窗口被意外地摧毁\n"
+
+#~ msgid "Font Selection"
+#~ msgstr "选择字体"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "使用 CUT_BUFFER0 来取代空选择"
+
+#~ msgid "&Filter"
+#~ msgstr "过滤(&F)"
+
+#~ msgid "&Cancel"
+#~ msgstr "取消(&C)"
+
+#~ msgid "Directories"
+#~ msgstr "目录"
+
+#~ msgid "Filter"
+#~ msgstr "过滤器"
+
+#~ msgid "&Help"
+#~ msgstr "帮助(&H)"
+
+#~ msgid "Files"
+#~ msgstr "文件"
+
+#~ msgid "&OK"
+#~ msgstr "确定(&O)"
+
+#~ msgid "Selection"
+#~ msgstr "选择"
+
+#~ msgid "Find &Next"
+#~ msgstr "查找下一个(&N)"
+
+#~ msgid "&Replace"
+#~ msgstr "替换(&R)"
+
+#~ msgid "Replace &All"
+#~ msgstr "全部替换(&A)"
+
+#~ msgid "&Undo"
+#~ msgstr "撤销(&U)"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: 找不到窗口标题 \"%s\""
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 不支持的参数: \"-%s\"；请使用 OLE 版本。"
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: 无法在 MDI 应用程序中打开窗口"
+
+#~ msgid "Close tab"
+#~ msgstr "关闭标签"
+
+#~ msgid "Open tab..."
+#~ msgstr "打开标签..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "查找字符串 (使用 '\\\\' 来查找 '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "查找和替换字符串 (使用 '\\\\' 来查找 '\\')"
+
+#~ msgid "Not Used"
+#~ msgstr "未使用"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "目录\t*.nothing\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 无法分配颜色表项，某些颜色可能不正确"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Fontset %s 缺少下列字符集的字体:"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Fontset 名称: %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "'%s' 不是固定宽度的字体"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Fontset 名称: %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "字体0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "字体1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "字体0的宽度：%<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "字体1的宽度: %<PRId64>\n"
+#~ "\n"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "指定了无效的字体"
+
+#~ msgid "&Dismiss"
+#~ msgstr "取消(&D)"
+
+#~ msgid "no specific match"
+#~ msgstr "找不到匹配的项"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - 字体选择器"
+
+#~ msgid "Name:"
+#~ msgstr "名称:"
+
+#~ msgid "Encoding:"
+#~ msgstr "编码:"
+
+#~ msgid "Font:"
+#~ msgstr "字体:"
+
+#~ msgid "Style:"
+#~ msgstr "风格:"
+
+#~ msgid "Size:"
+#~ msgstr "尺寸:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata 错误"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 错误"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: 无法打开 cscope 数据库: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: 无法获取 cscope 数据库信息"
+
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: 已达到 cscope 的最大连接数"
+
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr "???: 抱歉，此命令不可用，无法加载 MzScheme 库"
+
+#~ msgid "invalid expression"
+#~ msgstr "无效的表达式"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "编译时没有启用表达式"
+
+#~ msgid "hidden option"
+#~ msgstr "隐藏的选项"
+
+#~ msgid "unknown option"
+#~ msgstr "未知的选项"
+
+#~ msgid "window index is out of range"
+#~ msgstr "窗口索引超出范围"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "无法打开缓冲区"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "无法保存撤销信息"
+
+#~ msgid "cannot delete line"
+#~ msgstr "无法删除行"
+
+#~ msgid "cannot replace line"
+#~ msgstr "无法替换行"
+
+#~ msgid "cannot insert line"
+#~ msgstr "无法插入行"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "字符串不能包含换行(NL)"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim 错误: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim 错误"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "缓冲区无效"
+
+#~ msgid "window is invalid"
+#~ msgstr "窗口无效"
+
+#~ msgid "linenr out of range"
+#~ msgstr "行号超出范围"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "不允许在 sandbox 中使用"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr "E263: 抱歉，此命令不可用，无法加载 Python 库。"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: 不能递归调用 Python"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "不能删除 OutputObject 属性"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace 必须是整数"
+
+#~ msgid "invalid attribute"
+#~ msgstr "无效的属性"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() 需要字符串列表作参数"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: 初始化 I/O 对象出错"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "试图引用已被删除的缓冲区"
+
+#~ msgid "line number out of range"
+#~ msgstr "行号超出范围"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<缓冲区对象(已删除): %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "无效的标记名称"
+
+#~ msgid "no such buffer"
+#~ msgstr "无此缓冲区"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "试图引用已被删除的窗口"
+
+#~ msgid "readonly attribute"
+#~ msgstr "只读属性"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "光标位置在缓冲区外"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<窗口对象(已删除): %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<窗口对象(未知): %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<窗口 %d>"
+
+#~ msgid "no such window"
+#~ msgstr "无此窗口"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: 抱歉，此命令不可用，无法加载 Ruby 库"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知的 longjmp 状态 %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "切换实现/定义"
+
+#~ msgid "Show base class of"
+#~ msgstr "显示 base class of:"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "显示被覆盖的成员函数"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "恢复: 从文件"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "恢复: 从对象"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "恢复: 从所有项目"
+
+#~ msgid "Retrieve"
+#~ msgstr "恢复"
+
+#~ msgid "Show source of"
+#~ msgstr "显示源代码: "
+
+#~ msgid "Find symbol"
+#~ msgstr "查找 symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "浏览 class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "显示层次关系的类"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "显示 restricted 层次关系的 class"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref 参考到"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref 被谁参考:"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref 有"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref 被谁使用:"
+
+#~ msgid "Show docu of"
+#~ msgstr "显示文件: "
+
+#~ msgid "Generate docu for"
+#~ msgstr "产生文件: "
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "不能连接到 SNiFF+。请检查环境变量 ($PATH 里必需可以找到 sniffemacs)\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 读取错误. 取消连接"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ 目前"
+
+#~ msgid "not "
+#~ msgstr "未"
+
+#~ msgid "connected"
+#~ msgstr "连接中"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 不正确的 SNiff+ 调用: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: 连接到 SNiFF+ 失败"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: 未连接到 SNiFF+"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: 不是 SNiFF+ 的缓冲区"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 写入错误。结束连接"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "无效的缓冲区号"
+
+#~ msgid "not implemented yet"
+#~ msgstr "尚未实现"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "无法设定行"
+
+#~ msgid "mark not set"
+#~ msgstr "没有设定标记"
+
+#~ msgid "row %d column %d"
+#~ msgstr "第 %d 行 第 %d 列"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "无法插入/追加行"
+
+#~ msgid "unknown flag: "
+#~ msgstr "未知的标志: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "未知的 vim 选项"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "键盘中断"
+
+#~ msgid "vim error"
+#~ msgstr "vim 错误"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "无法创建缓冲区/窗口命令: 对象将被删除"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "无法注册回调命令: 缓冲区/窗口已被删除"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E280: TCL 严重错误: reflist 损坏！？请报告给 vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "无法注册回调命令: 找不到缓冲区/窗口引用"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: 抱歉，此命令不可用，无法加载 Tcl 库"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr "E281: TCL 错误: 退出返回值不是整数！？请报告给 vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 退出返回值 %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "无法获取行"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "无法注册命令服务器名"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248:  无法发送命令到目的程序"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 使用了无效的服务器 id: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 实例注册属性有误。已删除！"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "此 Vim 编译时没有加入 diff 功能"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: 错误: 无法从 NetBeans 中启动 gvim\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t注册此 gvim 到 OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\t取消 OLE 中的 gvim 注册"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\t使用图形界面 (同 \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  或  --nofork\t前台: 启动图形界面时不 fork"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose 等级"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t不使用 newcli 来打开窗口"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\t使用 <device> 进行输入输出"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t使用 <gvimrc> 替代任何 .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t编辑加密的文件"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t将 vim 与指定的 X-server 连接"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\t不连接到 X Server"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  同 --remote 但会等待文件完成编辑"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  同上，找不到服务器时不抱怨"
+
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr "--remote-tab <files>  同 --remote 但对每个文件打开一个标签页"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 服务器并退出"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t在 Vim 服务器上求 <expr> 的值并打印结果"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t列出可用的 Vim 服务器名称并退出"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t发送到或成为 Vim 服务器 <name>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (Motif 版本) 可识别的参数:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (neXtaw 版本) 可识别的参数:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (Athena 版本) 可识别的参数:\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t在 <display> 上运行 vim"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t启动后最小化"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\t读取 Resource 时把 vim 视为 <name>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (尚未实现)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t使用 <color> 作为背景色 (也可用 -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t使用 <color> 作为一般文字颜色 (也可用 -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t使用 <font> 作为一般字体 (也可用 -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t使用 <font> 作为粗体字体"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t使用 <font> 作为斜体字体"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t使用 <geom> 作为初始位置 (也可用 -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t设定边框宽度为 <width> (也可用 -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width> 设定滚动条宽度为 <width> (也可用 -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t设定菜单栏高度为 <height> (也可用 -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t使用反显 (也可用 -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t不使用反显 (也可用 +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t设定指定的资源"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (RISC OS 版本) 可识别的参数:\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <number>\t窗口初始宽度"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <number>\t窗口初始高度"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (GTK+ 版本) 可识别的参数:\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t在 <display> 上运行 vim (也可用 --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t设置用于区分主窗口的窗口角色名"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t在另一个 GTK 部件中打开 Vim"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\t在父应用程序中打开 Vim"
+
+#~ msgid "No display"
+#~ msgstr "没有 display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 发送失败。\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 发送失败。尝试本地执行\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d 中 %d 已编辑"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "没有 display: 发送表达式失败。\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 发送表达式失败。\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 无效的代码页"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: 无法创建输入上下文"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: 无法打开输入法"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: 无法设定输入法的释放回调函数"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 输入法不支持任何风格"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 输入法不支持我的预编辑类型"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: over-the-spot 风格需要 Fontset"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: 你的 GTK+ 比 1.2.3 旧。状态区不可用。"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: 输入法服务器未运行"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [不能在该版本的 Vim 上使用]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "撕下此菜单"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "选择目录对话框"
+
+#~ msgid "Save File dialog"
+#~ msgstr "保存文件对话框"
+
+#~ msgid "Open File dialog"
+#~ msgstr "打开文件对话框"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: 抱歉，控制台模式下没有文件浏览器"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: 正在保留文件……\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 结束。\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "错误: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 此行过长"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 无效的鼠标形状"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "输入密码: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "请再输入一次: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "两次密码不匹配！"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "无法连接到 Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "无法连接到 Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 连接信息文件中错误的访问模式: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "从 Netbeans 套接字读取"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: 求值功能不可用"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "释放了 %<PRId64> 行"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: 在图形界面中不能改变终端"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: 请用 \":gui\" 启动图形界面"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: 在 GTK+ 2 图形界面中不能更改"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 无效的字体"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 无法选择 Fontset"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 无效的 Fontset"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: 无法选择宽字体"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 无效的宽字体"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: 不支持鼠标"
+
+#~ msgid "cannot open "
+#~ msgstr "不能打开"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: 不能打开窗口!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "需要 Amigados 版本 2.04 以上\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "需要 %s 版本 %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "不能打开 NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "不能创建 "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim 返回值: %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "不能切换主控台(console)模式 !?\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 不是主控台(console)??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: 不能用 -f 选项执行 shell"
+
+#~ msgid "Cannot execute "
+#~ msgstr "不能执行 "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " 已返回\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE 太小"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 错误"
+
+#~ msgid "Message"
+#~ msgstr "消息"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' 不是 80, 不能执行外部命令"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: 选择打印机失败"
+
+#~ msgid "to %s on %s"
+#~ msgstr "从 %s 到 %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 未知的打印机字体: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 打印错误: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "打印 '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 字符集 \"%s\" 不能对应字体\"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 双重信号，退出中\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: 拦截到致命信号(deadly signal) %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 拦截到致命信号(deadly signal)\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "打开 X display 用时 %<PRId64> 秒"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X 错误\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "测试 X display 失败"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "打开 X display 超时"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法执行 shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法建立管道\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法 fork\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "命令已结束\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP 丢失了到 ICE 的连接"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "打开 X display 失败"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP 处理 save-yourself 请求"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP 打开连接"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE 连接监视失败"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection 调用失败: %s"
+
+#~ msgid "At line"
+#~ msgstr "在行号 "
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "无法加载 vim32.dll！"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM 错误"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "无法修正到 DLL 的函数指针!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "Shell 返回 %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: 拦截到 %s 事件\n"
+
+#~ msgid "close"
+#~ msgstr "关闭"
+
+#~ msgid "logoff"
+#~ msgstr "注消"
+
+#~ msgid "shutdown"
+#~ msgstr "关机"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 找不到命令"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "在你的 $PATH 中找不到 VIMRUN.EXE。\n"
+#~ "外部命令执行完毕后将不会暂停。\n"
+#~ "进一步说明请见 :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim 警告"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "不支持 %s 中的转换"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: 使用了不正确的参数"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag 文件路径被截断为 %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "启动新 shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "无法撤销；请继续"
+
+#~ msgid "number changes  time"
+#~ msgstr "  编号    改变  时间"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 位图形界面版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 位图形界面版本"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " Win32s 模式"
+
+#~ msgid " with OLE support"
+#~ msgstr " 带 OLE 支持"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 位控制台版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 位控制台版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 位 MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 位 MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "大型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "正常版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "小型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "微型版本 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "带 GTK2-GNOME 图形界面。"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "带 GTK-GNOME 图形界面。"
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "带 GTK2 图形界面。"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "带 GTK 图形界面。"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "带 X11-Motif 图形界面。"
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "带 X11-neXtaw 图形界面。"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "带 X11-Athena 图形界面。"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "带 Photon 图形界面。"
+
+#~ msgid "with GUI."
+#~ msgstr "带图形界面。"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "带 Carbon 图形界面。"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "带 Cocoa 图形界面。"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "带(传统)图形界面。"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "    系统 gvimrc 文件: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    用户 gvimrc 文件: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "第二用户 gvimrc 文件: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "第三用户 gvimrc 文件: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "        系统菜单文件: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "编译器: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "菜单  Help->Orphans           查看说明           "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "无模式运行，输入文字即插入"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "菜单  Edit->Global Settings->Toggle Insert Mode  "
 
 #, fuzzy
 #~ msgid "                              for two modes      "
 #~ msgstr " # pid    数据库名称                          prepend path\n"
 
-#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-#~ msgstr ""
-
 #, fuzzy
 #~ msgid "                              for Vim defaults   "
 #~ msgstr " # pid    数据库名称                          prepend path\n"
 
-msgid "Sponsor Vim development!"
-msgstr "赞助 Vim 的开发！"
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "警告: 检测到 Windows 95/98/ME"
 
-msgid "Become a registered Vim user!"
-msgstr "成为 Vim 的注册用户！"
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "输入  :help windows95<Enter>  查看相关说明    "
 
-msgid "type  :help sponsor<Enter>    for information "
-msgstr "输入  :help sponsor<Enter>    查看说明        "
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: 无法加载库 %s"
 
-msgid "type  :help register<Enter>   for information "
-msgstr "输入  :help register<Enter>   查看说明        "
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "抱歉，此命令不可用: 无法加载 Perl 库。"
 
-msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "菜单  Help->Sponsor/Register  查看说明           "
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "用多个 Vim 编辑(&M)"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "警告: 检测到 Windows 95/98/ME"
+#~ msgid "Edit with single &Vim"
+#~ msgstr "用单个 Vim 编辑(&V)"
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "输入  :help windows95<Enter>  查看相关说明    "
+#~ msgid "Diff with Vim"
+#~ msgstr "用 Vim 比较(diff)"
 
-msgid "Already only one window"
-msgstr "已经只剩一个窗口了"
+#~ msgid "Edit with &Vim"
+#~ msgstr "用 Vim 编辑(&V)"
 
-msgid "E441: There is no preview window"
-msgstr "E441: 没有预览窗口"
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "用当前的 Vim 编辑 - "
 
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: 不能同时进行 topleft 和 botright 分割"
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "用 Vim 编辑选中的文件"
 
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: 有其它分割窗口时不能旋转"
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "创建进程失败: 请检查 gvim 是否在路径中！"
 
-msgid "E444: Cannot close last window"
-msgstr "E444: 不能关闭最后一个窗口"
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 错误"
 
-msgid "E445: Other window contains changes"
-msgstr "E445: 其它窗口有改变的内容"
+#~ msgid "Path length too long!"
+#~ msgstr "路径太长！"
 
-msgid "E446: No file name under cursor"
-msgstr "E446: 光标处没有文件名"
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 未知的 Fontset: %s"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: 在路径中找不到文件 \"%s\""
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 未知的字体: %s"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: 无法加载库 %s"
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: 字体 \"%s\" 不是等宽字体"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "抱歉，此命令不可用: 无法加载 Perl 库。"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: 无法加载库函数 %s"
 
-#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-#~ msgstr ""
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: 无法使用 Hebrew: 编译时没有启用\n"
 
-msgid "Edit with &multiple Vims"
-msgstr "用多个 Vim 编辑(&M)"
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: 无法使用 Farsi: 编译时没有启用\n"
 
-msgid "Edit with single &Vim"
-msgstr "用单个 Vim 编辑(&V)"
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: 无法使用 Arabic: 编译时没有启用\n"
 
-msgid "Diff with Vim"
-msgstr "用 Vim 比较(diff)"
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
 
-msgid "Edit with &Vim"
-msgstr "用 Vim 编辑(&V)"
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: 无法打开 display"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "用当前的 Vim 编辑 - "
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 收到无效的表达式"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "用 Vim 编辑选中的文件"
-
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "创建进程失败: 请检查 gvim 是否在路径中！"
-
-msgid "gvimext.dll error"
-msgstr "gvimext.dll 错误"
-
-msgid "Path length too long!"
-msgstr "路径太长！"
-
-msgid "--No lines in buffer--"
-msgstr "--缓冲区无内容--"
-
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: 命令被中止"
-
-msgid "E471: Argument required"
-msgstr "E471: 需要参数"
-
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ 后面应该跟有 /、? 或 &"
-
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
-
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"
-
-msgid "E171: Missing :endif"
-msgstr "E171: 缺少 :endif"
-
-msgid "E600: Missing :endtry"
-msgstr "E600: 缺少 :endtry"
-
-msgid "E170: Missing :endwhile"
-msgstr "E170: 缺少 :endwhile"
-
-msgid "E170: Missing :endfor"
-msgstr "E170: 缺少 :endfor"
-
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile 缺少对应的 :while"
-
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor 缺少对应的 :for"
-
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 文件已存在 (请加 ! 强制执行)"
-
-msgid "E472: Command failed"
-msgstr "E472: 命令执行失败"
-
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 未知的 Fontset: %s"
-
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 未知的字体: %s"
-
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: 字体 \"%s\" 不是等宽字体"
-
-msgid "E473: Internal error"
-msgstr "E473: 内部错误"
-
-msgid "Interrupted"
-msgstr "已中断"
-
-msgid "E14: Invalid address"
-msgstr "E14: 无效的地址"
-
-msgid "E474: Invalid argument"
-msgstr "E474: 无效的参数"
-
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 无效的参数: %s"
-
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 无效的表达式: %s"
-
-msgid "E16: Invalid range"
-msgstr "E16: 无效的范围"
-
-msgid "E476: Invalid command"
-msgstr "E476: 无效的命令"
-
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" 是目录"
-
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 调用函数库 \"%s()\" 失败"
-
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: 无法加载库函数 %s"
-
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 标记的行号无效"
-
-msgid "E20: Mark not set"
-msgstr "E20: 没有设定标记"
-
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 不能修改，因为选项 'modifiable' 是关的"
-
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 脚本嵌套过深"
-
-msgid "E23: No alternate file"
-msgstr "E23: 没有交替文件"
-
-msgid "E24: No such abbreviation"
-msgstr "E24: 没有这个缩写"
-
-msgid "E477: No ! allowed"
-msgstr "E477: 不能使用 \"!\""
-
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: 无法使用图形界面: 编译时没有启用"
-
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: 无法使用 Hebrew: 编译时没有启用\n"
-
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: 无法使用 Farsi: 编译时没有启用\n"
-
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: 无法使用 Arabic: 编译时没有启用\n"
-
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 没有这个高亮群组名: %s"
-
-msgid "E29: No inserted text yet"
-msgstr "E29: 没有插入过文字"
-
-msgid "E30: No previous command line"
-msgstr "E30: 没有前一个命令行"
-
-msgid "E31: No such mapping"
-msgstr "E31: 没有这个映射"
-
-msgid "E479: No match"
-msgstr "E479: 没有匹配"
-
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 没有匹配: %s"
-
-msgid "E32: No file name"
-msgstr "E32: 没有文件名"
-
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 没有前一个替换正则表达式"
-
-msgid "E34: No previous command"
-msgstr "E34: 没有前一个命令"
-
-msgid "E35: No previous regular expression"
-msgstr "E35: 没有前一个正则表达式"
-
-msgid "E481: No range allowed"
-msgstr "E481: 不能使用范围"
-
-msgid "E36: Not enough room"
-msgstr "E36: 没有足够的空间"
-
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
-
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: 无法创建文件 %s"
-
-msgid "E483: Can't get temp file name"
-msgstr "E483: 无法获取临时文件名"
-
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: 无法打开文件 %s"
-
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: 无法读取文件 %s"
-
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 已修改但尚未保存 (可用 ! 强制执行)"
-
-msgid "E38: Null argument"
-msgstr "E38: 空的参数"
-
-msgid "E39: Number expected"
-msgstr "E39: 此处需要数字"
-
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 无法打开错误文件 %s"
-
-msgid "E233: cannot open display"
-msgstr "E233: 无法打开 display"
-
-msgid "E41: Out of memory!"
-msgstr "E41: 内存不足！"
-
-msgid "Pattern not found"
-msgstr "找不到模式"
-
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 找不到模式: %s"
-
-msgid "E487: Argument must be positive"
-msgstr "E487: 参数必须是正数"
-
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 无法回到前一个目录"
-
-msgid "E42: No Errors"
-msgstr "E42: 没有错误"
-
-msgid "E776: No location list"
-msgstr "E776: 没有 location 列表"
-
-msgid "E43: Damaged match string"
-msgstr "E43: 已损坏的匹配字符串"
-
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 已损坏的正则表达式程序"
-
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 已设定选项 'readonly' (请加 ! 强制执行)"
-
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 不能改变只读变量 \"%s\""
-
-#, c-format
-msgid "E46: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: 不能在 sandbox 中设定变量: \"%s\""
-
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 读取错误文件失败"
-
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: 不允许在 sandbox 中使用"
-
-msgid "E523: Not allowed here"
-msgstr "E523: 不允许在此使用"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 不支持设定屏幕模式"
-
-msgid "E49: Invalid scroll size"
-msgstr "E49: 无效的滚动大小"
-
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 选项 'shell' 为空"
-
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: 无法读取 sign 数据！"
-
-msgid "E72: Close error on swap file"
-msgstr "E72: 交换文件关闭错误"
-
-msgid "E73: tag stack empty"
-msgstr "E73: tag 堆栈为空"
-
-msgid "E74: Command too complex"
-msgstr "E74: 命令过复杂"
-
-msgid "E75: Name too long"
-msgstr "E75: 名字过长"
-
-msgid "E76: Too many ["
-msgstr "E76: [ 过多"
-
-msgid "E77: Too many file names"
-msgstr "E77: 文件名过多"
-
-msgid "E488: Trailing characters"
-msgstr "E488: 多余的尾部字符"
-
-msgid "E78: Unknown mark"
-msgstr "E78: 未知的标记"
-
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 无法扩展通配符"
-
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' 不能小于 'winminheight'"
-
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' 不能小于 'winminwidth'"
-
-msgid "E80: Error while writing"
-msgstr "E80: 写入出错"
-
-msgid "Zero count"
-msgstr "计数为零"
-
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: 在脚本环境外使用了 <SID>"
-
-msgid "E449: Invalid expression received"
-msgstr "E449: 收到无效的表达式"
-
-#~ msgid "E463: Region is guarded, cannot modify"
-#~ msgstr ""
-
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans 不允许改变只读文件"
-
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 内部错误: %s"
-
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: 表达式的内存使用超出 'maxmempattern'"
-
-msgid "E749: empty buffer"
-msgstr "E749: 空的缓冲区"
-
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 无效的搜索表达式或分隔符"
-
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 文件已在另一个缓冲区中被加载"
-
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: 没有设定选项 '%s'"
-
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "已查找到文件开头，再从结尾继续查找"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "已查找到文件结尾，再从开头继续查找"
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans 不允许改变只读文件"
 
 #~ msgid "Affix flags ignored when PFXPOSTPONE used in %s line %d: %s"
 #~ msgstr "%s 第 %d 行，使用 PFXPOSTPONE 时附加标志被忽略: %s"
@@ -6054,18 +7858,6 @@ msgstr "已查找到文件结尾，再从开头继续查找"
 
 #~ msgid "E106: Unknown variable: \"%s\""
 #~ msgstr "E106: 未定义的变量: \"%s\""
-
-#~ msgid "E119: Not enough arguments for function: %s"
-#~ msgstr "E119: 函数 %s 的参数太少"
-
-#~ msgid "E120: Using <SID> not in a script context: %s"
-#~ msgstr "E120: <SID> 不能在 script 上下文外使用: %s"
-
-#~ msgid "E123: Undefined function: %s"
-#~ msgstr "E123: 函数 %s 尚未定义"
-
-#~ msgid "E127: Cannot redefine function %s: It is in use"
-#~ msgstr "E127: 函数 %s 正在使用中，不能重新定义"
 
 #~ msgid "function "
 #~ msgstr "函数 "

--- a/src/nvim/po/zh_CN.po
+++ b/src/nvim/po/zh_CN.po
@@ -4,7 +4,7 @@
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
 # FIRST AUTHOR  Wang Jun <junw@turbolinux.com.cn>
-# 
+#
 # TRANSLATORS
 #   Edyfox <edyfox@gmail.com>
 #   Yuheng Xie <elephant@linux.net.cn>
@@ -15,146 +15,213 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Simplified Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-04-21 15:16+0800\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: 2006-04-21 14:00+0800\n"
 "Last-Translator: Yuheng Xie <elephant@linux.net.cn>\n"
 "Language-Team: Simplified Chinese <i18n-translation@lists.linux.net.cn>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=gb2312\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "选项参数后的内容无效"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr "[Location 列表]"
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr "[Quickfix 列表]"
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: 无法分配任何缓冲区，退出程序..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: 无法分配缓冲区，使用另一个缓冲区..."
 
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 没有释放任何缓冲区"
 
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 没有删除任何缓冲区"
 
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 没有清除任何缓冲区"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "释放了 1 个缓冲区"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "释放了 %d 个缓冲区"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "删除了 1 个缓冲区"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "删除了 %d 个缓冲区"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "清除了 1 个缓冲区"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "清除了 %d 个缓冲区"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 无法释放最后一个缓冲区"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 没有修改过的缓冲区"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: 没有可列出的缓冲区"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: 缓冲区 %<PRId64> 不存在"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 无法切换，已是最后一个缓冲区"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 无法切换，已是第一个缓冲区"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: 缓冲区 %<PRId64> 已修改但尚未保存 (请加 ! 强制执行)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 无法释放最后一个缓冲区"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 文件名过多"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: 找不到缓冲区 %<PRId64>"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: 找到不止一个 %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: 没有匹配的缓冲区 %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "第 %<PRId64> 行"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有缓冲区使用该名称"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [已修改]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未编辑]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新文件]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[读错误]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[只读]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[只读]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "%<PRId64> 行 --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64> / %<PRId64> --%d%%-- 列 "
 
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
 msgid "[No Name]"
 msgstr "[未命名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "帮助"
 
+#: ../buffer.c:3225 ../screen.c:4883
 msgid "[Help]"
 msgstr "[帮助]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[预览]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全部"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "底端"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "顶端"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -162,12 +229,11 @@ msgstr ""
 "\n"
 "# 缓冲区列表:\n"
 
-msgid "[Location List]"
-msgstr "[Location 列表]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[Quickfix List]"
-msgstr "[Quickfix 列表]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -175,127 +241,203 @@ msgstr ""
 "\n"
 "--- Signs ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s 的 Signs:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  id=%d  名称=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: 缺少冒号"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 无效的模式"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 此处需要数字"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 无效的百分比"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: 不能比较(diff) %<PRId64> 个以上的缓冲区"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: 无法打开 termcap 文件"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 无法创建 diff"
 
-msgid "Patch file"
-msgstr "Patch 文件"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: 无法读取 diff 的输出"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: 无法读取 diff 的输出"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 当前缓冲区不在 diff 模式"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: 没有其它处于 diff 模式的缓冲区"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 没有其它处于 diff 模式的缓冲区"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: 有两个以上的缓冲区处于 diff 模式，不能决定用哪一个"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: 找不到缓冲区 \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: 缓冲区 \"%s\" 不在 diff 模式"
 
+#: ../diff.c:2193
 msgid "E787: Buffer changed unexpectedly"
 msgstr "E787: 意外地改变了缓冲区"
 
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 复合字符(digraph)中不能使用 Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: 找不到 Keymap 文件"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: 不是在脚本文件中使用 :loadkeymap "
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " 关键字补全 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
+#: ../edit.c:83
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X 模式 (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 整行补全 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " 文件名补全 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " Tag 补全 (^]^N^P)"
 
+#: ../edit.c:88
 #, fuzzy
-#~ msgid " Path pattern completion (^N^P)"
-#~ msgstr " 路径模式补全 (^N^P)"
+msgid " Path pattern completion (^N^P)"
+msgstr " 路径模式补全 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定义补全 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Dictionary 补全 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus 补全 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " 命令行补全 (^V^N^P)"
 
+#: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
 msgstr " 用户自定义补全 (^U^N^P)"
 
+#: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
+#: ../edit.c:96
 msgid " Spelling suggestion (s^N^P)"
 msgstr " 拼写建议 (s^N^P)"
 
+#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " 关键字局部补全 (^N^P)"
 
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "已到段落结尾"
 
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
+
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "选项 'dictionary' 为空"
 
+#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "选项 'thesaurus' 为空"
 
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "正在扫描 dictionary: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (插入) Scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (替换) Scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "正在扫描: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "扫描标签."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 增加"
 
@@ -303,375 +445,585 @@ msgstr " 增加"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 查找中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "回到起点"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "另一行的词"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "唯一匹配"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "匹配 %d / %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "匹配 %d"
 
+#: ../eval.c:137
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: :let 中出现异常字符"
 
+#: ../eval.c:138
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
 msgstr "E684: List 索引超出范围: %<PRId64>"
 
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 未定义的变量: %s"
 
+#: ../eval.c:140
 msgid "E111: Missing ']'"
 msgstr "E111: 缺少 ']'"
 
+#: ../eval.c:141
 #, c-format
 msgid "E686: Argument of %s must be a List"
 msgstr "E686: %s 的参数必须是 List"
 
+#: ../eval.c:143
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
 msgstr "E712: %s 的参数必须是 List 或者 Dictionary"
 
+#: ../eval.c:144
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Dictionary 的键不能为空"
 
+#: ../eval.c:145
 msgid "E714: List required"
 msgstr "E714: 需要 List"
 
+#: ../eval.c:146
 msgid "E715: Dictionary required"
 msgstr "E715: 需要 Dictionary"
 
+#: ../eval.c:147
 #, c-format
 msgid "E118: Too many arguments for function: %s"
 msgstr "E118: 函数的参数过多: %s"
 
+#: ../eval.c:148
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
 msgstr "E716: Dictionary 中不存在键: %s"
 
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 函数 %s 已存在，请加 ! 强制替换"
 
+#: ../eval.c:151
 msgid "E717: Dictionary entry already exists"
 msgstr "E717: Dictionary 项已存在"
 
+#: ../eval.c:152
 msgid "E718: Funcref required"
 msgstr "E718: 需要 Funcref"
 
+#: ../eval.c:153
 msgid "E719: Cannot use [:] with a Dictionary"
 msgstr "E719: 不能对 Dictionary 使用 [:]"
 
+#: ../eval.c:154
 #, c-format
 msgid "E734: Wrong variable type for %s="
 msgstr "E734: %s= 的变量类型不正确"
 
+#: ../eval.c:155
 #, c-format
 msgid "E130: Unknown function: %s"
 msgstr "E130: 未知的函数: %s"
 
+#: ../eval.c:156
 #, c-format
 msgid "E461: Illegal variable name: %s"
 msgstr "E461: 无效的变量名: %s"
 
+#: ../eval.c:157
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: 将 List 作 String 使用"
+
+#: ../eval.c:1830
 msgid "E687: Less targets than List items"
 msgstr "E687: 目标比 List 项数少"
 
+#: ../eval.c:1834
 msgid "E688: More targets than List items"
 msgstr "E688: 目标比 List 项数多"
 
+#: ../eval.c:1906
 msgid "Double ; in list of variables"
 msgstr "变量列表中出现两个 ;"
 
+#: ../eval.c:2078
 #, c-format
 msgid "E738: Can't list variables for %s"
 msgstr "E738: 无法列出 %s 的变量"
 
+#: ../eval.c:2391
 msgid "E689: Can only index a List or Dictionary"
 msgstr "E689: 只能索引 List 或 Dictionary"
 
+#: ../eval.c:2396
 msgid "E708: [:] must come last"
 msgstr "E708: [:] 必须在最后"
 
+#: ../eval.c:2439
 msgid "E709: [:] requires a List value"
 msgstr "E709: [:] 需要一个 List 值"
 
+#: ../eval.c:2674
 msgid "E710: List value has more items than target"
 msgstr "E710: List 值的项比目标多"
 
+#: ../eval.c:2678
 msgid "E711: List value has not enough items"
 msgstr "E711: List 值没有足够多的项"
 
+#: ../eval.c:2867
 msgid "E690: Missing \"in\" after :for"
 msgstr "E690: :for 后缺少 \"in\""
 
+#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: 缺少括号: %s"
 
+#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: 无此变量: \"%s\""
 
+#: ../eval.c:3333
 msgid "E743: variable nested too deep for (un)lock"
 msgstr "E743: (un)lock 的变量嵌套过深"
 
+#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' 后缺少 ':'"
 
+#: ../eval.c:3893
 msgid "E691: Can only compare List with List"
 msgstr "E691: 只能比较 List 和 List"
 
+#: ../eval.c:3895
 msgid "E692: Invalid operation for Lists"
 msgstr "E692: 对 List 无效的操作"
 
+#: ../eval.c:3915
 msgid "E735: Can only compare Dictionary with Dictionary"
 msgstr "E735: 只能比较 Dictionary 和 Dictionary"
 
+#: ../eval.c:3917
 msgid "E736: Invalid operation for Dictionary"
 msgstr "E736: 对 Dictionary 无效的操作"
 
+#: ../eval.c:3932
 msgid "E693: Can only compare Funcref with Funcref"
 msgstr "E693: 只能比较 Funcref 和 Funcref"
 
+#: ../eval.c:3934
 msgid "E694: Invalid operation for Funcrefs"
 msgstr "E694: 对 Funcrefs 无效的操作"
 
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: 不能对 Dictionary 使用 [:]"
+
+#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: 缺少 ')'"
 
+#: ../eval.c:4609
 msgid "E695: Cannot index a Funcref"
 msgstr "E695: 不能索引一个 Funcref"
 
+#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: 缺少选项名称: %s"
 
+#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: 未知的选项: %s"
 
+#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: 缺少引号: %s"
 
+#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: 缺少引号: %s"
 
+#: ../eval.c:5084
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: List 中缺少逗号: %s"
 
+#: ../eval.c:5091
 #, c-format
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: List 缺少结束符 ']': %s"
 
+#: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
 msgstr "E720: Dictionary 中缺少冒号: %s"
 
+#: ../eval.c:6499
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
 msgstr "E721: Dictionary 中出现重复的键: \"%s\""
 
+#: ../eval.c:6517
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
 msgstr "E722: Dictionary 中缺少逗号: %s"
 
+#: ../eval.c:6524
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Dictionary 缺少结束符 '}': %s"
 
+#: ../eval.c:6555
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: 变量嵌套过深无法显示"
 
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: 函数的参数过多: %s"
+
+#: ../eval.c:7190
+#, fuzzy, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E118: 函数的参数过多: %s"
+
+#: ../eval.c:7377
+#, fuzzy, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E130: 未知的函数: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: 函数 %s 的参数太少"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> 不能在 script 上下文外使用: %s"
+
+#: ../eval.c:7391
+#, fuzzy, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E720: Dictionary 中缺少冒号: %s"
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: = 后面需要数字"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:7907
 msgid "E699: Too many arguments"
 msgstr "E699: 参数过多"
 
+#: ../eval.c:8073
 msgid "E785: complete() can only be used in Insert mode"
 msgstr "E785: complete() 只能在插入模式中使用"
 
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
+#: ../eval.c:8156
 msgid "&Ok"
 msgstr "确定(&O)"
 
+#: ../eval.c:8676
 #, c-format
 msgid "E737: Key already exists: %s"
 msgstr "E737: 键已存在: %s"
 
+#: ../eval.c:8692
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd 参数"
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:8916
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld 行: "
 
+#: ../eval.c:9291
 #, c-format
 msgid "E700: Unknown function: %s"
 msgstr "E700: 未知的函数: %s"
 
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"确定(&O)\n"
-"取消(&C)"
-
+#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() 的调用次数多于 inputsave()"
 
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:10841
 msgid "E786: Range not allowed"
 msgstr "E786: 不允许的范围"
 
+#: ../eval.c:11140
 msgid "E701: Invalid type for len()"
 msgstr "E701: len() 的类型无效"
 
+#: ../eval.c:11980
 msgid "E726: Stride is zero"
 msgstr "E726: 步长为零"
 
+#: ../eval.c:11982
 msgid "E727: Start past end"
 msgstr "E727: 起始值在终止值后"
 
+#: ../eval.c:12024 ../eval.c:15297
 msgid "<empty>"
 msgstr "<空>"
 
-msgid "E240: No connection to Vim server"
-msgstr "E240: 没有到 Vim 服务器的连接"
+#: ../eval.c:12282
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd 参数"
 
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: 无法发送到 %s"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: 无法读取服务器响应"
-
+#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: 符号连接过多(循环？)"
 
-msgid "E258: Unable to send to client"
-msgstr "E258: 无法发送到客户端"
+#: ../eval.c:12593
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c 参数"
 
+#: ../eval.c:13721
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c 参数"
+
+#: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: Sort 比较函数失败"
 
+#: ../eval.c:13806
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Sort 比较函数失败"
+
+#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(无效)"
 
+#: ../eval.c:14590
 msgid "E677: Error writing temp file"
 msgstr "E677: 写临时文件出错"
 
+#: ../eval.c:16159
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: 将 List 作数字使用"
+
+#: ../eval.c:16162
 msgid "E703: Using a Funcref as a Number"
 msgstr "E703: 将 Funcref 作数字使用"
 
+#: ../eval.c:16170
 msgid "E745: Using a List as a Number"
 msgstr "E745: 将 List 作数字使用"
 
+#: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 将 Dictionary 作数字使用"
 
+#: ../eval.c:16259
 msgid "E729: using Funcref as a String"
 msgstr "E729: 将 Funcref 作 String 使用"
 
+#: ../eval.c:16262
 msgid "E730: using List as a String"
 msgstr "E730: 将 List 作 String 使用"
 
+#: ../eval.c:16265
 msgid "E731: using Dictionary as a String"
 msgstr "E731: 将 Dictionary 作 String 使用"
 
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E704: Funcref 变量名必须以大写字母开头: %s"
-
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: 变量名与已有函数名冲突: %s"
-
+#: ../eval.c:16619
 #, c-format
 msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: 变量类型不匹配: %s"
 
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: 无法列出 %s 的变量"
+
+#: ../eval.c:16724
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funcref 变量名必须以大写字母开头: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: 变量名与已有函数名冲突: %s"
+
+#: ../eval.c:16763
 #, c-format
 msgid "E741: Value is locked: %s"
 msgstr "E741: 值已锁定: %s"
 
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
 msgid "Unknown"
 msgstr "未知"
 
+#: ../eval.c:16768
 #, c-format
 msgid "E742: Cannot change value of %s"
 msgstr "E742: 无法改变 %s 的值"
 
+#: ../eval.c:16838
 msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: 变量嵌套过深无法复制"
 
+#: ../eval.c:17249
+#, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E123: 函数 %s 尚未定义"
+
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: 缺少 '(': %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: 不能设定 IC 值"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 无效的参数: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E125: 无效的参数: %s"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: 缺少 :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E746: 函数名与脚本文件名不匹配: %s"
+
+#: ../eval.c:17549
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E127: 函数 %s 正在使用中，不能重新定义"
+
+#: ../eval.c:17604
 #, c-format
 msgid "E746: Function name does not match script file name: %s"
 msgstr "E746: 函数名与脚本文件名不匹配: %s"
 
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 需要函数名"
 
-#, c-format
-msgid "E128: Function name must start with a capital or contain a colon: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 函数名必须以大写字母开头或者包含冒号: %s"
 
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 函数名必须以大写字母开头或者包含冒号: %s"
+
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 无法删除函数 %s: 正在使用中"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 函数调用深度超出 'maxfuncdepth'"
 
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "调用 %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s 已中止"
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s 返回 #%<PRId64> "
 
+#: ../eval.c:18670
 #, c-format
 msgid "%s returning %s"
 msgstr "%s 返回 %s"
 
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "在 %s 中继续"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return 不在函数中"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -679,6 +1031,7 @@ msgstr ""
 "\n"
 "# 全局变量:\n"
 
+#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -686,79 +1039,110 @@ msgstr ""
 "\n"
 "\t最近修改于 "
 
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "没有包含文件"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  十六进制 %02x,  八进制 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 十六进制 %04x, 八进制 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 十六进制 %08x, 八进制 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 把行移动到自已中"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "移动了 1 行"
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "移动了 %<PRId64> 行"
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "过滤了 %<PRId64> 行"
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[已修改但尚未保存]\n"
 
 # bad to translate
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 位于行: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: 错误过多，忽略文件的剩余部分"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "读取 viminfo 文件 \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 信息"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " 标记"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "没有包含文件"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失败"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo 文件不可写入: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: 无法写入 viminfo 文件 %s！"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "写入 viminfo 文件 \"%s\""
 
 # do not translate to avoid writing Chinese in files
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, fuzzy, c-format
-#~ msgid "# This viminfo file was generated by Vim %s.\n"
-#~ msgstr "# 这个 viminfo 文件是由 Vim %s 生成的。\n"
+msgid "# This viminfo file was generated by Vim %s.\n"
+msgstr "# 这个 viminfo 文件是由 Vim %s 生成的。\n"
 
 # do not translate to avoid writing Chinese in files
-#, fuzzy, c-format
+#: ../ex_cmds.c:1722
+#, fuzzy
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -767,41 +1151,48 @@ msgstr ""
 "\n"
 
 # do not translate to avoid writing Chinese in files
-#, fuzzy, c-format
-#~ msgid "# Value of 'encoding' when this file was written\n"
-#~ msgstr "# 'encoding' 在此文件建立时的值\n"
+#: ../ex_cmds.c:1723
+#, fuzzy
+msgid "# Value of 'encoding' when this file was written\n"
+msgstr "# 'encoding' 在此文件建立时的值\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "无效的启动字符"
 
-msgid "Save As"
-msgstr "另存为"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "要写入部分文件吗？"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: 请使用 ! 来写入部分缓冲区"
 
+#: ../ex_cmds.c:2281
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "覆盖已存在的文件 \"%s\" 吗？"
 
+#: ../ex_cmds.c:2317
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "交换文件 \"%s\" 已存在，确实要覆盖吗？"
 
+#: ../ex_cmds.c:2326
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 交换文件已存在: %s (:silent! 强制执行)"
 
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: 缓冲区 %<PRId64> 没有文件名"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 文件未写入: 写入被 'write' 选项禁用"
 
+#: ../ex_cmds.c:2434
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -810,62 +1201,93 @@ msgstr ""
 "\"%s\" 已设定 'readonly' 选项。\n"
 "确实要覆盖吗？"
 
-msgid "Edit File"
-msgstr "编辑文件"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "只读 (请加 ! 强制执行)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: 自动命令意外地删除了新缓冲区 %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z 不接受非数字的参数"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim 中禁止使用 shell 命令"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正则表达式不能用字母作分界"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "替换为 %s (y/n/a/q/l/^E/^Y)？"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(已中断) "
 
+#: ../ex_cmds.c:4384
 msgid "1 match"
 msgstr "1 个匹配，"
 
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 次替换，"
 
+#: ../ex_cmds.c:4387
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> 个匹配，"
 
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> 次替换，"
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr "共 1 行"
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr "共 %<PRId64> 行"
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 不能递归执行"
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: global 缺少正则表达式"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "每行都匹配表达式: %s"
 
-# do not translate to avoid writing Chinese in files
+#: ../ex_cmds.c:4510
 #, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "找不到模式"
+
+# do not translate to avoid writing Chinese in files
+#: ../ex_cmds.c:4587
+#, fuzzy
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -875,263 +1297,335 @@ msgstr ""
 "# 最近的替换字符串:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 不要慌！"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 抱歉，没有 '%s' 的 %s 的说明"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 抱歉，没有 %s 的说明"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "抱歉，找不到帮助文件 \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: 不是目录: %s"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 无法打开并写入 %s"
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 无法打开并读取 %s"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 在一种语言中混合了多种帮助文件编码: %s"
 
+#: ../ex_cmds.c:5565
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Tag \"%s\" 在文件 %s/%s 中重复出现"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未知的 sign 命令: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: 缺少 sign 名称"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Signs 定义过多"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 无效的 sign 文字: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 未知的 sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: 缺少 sign 号"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 无效的缓冲区名: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 无效的 sign ID: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (找不到)"
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (不支持)"
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[已删除]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "进入调试模式。输入 \"cont\" 继续运行。"
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "第 %<PRId64> 行: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "命令: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "断点 \"%s%s\" 第 %<PRId64> 行"
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 找不到断点: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "没有定义断点"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  第 %<PRId64> 行"
 
-msgid "E750: First use :profile start <fname>"
+#: ../ex_cmds2.c:942
+#, fuzzy
+msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 请先使用 :profile start <fname>"
 
+#: ../ex_cmds2.c:1269
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "将改变保存到 \"%s\" 吗？"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "未命名"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: 缓冲区 \"%s\" 已修改但尚未保存"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "警告: 意外地进入了其它缓冲区 (请检查自动命令)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 只有一个文件可编辑"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 无法切换，已是第一个文件"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 无法切换，已是最后一个文件"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: 不支持编译器: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "正在查找 \"%s\"，在 \"%s\" 中"
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "正在查找 \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "在 'runtimepath' 中找不到 \"%s\""
 
-msgid "Source Vim script"
-msgstr "执行 Vim 脚本"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "不能执行目录: \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "不能执行 \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "第 %<PRId64> 行: 不能执行 \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "执行 \"%s\""
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "第 %<PRId64> 行: 执行 \"%s\""
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "结束执行 %s"
 
+#: ../ex_cmds2.c:2765
 msgid "modeline"
 msgstr "modeline"
 
+#: ../ex_cmds2.c:2767
 msgid "--cmd argument"
 msgstr "--cmd 参数"
 
+#: ../ex_cmds2.c:2769
 msgid "-c argument"
 msgstr "-c 参数"
 
+#: ../ex_cmds2.c:2771
 msgid "environment variable"
 msgstr "环境变量"
 
-#~ msgid "error handler"
-#~ msgstr ""
+#: ../ex_cmds2.c:2773
+msgid "error handler"
+msgstr ""
 
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 警告: 错误的行分隔符，可能是少了 ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: 在脚本文件外使用了 :scriptencoding"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: 在脚本文件外使用了 :finish"
 
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "当前的 %s语言: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 不能设定语言为 \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "进入 Ex 模式。输入 \"visual\" 回到正常模式。"
 
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: 已到文件末尾"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: 命令递归层数过多"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 异常没有被捕获: %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "脚本文件结束"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "函数结束"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: 不确定的用户自定义命令"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: 不是编辑器的命令"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 使用了逆向的范围"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "使用了逆向的范围，确定交换吗"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: 请使用 w 或 w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: 抱歉，命令在此版本中不可用"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: 只允许一个文件名"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "还有 1 个文件未编辑。确实要退出吗？"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "还有 %d 个文件未编辑。确实要退出吗？"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 还有 1 个文件未编辑"
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 还有 %<PRId64> 个文件未编辑"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已存在: 请加 ! 强制替换"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1139,275 +1633,339 @@ msgstr ""
 "\n"
 "    名称        参数 范围  补全      定义      "
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "找不到用户自定义命令"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 没有指定属性"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 无效的参数个数"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: 不能指定两次计数"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: 无效的计数默认值"
 
+#: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
 msgstr "E179: -complete 需要参数"
 
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 无效的属性: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 无效的命令名"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: 用户自定义命令必须以大写字母开头"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: 不确定的用户自定义命令"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: 没有这个用户自定义命令: %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: 无效的补全类型: %s"
 
+#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: 只有 custom 补全才允许参数"
 
+#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Custom 补全需要一个函数参数"
 
-#, c-format
-msgid "E185: Cannot find color scheme %s"
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: 找不到配色方案 %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "您好，Vim 用户！"
 
+#: ../ex_docmd.c:5431
 msgid "E784: Cannot close last tab page"
 msgstr "E784: 不能关闭最后一个 tab 页"
 
+#: ../ex_docmd.c:5462
 msgid "Already only one tab page"
 msgstr "已经只剩一个 tab 页了"
 
-msgid "Edit File in new window"
-msgstr "在新窗口编辑文件"
-
+#: ../ex_docmd.c:6004
 #, c-format
 msgid "Tab page %d"
 msgstr "Tab 页 %d"
 
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "无交换文件"
 
-msgid "Append File"
-msgstr "追加文件"
-
+#: ../ex_docmd.c:6478
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr "E747: 不能改变目录，缓冲区已修改 (请加 ! 强制执行)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 前一个目录不存在"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize 需要两个数字参数"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "窗口位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: 在此平台上不能获得窗口位置"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos 需要两个数字参数"
 
-msgid "Save Redirection"
-msgstr "保存重定向"
-
-msgid "Save View"
-msgstr "保存视图"
-
-msgid "Save Session"
-msgstr "保存会话"
-
-msgid "Save Setup"
-msgstr "保存设定"
-
+#: ../ex_docmd.c:7241
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: 无法创建目录: %s"
 
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" 已存在 (请加 ! 强制执行)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: 无法打开并写入 \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 参数必须是一个字母或者正/反引号"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal 递归层数过深"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: 没有用于替换 '#' 的交替文件名"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: 没有用于替换 \"<afile>\" 的自动命令文件名"
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: 没有用于替换 \"<abuf>\" 的自动命令缓冲区号"
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: 没有用于替换 \"<amatch>\" 的自动命令匹配名"
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: 没有用于替换 \"<sfile>\" 的 :source 文件名"
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: 没有用于替换 \"<sfile>\" 的 :source 文件名"
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%' 或 '#' 为空文件名，只能用于 \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 结果为空字符串"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: 无法打开并读取 viminfo 文件"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: 此版本无复合字符(digraph)"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 不能 :throw 前缀为 'Vim' 的异常"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "抛出异常: %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "完成异常: %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "丢弃异常: %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s，第 %<PRId64> 行"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "捕获异常: %s"
 
+#: ../ex_eval.c:676
 #, c-format
-#~ msgid "%s made pending"
-#~ msgstr ""
+msgid "%s made pending"
+msgstr ""
 
+#: ../ex_eval.c:679
 #, fuzzy, c-format
-#~ msgid "%s resumed"
-#~ msgstr " 已返回\n"
+msgid "%s resumed"
+msgstr " 已返回\n"
 
+#: ../ex_eval.c:683
 #, c-format
-#~ msgid "%s discarded"
-#~ msgstr ""
+msgid "%s discarded"
+msgstr ""
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "异常"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "错误和中断"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "错误"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "中断"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if 嵌套层数过深"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif 缺少对应的 :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else 缺少对应的 :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif 缺少对应的 :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 多个 :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif 在 :else 后面"
 
+#: ../ex_eval.c:941
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for 嵌套层数过深"
 
+#: ../ex_eval.c:1028
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue 缺少对应的 :while 或 :for"
 
+#: ../ex_eval.c:1061
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break 缺少对应的 :while 或 :for"
 
+#: ../ex_eval.c:1102
 msgid "E732: Using :endfor with :while"
 msgstr "E732: :while 以 :endfor 结尾"
 
+#: ../ex_eval.c:1104
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: :for 以 :endwhile 结尾"
 
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try 嵌套层数过深"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch 缺少对应的 :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch 在 :finally 后面"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally 缺少对应的 :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 多个 :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry 缺少对应的 :try"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction 不在函数内"
 
+#: ../ex_getln.c:1643
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: 目前不允许编辑别的缓冲区"
 
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E788: 目前不允许编辑别的缓冲区"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "tag 名"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " 类型 文件\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "选项 'history' 为零"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5046
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -1417,211 +1975,307 @@ msgstr ""
 "# %s 历史记录 (从新到旧):\n"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5047
 #, fuzzy
-#~ msgid "Command Line"
-#~ msgstr "命令行"
+msgid "Command Line"
+msgstr "命令行"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5048
 #, fuzzy
-#~ msgid "Search String"
-#~ msgstr "查找字符串"
+msgid "Search String"
+msgstr "查找字符串"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5049
 #, fuzzy
-#~ msgid "Expression"
-#~ msgstr "表达式"
+msgid "Expression"
+msgstr "表达式"
 
 # do not translate to avoid writing Chinese in files
+#: ../ex_getln.c:5050
 #, fuzzy
-#~ msgid "Input Line"
-#~ msgstr "输入行"
+msgid "Input Line"
+msgstr "输入行"
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar 超过命令长度"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: 活动窗口或缓冲区已被删除"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr "E343: 无效的路径: '**[number]' 必须在路径末尾或者后面接 '%s'。"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath 中找不到目录 \"%s\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: 在路径中找不到文件 \"%s\""
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: 在路径中找不到更多的文件 \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: 在路径中找不到更多的文件 \"%s\""
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "无效的文件名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "是目录"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "不是文件"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[新文件]"
 
+#: ../fileio.c:511
 msgid "[New DIRECTORY]"
 msgstr "[新目录]"
 
+#: ../fileio.c:529 ../fileio.c:532
 msgid "[File too big]"
 msgstr "[文件过大]"
 
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[权限不足]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre 自动命令导致文件不可读"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre 自动命令不允许改变当前缓冲区"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 从标准输入读取...\n"
 
-msgid "Reading from stdin..."
-msgstr "从标准输入读取..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 转换导致文件不可读"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[只读]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "1 个字符"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[缺少 CR]'"
 
-msgid "[NL found]"
-msgstr "[找到 NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[长行分割]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未转换]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[已转换]"
 
-msgid "[crypted]"
-msgstr "[已加密]"
-
+#: ../fileio.c:1831
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "[第 %<PRId64> 行转换错误]"
 
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[第 %<PRId64> 行无效字符]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[读错误]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "找不到用于转换的临时文件"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "'charconvert' 转换失败"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "无法读取 'charconvert' 的输出"
 
+#: ../fileio.c:2437
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: 找不到 acwrite 缓冲区对应的自动命令"
 
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: 自动命令删除或释放了要写入的缓冲区"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: 自动命令意外地改变了行数"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans 不允许未修改的缓冲区写入"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "NetBeans 不允许缓冲区部分写入"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "不是文件或可写的设备"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "只读 (请加 ! 强制执行)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: 无法写入备份文件 (请加 ! 强制执行)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: 关闭备份文件出错 (请加 ! 强制执行)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: 无法读取文件以供备份 (请加 ! 强制执行)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: 无法创建备份文件 (请加 ! 强制执行)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: 无法生成备份文件 (请加 ! 强制执行)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Resource fork 会丢失 (请加 ! 强制执行)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 找不到用于写入的临时文件"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 无法转换 (请加 ! 强制不转换写入)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: 无法打开并写入链接文件"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 无法打开并写入文件"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: 同步失败"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 关闭失败"
 
+#: ../fileio.c:3436
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 写入错误，转换失败 (请将 'fenc' 置空以强制执行)"
 
+#: ../fileio.c:3441
+#, fuzzy, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr "E513: 写入错误，转换失败 (请将 'fenc' 置空以强制执行)"
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 写入错误 (文件系统已满？)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " 转换错误"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "第 %<PRId64> 行"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[设备]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 已追加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 已写入"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patchmode: 无法保存原始文件"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Patchmode: 无法生成空的原始文件"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: 无法删除备份文件"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1629,105 +2283,134 @@ msgstr ""
 "\n"
 "警告: 原始文件可能已丢失或损坏\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "在文件正确写入前请勿退出编辑器！"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos 格式]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac 格式]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix 格式]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行，"
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行，"
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 个字符"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> 个字符"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[最后一行不完整]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 此文件自读入后已发生变动！！！"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "确实要写入吗"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: 写入文件 \"%s\" 出错"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: 关闭文件 \"%s\" 出错"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: 读取文件 \"%s\" 出错"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell 自动命令删除了缓冲区"
 
+#: ../fileio.c:4894
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: 文件 \"%s\" 已经不存在"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: 文件 \"%s\" 已变动，并且在 Vim 中的缓冲区也已变动"
 
+#: ../fileio.c:4907
 msgid "See \":help W12\" for more info."
 msgstr "进一步说明请见 \":help W12\""
 
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: 编辑开始后，文件 \"%s\" 已变动"
 
+#: ../fileio.c:4911
 msgid "See \":help W11\" for more info."
 msgstr "进一步说明请见 \":help W11\""
 
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: 编辑开始后，文件 \"%s\" 的模式已变动"
 
+#: ../fileio.c:4915
 msgid "See \":help W16\" for more info."
 msgstr "进一步说明请见 \":help W16\""
 
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: 编辑开始后，文件 \"%s\" 已被创建"
 
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1735,39 +2418,48 @@ msgstr ""
 "确定(&O)\n"
 "加载文件(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: 无法为重新加载 \"%s\" 做准备"
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: 无法重新加载 \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--已删除--"
 
+#: ../fileio.c:5732
 #, c-format
-#~ msgid "auto-removing autocommand: %s <buffer=%d>"
-#~ msgstr ""
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
 
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: 无此组: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * 后面有无效字符: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: 无此事件: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: 无此组或事件: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1775,565 +2467,797 @@ msgstr ""
 "\n"
 "--- 自动命令 ---"
 
+#: ../fileio.c:6293
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: 无效的缓冲区号 "
 
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 不能对所有事件执行自动命令"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "没有匹配的自动命令"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: 自动命令嵌套层数过深"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s 自动命令 \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "执行 %s"
 
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "自动命令 %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: 缺少 {。"
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: 缺少 }。"
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 找不到折叠"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 不能在当前的 'foldmethod' 下创建折叠"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 不能在当前的 'foldmethod' 下删除折叠"
 
+#: ../fold.c:1784
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--已折叠 %3ld 行"
 
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 添加到已读缓冲区中"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 递归映射"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: 全局缩写 %s 已存在"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: 全局映射 %s 已存在"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: 缩写 %s 已存在"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: 映射 %s 已存在"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "找不到缩写"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "找不到映射"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 无效的模式"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: 无法启动图形界面"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--缓冲区无内容--"
 
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: 命令被中止"
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 需要参数"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ 后面应该跟有 /、? 或 &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"
+
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: 缺少 :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: 缺少 :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: 缺少 :endwhile"
+
+#: ../globals.h:1006
+msgid "E170: Missing :endfor"
+msgstr "E170: 缺少 :endfor"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile 缺少对应的 :while"
+
+#: ../globals.h:1008
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor 缺少对应的 :for"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 文件已存在 (请加 ! 强制执行)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: 命令执行失败"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 内部错误"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "已中断"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 无效的地址"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 无效的参数"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: 无法读取文件 \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 无效的参数: %s"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 无法启动图形界面，找不到有效的字体"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 无效的 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' 的值无效"
-
+#: ../globals.h:1016
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: 无法分配颜色 %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 无效的表达式: %s"
 
-msgid "No match at cursor, finding next"
-msgstr "在光标处没有匹配，查找下一个"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 无效的范围"
 
-msgid "<cannot open> "
-msgstr "<无法打开>"
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 无效的命令"
 
+#: ../globals.h:1019
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: 无法获取字体 %s"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" 是目录"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 无法返回当前目录"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 无效的滚动大小"
 
-msgid "Pathname:"
-msgstr "路径:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 无法获取当前目录"
-
-msgid "OK"
-msgstr "确定"
-
-msgid "Cancel"
-msgstr "取消"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "滚动条部件: 无法获取滑块图像的几何大小"
-
-msgid "Vim dialog"
-msgstr "Vim 对话框"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: 不能同时使用消息和回调函数来创建 BalloonEval"
-
-msgid "Vim dialog..."
-msgstr "Vim 对话框..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"是(&Y)\n"
-"否(&N)\n"
-"取消(&C)"
 
-msgid "Input _Methods"
-msgstr "输入法(_M)"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 查找和替换..."
-
-msgid "VIM - Search..."
-msgstr "VIM - 查找..."
-
-msgid "Find what:"
-msgstr "查找内容:"
-
-msgid "Replace with:"
-msgstr "替换为:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "匹配完整的词"
-
-#. match case button
-msgid "Match case"
-msgstr "匹配大小写"
-
-msgid "Direction"
-msgstr "方向"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "向上"
-
-msgid "Down"
-msgstr "向下"
-
-msgid "Find Next"
-msgstr "查找下一个"
-
-msgid "Replace"
-msgstr "替换"
-
-msgid "Replace All"
-msgstr "全部替换"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: 从会话管理器收到 \"die\" 请求\n"
-
-msgid "Close"
-msgstr "关闭"
-
-msgid "New tab"
-msgstr "新建标签"
-
-msgid "Open Tab..."
-msgstr "打开标签..."
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: 主窗口被意外地摧毁\n"
-
-msgid "Font Selection"
-msgstr "选择字体"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "使用 CUT_BUFFER0 来取代空选择"
-
-msgid "&Filter"
-msgstr "过滤(&F)"
-
-msgid "&Cancel"
-msgstr "取消(&C)"
-
-msgid "Directories"
-msgstr "目录"
-
-msgid "Filter"
-msgstr "过滤器"
-
-msgid "&Help"
-msgstr "帮助(&H)"
-
-msgid "Files"
-msgstr "文件"
-
-msgid "&OK"
-msgstr "确定(&O)"
-
-msgid "Selection"
-msgstr "选择"
-
-msgid "Find &Next"
-msgstr "查找下一个(&N)"
-
-msgid "&Replace"
-msgstr "替换(&R)"
-
-msgid "Replace &All"
-msgstr "全部替换(&A)"
-
-msgid "&Undo"
-msgstr "撤销(&U)"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: 找不到窗口标题 \"%s\""
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 不支持的参数: \"-%s\"；请使用 OLE 版本。"
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: 无法在 MDI 应用程序中打开窗口"
-
-msgid "Close tab"
-msgstr "关闭标签"
-
-msgid "Open tab..."
-msgstr "打开标签..."
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "查找字符串 (使用 '\\\\' 来查找 '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "查找和替换字符串 (使用 '\\\\' 来查找 '\\')"
-
-#. We fake this: Use a filter that doesn't select anything and a default
-#. * file name that won't be used.
-msgid "Not Used"
-msgstr "未使用"
-
-msgid "Directory\t*.nothing\n"
-msgstr "目录\t*.nothing\n"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 无法分配颜色表项，某些颜色可能不正确"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Fontset %s 缺少下列字符集的字体:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: Fontset 名称: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "'%s' 不是固定宽度的字体"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: Fontset 名称: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "字体0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "字体1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "字体0的宽度：%<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"字体1的宽度: %<PRId64>\n"
-"\n"
 
-msgid "Invalid font specification"
-msgstr "指定了无效的字体"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 调用函数库 \"%s()\" 失败"
 
-msgid "&Dismiss"
-msgstr "取消(&D)"
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 标记的行号无效"
 
-msgid "no specific match"
-msgstr "找不到匹配的项"
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 没有设定标记"
 
-msgid "Vim - Font Selector"
-msgstr "Vim - 字体选择器"
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 不能修改，因为选项 'modifiable' 是关的"
 
-msgid "Name:"
-msgstr "名称:"
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 脚本嵌套过深"
 
-#. create toggle button
-#~ msgid "Show size in Points"
-#~ msgstr ""
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 没有交替文件"
 
-msgid "Encoding:"
-msgstr "编码:"
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: 没有这个缩写"
 
-msgid "Font:"
-msgstr "字体:"
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: 不能使用 \"!\""
 
-msgid "Style:"
-msgstr "风格:"
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: 无法使用图形界面: 编译时没有启用"
 
-msgid "Size:"
-msgstr "尺寸:"
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 没有这个高亮群组名: %s"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul automata 错误"
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: 没有插入过文字"
 
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 没有前一个命令行"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: 没有这个映射"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 没有匹配"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 没有匹配: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: 没有文件名"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 没有前一个替换正则表达式"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: 没有前一个命令"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 没有前一个正则表达式"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 不能使用范围"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: 没有足够的空间"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: 无法创建文件 %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 无法获取临时文件名"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: 无法打开文件 %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: 无法读取文件 %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 已修改但尚未保存 (可用 ! 强制执行)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[已修改但尚未保存]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 空的参数"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 此处需要数字"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 无法打开错误文件 %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: 内存不足！"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "找不到模式"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 找不到模式: %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 参数必须是正数"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 无法回到前一个目录"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: 没有错误"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr "E776: 没有 location 列表"
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 已损坏的匹配字符串"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: 已损坏的正则表达式程序"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 已设定选项 'readonly' (请加 ! 强制执行)"
+
+#: ../globals.h:1073
+#, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 不能改变只读变量 \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: 不能在 sandbox 中设定变量: \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 读取错误文件失败"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: 不允许在 sandbox 中使用"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: 不允许在此使用"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 不支持设定屏幕模式"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 无效的滚动大小"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 选项 'shell' 为空"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: 无法读取 sign 数据！"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: 交换文件关闭错误"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: tag 堆栈为空"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: 命令过复杂"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名字过长"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: [ 过多"
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: 文件名过多"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 多余的尾部字符"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 未知的标记"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 无法扩展通配符"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' 不能小于 'winminheight'"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' 不能小于 'winminwidth'"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 写入出错"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "计数为零"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: 在脚本环境外使用了 <SID>"
+
+#: ../globals.h:1102
+#, c-format
+msgid "E685: Internal error: %s"
+msgstr "E685: 内部错误: %s"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr "E363: 表达式的内存使用超出 'maxmempattern'"
+
+#: ../globals.h:1105
+msgid "E749: empty buffer"
+msgstr "E749: 空的缓冲区"
+
+#: ../globals.h:1108
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: 无效的搜索表达式或分隔符"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 文件已在另一个缓冲区中被加载"
+
+#: ../globals.h:1110
+#, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E764: 没有设定选项 '%s'"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 无效的寄存器名: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "已查找到文件开头，再从结尾继续查找"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "已查找到文件结尾，再从开头继续查找"
+
+#: ../hardcopy.c:240
 msgid "E550: Missing colon"
 msgstr "E550: 缺少冒号"
 
+#: ../hardcopy.c:252
 msgid "E551: Illegal component"
 msgstr "E551: 无效的部分"
 
+#: ../hardcopy.c:259
 msgid "E552: digit expected"
 msgstr "E552: 应该要有数字"
 
+#: ../hardcopy.c:473
 #, c-format
 msgid "Page %d"
 msgstr "第 %d 页"
 
+#: ../hardcopy.c:597
 msgid "No text to be printed"
 msgstr "没有要打印的文字"
 
+#: ../hardcopy.c:668
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "正在打印第 %d 页 (%d%%)"
 
+#: ../hardcopy.c:680
 #, c-format
 msgid " Copy %d of %d"
 msgstr "复制 %d / %d"
 
+#: ../hardcopy.c:733
 #, c-format
 msgid "Printed: %s"
 msgstr "已打印: %s"
 
+#: ../hardcopy.c:740
 msgid "Printing aborted"
 msgstr "打印中止"
 
+#: ../hardcopy.c:1365
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: 写入 PostScript 输出文件出错"
 
+#: ../hardcopy.c:1747
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: 无法打开文件 \"%s\""
 
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: 无法读取 PostScript 资源文件 \"%s\""
 
+#: ../hardcopy.c:1772
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: 文件 \"%s\" 不是 PostScript 资源文件"
 
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: 文件 \"%s\" 不是已支持的 PostScript 资源文件"
 
+#: ../hardcopy.c:1856
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" 资源文件版本不正确"
 
+#: ../hardcopy.c:2225
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: 不兼容的多字节编码和字符集。"
 
+#: ../hardcopy.c:2238
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset 在多字节编码下不能为空。"
 
+#: ../hardcopy.c:2254
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: 没有指定多字节打印的默认字体。"
 
+#: ../hardcopy.c:2426
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: 无法打开 PostScript 输出文件"
 
+#: ../hardcopy.c:2458
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: 无法打开文件 \"%s\""
 
+#: ../hardcopy.c:2583
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"prolog.ps\""
 
+#: ../hardcopy.c:2593
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"cidfont.ps\""
 
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: 找不到 PostScript 资源文件 \"%s.ps\""
 
+#: ../hardcopy.c:2654
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr "E620: 无法转换至打印编码 \"%s\""
 
+#: ../hardcopy.c:2877
 msgid "Sending to printer..."
 msgstr "发送到打印机……"
 
+#: ../hardcopy.c:2881
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: 无法打印 PostScript 文件"
 
+#: ../hardcopy.c:2883
 msgid "Print job sent."
 msgstr "打印任务已被发送。"
 
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "添加一个新的数据库"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "查询一个模式"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "显示此信息"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "结束一个连接"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "重置所有连接"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "显示连接"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 用法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "这个 cscope 命令不支持分割窗口。\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 用法: cstag <ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: 找不到 tag"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) 错误: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat 错误"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s 不是目录或有效的 cscope 数据库"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "添加了 cscope 数据库 %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: 读取 cscope 连接 %<PRId64> 出错"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 查找类型"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: 无法创建 cscope 管道"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: 无法对 cscope 进行 fork"
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection 执行失败"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection 执行失败"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: 无法生成 cscope 进程"
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen to_fp 失败"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen fr_fp 失败"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: 无法生成 cscope 进程"
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: 没有 cscope 连接"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: cscope 查询 %s %s 没有找到匹配的结果"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cscopequickfix 标志 %c 对 %c 无效"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: cscope 查询 %s %s 没有找到匹配的结果"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope 命令:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (用法: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: 无法打开 cscope 数据库: %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: 无法获取 cscope 数据库信息"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重复的 cscope 数据库未被加入"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: 已达到 cscope 的最大连接数"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: 找不到 cscope 连接 %s"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope 连接 %s 已关闭"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches 严重错误"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope tag: %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -2341,363 +3265,87 @@ msgstr ""
 "\n"
 "   #   行  "
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "文件名 / 上下文 / 行\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope 错误: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "所有 cscope 数据库已被重置"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "没有 cscope 连接\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    数据库名                            prepend path\n"
 
-msgid ""
-"???: Sorry, this command is disabled, the MzScheme library could not be "
-"loaded."
-msgstr "???: 抱歉，此命令不可用，无法加载 MzScheme 库"
-
-msgid "invalid expression"
-msgstr "无效的表达式"
-
-msgid "expressions disabled at compile time"
-msgstr "编译时没有启用表达式"
-
-msgid "hidden option"
-msgstr "隐藏的选项"
-
-msgid "unknown option"
-msgstr "未知的选项"
-
-msgid "window index is out of range"
-msgstr "窗口索引超出范围"
-
-msgid "couldn't open buffer"
-msgstr "无法打开缓冲区"
-
-msgid "cannot save undo information"
-msgstr "无法保存撤销信息"
-
-msgid "cannot delete line"
-msgstr "无法删除行"
-
-msgid "cannot replace line"
-msgstr "无法替换行"
-
-msgid "cannot insert line"
-msgstr "无法插入行"
-
-msgid "string cannot contain newlines"
-msgstr "字符串不能包含换行(NL)"
-
-msgid "Vim error: ~a"
-msgstr "Vim 错误: ~a"
-
-msgid "Vim error"
-msgstr "Vim 错误"
-
-msgid "buffer is invalid"
-msgstr "缓冲区无效"
-
-msgid "window is invalid"
-msgstr "窗口无效"
-
-msgid "linenr out of range"
-msgstr "行号超出范围"
-
-msgid "not allowed in the Vim sandbox"
-msgstr "不允许在 sandbox 中使用"
-
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr "E263: 抱歉，此命令不可用，无法加载 Python 库。"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: 不能递归调用 Python"
-
-msgid "can't delete OutputObject attributes"
-msgstr "不能删除 OutputObject 属性"
-
-msgid "softspace must be an integer"
-msgstr "softspace 必须是整数"
-
-msgid "invalid attribute"
-msgstr "无效的属性"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() 需要字符串列表作参数"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: 初始化 I/O 对象出错"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "试图引用已被删除的缓冲区"
-
-msgid "line number out of range"
-msgstr "行号超出范围"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<缓冲区对象(已删除): %8lX>"
-
-msgid "invalid mark name"
-msgstr "无效的标记名称"
-
-msgid "no such buffer"
-msgstr "无此缓冲区"
-
-msgid "attempt to refer to deleted window"
-msgstr "试图引用已被删除的窗口"
-
-msgid "readonly attribute"
-msgstr "只读属性"
-
-msgid "cursor position outside buffer"
-msgstr "光标位置在缓冲区外"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<窗口对象(已删除): %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<窗口对象(未知): %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<窗口 %d>"
-
-msgid "no such window"
-msgstr "无此窗口"
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: 抱歉，此命令不可用，无法加载 Ruby 库"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知的 longjmp 状态 %d"
-
-msgid "Toggle implementation/definition"
-msgstr "切换实现/定义"
-
-msgid "Show base class of"
-msgstr "显示 base class of:"
-
-msgid "Show overridden member function"
-msgstr "显示被覆盖的成员函数"
-
-msgid "Retrieve from file"
-msgstr "恢复: 从文件"
-
-msgid "Retrieve from project"
-msgstr "恢复: 从对象"
-
-msgid "Retrieve from all projects"
-msgstr "恢复: 从所有项目"
-
-msgid "Retrieve"
-msgstr "恢复"
-
-msgid "Show source of"
-msgstr "显示源代码: "
-
-msgid "Find symbol"
-msgstr "查找 symbol"
-
-msgid "Browse class"
-msgstr "浏览 class"
-
-msgid "Show class in hierarchy"
-msgstr "显示层次关系的类"
-
-msgid "Show class in restricted hierarchy"
-msgstr "显示 restricted 层次关系的 class"
-
-msgid "Xref refers to"
-msgstr "Xref 参考到"
-
-msgid "Xref referred by"
-msgstr "Xref 被谁参考:"
-
-msgid "Xref has a"
-msgstr "Xref 有"
-
-msgid "Xref used by"
-msgstr "Xref 被谁使用:"
-
-msgid "Show docu of"
-msgstr "显示文件: "
-
-msgid "Generate docu for"
-msgstr "产生文件: "
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr "不能连接到 SNiFF+。请检查环境变量 ($PATH 里必需可以找到 sniffemacs)\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 读取错误. 取消连接"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ 目前"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "连接中"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 不正确的 SNiff+ 调用: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: 连接到 SNiFF+ 失败"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: 未连接到 SNiFF+"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: 不是 SNiFF+ 的缓冲区"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 写入错误。结束连接"
-
-msgid "invalid buffer number"
-msgstr "无效的缓冲区号"
-
-msgid "not implemented yet"
-msgstr "尚未实现"
-
-#. ???
-msgid "cannot set line(s)"
-msgstr "无法设定行"
-
-msgid "mark not set"
-msgstr "没有设定标记"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "第 %d 行 第 %d 列"
-
-msgid "cannot insert/append line"
-msgstr "无法插入/追加行"
-
-msgid "unknown flag: "
-msgstr "未知的标志: "
-
-msgid "unknown vimOption"
-msgstr "未知的 vim 选项"
-
-msgid "keyboard interrupt"
-msgstr "键盘中断"
-
-msgid "vim error"
-msgstr "vim 错误"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "无法创建缓冲区/窗口命令: 对象将被删除"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "无法注册回调命令: 缓冲区/窗口已被删除"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr "E280: TCL 严重错误: reflist 损坏！？请报告给 vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "无法注册回调命令: 找不到缓冲区/窗口引用"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: 抱歉，此命令不可用，无法加载 Tcl 库"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: TCL 错误: 退出返回值不是整数！？请报告给 vim-dev@vim.org"
-
-#, c-format
-msgid "E572: exit code %d"
-msgstr "E572: 退出返回值 %d"
-
-msgid "cannot get line"
-msgstr "无法获取行"
-
-msgid "Unable to register a command server name"
-msgstr "无法注册命令服务器名"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248:  无法发送命令到目的程序"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 使用了无效的服务器 id: %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 实例注册属性有误。已删除！"
-
+#: ../main.c:144
 msgid "Unknown option argument"
 msgstr "未知的选项参数"
 
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "编辑参数过多"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "缺少必要的参数"
 
+#: ../main.c:150
 msgid "Garbage after option argument"
 msgstr "选项参数后的内容无效"
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "\"+command\"、\"-c command\" 或 \"--cmd command\" 参数过多"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "无效的参数"
 
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "还有 %d 个文件等待编辑\n"
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "此 Vim 编译时没有加入 diff 功能"
-
+#: ../main.c:1342
 msgid "Attempt to open script file again: \""
 msgstr "试图再次打开脚本文件: \""
 
+#: ../main.c:1350
 msgid "Cannot open for reading: \""
 msgstr "无法打开并读取: \""
 
+#: ../main.c:1393
 msgid "Cannot open for script output: \""
 msgstr "无法打开并输出脚本: \""
 
-msgid "Vim: Error: Failure to start gvim from NetBeans\n"
-msgstr "Vim: 错误: 无法从 NetBeans 中启动 gvim\n"
-
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 输出不是到终端(屏幕)\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 警告: 输入不是来自终端(键盘)\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc 命令行"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: 无法读取 \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2705,18 +3353,23 @@ msgstr ""
 "\n"
 "更多信息请见: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[文件 ..]       编辑指定的文件"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               从标准输入(stdin)读取文本"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          编辑 tag 定义处的文件"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  编辑第一个出错处的文件"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2726,9 +3379,11 @@ msgstr ""
 "\n"
 "用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr " vim [参数] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2736,9 +3391,7 @@ msgstr ""
 "\n"
 "  或:"
 
-#~ msgid "where case is ignored prepend / to make flag upper case"
-#~ msgstr ""
-
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2748,318 +3401,189 @@ msgstr ""
 "\n"
 "参数:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t在这以后只有文件名"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t不扩展通配符"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\t注册此 gvim 到 OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\t取消 OLE 中的 gvim 注册"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\t使用图形界面 (同 \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  或  --nofork\t前台: 启动图形界面时不 fork"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi 模式 (同 \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx 模式 (同 \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t安静(批处理)模式 (只能与 \"ex\" 一起使用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff 模式 (同 \"vimdiff\")"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\t容易模式 (同 \"evim\"，无模式)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t只读模式 (同 \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t限制模式 (同 \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t不可修改(写入文件)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t文本不可修改"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t二进制模式"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp 模式"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\t兼容传统的 Vi: 'compatible'"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\t不完全兼容传统的 Vi: 'nocompatible'"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tVerbose 等级"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t调试模式"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t不使用交换文件，只使用内存"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t列出交换文件并退出"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (跟文件名)\t\t恢复崩溃的会话"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t同 -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t不使用 newcli 来打开窗口"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\t使用 <device> 进行输入输出"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\t以 Arabic 模式启动"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\t以 Hebrew 模式启动"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\t以 Farsi 模式启动"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t设定终端类型为 <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t使用 <vimrc> 替代任何 .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t使用 <gvimrc> 替代任何 .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t不加载 plugin 脚本"
 
+#: ../main.c:2227
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-P[N]\t\t打开 N 个标签页 (默认值: 每个文件一个)"
 
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\t打开 N 个窗口 (默认值: 每个文件一个)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t同 -o 但垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t启动后跳到文件末尾"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t启动后跳到第 <lnum> 行"
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\t加载任何 vimrc 文件前执行 <command>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t加载第一个文件后执行 <command>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t加载第一个文件后执行文件 <session>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t从文件 <scriptin> 读入正常模式的命令"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t将所有输入的命令追加到文件 <scriptout>"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t将所有输入的命令写入到文件 <scriptout>"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t编辑加密的文件"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
 
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t将 vim 与指定的 X-server 连接"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\t不连接到 X Server"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  同 --remote 但会等待文件完成编辑"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  同上，找不到服务器时不抱怨"
-
-msgid "--remote-tab <files>  As --remote but open tab page for each file"
-msgstr "--remote-tab <files>  同 --remote 但对每个文件打开一个标签页"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 服务器并退出"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t在 Vim 服务器上求 <expr> 的值并打印结果"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t列出可用的 Vim 服务器名称并退出"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t发送到或成为 Vim 服务器 <name>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 取代 .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  或  --help\t打印帮助(本信息)并退出"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t打印版本信息并退出"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim (Motif 版本) 可识别的参数:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim (neXtaw 版本) 可识别的参数:\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim (Athena 版本) 可识别的参数:\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t在 <display> 上运行 vim"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t启动后最小化"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\t读取 Resource 时把 vim 视为 <name>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (尚未实现)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t使用 <color> 作为背景色 (也可用 -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t使用 <color> 作为一般文字颜色 (也可用 -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t使用 <font> 作为一般字体 (也可用 -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t使用 <font> 作为粗体字体"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t使用 <font> 作为斜体字体"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t使用 <geom> 作为初始位置 (也可用 -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t设定边框宽度为 <width> (也可用 -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width> 设定滚动条宽度为 <width> (也可用 -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t设定菜单栏高度为 <height> (也可用 -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t使用反显 (也可用 -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t不使用反显 (也可用 +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t设定指定的资源"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim (RISC OS 版本) 可识别的参数:\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <number>\t窗口初始宽度"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <number>\t窗口初始高度"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim (GTK+ 版本) 可识别的参数:\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t在 <display> 上运行 vim (也可用 --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t设置用于区分主窗口的窗口角色名"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t在另一个 GTK 部件中打开 Vim"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\t在父应用程序中打开 Vim"
-
-msgid "No display"
-msgstr "没有 display"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 发送失败。\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 发送失败。尝试本地执行\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "%d 中 %d 已编辑"
-
-msgid "No display: Send expression failed.\n"
-msgstr "没有 display: 发送表达式失败。\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 发送表达式失败。\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "没有设定标记"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: 没有匹配 \"%s\" 的标记"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3068,6 +3592,7 @@ msgstr ""
 "标记   行   列 文件/文本"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3076,6 +3601,7 @@ msgstr ""
 " 跳转   行   列 文件/文本"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -3083,7 +3609,7 @@ msgstr ""
 "\n"
 "  改变   行   列 文本"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3092,7 +3618,7 @@ msgstr ""
 "# 文件标记:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3100,7 +3626,7 @@ msgstr ""
 "\n"
 "# 跳转列表 (从新到旧):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3108,94 +3634,84 @@ msgstr ""
 "\n"
 "# 文件内的标记历史记录 (从新到旧):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "缺少 '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 无效的代码页"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: 不能设定 IC 值"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: 无法创建输入上下文"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: 无法打开输入法"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: 无法设定输入法的释放回调函数"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 输入法不支持任何风格"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 输入法不支持我的预编辑类型"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: over-the-spot 风格需要 Fontset"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: 你的 GTK+ 比 1.2.3 旧。状态区不可用。"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: 输入法服务器未运行"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: 块未被锁定"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: 交换文件读取定位错误"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: 交换文件读取错误"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: 交换文件写入定位错误"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: 交换文件写入错误"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: 交换文件已存在 (符号连接攻击？)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: 找不到块 0？"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: 找不到块 1？"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: 找不到块 2？"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: 噢，交换文件不见了！！！"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: 无法重命名交换文件"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: 无法打开 \"%s\" 的交换文件，恢复将不可能"
 
+#: ../memline.c:666
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): 找不到块 0？"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: 找不到 %s 的交换文件"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "请输入要使用的交换文件编号 (0 退出): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: 无法打开 %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "无法读取块 0: "
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3203,22 +3719,28 @@ msgstr ""
 "\n"
 "可能你没做过任何修改或是 Vim 还来不及更新交换文件。"
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " 不能在该版本的 Vim 中使用。\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "使用 Vim 3.0。\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s 看起来不像是 Vim 交换文件"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " 不能在这台电脑上使用。\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "此文件创建于 "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3226,78 +3748,100 @@ msgstr ""
 "，\n"
 "或是此文件已损坏。"
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "使用交换文件 \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原始文件 \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原始文件可能已被修改"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: 无法从 %s 读取块 1"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1065
 #, fuzzy
-#~ msgid "???MANY LINES MISSING"
-#~ msgstr "???缺少了太多行"
+msgid "???MANY LINES MISSING"
+msgstr "???缺少了太多行"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1076
 #, fuzzy
-#~ msgid "???LINE COUNT WRONG"
-#~ msgstr "???行数错误"
+msgid "???LINE COUNT WRONG"
+msgstr "???行数错误"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1082
 #, fuzzy
-#~ msgid "???EMPTY BLOCK"
-#~ msgstr "???空的块"
+msgid "???EMPTY BLOCK"
+msgstr "???空的块"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1103
 #, fuzzy
-#~ msgid "???LINES MISSING"
-#~ msgstr "???缺少了一些行"
+msgid "???LINES MISSING"
+msgstr "???缺少了一些行"
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: 块 1 ID 错误 (%s 不是交换文件？)"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1133
 #, fuzzy
-#~ msgid "???BLOCK MISSING"
-#~ msgstr "???缺少块"
+msgid "???BLOCK MISSING"
+msgstr "???缺少块"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1147
 #, fuzzy
-#~ msgid "??? from here until ???END lines may be messed up"
-#~ msgstr "??? 从这里到 ???END 的行可能已混乱"
+msgid "??? from here until ???END lines may be messed up"
+msgstr "??? 从这里到 ???END 的行可能已混乱"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1164
 #, fuzzy
-#~ msgid "??? from here until ???END lines may have been inserted/deleted"
-#~ msgstr "??? 从这里到 ???END 的行可能已被插入/删除过"
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr "??? 从这里到 ???END 的行可能已被插入/删除过"
 
 # do not translate to avoid writing Chinese in files
+#: ../memline.c:1181
 #, fuzzy
-#~ msgid "???END"
-#~ msgstr "???END"
+msgid "???END"
+msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: 恢复已被中断"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: 恢复时发生错误；请注意开头为 ??? 的行"
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "更多信息请见 \":help E312\""
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "恢复完毕。请确定一切正常。"
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3305,50 +3849,71 @@ msgstr ""
 "\n"
 "(你可能想要将这个文件另存为别的文件名\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "再运行 diff 与原文件比较以检查是否有改变)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "然后把 .swp 文件删掉。\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "找到交换文件:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   位于当前目录:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   使用指定的名字:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   位于目录 "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- 无 --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            所有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    日期: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              日期: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "         [来自 Vim 版本 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [不像是 Vim 交换文件]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "            文件名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3356,12 +3921,15 @@ msgstr ""
 "\n"
 "            修改过: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "是"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "否"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -3369,9 +3937,11 @@ msgstr ""
 "\n"
 "            用户名: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "      主机名: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -3379,6 +3949,7 @@ msgstr ""
 "\n"
 "            主机名: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -3386,16 +3957,11 @@ msgstr ""
 "\n"
 "           进程 ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (仍在运行)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [不能在该版本的 Vim 上使用]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3403,75 +3969,97 @@ msgstr ""
 "\n"
 "         [不能在本机上使用]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [无法读取]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [无法打开]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: 无法保留，没有交换文件"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "文件已保留"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 保留失败"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 无效的 lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 找不到第 %<PRId64> 行"
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指针块 id 错误 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx 应该是 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新了太多的块？"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: 指针块 id 错误 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "删除了块 1？"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 找不到第 %<PRId64> 行"
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指针块 id 错误"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count 为零"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行号超出范围: %<PRId64> 超出结尾"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: 块 %<PRId64> 行数错误"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "堆栈大小增加"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: 指针块 id 错误 2"
 
+#: ../memline.c:3070
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: \"%s\" 符号连接出现循环"
 
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3479,38 +4067,44 @@ msgstr ""
 "\n"
 "发现交换文件 \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "正在打开文件 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      比交换文件新！\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 另一个程序可能也在编辑同一个文件。\n"
 "    如果是这样，修改时请注意避免同一个文件产生两个不同的版本。\n"
 "\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    退出，或小心地继续。\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 上次编辑此文件时崩溃。\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    如果是这样，请用 \":recover\" 或 \"vim -r "
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3518,9 +4112,11 @@ msgstr ""
 "\"\n"
 "    恢复修改的内容 (请见 \":help recovery\")。\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    如果你已经进行了恢复，请删除交换文件 \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3528,18 +4124,23 @@ msgstr ""
 "\"\n"
 "    以避免再看到此消息。\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "交换文件 \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" 已存在！"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "交换文件已存在！"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3553,6 +4154,7 @@ msgstr ""
 "退出(&Q)\n"
 "中止(&A)"
 
+#: ../memline.c:3467
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3568,30 +4170,57 @@ msgstr ""
 "退出(&Q)\n"
 "中止(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: 找到太多交换文件"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: 菜单项的某部分路径不是子菜单"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: 菜单只在其它模式中存在"
 
+#: ../menu.c:64
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: 没有菜单 \"%s\""
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+#, fuzzy
+msgid "E792: Empty menu name"
+msgstr "E749: 空的缓冲区"
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: 菜单路径不能指向子菜单"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: 不能把菜单项直接加到菜单栏中"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 分隔线不能是菜单路径的一部分"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3599,60 +4228,73 @@ msgstr ""
 "\n"
 "--- 菜单 ---"
 
-msgid "Tear off this menu"
-msgstr "撕下此菜单"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: 菜单路径必须指向菜单项"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: 找不到菜单: %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s 模式中菜单未定义"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: 菜单路径必须指向子菜单"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: 找不到菜单 - 请检查菜单名称"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "处理 %s 时发生错误:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "第 %4ld 行:"
 
+#: ../message.c:617
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 无效的寄存器名: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "简体中文消息维护者: Yuheng Xie <elephant@linux.net.cn>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "已中断: "
 
+#: ../message.c:988
 msgid "Press ENTER or type command to continue"
 msgstr "请按 ENTER 或其它命令继续"
 
+#: ../message.c:1843
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s 第 %<PRId64> 行"
 
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 更多 --"
 
+#: ../message.c:2398
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr " 空格/d/j: 屏幕/页/行 下翻，b/u/k: 上翻，q: 退出 "
 
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "问题"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3660,6 +4302,17 @@ msgstr ""
 "是(&Y)\n"
 "否(&N)"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"是(&Y)\n"
+"否(&N)\n"
+"取消(&C)"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3673,257 +4326,177 @@ msgstr ""
 "全部丢弃(&D)\n"
 "取消(&C)"
 
-msgid "Select Directory dialog"
-msgstr "选择目录对话框"
-
-msgid "Save File dialog"
-msgstr "保存文件对话框"
-
-msgid "Open File dialog"
-msgstr "打开文件对话框"
-
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: 抱歉，控制台模式下没有文件浏览器"
-
+#: ../message.c:3058
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() 的参数不足"
 
+#: ../message.c:3119
+#, fuzzy
+msgid "E807: Expected Float argument for printf()"
+msgstr "E766: printf() 的参数不足"
+
+#: ../message.c:3873
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: printf() 的参数过多"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 警告: 正在修改一个只读文件"
 
-msgid "Type number or click with mouse (<Enter> cancels): "
+#: ../misc1.c:2537
+#, fuzzy
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr "请输入数字或点击鼠标 (<Enter> 取消): "
 
-msgid "Choice number (<Enter> cancels): "
+#: ../misc1.c:2539
+#, fuzzy
+msgid "Type number and <Enter> (empty cancels): "
 msgstr "请选择数字 (<Enter> 取消): "
 
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "多了 1 行"
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "少了 1 行"
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "多了 %<PRId64> 行"
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "少了 %<PRId64> 行"
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (已中断)"
 
+#: ../misc1.c:2635
 msgid "Beep!"
 msgstr "Beep!"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: 正在保留文件……\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 结束。\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "错误: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
-msgstr ""
-"\n"
-"[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 %<PRIu64>\n"
-
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 此行过长"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "调用 shell 执行: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: 缺少冒号"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 无效的模式"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 无效的鼠标形状"
-
-msgid "E548: digit expected"
-msgstr "E548: 此处需要数字"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 无效的百分比"
-
-msgid "Enter encryption key: "
-msgstr "输入密码: "
-
-msgid "Enter same key again: "
-msgstr "请再输入一次: "
-
-msgid "Keys don't match!"
-msgstr "两次密码不匹配！"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr "E343: 无效的路径: '**[number]' 必须在路径末尾或者后面接 '%s'。"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath 中找不到目录 \"%s\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: 在路径中找不到文件 \"%s\""
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: 在路径中找不到更多的文件 \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: 在路径中找不到更多的文件 \"%s\""
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "无法连接到 Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "无法连接到 Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans 连接信息文件中错误的访问模式: \"%s\""
-
-msgid "read from Netbeans socket"
-msgstr "从 Netbeans 套接字读取"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
-
-msgid "E505: "
-msgstr "E505: "
-
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E774: 'operatorfunc' 为空"
-
-msgid "E775: Eval feature not available"
-msgstr "E775: 求值功能不可用"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "警告: 你的终端不能显示高亮"
-
-msgid "E348: No string under cursor"
-msgstr "E348: 光标处没有字符串"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: 光标处没有识别字"
 
+#: ../normal.c:1866
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' 为空"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "警告: 你的终端不能显示高亮"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: 光标处没有字符串"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 不能在当前的 'foldmethod' 下删除 fold"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 改变列表为空"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 已在改变列表的开始处"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "输入  :quit<Enter>  退出 Vim"
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "1 行 %s 了 1 次"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "1 行 %s 了 %d 次"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行 %s 了 1 次"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行 %s 了 %d 次"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "缩进 %<PRId64> 行…… "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "缩进了 1 行 "
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "缩进了 %<PRId64> 行 "
 
+#: ../ops.c:938
 msgid "E748: No previously used register"
 msgstr "E748: 没有前一个使用的寄存器"
 
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "无法复制；改为删除"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "改变了 1 行"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "改变了 %<PRId64> 行"
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "释放了 %<PRId64> 行"
-
+#: ../ops.c:2521
 msgid "block of 1 line yanked"
 msgstr "复制了 1 行的块"
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "复制了 1 行"
 
+#: ../ops.c:2525
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "复制了 %<PRId64> 行的块"
 
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "复制了 %<PRId64> 行"
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: 寄存器 %s 里没有东西"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3931,10 +4504,11 @@ msgstr ""
 "\n"
 "--- 寄存器 ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "无效的寄存器名"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3942,155 +4516,194 @@ msgstr ""
 "\n"
 "# 寄存器:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的寄存器类型 %d"
 
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 列; "
 
-#, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字节"
-
+#: ../ops.c:5097
 #, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
-"Bytes"
-msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
-
-#, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字节"
-
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
-"%<PRId64>"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个"
-"字节"
+"选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/"
+"%<PRId64> 个字节"
 
+#: ../ops.c:5105
 #, c-format
-#~ msgid "(+%<PRId64> for BOM)"
-#~ msgstr ""
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/"
+"%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
 
-#~ msgid "%<%f%h%m%=Page %N"
-#~ msgstr ""
+#: ../ops.c:5123
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 "
+"%<PRId64>/%<PRId64> 个字节"
 
+#: ../ops.c:5133
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 "
+"%<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个字节"
+
+#: ../ops.c:5146
+#, c-format
+msgid "(+%<PRId64> for BOM)"
+msgstr ""
+
+#: ../option.c:1238
+msgid "%<%f%h%m%=Page %N"
+msgstr ""
+
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "感谢您选择 Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 未知的选项"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: 不支持该选项"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: 不允许在 modeline 中使用"
 
+#: ../option.c:2815
+msgid "E846: Key code not set"
+msgstr ""
+
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = 后面需要数字"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Termcap 里面找不到"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 无效的字符 <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 不能设定 'term' 为空字符串"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: 在图形界面中不能改变终端"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: 请用 \":gui\" 启动图形界面"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' 和 'patchmode' 相等"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: 在 GTK+ 2 图形界面中不能更改"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: 缺少冒号"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 字符串长度为零"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> 后面缺少数字"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: 缺少逗号"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: 必须指定一个 ' 值"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 包含不可显示字符或宽字符"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 无效的字体"
-
-msgid "E597: can't select fontset"
-msgstr "E597: 无法选择 Fontset"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 无效的 Fontset"
-
-msgid "E533: can't select wide font"
-msgstr "E533: 无法选择宽字体"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 无效的宽字体"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> 后面有无效的字符"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: 需要逗号"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' 必须为空或包含 %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: 不支持鼠标"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 没有结束的表达式序列"
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 项目过多"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: 错乱的组"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: 预览窗口已存在"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic 需要 UTF-8，请执行 ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 至少需要 %d 行"
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 至少需要 %d 列"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 未知的选项: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: = 后面需要数字"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4098,6 +4711,7 @@ msgstr ""
 "\n"
 "--- 终端编码 ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4105,6 +4719,7 @@ msgstr ""
 "\n"
 "--- 全局选项值 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4112,6 +4727,7 @@ msgstr ""
 "\n"
 "--- 局部选项值 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4119,126 +4735,21 @@ msgstr ""
 "\n"
 "--- 选项 ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp 错误"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': 找不到 %s 对应的字符"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': 分号后有多余的字符: %s"
 
-msgid "cannot open "
-msgstr "不能打开"
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: 不能打开窗口!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "需要 Amigados 版本 2.04 以上\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "需要 %s 版本 %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "不能打开 NIL:\n"
-
-msgid "Cannot create "
-msgstr "不能创建 "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim 返回值: %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "不能切换主控台(console)模式 !?\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: 不是主控台(console)??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: 不能用 -f 选项执行 shell"
-
-msgid "Cannot execute "
-msgstr "不能执行 "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " 已返回\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE 太小"
-
-msgid "I/O ERROR"
-msgstr "I/O 错误"
-
-msgid "Message"
-msgstr "消息"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' 不是 80, 不能执行外部命令"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: 选择打印机失败"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "从 %s 到 %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 未知的打印机字体: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 打印错误: %s"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "打印 '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 字符集 \"%s\" 不能对应字体\"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 双重信号，退出中\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: 拦截到致命信号(deadly signal) %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 拦截到致命信号(deadly signal)\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "打开 X display 用时 %<PRId64> 秒"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X 错误\n"
-
-msgid "Testing the X display failed"
-msgstr "测试 X display 失败"
-
-msgid "Opening the X display timed out"
-msgstr "打开 X display 超时"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4246,13 +4757,7 @@ msgstr ""
 "\n"
 "无法执行 shell"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"无法执行 shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -4260,472 +4765,616 @@ msgstr ""
 "\n"
 "Shell 已返回"
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"无法建立管道\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"无法 fork\n"
-
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"命令已结束\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP 丢失了到 ICE 的连接"
 
 # do not translate
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-msgid "Opening the X display failed"
-msgstr "打开 X display 失败"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP 处理 save-yourself 请求"
-
-msgid "XSMP opening connection"
-msgstr "XSMP 打开连接"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE 连接监视失败"
-
+#: ../path.c:1449
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection 调用失败: %s"
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: 在路径中找不到文件 \"%s\""
 
-msgid "At line"
-msgstr "在行号 "
-
-msgid "Could not load vim32.dll!"
-msgstr "无法加载 vim32.dll！"
-
-msgid "VIM Error"
-msgstr "VIM 错误"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "无法修正到 DLL 的函数指针!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "Shell 返回 %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: 拦截到 %s 事件\n"
-
-msgid "close"
-msgstr "关闭"
-
-msgid "logoff"
-msgstr "注消"
-
-msgid "shutdown"
-msgstr "关机"
-
-msgid "E371: Command not found"
-msgstr "E371: 找不到命令"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
-msgstr ""
-"在你的 $PATH 中找不到 VIMRUN.EXE。\n"
-"外部命令执行完毕后将不会暂停。\n"
-"进一步说明请见 :help win32-vimrun"
-
-msgid "Vim Warning"
-msgstr "Vim 警告"
-
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: 格式化字符串里有太多 %%%c "
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: 格式化字符串不应该出现 %%%c "
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: 格式化字符串里少了 ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: 格式化字符串里有不支持的 %%%c "
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: 格式化字符串开头里有不正确的 %%%c "
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: 格式化字符串里有不正确的 %%%c "
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' 未设定"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: 找不到目录名称或是空的目录名称"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 没有更多的项"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d / %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行已删除)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Quickfix 堆栈底端"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Quickfix 堆栈顶端"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "错误列表 %d / %d；共 %d 个错误"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 无法写入，已设定选项 'buftype'"
 
+#: ../quickfix.c:2812
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: 缺少文件名或模式无效"
 
+#: ../quickfix.c:2911
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "无法打开文件 \"%s\""
 
+#: ../quickfix.c:3429
 msgid "E681: Buffer is not loaded"
 msgstr "E681: 缓冲区未加载"
 
+#: ../quickfix.c:3487
 msgid "E777: String or List expected"
 msgstr "E777: 此处需要 String 或者 List"
 
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: %s%%[] 中有无效的项"
 
-msgid "E339: Pattern too long"
-msgstr "E339: 模式太长"
-
-msgid "E50: Too many \\z("
-msgstr "E50: 太多 \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: 太多 %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: 不匹配的 \\z("
-
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: 不匹配的 %s%%("
-
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: 不匹配的 %s("
-
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: 不匹配的 %s)"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: %s@ 后面有无效的字符"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: 太多复杂的 %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: 嵌套的 %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: 嵌套的 %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: 不正确地使用 \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 前面无内容"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: 无效的回引"
-
-msgid "E66: \\z( not allowed here"
-msgstr "E66: 此处不允许 \\z("
-
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: 此处不允许 \\z1 等"
-
-msgid "E68: Invalid character after \\z"
-msgstr "E68: \\z 后面有无效的字符"
-
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: %s%%[ 后缺少 ]"
-
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: 空的 %s%%[]"
-
-#, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E678: %s%%[dxouU] 后面有无效的字符"
-
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: %s%% 后面有无效的字符"
-
+#: ../regexp.c:374
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: %s[ 后缺少 ]"
 
+#: ../regexp.c:375
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: 不匹配的 %s%%("
+
+#: ../regexp.c:376
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: 不匹配的 %s("
+
+#: ../regexp.c:377
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: 不匹配的 %s)"
+
+#: ../regexp.c:378
+msgid "E66: \\z( not allowed here"
+msgstr "E66: 此处不允许 \\z("
+
+#: ../regexp.c:379
+msgid "E67: \\z1 et al. not allowed here"
+msgstr "E67: 此处不允许 \\z1 等"
+
+#: ../regexp.c:380
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ 后缺少 ]"
+
+#: ../regexp.c:381
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: 空的 %s%%[]"
+
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: 模式太长"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: 太多 %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: 不匹配的 \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: %s@ 后面有无效的字符"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: 太多复杂的 %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: 嵌套的 %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: 嵌套的 %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: 不正确地使用 \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 前面无内容"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: 无效的回引"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: \\z 后面有无效的字符"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: %s%%[dxouU] 后面有无效的字符"
+
+#: ../regexp.c:2107
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: %s%% 后面有无效的字符"
+
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: %s{...} 中语法错误"
 
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部符合:\n"
 
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
+
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: 找不到用于写入的临时文件"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-替换"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 替换"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反向"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 插入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (插入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (替换)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (V-替换)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrew"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabic"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (语言)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (粘帖)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " 可视"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " 可视 行"
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " 可视 块"
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " 选择"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 选择 行"
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 选择 块"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "记录中"
 
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 无效的查找字符串: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 已查找到文件开头仍找不到 %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 已查找到文件结尾仍找不到 %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: 在 ';' 后面应该有 '?' 或 '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (包括上次列出符合项)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- 包含文件 "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "找不到 "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "在路径 ---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (已列出)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  找不到"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "查找包含文件: %s"
 
+#: ../search.c:4216
 #, c-format
 msgid "Searching included file %s"
 msgstr "查找包含的文件 %s"
 
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 当前行匹配"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "所有包含文件都已找到"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "没有包含文件"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 找不到定义"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: 找不到 pattern"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "1 次替换，"
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
 msgid "E759: Format error in spell file"
 msgstr "E759: 拼写文件格式错误"
 
+#: ../spell.c:952
 msgid "E758: Truncated spell file"
 msgstr "E758: 已截断的拼写文件"
 
+#: ../spell.c:953
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "%s 第 %d 行，多余的后续字符: %s"
 
+#: ../spell.c:954
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "%s 第 %d 行，附加项名字太长: %s"
 
+#: ../spell.c:955
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: 附加文件 FOL、LOW 或 UPP 中格式错误"
 
+#: ../spell.c:957
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: FOL、LOW 或 UPP 中字符超出范围"
 
+#: ../spell.c:958
 msgid "Compressing word tree..."
 msgstr "压缩单词树……"
 
+#: ../spell.c:1951
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: 拼写检查未启用"
 
+#: ../spell.c:2249
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr "警告: 找不到单词列表 \"%s.%s.spl\" or \"%s.ascii.spl\""
 
+#: ../spell.c:2473
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "读取拼写文件 \"%s\""
 
+#: ../spell.c:2496
 msgid "E757: This does not look like a spell file"
 msgstr "E757: 这看起来不像是拼写文件"
 
+#: ../spell.c:2501
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: 旧版本的拼写文件，需要更新"
 
+#: ../spell.c:2504
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: 为更高版本的 Vim 所用的拼写文件"
 
+#: ../spell.c:2602
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: 拼写文件中存在不支持的节"
 
+#: ../spell.c:3762
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "警告: 区域 %s 不支持"
 
+#: ../spell.c:4550
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "读取附加文件 %s ……"
 
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "单词 %s 转换失败，第 %d 行: %s"
 
+#: ../spell.c:4630 ../spell.c:6170
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "不支持 %s 中的转换: 从 %s 到 %s"
 
-#, c-format
-msgid "Conversion in %s not supported"
-msgstr "不支持 %s 中的转换"
-
+#: ../spell.c:4642
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "%s 第 %d 行，FLAG 的值无效: %s"
 
+#: ../spell.c:4655
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "%s 第 %d 行，在使用标志后出现 FLAG: %s"
 
+#: ../spell.c:4723
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4731
 #, c-format
-#~ msgid ""
-#~ "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-#~ "%d"
-#~ msgstr ""
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
 
+#: ../spell.c:4747
+#, fuzzy, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
+
+#: ../spell.c:4771
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDWORDMAX 值: %s"
 
+#: ../spell.c:4777
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
 
+#: ../spell.c:4783
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 COMPOUNDSYLMAX 值: %s"
 
+#: ../spell.c:4795
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的 CHECKCOMPOUNDPATTERN 值: %s"
 
+#: ../spell.c:4847
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr "%s 第 %d 行，在连续的附加块中出现不同的组合标志: %s"
 
+#: ../spell.c:4850
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的附加项: %s"
 
+#: ../spell.c:4871
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -4734,266 +5383,334 @@ msgstr ""
 "%s 第 %d 行，附加项被 BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST 使"
 "用: %s"
 
+#: ../spell.c:4893
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "%s 第 %d 行，此处需要 Y 或 N: %s"
 
+#: ../spell.c:4968
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "%s 第 %d 行，错误的条件: %s"
 
+#: ../spell.c:5091
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "%s 第 %d 行，此处需要 REP(SAL) 计数"
 
+#: ../spell.c:5120
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "%s 第 %d 行，此处需要 MAP 计数"
 
+#: ../spell.c:5132
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "%s 第 %d 行，MAP 中存在重复的字符"
 
+#: ../spell.c:5176
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "%s 第 %d 行，无法识别或重复的项: %s"
 
+#: ../spell.c:5197
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "%s 中缺少 FOL/LOW/UPP 行"
 
+#: ../spell.c:5220
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "在没有 SYLLABLE 的情况下使用了 COMPOUNDSYLMAX"
 
+#: ../spell.c:5236
 msgid "Too many postponed prefixes"
 msgstr "太多延迟前缀"
 
+#: ../spell.c:5238
 msgid "Too many compound flags"
 msgstr "太多组合标志"
 
+#: ../spell.c:5240
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "太多延迟前缀和/或组合标志"
 
+#: ../spell.c:5250
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "%s 中缺少 SOFO%s 行"
 
+#: ../spell.c:5253
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "%s 同时出现 SQL 和 SOFO 行"
 
+#: ../spell.c:5331
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "%s 第 %d 行，标志不是数字: %s"
 
+#: ../spell.c:5334
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "%s 第 %d 行，无效的标志: %s"
 
+#: ../spell.c:5493 ../spell.c:5501
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr "%s 的值与另一个 .aff 文件中使用的值不相同"
 
+#: ../spell.c:5602
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "读取字典文件 %s ……"
 
+#: ../spell.c:5611
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: %s 中没有单词计数"
 
+#: ../spell.c:5669
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "第 %6d 行，第 %6d 个单词 - %s"
 
+#: ../spell.c:5691
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的单词: %s"
 
+#: ../spell.c:5694
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "%s 第 %d 行，首次重复的单词: %s"
 
+#: ../spell.c:5746
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "存在 %d 个重复的单词，在 %s 中"
 
+#: ../spell.c:5748
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "忽略了含有非 ASCII 字符的 %d 个单词，在 %s 中"
 
+#: ../spell.c:6115
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "读取单词文件 %s ……"
 
+#: ../spell.c:6155
 #, c-format
-#~ msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-#~ msgstr ""
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
 
+#: ../spell.c:6159
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，单词后的 /encoding= 行已被忽略: %s"
 
+#: ../spell.c:6180
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，重复的 /regions= 行已被忽略: %s"
 
+#: ../spell.c:6185
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "%s 第 %d 行，太多区域: %s"
 
+#: ../spell.c:6198
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "%s 第 %d 行，/ 行已被忽略: %s"
 
+#: ../spell.c:6224
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "%s 第 %d 行，无效的区域号: %s"
 
+#: ../spell.c:6230
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "%s 第 %d 行，不可识别的标志: %s"
 
+#: ../spell.c:6257
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "忽略了含有非 ASCII 字符的 %d 个单词"
 
+#: ../spell.c:6656
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "压缩了 %d/%d 个节点；剩余 %d (%d%%)"
 
+#: ../spell.c:7340
 msgid "Reading back spell file..."
 msgstr "读取拼写文件……"
 
-#.
-#. * Go through the trie of good words, soundfold each word and add it to
-#. * the soundfold trie.
-#.
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
 msgid "Performing soundfolding..."
 msgstr "正在 soundfolding……"
 
+#: ../spell.c:7368
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "soundfolding 后的单词数: %<PRId64>"
 
+#: ../spell.c:7476
 #, c-format
 msgid "Total number of words: %d"
 msgstr "单词总数: %d"
 
+#: ../spell.c:7655
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "写入建议文件 %s ……"
 
+#: ../spell.c:7707 ../spell.c:7927
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "估计运行时内存用量: %d 字节"
 
+#: ../spell.c:7820
 msgid "E751: Output file name must not have region name"
 msgstr "E751: 输出文件名不能含有区域名"
 
+#: ../spell.c:7822
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: 最多只支持 8 个区域"
 
+#: ../spell.c:7846
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: %s 出现无效的范围"
 
+#: ../spell.c:7907
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "警告: 同时指定了 compounding 和 NOBREAK"
 
+#: ../spell.c:7920
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "写入拼写文件 %s ……"
 
+#: ../spell.c:7925
 msgid "Done!"
 msgstr "完成！"
 
+#: ../spell.c:8034
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' 没有 %<PRId64> 项"
 
-#, c-format
-msgid "Word removed from %s"
+#: ../spell.c:8074
+#, fuzzy, c-format
+msgid "Word '%.*s' removed from %s"
 msgstr "从 %s 中删除了单词"
 
-#, c-format
-msgid "Word added to %s"
+#: ../spell.c:8117
+#, fuzzy, c-format
+msgid "Word '%.*s' added to %s"
 msgstr "向 %s 中添加了单词"
 
+#: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: 拼写文件之间的字符不相同"
 
+#: ../spell.c:8684
 msgid "Sorry, no suggestions"
 msgstr "抱歉，没有建议"
 
+#: ../spell.c:8687
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "抱歉，只有 %<PRId64> 条建议"
 
+#. for when 'cmdheight' > 1
 #. avoid more prompt
+#: ../spell.c:8704
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "将 \"%.*s\" 改为："
 
+#: ../spell.c:8737
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
+#: ../spell.c:8882
 msgid "E752: No previous spell replacement"
 msgstr "E752: 之前没有拼写替换"
 
+#: ../spell.c:8925
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: 找不到: %s"
 
+#: ../spell.c:9276
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: 看起来不像是 .sug 文件: %s"
 
+#: ../spell.c:9282
 #, c-format
-#~ msgid "E779: Old .sug file, needs to be updated: %s"
-#~ msgstr ""
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
 
+#: ../spell.c:9286
 #, c-format
-#~ msgid "E780: .sug file is for newer version of Vim: %s"
-#~ msgstr ""
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
 
+#: ../spell.c:9295
 #, c-format
-#~ msgid "E781: .sug file doesn't match .spl file: %s"
-#~ msgstr ""
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
 
+#: ../spell.c:9305
 #, fuzzy, c-format
-#~ msgid "E782: error while reading .sug file: %s"
-#~ msgstr "E47: 读取错误文件失败"
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: 读取错误文件失败"
 
 #. This should have been checked when generating the .spl
-#. * file.
-#~ msgid "E783: duplicate char in MAP entry"
-#~ msgstr ""
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
 
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "这个缓冲区没有定义任何语法项"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 无效的参数: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 无此语法 cluster: \"%s\""
 
-msgid "No Syntax items defined for this buffer"
-msgstr "这个缓冲区没有定义任何语法项"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C风格注释同步中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "没有同步"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同步开始"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr "行号超出范围"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5001,6 +5718,7 @@ msgstr ""
 "\n"
 "--- 语法同步项目 (Syntax sync items) ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5008,6 +5726,7 @@ msgstr ""
 "\n"
 "同步中:"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5015,200 +5734,276 @@ msgstr ""
 "\n"
 "--- 语法项目 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 无此语法 cluster: \"%s\""
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "最小"
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "最大"
 
+#: ../syntax.c:3513
 #, fuzzy
-#~ msgid "; match "
-#~ msgstr "匹配 %d"
+msgid "; match "
+msgstr "匹配 %d"
 
+#: ../syntax.c:3515
 #, fuzzy
-#~ msgid " line breaks"
-#~ msgstr "少于一行"
+msgid " line breaks"
+msgstr "少于一行"
 
+#: ../syntax.c:4076
 msgid "E395: contains argument not accepted here"
 msgstr "E395: 使用了不正确的参数"
 
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: 使用了不正确的参数"
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: 无效的参数"
 
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: 使用了不正确的参数"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: 找不到 %s 的 region item"
 
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: 需要文件名称"
 
-#, c-format
-msgid "E747: Missing ']': %s"
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 文件名过多"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
 msgstr "E747: 缺少 ']': %s"
 
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: 缺少 '=': %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: syntax region %s 的参数太少"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 无此语法 cluster: \"%s\""
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: 没有指定的属性"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: 找不到分隔符号: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: '%s' 后面的东西不能识别"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 语法同步: 连接行符号指定了两次"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 无效的参数: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 缺少等号: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空的参数: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s 不能在此出现"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s 必须是列表里的第一个"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 不正确的组名: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 不正确的 :syntax 子命令: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: 加载 syncolor.vim 时出现嵌套循环"
 
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: 找不到 highlight group: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 参数太少: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 参数过多: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: 已设定组, 忽略 highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 不该有的等号: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 缺少等号: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 缺少参数: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不合法的值: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 错误的前景颜色"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 错误的背景颜色"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: 错误的颜色名称或数值: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 终端编码太长: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 无效的参数: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 使用了太多不同的高亮度属性"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 组名中存在不可显示字符"
 
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: 组名中含有无效字符"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: 已在 tag 堆栈底部"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: 已在 tag 堆栈顶部"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 已到第一个匹配的 tag"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: 找不到 tag: %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "文件\n"
 
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 只有一个匹配的 tag"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 己到最后一个匹配的 tag"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "文件 \"%s\" 不存在"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "找到 tag: %d / %d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " 或更多"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  以不同大小写来使用 tag！"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: 文件 \"%s\" 不存在"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5216,59 +6011,79 @@ msgstr ""
 "\n"
 "  # 到 tag         从   行    在 文件/文本"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "查找 tag 文件 %s"
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tag 文件路径被截断为 %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 文件 \"%s\" 格式错误"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "在第 %<PRId64> 字节之前"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag 文件未排序: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: 没有 tag 文件"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: 找不到 tag 模式"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: 找不到 tag，试着猜！"
 
+#: ../tag.c:2797
+#, fuzzy, c-format
+msgid "Duplicate field name: %s"
+msgstr "%s 第 %d 行，重复的附加项: %s"
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' 未知。可用的内建终端有:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "默认值为: '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: 无法打开 termcap 文件"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: 在 terminfo 中找不到终端项"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: 在 termcap 中找不到终端项"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap 中没有 \"%s\" 项"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 终端需要能力 \"cm\""
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -5276,146 +6091,170 @@ msgstr ""
 "\n"
 "--- 终端按键 ---"
 
-msgid "new shell started\n"
-msgstr "启动新 shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 读错误，退出中...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "无法撤销；请继续"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+#, fuzzy
+msgid "E881: Line count changed unexpectedly"
+msgstr "E787: 意外地改变了缓冲区"
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: 无法打开并写入文件"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "写入 viminfo 文件 \"%s\""
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: 交换文件写入错误"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "读取单词文件 %s ……"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: 无法打开并读取 viminfo 文件"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E753: 找不到: %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: 无法打开文件 %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "结束执行 %s"
+
+#: ../undo.c:1586 ../undo.c:1812
 msgid "Already at oldest change"
 msgstr "已位于最旧的改变"
 
+#: ../undo.c:1597 ../undo.c:1814
 msgid "Already at newest change"
 msgstr "已位于最新的改变"
 
-#, c-format
-msgid "Undo number %<PRId64> not found"
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
 msgstr "找不到撤销号 %<PRId64>"
 
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行号错误"
 
+#: ../undo.c:2183
 msgid "more line"
 msgstr "行被加入"
 
+#: ../undo.c:2185
 msgid "more lines"
 msgstr "行被加入"
 
+#: ../undo.c:2187
 msgid "line less"
 msgstr "行被去掉"
 
+#: ../undo.c:2189
 msgid "fewer lines"
 msgstr "行被去掉"
 
+#: ../undo.c:2193
 msgid "change"
 msgstr "行发生改变"
 
+#: ../undo.c:2195
 msgid "changes"
 msgstr "行发生改变"
 
+#: ../undo.c:2225
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s；%s #%<PRId64>  %s"
 
+#: ../undo.c:2228
 msgid "before"
 msgstr "before"
 
+#: ../undo.c:2228
 msgid "after"
 msgstr "after"
 
+#: ../undo.c:2325
 msgid "Nothing to undo"
 msgstr "无可撤销"
 
-msgid "number changes  time"
-msgstr "  编号    改变  时间"
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
 
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 列; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s 不能在此出现"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: 撤销列表损坏"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: 找不到要撤销的行"
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 位图形界面版本"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 位图形界面版本"
-
-msgid " in Win32s mode"
-msgstr " Win32s 模式"
-
-msgid " with OLE support"
-msgstr " 带 OLE 支持"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 位控制台版本"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 16 位控制台版本"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 位 MS-DOS 版本"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 位 MS-DOS 版本"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版本"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版本"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版本"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS 版本"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -5423,9 +6262,18 @@ msgstr ""
 "\n"
 "包含补丁: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "外部符合:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "修改者 "
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -5433,9 +6281,11 @@ msgstr ""
 "\n"
 "编译"
 
+#: ../version.c:649
 msgid "by "
 msgstr "者 "
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -5443,605 +6293,1559 @@ msgstr ""
 "\n"
 "巨型版本 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"大型版本 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"正常版本 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"小型版本 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"微型版本 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "无图形界面。"
 
-msgid "with GTK2-GNOME GUI."
-msgstr "带 GTK2-GNOME 图形界面。"
-
-msgid "with GTK-GNOME GUI."
-msgstr "带 GTK-GNOME 图形界面。"
-
-msgid "with GTK2 GUI."
-msgstr "带 GTK2 图形界面。"
-
-msgid "with GTK GUI."
-msgstr "带 GTK 图形界面。"
-
-msgid "with X11-Motif GUI."
-msgstr "带 X11-Motif 图形界面。"
-
-msgid "with X11-neXtaw GUI."
-msgstr "带 X11-neXtaw 图形界面。"
-
-msgid "with X11-Athena GUI."
-msgstr "带 X11-Athena 图形界面。"
-
-msgid "with Photon GUI."
-msgstr "带 Photon 图形界面。"
-
-msgid "with GUI."
-msgstr "带图形界面。"
-
-msgid "with Carbon GUI."
-msgstr "带 Carbon 图形界面。"
-
-msgid "with Cocoa GUI."
-msgstr "带 Cocoa 图形界面。"
-
-msgid "with (classic) GUI."
-msgstr "带(传统)图形界面。"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr "  可使用(+)与不可使用(-)的功能:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "     系统 vimrc 文件: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "     用户 vimrc 文件: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr " 第二用户 vimrc 文件: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr " 第三用户 vimrc 文件: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "      用户 exrc 文件: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  第二用户 exrc 文件: \""
 
-msgid "  system gvimrc file: \""
-msgstr "    系统 gvimrc 文件: \""
-
-msgid "    user gvimrc file: \""
-msgstr "    用户 gvimrc 文件: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "第二用户 gvimrc 文件: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "第三用户 gvimrc 文件: \""
-
-msgid "    system menu file: \""
-msgstr "        系统菜单文件: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "         $VIM 预设值: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "  $VIMRUNTIME 预设值: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "编译方式: "
 
-msgid "Compiler: "
-msgstr "编译器: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "链接方式: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  调试版本"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "版本 "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "维护人 Bram Moolenaar 等"
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim 是可自由分发的开放源代码软件"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "帮助乌干达的可怜儿童！"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "输入  :help iccf<Enter>       查看说明        "
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "输入  :q<Enter>               退出            "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "输入  :help<Enter>  或  <F1>  查看在线帮助    "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "输入  :help version7<Enter>   查看版本信息    "
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "运行于 Vi 兼容模式"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "输入  :set nocp<Enter>        恢复默认的 Vim  "
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "输入  :help cp-default<Enter> 查看相关说明    "
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "菜单  Help->Orphans           查看说明           "
+#: ../version.c:827
+msgid "Sponsor Vim development!"
+msgstr "赞助 Vim 的开发！"
 
-msgid "Running modeless, typed text is inserted"
-msgstr "无模式运行，输入文字即插入"
+#: ../version.c:828
+msgid "Become a registered Vim user!"
+msgstr "成为 Vim 的注册用户！"
 
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "菜单  Edit->Global Settings->Toggle Insert Mode  "
+#: ../version.c:831
+msgid "type  :help sponsor<Enter>    for information "
+msgstr "输入  :help sponsor<Enter>    查看说明        "
+
+#: ../version.c:832
+msgid "type  :help register<Enter>   for information "
+msgstr "输入  :help register<Enter>   查看说明        "
+
+#: ../version.c:834
+msgid "menu  Help->Sponsor/Register  for information    "
+msgstr "菜单  Help->Sponsor/Register  查看说明           "
+
+#: ../window.c:119
+msgid "Already only one window"
+msgstr "已经只剩一个窗口了"
+
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: 没有预览窗口"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: 不能同时进行 topleft 和 botright 分割"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: 有其它分割窗口时不能旋转"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: 不能关闭最后一个窗口"
+
+#: ../window.c:2717
+msgid "E445: Other window contains changes"
+msgstr "E445: 其它窗口有改变的内容"
+
+#: ../window.c:4805
+msgid "E446: No file name under cursor"
+msgstr "E446: 光标处没有文件名"
+
+#~ msgid "Patch file"
+#~ msgstr "Patch 文件"
+
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "确定(&O)\n"
+#~ "取消(&C)"
+
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: 没有到 Vim 服务器的连接"
+
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: 无法发送到 %s"
+
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 无法读取服务器响应"
+
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 无法发送到客户端"
+
+#~ msgid "Save As"
+#~ msgstr "另存为"
+
+#~ msgid "Edit File"
+#~ msgstr "编辑文件"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (找不到)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "执行 Vim 脚本"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "在新窗口编辑文件"
+
+#~ msgid "Append File"
+#~ msgstr "追加文件"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "窗口位置: X %d, Y %d"
+
+#~ msgid "Save Redirection"
+#~ msgstr "保存重定向"
+
+#~ msgid "Save View"
+#~ msgstr "保存视图"
+
+#~ msgid "Save Session"
+#~ msgstr "保存会话"
+
+#~ msgid "Save Setup"
+#~ msgstr "保存设定"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 此版本无复合字符(digraph)"
+
+#~ msgid "Reading from stdin..."
+#~ msgstr "从标准输入读取..."
+
+#~ msgid "[NL found]"
+#~ msgstr "[找到 NL]"
+
+#~ msgid "[crypted]"
+#~ msgstr "[已加密]"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans 不允许未修改的缓冲区写入"
+
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "NetBeans 不允许缓冲区部分写入"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resource fork 会丢失 (请加 ! 强制执行)"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: 无法启动图形界面"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: 无法读取文件 \"%s\""
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 无法启动图形界面，找不到有效的字体"
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 无效的 'guifontwide'"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 的值无效"
+
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: 无法分配颜色 %s"
+
+#~ msgid "No match at cursor, finding next"
+#~ msgstr "在光标处没有匹配，查找下一个"
+
+#~ msgid "<cannot open> "
+#~ msgstr "<无法打开>"
+
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 无法获取字体 %s"
+
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 无法返回当前目录"
+
+#~ msgid "Pathname:"
+#~ msgstr "路径:"
+
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 无法获取当前目录"
+
+#~ msgid "OK"
+#~ msgstr "确定"
+
+#~ msgid "Cancel"
+#~ msgstr "取消"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "滚动条部件: 无法获取滑块图像的几何大小"
+
+#~ msgid "Vim dialog"
+#~ msgstr "Vim 对话框"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: 不能同时使用消息和回调函数来创建 BalloonEval"
+
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim 对话框..."
+
+#~ msgid "Input _Methods"
+#~ msgstr "输入法(_M)"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 查找和替换..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 查找..."
+
+#~ msgid "Find what:"
+#~ msgstr "查找内容:"
+
+#~ msgid "Replace with:"
+#~ msgstr "替换为:"
+
+#~ msgid "Match whole word only"
+#~ msgstr "匹配完整的词"
+
+#~ msgid "Match case"
+#~ msgstr "匹配大小写"
+
+#~ msgid "Direction"
+#~ msgstr "方向"
+
+#~ msgid "Up"
+#~ msgstr "向上"
+
+#~ msgid "Down"
+#~ msgstr "向下"
+
+#~ msgid "Find Next"
+#~ msgstr "查找下一个"
+
+#~ msgid "Replace"
+#~ msgstr "替换"
+
+#~ msgid "Replace All"
+#~ msgstr "全部替换"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: 从会话管理器收到 \"die\" 请求\n"
+
+#~ msgid "Close"
+#~ msgstr "关闭"
+
+#~ msgid "New tab"
+#~ msgstr "新建标签"
+
+#~ msgid "Open Tab..."
+#~ msgstr "打开标签..."
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: 主窗口被意外地摧毁\n"
+
+#~ msgid "Font Selection"
+#~ msgstr "选择字体"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "使用 CUT_BUFFER0 来取代空选择"
+
+#~ msgid "&Filter"
+#~ msgstr "过滤(&F)"
+
+#~ msgid "&Cancel"
+#~ msgstr "取消(&C)"
+
+#~ msgid "Directories"
+#~ msgstr "目录"
+
+#~ msgid "Filter"
+#~ msgstr "过滤器"
+
+#~ msgid "&Help"
+#~ msgstr "帮助(&H)"
+
+#~ msgid "Files"
+#~ msgstr "文件"
+
+#~ msgid "&OK"
+#~ msgstr "确定(&O)"
+
+#~ msgid "Selection"
+#~ msgstr "选择"
+
+#~ msgid "Find &Next"
+#~ msgstr "查找下一个(&N)"
+
+#~ msgid "&Replace"
+#~ msgstr "替换(&R)"
+
+#~ msgid "Replace &All"
+#~ msgstr "全部替换(&A)"
+
+#~ msgid "&Undo"
+#~ msgstr "撤销(&U)"
+
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: 找不到窗口标题 \"%s\""
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 不支持的参数: \"-%s\"；请使用 OLE 版本。"
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: 无法在 MDI 应用程序中打开窗口"
+
+#~ msgid "Close tab"
+#~ msgstr "关闭标签"
+
+#~ msgid "Open tab..."
+#~ msgstr "打开标签..."
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "查找字符串 (使用 '\\\\' 来查找 '\\')"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "查找和替换字符串 (使用 '\\\\' 来查找 '\\')"
+
+#~ msgid "Not Used"
+#~ msgstr "未使用"
+
+#~ msgid "Directory\t*.nothing\n"
+#~ msgstr "目录\t*.nothing\n"
+
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 无法分配颜色表项，某些颜色可能不正确"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Fontset %s 缺少下列字符集的字体:"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: Fontset 名称: %s"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "'%s' 不是固定宽度的字体"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: Fontset 名称: %s\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "字体0: %s\n"
+
+#~ msgid "Font1: %s\n"
+#~ msgstr "字体1: %s\n"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "字体0的宽度：%<PRId64>\n"
+
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "字体1的宽度: %<PRId64>\n"
+#~ "\n"
+
+#~ msgid "Invalid font specification"
+#~ msgstr "指定了无效的字体"
+
+#~ msgid "&Dismiss"
+#~ msgstr "取消(&D)"
+
+#~ msgid "no specific match"
+#~ msgstr "找不到匹配的项"
+
+#~ msgid "Vim - Font Selector"
+#~ msgstr "Vim - 字体选择器"
+
+#~ msgid "Name:"
+#~ msgstr "名称:"
+
+#~ msgid "Encoding:"
+#~ msgstr "编码:"
+
+#~ msgid "Font:"
+#~ msgstr "字体:"
+
+#~ msgid "Style:"
+#~ msgstr "风格:"
+
+#~ msgid "Size:"
+#~ msgstr "尺寸:"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata 错误"
+
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 错误"
+
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: 无法打开 cscope 数据库: %s"
+
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: 无法获取 cscope 数据库信息"
+
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: 已达到 cscope 的最大连接数"
+
+#~ msgid ""
+#~ "???: Sorry, this command is disabled, the MzScheme library could not be "
+#~ "loaded."
+#~ msgstr "???: 抱歉，此命令不可用，无法加载 MzScheme 库"
+
+#~ msgid "invalid expression"
+#~ msgstr "无效的表达式"
+
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "编译时没有启用表达式"
+
+#~ msgid "hidden option"
+#~ msgstr "隐藏的选项"
+
+#~ msgid "unknown option"
+#~ msgstr "未知的选项"
+
+#~ msgid "window index is out of range"
+#~ msgstr "窗口索引超出范围"
+
+#~ msgid "couldn't open buffer"
+#~ msgstr "无法打开缓冲区"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "无法保存撤销信息"
+
+#~ msgid "cannot delete line"
+#~ msgstr "无法删除行"
+
+#~ msgid "cannot replace line"
+#~ msgstr "无法替换行"
+
+#~ msgid "cannot insert line"
+#~ msgstr "无法插入行"
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "字符串不能包含换行(NL)"
+
+#~ msgid "Vim error: ~a"
+#~ msgstr "Vim 错误: ~a"
+
+#~ msgid "Vim error"
+#~ msgstr "Vim 错误"
+
+#~ msgid "buffer is invalid"
+#~ msgstr "缓冲区无效"
+
+#~ msgid "window is invalid"
+#~ msgstr "窗口无效"
+
+#~ msgid "linenr out of range"
+#~ msgstr "行号超出范围"
+
+#~ msgid "not allowed in the Vim sandbox"
+#~ msgstr "不允许在 sandbox 中使用"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr "E263: 抱歉，此命令不可用，无法加载 Python 库。"
+
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: 不能递归调用 Python"
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "不能删除 OutputObject 属性"
+
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace 必须是整数"
+
+#~ msgid "invalid attribute"
+#~ msgstr "无效的属性"
+
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() 需要字符串列表作参数"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: 初始化 I/O 对象出错"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "试图引用已被删除的缓冲区"
+
+#~ msgid "line number out of range"
+#~ msgstr "行号超出范围"
+
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<缓冲区对象(已删除): %8lX>"
+
+#~ msgid "invalid mark name"
+#~ msgstr "无效的标记名称"
+
+#~ msgid "no such buffer"
+#~ msgstr "无此缓冲区"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "试图引用已被删除的窗口"
+
+#~ msgid "readonly attribute"
+#~ msgstr "只读属性"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "光标位置在缓冲区外"
+
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<窗口对象(已删除): %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<窗口对象(未知): %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<窗口 %d>"
+
+#~ msgid "no such window"
+#~ msgstr "无此窗口"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: 抱歉，此命令不可用，无法加载 Ruby 库"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知的 longjmp 状态 %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "切换实现/定义"
+
+#~ msgid "Show base class of"
+#~ msgstr "显示 base class of:"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "显示被覆盖的成员函数"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "恢复: 从文件"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "恢复: 从对象"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "恢复: 从所有项目"
+
+#~ msgid "Retrieve"
+#~ msgstr "恢复"
+
+#~ msgid "Show source of"
+#~ msgstr "显示源代码: "
+
+#~ msgid "Find symbol"
+#~ msgstr "查找 symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "浏览 class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "显示层次关系的类"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "显示 restricted 层次关系的 class"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref 参考到"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref 被谁参考:"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref 有"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref 被谁使用:"
+
+#~ msgid "Show docu of"
+#~ msgstr "显示文件: "
+
+#~ msgid "Generate docu for"
+#~ msgstr "产生文件: "
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "不能连接到 SNiFF+。请检查环境变量 ($PATH 里必需可以找到 sniffemacs)\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 读取错误. 取消连接"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ 目前"
+
+#~ msgid "not "
+#~ msgstr "未"
+
+#~ msgid "connected"
+#~ msgstr "连接中"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 不正确的 SNiff+ 调用: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: 连接到 SNiFF+ 失败"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: 未连接到 SNiFF+"
+
+#~ msgid "E279: Not a SNiFF+ buffer"
+#~ msgstr "E279: 不是 SNiFF+ 的缓冲区"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 写入错误。结束连接"
+
+#~ msgid "invalid buffer number"
+#~ msgstr "无效的缓冲区号"
+
+#~ msgid "not implemented yet"
+#~ msgstr "尚未实现"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "无法设定行"
+
+#~ msgid "mark not set"
+#~ msgstr "没有设定标记"
+
+#~ msgid "row %d column %d"
+#~ msgstr "第 %d 行 第 %d 列"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "无法插入/追加行"
+
+#~ msgid "unknown flag: "
+#~ msgstr "未知的标志: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "未知的 vim 选项"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "键盘中断"
+
+#~ msgid "vim error"
+#~ msgstr "vim 错误"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "无法创建缓冲区/窗口命令: 对象将被删除"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "无法注册回调命令: 缓冲区/窗口已被删除"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E280: TCL 严重错误: reflist 损坏！？请报告给 vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "无法注册回调命令: 找不到缓冲区/窗口引用"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: 抱歉，此命令不可用，无法加载 Tcl 库"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr "E281: TCL 错误: 退出返回值不是整数！？请报告给 vim-dev@vim.org"
+
+#~ msgid "E572: exit code %d"
+#~ msgstr "E572: 退出返回值 %d"
+
+#~ msgid "cannot get line"
+#~ msgstr "无法获取行"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "无法注册命令服务器名"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248:  无法发送命令到目的程序"
+
+#~ msgid "E573: Invalid server id used: %s"
+#~ msgstr "E573: 使用了无效的服务器 id: %s"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 实例注册属性有误。已删除！"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "此 Vim 编译时没有加入 diff 功能"
+
+#~ msgid "Vim: Error: Failure to start gvim from NetBeans\n"
+#~ msgstr "Vim: 错误: 无法从 NetBeans 中启动 gvim\n"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t注册此 gvim 到 OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\t取消 OLE 中的 gvim 注册"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\t使用图形界面 (同 \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  或  --nofork\t前台: 启动图形界面时不 fork"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose 等级"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t不使用 newcli 来打开窗口"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\t使用 <device> 进行输入输出"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t使用 <gvimrc> 替代任何 .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t编辑加密的文件"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t将 vim 与指定的 X-server 连接"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\t不连接到 X Server"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  同 --remote 但会等待文件完成编辑"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  同上，找不到服务器时不抱怨"
+
+#~ msgid "--remote-tab <files>  As --remote but open tab page for each file"
+#~ msgstr "--remote-tab <files>  同 --remote 但对每个文件打开一个标签页"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 服务器并退出"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t在 Vim 服务器上求 <expr> 的值并打印结果"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t列出可用的 Vim 服务器名称并退出"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t发送到或成为 Vim 服务器 <name>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (Motif 版本) 可识别的参数:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (neXtaw 版本) 可识别的参数:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (Athena 版本) 可识别的参数:\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t在 <display> 上运行 vim"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t启动后最小化"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\t读取 Resource 时把 vim 视为 <name>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (尚未实现)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t使用 <color> 作为背景色 (也可用 -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t使用 <color> 作为一般文字颜色 (也可用 -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t使用 <font> 作为一般字体 (也可用 -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t使用 <font> 作为粗体字体"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t使用 <font> 作为斜体字体"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t使用 <geom> 作为初始位置 (也可用 -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t设定边框宽度为 <width> (也可用 -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width> 设定滚动条宽度为 <width> (也可用 -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t设定菜单栏高度为 <height> (也可用 -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t使用反显 (也可用 -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t不使用反显 (也可用 +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t设定指定的资源"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (RISC OS 版本) 可识别的参数:\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <number>\t窗口初始宽度"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <number>\t窗口初始高度"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim (GTK+ 版本) 可识别的参数:\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t在 <display> 上运行 vim (也可用 --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t设置用于区分主窗口的窗口角色名"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t在另一个 GTK 部件中打开 Vim"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\t在父应用程序中打开 Vim"
+
+#~ msgid "No display"
+#~ msgstr "没有 display"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 发送失败。\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 发送失败。尝试本地执行\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "%d 中 %d 已编辑"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "没有 display: 发送表达式失败。\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 发送表达式失败。\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 无效的代码页"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: 无法创建输入上下文"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: 无法打开输入法"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: 无法设定输入法的释放回调函数"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 输入法不支持任何风格"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 输入法不支持我的预编辑类型"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: over-the-spot 风格需要 Fontset"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: 你的 GTK+ 比 1.2.3 旧。状态区不可用。"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: 输入法服务器未运行"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [不能在该版本的 Vim 上使用]"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "撕下此菜单"
+
+#~ msgid "Select Directory dialog"
+#~ msgstr "选择目录对话框"
+
+#~ msgid "Save File dialog"
+#~ msgstr "保存文件对话框"
+
+#~ msgid "Open File dialog"
+#~ msgstr "打开文件对话框"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: 抱歉，控制台模式下没有文件浏览器"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: 正在保留文件……\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 结束。\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "错误: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 此行过长"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 无效的鼠标形状"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "输入密码: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "请再输入一次: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "两次密码不匹配！"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "无法连接到 Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "无法连接到 Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 连接信息文件中错误的访问模式: \"%s\""
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "从 Netbeans 套接字读取"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
+
+#~ msgid "E505: "
+#~ msgstr "E505: "
+
+#~ msgid "E775: Eval feature not available"
+#~ msgstr "E775: 求值功能不可用"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "释放了 %<PRId64> 行"
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: 在图形界面中不能改变终端"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: 请用 \":gui\" 启动图形界面"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: 在 GTK+ 2 图形界面中不能更改"
+
+#~ msgid "E596: Invalid font(s)"
+#~ msgstr "E596: 无效的字体"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 无法选择 Fontset"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 无效的 Fontset"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: 无法选择宽字体"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 无效的宽字体"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: 不支持鼠标"
+
+#~ msgid "cannot open "
+#~ msgstr "不能打开"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: 不能打开窗口!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "需要 Amigados 版本 2.04 以上\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "需要 %s 版本 %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "不能打开 NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "不能创建 "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim 返回值: %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "不能切换主控台(console)模式 !?\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 不是主控台(console)??\n"
+
+#~ msgid "E360: Cannot execute shell with -f option"
+#~ msgstr "E360: 不能用 -f 选项执行 shell"
+
+#~ msgid "Cannot execute "
+#~ msgstr "不能执行 "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " 已返回\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE 太小"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 错误"
+
+#~ msgid "Message"
+#~ msgstr "消息"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' 不是 80, 不能执行外部命令"
+
+#~ msgid "E237: Printer selection failed"
+#~ msgstr "E237: 选择打印机失败"
+
+#~ msgid "to %s on %s"
+#~ msgstr "从 %s 到 %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 未知的打印机字体: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 打印错误: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "打印 '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 字符集 \"%s\" 不能对应字体\"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 不正确的字符 '%c' 出现在字体名称 \"%s\" 内"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 双重信号，退出中\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: 拦截到致命信号(deadly signal) %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 拦截到致命信号(deadly signal)\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "打开 X display 用时 %<PRId64> 秒"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X 错误\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "测试 X display 失败"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "打开 X display 超时"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法执行 shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法建立管道\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "无法 fork\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "命令已结束\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP 丢失了到 ICE 的连接"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "打开 X display 失败"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP 处理 save-yourself 请求"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "XSMP 打开连接"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE 连接监视失败"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection 调用失败: %s"
+
+#~ msgid "At line"
+#~ msgstr "在行号 "
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "无法加载 vim32.dll！"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM 错误"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "无法修正到 DLL 的函数指针!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "Shell 返回 %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: 拦截到 %s 事件\n"
+
+#~ msgid "close"
+#~ msgstr "关闭"
+
+#~ msgid "logoff"
+#~ msgstr "注消"
+
+#~ msgid "shutdown"
+#~ msgstr "关机"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 找不到命令"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "在你的 $PATH 中找不到 VIMRUN.EXE。\n"
+#~ "外部命令执行完毕后将不会暂停。\n"
+#~ "进一步说明请见 :help win32-vimrun"
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim 警告"
+
+#~ msgid "Conversion in %s not supported"
+#~ msgstr "不支持 %s 中的转换"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: 使用了不正确的参数"
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag 文件路径被截断为 %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "启动新 shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "无法撤销；请继续"
+
+#~ msgid "number changes  time"
+#~ msgstr "  编号    改变  时间"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 位图形界面版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 位图形界面版本"
+
+#~ msgid " in Win32s mode"
+#~ msgstr " Win32s 模式"
+
+#~ msgid " with OLE support"
+#~ msgstr " 带 OLE 支持"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 位控制台版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16 位控制台版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 位 MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 位 MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "大型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "正常版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "小型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "微型版本 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "带 GTK2-GNOME 图形界面。"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "带 GTK-GNOME 图形界面。"
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "带 GTK2 图形界面。"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "带 GTK 图形界面。"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "带 X11-Motif 图形界面。"
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "带 X11-neXtaw 图形界面。"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "带 X11-Athena 图形界面。"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "带 Photon 图形界面。"
+
+#~ msgid "with GUI."
+#~ msgstr "带图形界面。"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "带 Carbon 图形界面。"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "带 Cocoa 图形界面。"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "带(传统)图形界面。"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "    系统 gvimrc 文件: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "    用户 gvimrc 文件: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "第二用户 gvimrc 文件: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "第三用户 gvimrc 文件: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "        系统菜单文件: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "编译器: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "菜单  Help->Orphans           查看说明           "
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "无模式运行，输入文字即插入"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "菜单  Edit->Global Settings->Toggle Insert Mode  "
 
 #, fuzzy
 #~ msgid "                              for two modes      "
 #~ msgstr " # pid    数据库名称                          prepend path\n"
 
-#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-#~ msgstr ""
-
 #, fuzzy
 #~ msgid "                              for Vim defaults   "
 #~ msgstr " # pid    数据库名称                          prepend path\n"
 
-msgid "Sponsor Vim development!"
-msgstr "赞助 Vim 的开发！"
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "警告: 检测到 Windows 95/98/ME"
 
-msgid "Become a registered Vim user!"
-msgstr "成为 Vim 的注册用户！"
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "输入  :help windows95<Enter>  查看相关说明    "
 
-msgid "type  :help sponsor<Enter>    for information "
-msgstr "输入  :help sponsor<Enter>    查看说明        "
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: 无法加载库 %s"
 
-msgid "type  :help register<Enter>   for information "
-msgstr "输入  :help register<Enter>   查看说明        "
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "抱歉，此命令不可用: 无法加载 Perl 库。"
 
-msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "菜单  Help->Sponsor/Register  查看说明           "
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "用多个 Vim 编辑(&M)"
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "警告: 检测到 Windows 95/98/ME"
+#~ msgid "Edit with single &Vim"
+#~ msgstr "用单个 Vim 编辑(&V)"
 
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "输入  :help windows95<Enter>  查看相关说明    "
+#~ msgid "Diff with Vim"
+#~ msgstr "用 Vim 比较(diff)"
 
-msgid "Already only one window"
-msgstr "已经只剩一个窗口了"
+#~ msgid "Edit with &Vim"
+#~ msgstr "用 Vim 编辑(&V)"
 
-msgid "E441: There is no preview window"
-msgstr "E441: 没有预览窗口"
+#~ msgid "Edit with existing Vim - "
+#~ msgstr "用当前的 Vim 编辑 - "
 
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: 不能同时进行 topleft 和 botright 分割"
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "用 Vim 编辑选中的文件"
 
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: 有其它分割窗口时不能旋转"
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "创建进程失败: 请检查 gvim 是否在路径中！"
 
-msgid "E444: Cannot close last window"
-msgstr "E444: 不能关闭最后一个窗口"
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 错误"
 
-msgid "E445: Other window contains changes"
-msgstr "E445: 其它窗口有改变的内容"
+#~ msgid "Path length too long!"
+#~ msgstr "路径太长！"
 
-msgid "E446: No file name under cursor"
-msgstr "E446: 光标处没有文件名"
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 未知的 Fontset: %s"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: 在路径中找不到文件 \"%s\""
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 未知的字体: %s"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: 无法加载库 %s"
+#~ msgid "E236: Font \"%s\" is not fixed-width"
+#~ msgstr "E236: 字体 \"%s\" 不是等宽字体"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "抱歉，此命令不可用: 无法加载 Perl 库。"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: 无法加载库函数 %s"
 
-#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-#~ msgstr ""
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: 无法使用 Hebrew: 编译时没有启用\n"
 
-msgid "Edit with &multiple Vims"
-msgstr "用多个 Vim 编辑(&M)"
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: 无法使用 Farsi: 编译时没有启用\n"
 
-msgid "Edit with single &Vim"
-msgstr "用单个 Vim 编辑(&V)"
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: 无法使用 Arabic: 编译时没有启用\n"
 
-msgid "Diff with Vim"
-msgstr "用 Vim 比较(diff)"
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
 
-msgid "Edit with &Vim"
-msgstr "用 Vim 编辑(&V)"
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: 无法打开 display"
 
-#. Now concatenate
-msgid "Edit with existing Vim - "
-msgstr "用当前的 Vim 编辑 - "
+#~ msgid "E449: Invalid expression received"
+#~ msgstr "E449: 收到无效的表达式"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "用 Vim 编辑选中的文件"
-
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "创建进程失败: 请检查 gvim 是否在路径中！"
-
-msgid "gvimext.dll error"
-msgstr "gvimext.dll 错误"
-
-msgid "Path length too long!"
-msgstr "路径太长！"
-
-msgid "--No lines in buffer--"
-msgstr "--缓冲区无内容--"
-
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: 命令被中止"
-
-msgid "E471: Argument required"
-msgstr "E471: 需要参数"
-
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ 后面应该跟有 /、? 或 &"
-
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
-
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"
-
-msgid "E171: Missing :endif"
-msgstr "E171: 缺少 :endif"
-
-msgid "E600: Missing :endtry"
-msgstr "E600: 缺少 :endtry"
-
-msgid "E170: Missing :endwhile"
-msgstr "E170: 缺少 :endwhile"
-
-msgid "E170: Missing :endfor"
-msgstr "E170: 缺少 :endfor"
-
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile 缺少对应的 :while"
-
-msgid "E588: :endfor without :for"
-msgstr "E588: :endfor 缺少对应的 :for"
-
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 文件已存在 (请加 ! 强制执行)"
-
-msgid "E472: Command failed"
-msgstr "E472: 命令执行失败"
-
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 未知的 Fontset: %s"
-
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 未知的字体: %s"
-
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: 字体 \"%s\" 不是等宽字体"
-
-msgid "E473: Internal error"
-msgstr "E473: 内部错误"
-
-msgid "Interrupted"
-msgstr "已中断"
-
-msgid "E14: Invalid address"
-msgstr "E14: 无效的地址"
-
-msgid "E474: Invalid argument"
-msgstr "E474: 无效的参数"
-
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 无效的参数: %s"
-
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 无效的表达式: %s"
-
-msgid "E16: Invalid range"
-msgstr "E16: 无效的范围"
-
-msgid "E476: Invalid command"
-msgstr "E476: 无效的命令"
-
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" 是目录"
-
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 调用函数库 \"%s()\" 失败"
-
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: 无法加载库函数 %s"
-
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 标记的行号无效"
-
-msgid "E20: Mark not set"
-msgstr "E20: 没有设定标记"
-
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 不能修改，因为选项 'modifiable' 是关的"
-
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 脚本嵌套过深"
-
-msgid "E23: No alternate file"
-msgstr "E23: 没有交替文件"
-
-msgid "E24: No such abbreviation"
-msgstr "E24: 没有这个缩写"
-
-msgid "E477: No ! allowed"
-msgstr "E477: 不能使用 \"!\""
-
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: 无法使用图形界面: 编译时没有启用"
-
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: 无法使用 Hebrew: 编译时没有启用\n"
-
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: 无法使用 Farsi: 编译时没有启用\n"
-
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: 无法使用 Arabic: 编译时没有启用\n"
-
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 没有这个高亮群组名: %s"
-
-msgid "E29: No inserted text yet"
-msgstr "E29: 没有插入过文字"
-
-msgid "E30: No previous command line"
-msgstr "E30: 没有前一个命令行"
-
-msgid "E31: No such mapping"
-msgstr "E31: 没有这个映射"
-
-msgid "E479: No match"
-msgstr "E479: 没有匹配"
-
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 没有匹配: %s"
-
-msgid "E32: No file name"
-msgstr "E32: 没有文件名"
-
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 没有前一个替换正则表达式"
-
-msgid "E34: No previous command"
-msgstr "E34: 没有前一个命令"
-
-msgid "E35: No previous regular expression"
-msgstr "E35: 没有前一个正则表达式"
-
-msgid "E481: No range allowed"
-msgstr "E481: 不能使用范围"
-
-msgid "E36: Not enough room"
-msgstr "E36: 没有足够的空间"
-
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: 没有名叫 \"%s\" 的已注册的服务器"
-
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: 无法创建文件 %s"
-
-msgid "E483: Can't get temp file name"
-msgstr "E483: 无法获取临时文件名"
-
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: 无法打开文件 %s"
-
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: 无法读取文件 %s"
-
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 已修改但尚未保存 (可用 ! 强制执行)"
-
-msgid "E38: Null argument"
-msgstr "E38: 空的参数"
-
-msgid "E39: Number expected"
-msgstr "E39: 此处需要数字"
-
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 无法打开错误文件 %s"
-
-msgid "E233: cannot open display"
-msgstr "E233: 无法打开 display"
-
-msgid "E41: Out of memory!"
-msgstr "E41: 内存不足！"
-
-msgid "Pattern not found"
-msgstr "找不到模式"
-
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 找不到模式: %s"
-
-msgid "E487: Argument must be positive"
-msgstr "E487: 参数必须是正数"
-
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 无法回到前一个目录"
-
-msgid "E42: No Errors"
-msgstr "E42: 没有错误"
-
-msgid "E776: No location list"
-msgstr "E776: 没有 location 列表"
-
-msgid "E43: Damaged match string"
-msgstr "E43: 已损坏的匹配字符串"
-
-msgid "E44: Corrupted regexp program"
-msgstr "E44: 已损坏的正则表达式程序"
-
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 已设定选项 'readonly' (请加 ! 强制执行)"
-
-#, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 不能改变只读变量 \"%s\""
-
-#, c-format
-msgid "E46: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: 不能在 sandbox 中设定变量: \"%s\""
-
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 读取错误文件失败"
-
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: 不允许在 sandbox 中使用"
-
-msgid "E523: Not allowed here"
-msgstr "E523: 不允许在此使用"
-
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 不支持设定屏幕模式"
-
-msgid "E49: Invalid scroll size"
-msgstr "E49: 无效的滚动大小"
-
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 选项 'shell' 为空"
-
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: 无法读取 sign 数据！"
-
-msgid "E72: Close error on swap file"
-msgstr "E72: 交换文件关闭错误"
-
-msgid "E73: tag stack empty"
-msgstr "E73: tag 堆栈为空"
-
-msgid "E74: Command too complex"
-msgstr "E74: 命令过复杂"
-
-msgid "E75: Name too long"
-msgstr "E75: 名字过长"
-
-msgid "E76: Too many ["
-msgstr "E76: [ 过多"
-
-msgid "E77: Too many file names"
-msgstr "E77: 文件名过多"
-
-msgid "E488: Trailing characters"
-msgstr "E488: 多余的尾部字符"
-
-msgid "E78: Unknown mark"
-msgstr "E78: 未知的标记"
-
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 无法扩展通配符"
-
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' 不能小于 'winminheight'"
-
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' 不能小于 'winminwidth'"
-
-msgid "E80: Error while writing"
-msgstr "E80: 写入出错"
-
-msgid "Zero count"
-msgstr "计数为零"
-
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: 在脚本环境外使用了 <SID>"
-
-msgid "E449: Invalid expression received"
-msgstr "E449: 收到无效的表达式"
-
-#~ msgid "E463: Region is guarded, cannot modify"
-#~ msgstr ""
-
-msgid "E744: NetBeans does not allow changes in read-only files"
-msgstr "E744: NetBeans 不允许改变只读文件"
-
-#, c-format
-msgid "E685: Internal error: %s"
-msgstr "E685: 内部错误: %s"
-
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: 表达式的内存使用超出 'maxmempattern'"
-
-msgid "E749: empty buffer"
-msgstr "E749: 空的缓冲区"
-
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E682: 无效的搜索表达式或分隔符"
-
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 文件已在另一个缓冲区中被加载"
-
-#, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E764: 没有设定选项 '%s'"
-
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "已查找到文件开头，再从结尾继续查找"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "已查找到文件结尾，再从开头继续查找"
+#~ msgid "E744: NetBeans does not allow changes in read-only files"
+#~ msgstr "E744: NetBeans 不允许改变只读文件"
 
 #~ msgid "Affix flags ignored when PFXPOSTPONE used in %s line %d: %s"
 #~ msgstr "%s 第 %d 行，使用 PFXPOSTPONE 时附加标志被忽略: %s"
@@ -6054,18 +7858,6 @@ msgstr "已查找到文件结尾，再从开头继续查找"
 
 #~ msgid "E106: Unknown variable: \"%s\""
 #~ msgstr "E106: 未定义的变量: \"%s\""
-
-#~ msgid "E119: Not enough arguments for function: %s"
-#~ msgstr "E119: 函数 %s 的参数太少"
-
-#~ msgid "E120: Using <SID> not in a script context: %s"
-#~ msgstr "E120: <SID> 不能在 script 上下文外使用: %s"
-
-#~ msgid "E123: Undefined function: %s"
-#~ msgstr "E123: 函数 %s 尚未定义"
-
-#~ msgid "E127: Cannot redefine function %s: It is in use"
-#~ msgstr "E127: 函数 %s 正在使用中，不能重新定义"
 
 #~ msgid "function "
 #~ msgstr "函数 "

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -43,150 +43,216 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Traditional Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-01-27 19:00+0800\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: Mon Feb 19 22:49:21 CST 2001\n"
 "Last-Translator: Hung-Te Lin <piaip@csie.ntu.edu.tw>\n"
 "Language-Team: Hung-Te Lin <piaip@csie.ntu.edu.tw>, Cecil Sheng "
 "<b7506022@csie.ntu.edu.tw>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "無法傳送回應訊息"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: 無法配置任何緩衝區，離開程式..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: 無法配置緩衝區，使用另一個緩衝區...."
 
-#, c-format
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: 沒有釋放任何緩衝區"
 
-#, c-format
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: 沒有刪除任何緩衝區"
 
-#, c-format
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: 沒有清除任何緩衝區"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "已釋放一個緩衝區"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "已釋放 %d 個緩衝區"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "已刪除一個緩衝區"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "已刪除 %d 個緩衝區"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "已刪除一個緩衝區"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "已刪除 %d 個緩衝區"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: 沒有修改過的緩衝區"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: 沒有列出的緩衝區"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: 緩衝區 %<PRId64> 不存在"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 無法切換到更後面的緩衝區"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: 無法切換到更前面的緩衝區"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: 已更改過緩衝區 %<PRId64> 但尚未存檔 (可用 ! 強制執行)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 無法釋放最後一個緩衝區"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 檔名過多"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: 找到一個以上的 %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: 找不到 %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "行 %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有緩衝區使用這個名字"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [已修改]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[未編輯]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[新檔案]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[讀取錯誤]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[唯讀]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[唯讀]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "行數 1 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "行數 %<PRId64> --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "行 %<PRId64>/%<PRId64> --%d%%-- 欄 "
 
-msgid "[No file]"
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+#, fuzzy
+msgid "[No Name]"
 msgstr "[未命名]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "[輔助說明]"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[輔助說明]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[預覽]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "全部"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "底端"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "頂端"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -194,12 +260,11 @@ msgstr ""
 "\n"
 "# 緩衝區列表:\n"
 
-msgid "[Error List]"
-msgstr "[錯誤列表]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[No File]"
-msgstr "[未命名]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -207,116 +272,206 @@ msgstr ""
 "\n"
 "--- 符號 ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s 的符號:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    行=%<PRId64>  id=%d  名稱=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: 缺少 colon"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: 不正確的模式"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: 應該要有數字"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: 不正確的百分比"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: 無法比較(diff) %<PRId64>個以上的緩衝區"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: 無法開啟 termcap 檔案"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: 不能建立 "
 
-msgid "Patch file"
-msgstr "Patch 檔案"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: 無法讀取 diff 的輸出"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: 無法讀取 diff 的輸出"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: 目前的緩衝區不是在 diff 模式"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: 沒有緩衝區在 diff 模式"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: 沒有緩衝區在 diff 模式"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: 有兩個以上的緩衝區在 diff 模式，無法決定要用哪一個"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: 找不到緩衝區: \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: 緩衝區 \"%s\" 不是在 diff 模式"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 複合字元(digraph)中不能使用 Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: 找不到 keymap 檔"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: 使用 :loadkeymap "
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " 關鍵字自動完成 (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^E^Y^L^]^F^I^K^D^V^N^P)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X 模式 (^E^Y^L^]^F^I^K^D^N^P)"
 
-#. Scroll has it's own msgs, in it's place there is the msg for local
-#. * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-msgid " Keyword Local completion (^N^P)"
-msgstr " 區域關鍵字自動完成 (^N^P)"
-
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " 整行自動完成 (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " 檔名自動完成 (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " 標籤自動完成 (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " 路徑自動完成 (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " 定義自動完成 (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " 字典自動完成 (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus 自動完成 (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " 命令列自動完成 (^V^N^P)"
 
+#: ../edit.c:94
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " 整行自動完成 (^L^N^P)"
+
+#: ../edit.c:95
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " 標籤自動完成 (^]^N^P)"
+
+#: ../edit.c:96
+#, fuzzy
+msgid " Spelling suggestion (s^N^P)"
+msgstr " 整行自動完成 (^L^N^P)"
+
+#: ../edit.c:97
+msgid " Keyword Local completion (^N^P)"
+msgstr " 區域關鍵字自動完成 (^N^P)"
+
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "已到段落結尾"
 
-msgid "'thesaurus' option is empty"
-msgstr "選項 'thesaurus' 未設定"
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
 
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "選項 'dictionary' 未設定"
 
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr "選項 'thesaurus' 未設定"
+
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "掃瞄字典: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (插入) Scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (取代) Scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "掃瞄中: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "掃瞄標籤."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " 增加"
 
@@ -324,201 +479,597 @@ msgstr " 增加"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- 搜尋中..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "回到起點"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "從別行開始的字 (?)"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "只有此項符合"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "找到 %d / %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "符合 %d"
 
-#. Skip further arguments but do continue to
-#. * search for a trailing command.
-#, c-format
-msgid "E106: Unknown variable: \"%s\""
-msgstr "E106: 未定義的變數: \"%s\""
+#: ../eval.c:137
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: '=' 前面出現了錯誤的字元"
 
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: 缺少對應的括號: %s"
+#: ../eval.c:138
+#, fuzzy, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
 
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: 無此變數: \"%s\""
-
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: '?' 後缺少 ':'"
-
-msgid "E110: Missing ')'"
-msgstr "E110: 缺少對應的 \")\""
-
-msgid "E111: Missing ']'"
-msgstr "E111: 缺少對應的 \"]\""
-
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: 缺少選項名稱: %s"
-
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: 不正確的選項: %s"
-
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: 缺少引號: %s"
-
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: 缺少引號: %s"
-
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: 函式 %s 的引數不正確"
-
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: 未定義的函式: %s"
-
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: 函式 %s 的引數過多"
-
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: 函式 %s 的引數太少"
-
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: <SID> 不能在 script 本文外使用: %s"
-
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
-msgid "&Ok"
-msgstr "確定(&O)"
-
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld 行: "
-
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"確定(&O)\n"
-"取消(&C)"
-
-msgid "called inputrestore() more often than inputsave()"
-msgstr "呼叫 inputrestore() 的次數比 inputsave() 還多"
-
-msgid "E655: Too many symbolic links (cycle?)"
-msgstr "E655: 太多層的符號鏈結(symlink) (循環?)"
-
-msgid "E240: No connection to Vim server"
-msgstr "E240: 沒有與 Vim Server 建立連線"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: 無法讀取伺服器的回應"
-
-msgid "E258: Unable to send to client"
-msgstr "E258: 無法傳送到 client"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: 無法傳送到 %s"
-
-msgid "(Invalid)"
-msgstr "(不正確)"
-
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: 變數 %s 尚未定義"
 
-#, c-format
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: 不合法的變數名稱: %s"
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr "E111: 缺少對應的 \"]\""
 
+#: ../eval.c:141
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "E487: 參數應該是正數"
+
+#: ../eval.c:143
+#, fuzzy, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E487: 參數應該是正數"
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: 找不到寫入用的暫存檔"
+
+#: ../eval.c:145
+#, fuzzy
+msgid "E714: List required"
+msgstr "E471: 需要指令參數"
+
+#: ../eval.c:146
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: 需要函式名稱"
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: 函式 %s 的引數過多"
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: 函式 %s 已經存在, 請使用 ! 強制取代"
 
+#: ../eval.c:151
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: 已有緩衝區使用這個名字"
+
+#: ../eval.c:152
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: 需要函式名稱"
+
+#: ../eval.c:153
+#, fuzzy
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E360: 不能用 -f 選項執行 shell"
+
+#: ../eval.c:154
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr ""
+
+#: ../eval.c:155
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: 未定義的函式: %s"
+
+#: ../eval.c:156
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: 不合法的變數名稱: %s"
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E138: 無法寫入 viminfo 檔案 %s !"
+
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E69: %s%%[ 後缺少 ]"
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: 缺少對應的括號: %s"
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: 無此變數: \"%s\""
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: '?' 後缺少 ':'"
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+#, fuzzy
+msgid "E692: Invalid operation for Lists"
+msgstr "E449: 收到不正確的運算式"
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: 不能用 -f 選項執行 shell"
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr "E110: 缺少對應的 \")\""
+
+#: ../eval.c:4609
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: 缺少選項名稱: %s"
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: 不正確的選項: %s"
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: 缺少引號: %s"
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: 缺少引號: %s"
+
+#: ../eval.c:5084
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: 缺少相等符號: %s"
+
+#: ../eval.c:5091
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: 缺少 \"=\": %s"
+
+#: ../eval.c:6475
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E242: 找不到顏色: %s"
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E242: 找不到顏色: %s"
+
+#: ../eval.c:6524
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: 缺少 :endfunction"
+
+#: ../eval.c:6555
+#, fuzzy
+msgid "E724: variable nested too deep for displaying"
+msgstr "E22: 巢狀遞迴呼叫太多層"
+
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: 函式 %s 的引數過多"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: 未定義的函式: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: 函式 %s 的引數太少"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> 不能在 script 本文外使用: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: = 後需要有數字"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "不正確的參數: "
+
+#: ../eval.c:7907
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "太多編輯參數"
+
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: 選單只能在其它模式中使用"
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr "確定(&O)"
+
+#: ../eval.c:8676
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: %s 的 mapping 已經存在"
+
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "vim [參數] "
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld 行: "
+
+#: ../eval.c:9291
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: 未定義的函式: %s"
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr "呼叫 inputrestore() 的次數比 inputsave() 還多"
+
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "太多編輯參數"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E481: 不可使用範圍指令"
+
+#: ../eval.c:11140
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E596: 不正確的字型"
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
+
+#: ../eval.c:12466
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: 太多層的符號鏈結(symlink) (循環?)"
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "不正確的參數: "
+
+#: ../eval.c:13776
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: 無法選擇此印表機"
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr "(不正確)"
+
+#: ../eval.c:14590
+#, fuzzy
+msgid "E677: Error writing temp file"
+msgstr "E208: 寫入檔案 \"%s\" 錯誤"
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+#, fuzzy
+msgid "E730: using List as a String"
+msgstr "E374: 格式化字串裡少了 ]"
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, fuzzy, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E93: 找到一個以上的 %s"
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+#: ../eval.c:16724
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr "未知"
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E284: 不能設定 IC 數值"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: 函式 %s 尚未定義"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: 缺少 \"(\": %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: 不能設定 IC 數值"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: 參數不正確: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: 缺少 :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: 函式 %s 正在使用中，無法重新定義"
 
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: 需要函式名稱"
 
-#, c-format
-msgid "E128: Function name must start with a capital: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: 函式名稱第一個字母必須大寫: %s"
 
-#, c-format
-msgid "E130: Undefined function: %s"
-msgstr "E130: 函式 %s 尚未定義"
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
 
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: 函式 %s 正在使用中，無法刪除"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: 函式遞迴呼叫層數超過 'maxfuncdepth'"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "呼叫 %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s 被強制中斷執行 "
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s 傳回值 #%<PRId64> "
 
-#, c-format
-msgid "%s returning \"%s\""
+#: ../eval.c:18670
+#, fuzzy, c-format
+msgid "%s returning %s"
 msgstr "%s 傳回值 \"%s\""
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "繼續: %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return 必須在函式裡使用"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -526,76 +1077,114 @@ msgstr ""
 "\n"
 "# 全域變數:\n"
 
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+"\n"
+"\t上次設定: "
+
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "沒有引入檔案"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  十六進位 %02x,  八進位 %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, 十六進位 %04x, 八進位 %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, 十六進位 %08x,  八進位 %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: 無法把行移到它自已內"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "已搬移 1 行 "
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "已搬移 %<PRId64> 行 "
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "已處理 %<PRId64> 行 "
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[更新後尚未儲存]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s 在行中: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: 過多錯誤, 忽略檔案其餘部分"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "讀取 viminfo 檔案 \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " 訊息"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " 標記"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "沒有引入檔案"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " 失敗"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo 檔案無法寫入: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: 無法寫入 viminfo 檔案 %s !"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "寫入 viminfo 檔案 \"%s\" 中"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# 本 viminfo 檔案是由 Vim %s 所產生.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -603,94 +1192,141 @@ msgstr ""
 "# 如果想要自行修改請特別小心！\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# 'encoding' 在此檔建立時的值\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "無效的起始字元"
 
-msgid "Save As"
-msgstr "另存新檔"
-
-#. Overwriting a file that is loaded in another buffer is not a
-#. * good idea.
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 您在另一個緩衝區也載入了這個檔案"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "要寫入部分檔案嗎？"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: 請使用 ! 以寫入部分緩衝區"
 
-#, c-format
-msgid "Overwrite existing file \"%.*s\"?"
+#: ../ex_cmds.c:2281
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
 msgstr "要覆寫已存在的檔案 \"%.*s\"？"
 
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
+
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: 緩衝區 %<PRId64> 沒有檔案名稱"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 檔案未寫入，因為 'write' 選項被關閉"
 
-#, c-format
+#: ../ex_cmds.c:2434
+#, fuzzy, c-format
 msgid ""
-"'readonly' option is set for \"%.*s\".\n"
+"'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "\"%.*s\" 已設定 'readonly' 選項.\n"
 "確定要覆寫嗎？"
 
-msgid "Edit File"
-msgstr "編輯檔案"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "是唯讀檔 (請使用 ! 強制執行)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autocommands 意外地刪除新緩衝區 %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z 不接受非數字的參數"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim 中禁止使用 shell 命令"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regular expression 無法用字母分隔 (?)"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "取代為 %s (y/n/a/q/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(已中斷) "
 
+#: ../ex_cmds.c:4384
+#, fuzzy
+msgid "1 match"
+msgstr "; 符合 "
+
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "取代一組 "
 
+#: ../ex_cmds.c:4387
+#, fuzzy, c-format
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 項改變"
+
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "取代 %<PRId64> 組 "
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr "，範圍：一行 "
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr "，範圍： %<PRId64> 行 "
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 無法遞迴執行 "
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: 沒有使用過 Regular expression (?)"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "每一行都找不到: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "找不到"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -700,319 +1336,338 @@ msgstr ""
 "# 前一組替代字串:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: 不要驚慌!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: 抱歉, 沒有關於 %s-%s 的說明"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: 抱歉, 沒有 %s 的說明"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "抱歉, 找不到說明檔 \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s 不是目錄"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: 無法以寫入模式開啟 \"%s\""
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: 無法讀取檔案: %s"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: 同一語言 (%s) 中有混合不同字元編碼的說明檔"
 
-#, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s"
+#: ../ex_cmds.c:5565
+#, fuzzy, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: 未定義的 sign command: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: 缺少 sign 名稱"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: 已定義太多 signs"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: 不正確的 sign 文字: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: 不正確的 sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: 缺少 sign number"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 緩衝區名稱錯誤: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Sign ID 錯誤: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (找不到) "
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (不支援) "
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[已刪除]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "進入除錯模式. 輸入 \"cont\" 以回到正常模式."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "行 %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "\"%s%s\" 中斷點: 第 %<PRId64> 行 "
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: 找不到中斷點: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "沒有定義中斷點"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  第 %<PRId64> 行 "
 
-#, c-format
-msgid "Save changes to \"%.*s\"?"
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
 msgstr "將變動存儲至 \"%.*s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "未命名"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: 已更改過緩衝區 \"%s\" 但尚未存檔 (可用 ! 強制執行)"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "注意: 已切換到其它緩衝區 (請檢查 Autocommands 有無錯誤)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: 只有一個檔案可編輯"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: 已經在第一個檔案了"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: 已經在最後一個檔案了"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: 編譯器不支援: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "搜尋中: \"%s\" -- \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "搜尋中: \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "在 'runtimepath' 裡找不到 \"%s\""
 
-msgid "Source Vim script"
-msgstr "執行 Vim script"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "無法執行目錄： \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "無法執行 \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "第 %<PRId64> 行: 無法執行 \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "執行 \"%s\" 中"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "第 %<PRId64> 行: 結束執行 %s"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "結束執行 %s"
 
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "還有一行 "
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr "vim [參數] "
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr "vim [參數] "
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+#, fuzzy
+msgid "error handler"
+msgstr "錯誤與中斷"
+
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: 注意: 錯誤的行分隔字元，可能是少了 ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: 在執行 script 檔案外不可使用 :scriptencoding"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: 在執行 script 檔案外不可使用 :finish"
 
-#, c-format
-msgid "Page %d"
-msgstr "第 %d 頁"
-
-msgid "No text to be printed"
-msgstr "沒有要列印的文字"
-
-#, c-format
-msgid "Printing page %d (%d%%)"
-msgstr "列印中: 第 %d 頁 (%d%%)"
-
-#, c-format
-msgid " Copy %d of %d"
-msgstr "複製 %d / %d"
-
-#, c-format
-msgid "Printed: %s"
-msgstr "已列印: %s"
-
-#, c-format
-msgid "Printing aborted"
-msgstr "已取消列印"
-
-msgid "E455: Error writing to PostScript output file"
-msgstr "E455: 無法寫入 PostScript 輸出檔"
-
-#, c-format
-msgid "E624: Can't open file \"%s\""
-msgstr "E624: 無法開啟檔案 \"%s\""
-
-#, c-format
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: 無法讀取 PostScript 資源檔 \"%s\""
-
-#, c-format
-msgid "E618: file \"%s\" is not a PostScript resource file"
-msgstr "E618: 檔案 \"%s\" 不是 PostScript 資源檔 "
-
-#, c-format
-msgid "E619: file \"%s\" is not a supported PostScript resource file"
-msgstr "E619: 不支援 PostScript 資源檔 \"%s\""
-
-#, c-format
-msgid "E621: \"%s\" resource file has wrong version"
-msgstr "E621: \"%s\" 資源檔版本錯誤"
-
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: 無法開啟 PostScript 輸出檔"
-
-#, c-format
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: 無法開啟檔案 \"%s\""
-
-msgid "E456: Can't find PostScript resource file \"prolog.ps\""
-msgstr "E456: 無法讀取 PostScript 資源檔 \"prolog.ps\""
-
-#, c-format
-msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: 無法讀取 PostScript 資源檔 \"%s.ps\""
-
-#, c-format
-msgid "E620: Unable to convert from multi-byte to \"%s\" encoding"
-msgstr "E620:無法轉換至 \"%s\" 字元編碼"
-
-msgid "Sending to printer..."
-msgstr "傳送資料到印表機..."
-
-msgid "E365: Failed to print PostScript file"
-msgstr "E365: 無法列印 PostScript 檔案"
-
-msgid "Print job sent."
-msgstr "已送出列印工作。"
-
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "目前的 %s語言: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: 不能設定語言成 \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "進入 Ex 模式. 輸入 \"visua\" 以回到正常模式."
 
-#. must be at EOF
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: 已到檔案結尾"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: 命令遞迴層數過多"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: 未攔截的例外： %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "命令檔結束"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "函式結尾"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: 使用者定義的命令會混淆"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: 不是編輯器的命令"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: 指定了向前參考的範圍"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "指定了向前參考的範圍，OK to swap"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: 請使用 w 或 w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: 抱歉, 本命令在此版本中沒有實作"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: 只能有一個檔"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "還有一個檔案未編輯. 確定要離開？"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "還有 %d 個檔案未編輯. 確定要離開？"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 還有一個檔案未編輯 "
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: 還有 %<PRId64> 個檔案未編輯"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已經存在, 請使用 ! 強制重新定義"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1020,248 +1675,348 @@ msgstr ""
 "\n"
 "    名稱        參數 範圍  完整      定義      "
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "找不到使用者定義的命令"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: 沒有指定的屬性"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: 不正確的參數數目"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: 不能指定兩次數目"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: 數目的預設參數不正確"
 
-msgid "E179: argument required for complete"
+#: ../ex_docmd.c:4625
+#, fuzzy
+msgid "E179: argument required for -complete"
 msgstr "E179: 指令需要參數才能完成"
 
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: 不完整的值: '%s'"
-
-msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: 自訂補完時才可補完參數"
-
-msgid "E467: Custom completion requires a function argument"
-msgstr "E467: 自訂補完需要函式為參數"
-
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: 不正確的屬性: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: 指令名稱不正確"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: 使用者自定指令必須以大寫字母開始"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: 使用者定義的命令會混淆"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: 沒有使用者自定的命令： %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: 不完整的值: '%s'"
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr "E468: 自訂補完時才可補完參數"
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr "E467: 自訂補完需要函式為參數"
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: 找不到顏色樣式 %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "嗨, Vim 使用者！"
 
-msgid "Edit File in new window"
-msgstr "在新視窗編輯檔案"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: 不能關閉最後一個視窗"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "已經只剩一個視窗了"
+
+#: ../ex_docmd.c:6004
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "第 %d 頁"
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "無暫存檔"
 
-msgid "Append File"
-msgstr "附加檔案"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr "E509: 無法建立備份檔 (請使用 ! 強制執行)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: 沒有前一個目錄"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: 無法辦識的標記"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize 需要兩個參數"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "視窗位置: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: 在您的平台上無法獲得視窗位置"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos 需要兩個參數"
 
-msgid "Save Redirection"
-msgstr "儲存 Redirection"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
+msgstr "無法執行目錄： \"%s\""
 
-msgid "Save View"
-msgstr "儲存 View"
-
-msgid "Save Session"
-msgstr "儲存 Session"
-
-msgid "Save Setup"
-msgstr "儲存設定"
-
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" 已存在 (請用 ! 強制執行)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: 無法以寫入模式開啟 \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: 參數必須是英文字母或向前/後的引號"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal 遞迴層數過深"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: 沒有 '#' 可替代的檔名"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: 沒有 Autocommand 檔名以取代 \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: 沒有 Autocommand 緩衝區名稱以取代 \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: 沒有 Autocommand 符合名稱以取代 \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%' 或 '#' 指向空檔名，只能用於 \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: 輸入為空字串"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: 無法讀取 viminfo"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: 本版本無複合字元(digraph)"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: 不能 :throw 用 'Vim' 開頭的例外"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "丟出例外： %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "例外結束： %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "已丟棄例外： %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "發生例外：%s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s 造成 pending"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s 已回復"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s 已丟棄"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "例外"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "錯誤與中斷"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "錯誤"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "中斷"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if 層數過深"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif 缺少對應的 :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else 缺少對應的 :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif 缺少對應的 :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: 多重 :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif 在 :else 之後"
 
-msgid "E585: :while nesting too deep"
+#: ../ex_eval.c:941
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while 層數過深"
 
-msgid "E586: :continue without :while"
+#: ../ex_eval.c:1028
+#, fuzzy
+msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue 缺少對應的 :while"
 
-msgid "E587: :break without :while"
+#: ../ex_eval.c:1061
+#, fuzzy
+msgid "E587: :break without :while or :for"
 msgstr "E587: :break 缺少對應的 :while"
 
+#: ../ex_eval.c:1102
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: 缺少 :endwhile"
+
+#: ../ex_eval.c:1104
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: 缺少 :endwhile"
+
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :if 層數過深"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch 沒有 :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch 在 :finally 之後"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally 沒有 :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: 多重 :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endif 缺少對應的 :if"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction 必須在函式內部使用"
 
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: 不能在 sandbox 裡出現"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: 找不到 %s"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "標籤名稱"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr "類檔案\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "選項 'history' 是零"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1270,194 +2025,302 @@ msgstr ""
 "\n"
 "# %s 歷史記錄 (新到舊):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "命令列"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "搜尋字串"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "運算式"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "輸入行 "
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar 超過命令長度"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: 已刪除掉作用中的視窗或暫存區"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr "E343: 不正確的路徑: '**[number]' 必需要在路徑結尾或要接著 '%s'"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath 中沒有目錄 \"%s\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: 在路徑中找不到檔案 \"%s\""
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: 在路徑中找不到更多的檔案 \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: 在路徑中找不到更多的檔案 \"%s\""
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "不正確的檔名"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "是目錄"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "不是檔案"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[未命名]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[權限不足]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre Autocommand 使程式無法讀取此檔"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *Filter* Autocommand 不可以更改緩衝區的內容"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: 從標準輸入讀取...\n"
 
-msgid "Reading from stdin..."
-msgstr "從標準輸入讀取..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: 轉換錯誤"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[唯讀]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "一個字元"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[缺少CR]'"
 
-msgid "[NL found]"
-msgstr "[找到NL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[分割過長行]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[未轉換]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[已轉換]"
 
-msgid "[crypted]"
-msgstr "[已加密]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[行 %<PRId64> 有不正確的位元]"
 
-msgid "[CONVERSION ERROR]"
-msgstr "轉換錯誤"
-
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[行 %<PRId64> 有不正確的位元]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[讀取錯誤]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "找不到轉換用的暫存檔"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "字元集轉換錯誤"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "無法讀取 'charconvert' 的輸出"
 
+#: ../fileio.c:2437
+#, fuzzy
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr "找不到對應的 autocommand"
+
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Autocommand 刪除或釋放了要寫入的緩衝區"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autocommand 意外地改變了行號"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans 不能寫出未修改的緩衝區"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "部份內容無法寫入 Netbeans 緩衝區"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "不是檔案或可寫入的裝置"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "是唯讀檔 (請使用 ! 強制執行)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: 無法寫入備份檔 (請使用 ! 強制執行)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: 無法關閉備份檔 (請使用 ! 強制執行)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: 無法讀取檔案以供備份 (請使用 ! 強制執行)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: 無法建立備份檔 (請使用 ! 強制執行)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: 無法製作備份檔 (請使用 ! 強制執行)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Resource fork 會消失 (請使用 ! 強制執行)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: 找不到寫入用的暫存檔"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: 無法轉換 (請使用 ! 強制不轉換寫入)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: 無法以寫入模式開啟連結檔案"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: 無法以寫入模式開啟"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync 命令執行失敗"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: 關閉失敗"
 
-msgid "E513: write error, conversion failed"
+#: ../fileio.c:3436
+#, fuzzy
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: 無法寫入 -- 轉換失敗"
 
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: 寫入錯誤 (檔案系統已滿？)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr "轉換錯誤"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "行 %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[裝置]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[新]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr "[a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " 已附加"
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr "[w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " 已寫入"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patch 模式: 無法儲存原始檔案"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Patch 模式: 無法變更空的原始檔案"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: 無法刪除備份檔"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1465,100 +2328,137 @@ msgstr ""
 "\n"
 "警告: 原始檔案流失或損壞\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "在檔案正確寫入前請勿離開編輯器!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos 格式]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac 格式]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix 格式]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 行, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> 行, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "一個字元"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64>個字元"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[結尾行不完整]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "警告: 本檔案自上次讀入後已變動!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "確定要寫入嗎"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: 寫入檔案 \"%s\" 錯誤"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: 關閉檔案 \"%s\" 錯誤"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: 讀取檔案 \"%s\" 錯誤"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell autocommand 刪除緩衝區"
 
-#, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
+#: ../fileio.c:4894
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
 msgstr "E211: 警告: 檔案 \"%s\" 已經不存在"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: 警告: 檔案 \"%s\" 自上次讀入後已變動, 而且編輯中的緩衝區也更動了"
 
+#: ../fileio.c:4907
+#, fuzzy
+msgid "See \":help W12\" for more info."
+msgstr "進一步說明請見 \":help W11\"。"
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: 警告: 檔案 \"%s\" 自上次讀入後已變動"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr "進一步說明請見 \":help W11\"。"
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: 警告: 檔案 \"%s\" 的權限與上次讀入時不一樣 (有變動過)"
 
+#: ../fileio.c:4915
+#, fuzzy
+msgid "See \":help W16\" for more info."
+msgstr "進一步說明請見 \":help W11\"。"
+
 # 'mode' seems better as translated to 'permission'?
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: 警告: 檔案 \"%s\" 在開始編輯後又被建立了"
 
-msgid "See \":help W11\" for more info."
-msgstr "進一步說明請見 \":help W11\"。"
-
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "警告"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1566,35 +2466,48 @@ msgstr ""
 "確定(&O)\n"
 "載入檔案(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: 無法準備重新載入 \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: 無法重新載入 \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--已刪除--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: 無此群組: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * 後面有不正確的字元: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: 無此事件: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: 無此群組或事件: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1602,390 +2515,802 @@ msgstr ""
 "\n"
 "--- Auto-Commands ---"
 
+#: ../fileio.c:6293
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr "緩衝區號碼錯誤"
+
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: 無法對所有事件執行 autocommand"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "找不到對應的 autocommand"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocommand 層數過深"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto commands: \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "執行 %s"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: 缺少 {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: 缺少 }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: 找不到任何 fold"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: 無法在目前的 'foldmethod' 下建立 fold"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: 無法在目前的 'foldmethod' 下刪除 fold"
 
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr "+--已 fold %3ld 行 "
+
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: 加入讀取緩衝區中"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: 遞迴 mapping"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s 已經有全域 abbreviation 了"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s 已經有全域 mapping 了"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s 已經有 abbreviation 了"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s 的 mapping 已經存在"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "找不到 abbreviation"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "沒有這個 mapping 對應"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: 不正確的模式"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: 無法啟動圖型界面"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--緩衝區無資料--"
 
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: 命令被強制中斷執行 "
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: 需要指令參數"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ 後面應該有 / ? 或 &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 不能在命令列視窗中使用。<CR>執行，CTRL-C 離開"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr "E12: exrc/vimrc 裡的指令無法執行 "
+
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: 缺少 :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: 缺少 :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: 缺少 :endwhile"
+
+#: ../globals.h:1006
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: 缺少 :endif"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile 缺少對應的 :while"
+
+#: ../globals.h:1008
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr "E580: :endif 缺少對應的 :if"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: 命令執行失敗"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: 內部錯誤"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "已中斷"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: 不正確的位址"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: 不正確的參數"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: 無法讀取檔案 \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 不正確的參數: %s"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: 無法啟動圖型界面，找不到可用的字型"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: 不正確的 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' 的值不正確"
-
+#: ../globals.h:1016
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: 不能配置顏色 %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: 不正確的運算式: %s"
 
-msgid "<cannot open> "
-msgstr "<不能開啟>"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: 不正確的範圍"
 
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: 不正確的命令"
+
+#: ../globals.h:1019
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: 不能使用 %s 字型"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" 是目錄"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: 無法回到目前目錄"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: 錯誤的捲動大小"
 
-msgid "Pathname:"
-msgstr "路徑:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: 無法取得目前目錄"
-
-msgid "OK"
-msgstr "確定"
-
-msgid "Cancel"
-msgstr "取消"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "捲動軸: 不能設定 thumb pixmap 的位置"
-
-msgid "Vim dialog"
-msgstr "Vim 對話盒"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: 不能對訊息與 callback 建立 BallonEval"
-
-msgid "Vim dialog..."
-msgstr "Vim 對話盒..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Y是\n"
-"&N否\n"
-"&C取消"
 
-msgid "Input _Methods"
-msgstr "輸入法"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - 尋找與取代..."
-
-msgid "VIM - Search..."
-msgstr "VIM - 尋找..."
-
-msgid "Find what:"
-msgstr "搜尋:"
-
-msgid "Replace with:"
-msgstr "取代為:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "只搜尋完全相同的字"
-
-#. match case button
-msgid "Match case"
-msgstr "符合大小寫"
-
-msgid "Direction"
-msgstr "方向"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "向上"
-
-msgid "Down"
-msgstr "向下"
-
-msgid "Find Next"
-msgstr "找下一個"
-
-msgid "Replace"
-msgstr "取代"
-
-msgid "Replace All"
-msgstr "取代全部"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: 由 Session 管理員收到 \"die\" 要求\n"
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: 主視窗爛掉\n"
-
-msgid "Font Selection"
-msgstr "字型選擇"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "使用 CUT_BUFFER0 來取代空選擇"
-
-msgid "Filter"
-msgstr "過濾器"
-
-msgid "Directories"
-msgstr "目錄"
-
-msgid "Help"
-msgstr "輔助說明"
-
-msgid "Files"
-msgstr "檔案"
-
-msgid "Selection"
-msgstr "選擇"
-
-msgid "Undo"
-msgstr "復原"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: 找不到標題為 \"%s\" 的視窗"
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: 不支援參數 \"-%s\"。請用 OLE 版本。"
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: 無法在 MDI 程式中開啟視窗"
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "搜尋字串 (使用 '\\\\' 來表示 '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "搜尋及取代字串 (使用 '\\\\' 來表示 '\\')"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: 無法配置 color map 項目，有些顏色看起來會怪怪的"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Fontset %s 沒有設定正確的字型以供顯示這些字元集:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: 字型集(Fontset)名稱: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "'%s' 不是固定寬度字型"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: 字型集(Fontset)名稱: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "字型%<PRId64> 寬度不是 字型0 的兩倍\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "字型0的寬度：%<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"字型1寬度: %<PRId64>\n"
-"\n"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul automata 錯誤"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 呼叫函式庫 \"%s\"() 失敗"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 標記的行號錯誤"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: 沒有設定標記"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 因為 'modifiable' 選項是關閉的，所以不能修改"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 巢狀遞迴呼叫太多層"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: 沒有替代的檔案"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: 沒有這個 abbreviation 對應"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: 不可使用 '!'"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: 因為編譯時沒有加入圖型界面的程式碼，所以無法使用圖型界面"
+
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 沒有名為 '%s' 的 highlight group"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: 還沒有插入文字過"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: 沒有前一項命令"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: 沒有這個 mapping 對應"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: 找不到"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 找不到: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: 沒有檔名"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 沒有前一個搜尋/取代的命令"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: 沒有前一個命令"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: 沒有前一個搜尋指令"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: 不可使用範圍指令"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: 沒有足夠的空間"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: 不能建立檔案 %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: 無法得知暫存檔名"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: 無法開啟檔案 %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: 無法讀取檔案 %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 已更改過檔案但尚未存檔 (可用 ! 強制執行)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[更新後尚未儲存]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: 空的 (Null) 參數"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: 應該要有數字"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 無法開啟錯誤檔案 %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: 記憶體不足!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "找不到"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 找不到 %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: 參數應該是正數"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 無法回到前一個目錄"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: 沒有錯誤"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr ""
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: 符合字串有問題"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: regexp 有問題"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 有設定 'readonly' 選項(唯讀) (可用 ! 強制執行)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 讀取錯誤檔案失敗"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: 不能在 sandbox 裡出現"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: 這裡不可使用"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 不支援設定螢幕模式"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: 錯誤的捲動大小"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'E71: 選項 'shell' 未設定"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: 無法讀取 sign data!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: 暫存檔關閉錯誤"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: 標籤堆疊已空"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: 命令太複雜"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: 名字太長"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: 太多 ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: 太多檔名"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: 你輸入了多餘的字元"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: 無法辦識的標記"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 無法展開萬用字元"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' 不能比 'winminheight' 更少"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' 不能比 'winminwidth' 更少"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: 寫入錯誤"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "數到零 (?)"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> 不能在 script 本文外使用."
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "E473: 內部錯誤"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr ""
+
+#: ../globals.h:1105
+#, fuzzy
+msgid "E749: empty buffer"
+msgstr "E279: 不是 SNiFF+ 的緩衝區"
+
+#: ../globals.h:1108
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: 錯誤的搜尋字串: %s"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 您在另一個緩衝區也載入了這個檔案"
+
+#: ../globals.h:1110
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: \"%s\" 不是固定寬度字型"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 暫存器名稱錯誤: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "已搜尋到檔案開頭；再從結尾繼續搜尋"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "已搜尋到檔案結尾；再從開頭繼續搜尋"
+
+#: ../hardcopy.c:240
+msgid "E550: Missing colon"
+msgstr "E550: 缺少 colon"
+
+#: ../hardcopy.c:252
+msgid "E551: Illegal component"
+msgstr "E551: 不正確的模式"
+
+#: ../hardcopy.c:259
+msgid "E552: digit expected"
+msgstr "E552: 應該要有數字"
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr "第 %d 頁"
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr "沒有要列印的文字"
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "列印中: 第 %d 頁 (%d%%)"
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr "複製 %d / %d"
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr "已列印: %s"
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr "已取消列印"
+
+#: ../hardcopy.c:1365
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: 無法寫入 PostScript 輸出檔"
+
+#: ../hardcopy.c:1747
+#, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E624: 無法開啟檔案 \"%s\""
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: 無法讀取 PostScript 資源檔 \"%s\""
+
+#: ../hardcopy.c:1772
+#, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E618: 檔案 \"%s\" 不是 PostScript 資源檔 "
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr "E619: 不支援 PostScript 資源檔 \"%s\""
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr "E621: \"%s\" 資源檔版本錯誤"
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: 無法開啟 PostScript 輸出檔"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: 無法開啟檔案 \"%s\""
+
+#: ../hardcopy.c:2583
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E456: 無法讀取 PostScript 資源檔 \"prolog.ps\""
+
+#: ../hardcopy.c:2593
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E456: 無法讀取 PostScript 資源檔 \"%s.ps\""
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E456: 無法讀取 PostScript 資源檔 \"%s.ps\""
+
+#: ../hardcopy.c:2654
+#, fuzzy, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr "E620:無法轉換至 \"%s\" 字元編碼"
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr "傳送資料到印表機..."
+
+#: ../hardcopy.c:2881
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: 無法列印 PostScript 檔案"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr "已送出列印工作。"
+
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "新增資料庫"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "輸入 pattern"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "顯示此訊息"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "結束連線"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "重設所有連線"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "顯示連線"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: 用法: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "這個 cscope 命令不支援分割螢幕\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: 用法: cstag <識別字ident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: 找不到 tag"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) 錯誤: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat 錯誤"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s 不是目錄或 cscope 資料庫"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "新增 cscope 資料庫 %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: 讀取 cscope 連線 %<PRId64> 錯誤"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 搜尋形態"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: 無法建立與 cscope 的 pipe 連線"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: 無法 fork 以執行 cscope "
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection 執行失敗"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection 執行失敗"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: 無法執行 cscope "
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen 失敗 (to_fp)"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen 失敗 (fr_fp)"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: 無法執行 cscope "
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: 沒有 cscope 連線"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: 找不到符合 cscope 的搜尋 %s / %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cscopequickfix 的 flac %c (%c) 不正確"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: 找不到符合 cscope 的搜尋 %s / %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope 命令:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (用法: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: 無法開啟 cscope 資料庫 %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: 無法取得 cscope 資料庫資訊"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: 重複的 cscope 資料庫未被加入"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: 已達到 cscope 最大連線數目"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: 找不到 cscope 連線 %s"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope 連線 %s 已關閉"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches 嚴重錯誤"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope 標籤(tag): %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -1993,324 +3318,89 @@ msgstr ""
 "\n"
 "   #   行  "
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "檔名     / 內文    / 行號\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Csope 錯誤: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "重設所有 cscope 資料庫"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "沒有 cscope 連線\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    資料庫名稱                          prepend path\n"
 
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr "E263: 抱歉，這個命令無法使用，Python 程式庫沒有載入。"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: 無法遞迴執行 Python "
-
-msgid "can't delete OutputObject attributes"
-msgstr "無法刪除 OutputObject 屬性"
-
-msgid "softspace must be an integer"
-msgstr "softspace 必需是整數"
-
-msgid "invalid attribute"
-msgstr "不正確的屬性"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() 需要 string list 當參數"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: 無法初始 I/O 物件"
-
-msgid "invalid expression"
-msgstr "不正確的運算式"
-
-msgid "expressions disabled at compile time"
-msgstr "因為編譯時沒有加入運算式(expression)的程式碼，所以無法使用運算式"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "試圖使用已被刪除的 buffer"
-
-msgid "line number out of range"
-msgstr "行號超出範圍"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<buffer 物件 (已刪除): %8lX>"
-
-msgid "invalid mark name"
-msgstr "標記名稱不正確"
-
-msgid "no such buffer"
-msgstr "無此 buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "試圖使用已被刪除的視窗"
-
-msgid "readonly attribute"
-msgstr "唯讀屬性"
-
-msgid "cursor position outside buffer"
-msgstr "游標定位在緩衝區之外"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<視窗物件(已刪除): %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<視窗物件(未知): %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<視窗 %d>"
-
-msgid "no such window"
-msgstr "無此視窗"
-
-msgid "cannot save undo information"
-msgstr "無法儲存復原資訊"
-
-msgid "cannot delete line"
-msgstr "不能刪除此行 "
-
-msgid "cannot replace line"
-msgstr "不能替代此行 "
-
-msgid "cannot insert line"
-msgstr "不能替代插入此行 "
-
-msgid "string cannot contain newlines"
-msgstr "字串無法包含新行 "
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: 此命令無法使用，無法載入 Ruby 程式庫(Library)"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: 未知的 longjmp status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "切換實作/定義"
-
-msgid "Show base class of"
-msgstr "顯示 base class of:"
-
-msgid "Show overridden member function"
-msgstr "顯示被 override 的 member function"
-
-msgid "Retrieve from file"
-msgstr "讀取: 從檔案"
-
-msgid "Retrieve from project"
-msgstr "讀取: 從物件"
-
-msgid "Retrieve from all projects"
-msgstr "讀取: 從所有 project"
-
-msgid "Retrieve"
-msgstr "讀取"
-
-msgid "Show source of"
-msgstr "顯示原始碼: "
-
-msgid "Find symbol"
-msgstr "搜尋 symbol"
-
-msgid "Browse class"
-msgstr "瀏覽 class"
-
-msgid "Show class in hierarchy"
-msgstr "顯示階層式的 class"
-
-msgid "Show class in restricted hierarchy"
-msgstr "顯示 restricted 階層式的 class"
-
-msgid "Xref refers to"
-msgstr "Xref 參考到"
-
-msgid "Xref referred by"
-msgstr "Xref 被誰參考:"
-
-msgid "Xref has a"
-msgstr "Xref 有"
-
-msgid "Xref used by"
-msgstr "Xref 被誰使用:"
-
-msgid "Show docu of"
-msgstr "顯示文件: "
-
-msgid "Generate docu for"
-msgstr "產生文件: "
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr "無法連線到 SNiFF+。請檢查環境變數 ($PATH 裡必需可以找到 sniffemacs)\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: 讀取錯誤. 取消連線"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ 目前"
-
-msgid "not "
-msgstr "未"
-
-msgid "connected"
-msgstr "連線中"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: 不正確的 SNiff+ 呼叫: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: 連線到 SNiFF+ 失敗"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: 未連線到 SNiFF+"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: 不是 SNiFF+ 的緩衝區"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: 寫入錯誤。結束連線"
-
-msgid "invalid buffer number"
-msgstr "緩衝區號碼錯誤"
-
-msgid "not implemented yet"
-msgstr "尚未實作"
-
-msgid "unknown option"
+#: ../main.c:144
+#, fuzzy
+msgid "Unknown option argument"
 msgstr "不正確的選項"
 
-#. ???
-msgid "cannot set line(s)"
-msgstr "不能設定行 "
-
-msgid "mark not set"
-msgstr "沒有設定標記"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "列 %d 行 %d"
-
-msgid "cannot insert/append line"
-msgstr "不能插入或附加此行 "
-
-msgid "unknown flag: "
-msgstr "錯誤的旗標: "
-
-msgid "unknown vimOption"
-msgstr "不正確的 VIM 選項"
-
-msgid "keyboard interrupt"
-msgstr "鍵盤中斷"
-
-msgid "vim error"
-msgstr "vim 錯誤"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "無法建立緩衝區/視窗命令: 物件將會被刪除"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "無法註冊 callback 命令: 緩衝區/視窗已經被刪除了"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr "E280: TCL 嚴重錯誤: reflist 爛掉了!? 請報告給 to vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "無法註冊 callback 命令: 找不到緩衝區/視窗"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: 此命令無法使用, 因為無法載入 Tcl 程式庫(Library)"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: TCL 錯誤: 結束碼不是整數!? 請報告給 to vim-dev@vim.org"
-
-msgid "cannot get line"
-msgstr "不能取得此行 "
-
-msgid "Unable to register a command server name"
-msgstr "無法註冊命令伺服器名稱"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: 無法送出命令到目的地程式"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: 不正確的伺服器 id : %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM 的 registry 設定項有誤。已刪除。"
-
-msgid "Unknown option"
-msgstr "不正確的選項"
-
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "太多編輯參數"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "缺少必要的參數:"
 
-msgid "Garbage after option"
+#: ../main.c:150
+#, fuzzy
+msgid "Garbage after option argument"
 msgstr "無法辨認此選項後的命令: "
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "太多 \"+command\" 、 \"-c command\" 或 \"--cmd command\" 參數"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "不正確的參數: "
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "您的 Vim 編譯時沒有加入 diff 的能力"
-
-msgid "Attempt to open script file again: \""
-msgstr "試圖再次開啟 script 檔: \""
-
-msgid "Cannot open for reading: \""
-msgstr "無法開啟以讀取: \""
-
-msgid "Cannot open for script output: \""
-msgstr "無法開啟為 script 輸出: \""
-
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "還有 %d 個檔案等待編輯\n"
 
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr "試圖再次開啟 script 檔: \""
+
+#: ../main.c:1350
+msgid "Cannot open for reading: \""
+msgstr "無法開啟以讀取: \""
+
+#: ../main.c:1393
+msgid "Cannot open for script output: \""
+msgstr "無法開啟為 script 輸出: \""
+
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 注意: 輸出不是終端機(螢幕)\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: 注意: 輸入不是終端機(鍵盤)\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "vimrc 前命令列"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: 無法讀取檔案 \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2318,18 +3408,23 @@ msgstr ""
 "\n"
 "查詢更多資訊請執行: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[檔案 ..]       編輯指定的檔案"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               從標準輸入(stdin)讀取檔案"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          編輯時使用指定的 tag"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  編輯時載入第一個錯誤"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2339,9 +3434,11 @@ msgstr ""
 "\n"
 " 用法:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr "vim [參數] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2349,6 +3446,7 @@ msgstr ""
 "\n"
 "   或:"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2358,312 +3456,190 @@ msgstr ""
 "\n"
 "參數:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t只有在這之後的檔案"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t不展開萬用字元"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\t註冊 gvim 到 OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\t取消 OLE 中的 gvim 註冊"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\t使用圖形界面 (同 \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  或  --nofork\t前景: 起始圖形界面時不 fork"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi 模式 (同 \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx 模式 (同 \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t安靜 (batch) 模式 (只能與 \"ex\" 一起使用)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff 模式 (同 \"vimdiff\", 可迅速比較兩檔案不同處)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\t簡易模式 (同 \"evim\", modeless)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t唯讀模式 (同 \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t限制模式 (同 \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t不可修改 (寫入檔案)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t不可修改文字"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t二進位模式"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp 模式"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\t'compatible' 傳統 Vi 相容模式"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\t'nocompatible' 不完全與傳統 Vi 相容，可使用 Vim 加強能力"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tVerbose 等級"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t除錯模式"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t不使用暫存檔, 只使用記憶體"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t列出暫存檔後離開"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (加檔名)       \t修復上次損毀的資料(Recover crashed session)"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t同 -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t不使用 newcli 來開啟視窗"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\t使用 <device> 做輸出入"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\t啟動為 Arabic 模式"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\t啟動為 Hebrew 模式"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\t啟動為 Farsi 模式"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t設定終端機為 <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t使用 <vimrc> 取代任何 .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t使用 <gvimrc> 取代任何 .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t不載入任何 plugin"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t同 -o 但使用垂直分割"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t啟動後跳到檔案結尾"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t啟動後跳到第 <lnum> 行 "
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\t載入任何 vimrc 前執行 <command>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t載入第一個檔案後執行 <command>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t載入第一個檔案後載入 Session 檔 <session>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t從 <scriptin> 讀入一般模式命令"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t對檔案 <scriptout> 附加(append)所有輸入的命令"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t對檔案 <scriptout> 寫入所有輸入的命令"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t編輯編碼過的檔案"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
 
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t將 vim 與指定的 X-server 連線"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\t不要連線到 X Server"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t編輯 Vim 伺服器上的 <files> 後離開"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  相同，但沒有伺服器時不警告"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  同 --remote, 但會等候檔案完成編輯"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  相同，但沒伺服器時不警告"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 伺服器並離開"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t在伺服器上執行 <expr> 並印出結果"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t列出可用的 Vim 伺服器名稱並離開"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t送至/成為 Vim 伺服器 <name>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 而非 .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  或  --help\t印出說明(也就是本訊息)後離開"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t印出版本資訊後離開"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim 認得的參數 (Motif 版):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim 認得的參數 (neXtaw 版):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim 認得的參數 (Athena 版):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t在視窗 <display> 執行 vim"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t啟動後圖示化(iconified)"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\t讀取 Resource 時把 vim 的名稱視為 <name>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (尚未實作)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t設定 <color> 為背景色 (也可用 -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t設定 <color> 為一般文字顏色 (也可用 -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t使用 <font> 為一般字型 (也可用 -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t使用 <font> 為粗體字型"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t使用 <font> 為斜體字型"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t使用<geom>為起始位置 (也可用 -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t使用寬度為 <width> 的邊框 (也可用 -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width>  設定捲動軸寬度為 <width> (也可用 -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t設定選單列的高度為 <height> (也可用 -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t使用反相顯示 (也可用 -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t不使用反相顯示 (也可用 +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t設定指定的 resource"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim 認得的參數 (RISC OS 版):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <number>\t視窗初始化寬度"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <number>\t視窗初始化高度"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim 認得的參數 (GTK+ 版):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t在 <display> 執行 vim (也可用 --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t設定獨特的角色(role)以區分主視窗"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t在另一個 GTK widget 內開啟 Vim"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\t在父程式中開啟 Vim"
-
-msgid "No display"
-msgstr "無顯示"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": 傳送失敗。\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": 送出失敗。試圖在本地執行\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "已編輯 %d/%d 個檔案"
-
-msgid "No display: Send expression failed.\n"
-msgstr "無 Display: 無法傳送運算式。\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": 無法傳送運算式。\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "沒有設定標記 (mark)"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: 找不到符合 \"%s\" 的標記(mark)"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2672,6 +3648,7 @@ msgstr ""
 "標記 行號  欄  檔案/文字"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2680,6 +3657,7 @@ msgstr ""
 " jump 行號  欄  檔案/文字"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -2687,7 +3665,7 @@ msgstr ""
 "\n"
 "改變   行號  欄  文字"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2696,7 +3674,7 @@ msgstr ""
 "# 檔案標記:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -2704,7 +3682,7 @@ msgstr ""
 "\n"
 "# Jumplist (由新到舊):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -2712,94 +3690,85 @@ msgstr ""
 "\n"
 "# 檔案內 Mark 記錄 (由新到舊):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "缺少對應的 '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: 不正確的 codepage"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: 不能設定 IC 數值"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: 無法建立 input context"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: 無法開啟輸入法"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: 警告: 無法移除 IM 的 callback"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: 輸入法不支援任何 style"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: 輸入法不支援任何 style"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: over-the-spot 需要字型集(Fontset)"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: 你的 GTK+ 比 1.2.3 還舊。無法使用狀態區。"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: 沒有執行中的輸入法管理程式(Input Method Server)"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: 區塊未被鎖定"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: 暫存檔讀取錯誤"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: 暫存檔讀取錯誤"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: 暫存檔寫入錯誤"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: 暫存檔寫入錯誤"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: 暫存檔已經存在! (小心符號連結的安全漏洞!?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: 找不到區塊 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: 找不到區塊 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: 找不到區塊 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: 噢噢, 暫存檔不見了!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: 無法改變暫存檔的名稱"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: 無法開啟暫存檔 \"%s\", 不可能修復了"
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_timestamp: 找不到區塊 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: 找不到 %s 的暫存檔"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "請選擇你要使用的暫存檔 (按0 離開): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: 無法開啟 %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "無法讀取區塊 0:"
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -2807,22 +3776,28 @@ msgstr ""
 "\n"
 "可能是你沒做過任何修改或是 Vim 還來不及更新暫存檔."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " 無法在本版本的 Vim 中使用.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "使用 Vim 3.0。\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s 看起來不像是 Vim 暫存檔"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " 無法在這臺電腦上使用.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "本檔案建立於 "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -2830,63 +3805,85 @@ msgstr ""
 ",\n"
 "或是這檔案已經損毀。"
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "使用暫存檔 \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "原始檔 \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: 警告: 原始檔案可能已經修改過了"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: 無法從 %s 讀取區塊 1"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???缺少太多行 "
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???行號錯誤"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???空的 BLOCK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???找不到一些行 "
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: 區塊 1 ID 錯誤 (%s 不是暫存檔?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???找不到BLOCK"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? 從這裡到 ???END 的內容可能有問題"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? 從這裡到 ???END 的內容可能被刪除/插入過"
 
 # do not translate
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: 修復已中斷"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: 修復時發生錯誤; 請注意開頭為 ??? 的行 "
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "詳細說明請見 \":help E312\""
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "復原完成. 請確定一切正常."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -2894,50 +3891,71 @@ msgstr ""
 "\n"
 "(你可能會想要把這個檔案另存別的檔名，\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "再執行 diff 與原檔案比較以檢查是否有改變)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "(D)直接刪除 .swp 暫存檔\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "找到以下的暫存檔:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   在目前的目錄:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Using specified name:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   在目錄 "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- 無 --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            擁有者: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    日期: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              日期: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "              [從 Vim 版本 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "                          [不像 Vim 的暫存檔]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "              檔名: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -2945,12 +3963,15 @@ msgstr ""
 "\n"
 "            修改過: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "是"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "否"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -2958,9 +3979,11 @@ msgstr ""
 "\n"
 "            使用者: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "    主機名稱: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -2968,6 +3991,7 @@ msgstr ""
 "\n"
 "          主機名稱: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -2975,16 +3999,11 @@ msgstr ""
 "\n"
 "        process ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (執行中)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [無法在本版本的 Vim 上使用]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -2992,71 +4011,97 @@ msgstr ""
 "\n"
 "         [無法在本電腦上使用]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [無法讀取]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [無法開啟]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: 無法保留, 不使用暫存檔"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "檔案已保留"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: 保留失敗"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: 錯誤的 lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: 找不到第 %<PRId64> 行 "
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指標區塊 id 錯誤 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx 應該是 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: 更新太多區塊?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: 指標區塊 id 錯誤 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "刪除區塊 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: 找不到第 %<PRId64> 行 "
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指標區塊 id 錯誤"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count 為零"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: 區塊 %<PRId64> 行數錯誤"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "堆疊大小增加"
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: 指標區塊 id 錯 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: 注意"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3064,37 +4109,43 @@ msgstr ""
 "\n"
 "找到暫存檔 \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "在開啟檔案 \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      比暫存檔更新!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) 可能有另一個程式也在編輯同一個檔案.\n"
 "    如果是這樣，請小心不要兩邊一起寫入，不然你的努力都會負諸流水。\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    離開，或是繼續編輯。\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) 前次編輯此檔時當機\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    如果是這樣, 請用 \":recover\" 或 \"vim -r"
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3102,9 +4153,11 @@ msgstr ""
 "\"\n"
 "    來救回修改資料 (詳細說明請看 \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    如果該救的都已經救了, 請直接刪除此暫存檔 \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3112,18 +4165,23 @@ msgstr ""
 "\"\n"
 "    以避免再看到此訊息.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "暫存檔 \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" 已經存在了!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - 注意"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "暫存檔已經存在!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3137,44 +4195,72 @@ msgstr ""
 "離開(&Q)\n"
 "跳出(&A)"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Abort\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "以唯讀方式開啟(&O)\n"
 "直接編輯(&E)\n"
 "修復(&R)\n"
 "離開(&Q)\n"
-"跳出(&A)\n"
-"刪除暫存檔(&D)"
+"跳出(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: 找到太多暫存檔"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 記憶體不足! (嘗試配置 %<PRIu64> 位元組)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: 部份選項路徑不是子選單"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: 選單只能在其它模式中使用"
 
-msgid "E329: No menu of that name"
+#: ../menu.c:64
+#, fuzzy, c-format
+msgid "E329: No menu \"%s\""
 msgstr "E329: 沒有那樣的選單"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: 選單路徑不能指向子選單"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: 不能直接把選項加到選單列中"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: 分隔線不能是選單路徑的一部份"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3182,63 +4268,76 @@ msgstr ""
 "\n"
 "--- 選單 ---"
 
-msgid "Tear off this menu"
-msgstr "切下此選單"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: 選單路徑必需指向一個選項"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: [選單] 找不到 %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s 模式未定義選單"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: 選單路徑必需指向子選單"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: 找不到選單 - 請檢查選單名稱"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "處理 %s 時發生錯誤:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "行 %4ld:"
 
-msgid "[string too long]"
-msgstr "[此行過長]"
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: 暫存器名稱錯誤: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "正體中文訊息維護者: Francis S.Lin <piaip@csie.ntu.edu."
 "tw>,                                 Cecil Sheng   <b7506022@csie.ntu.edu.tw>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "已中斷: "
 
-msgid "Hit ENTER to continue"
-msgstr "請按 ENTER 繼續"
-
-msgid "Hit ENTER or type command to continue"
+#: ../message.c:988
+#, fuzzy
+msgid "Press ENTER or type command to continue"
 msgstr "請按 ENTER 或其它命令以繼續"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- 尚有 --"
 
-msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-msgstr " (RET/BS: 向下/向上一行, 空白鍵/b: 一頁, d/u: 半頁, q: 離開)"
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
-msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-msgstr " (RET: 向下一行, 空白鍵: 一頁, d: 半頁, q: 離開)"
-
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "問題"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3246,6 +4345,17 @@ msgstr ""
 "&Y是\n"
 "&N否"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Y是\n"
+"&N否\n"
+"&C取消"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3259,229 +4369,179 @@ msgstr ""
 "&D全部不存\n"
 "&C取消"
 
-msgid "Save File dialog"
-msgstr "存檔"
+#: ../message.c:3058
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: 函式 %s 的引數不正確"
 
-msgid "Open File dialog"
-msgstr "開檔"
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
 
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: 主控台(Console)模式時沒有檔案瀏覽器(file browser)"
+#: ../message.c:3873
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: 函式 %s 的引數過多"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: 注意: 你正在修改一個唯讀檔"
 
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "還有一行 "
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "少於一行 "
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "多了 %<PRId64> 行 "
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "少了 %<PRId64> 行 "
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (已中斷)"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: 保留檔案中...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: 結束.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "錯誤: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
+#: ../misc1.c:2635
+msgid "Beep!"
 msgstr ""
-"\n"
-"[bytes] 全部 alloc-freed %<PRIu64>-%<PRIu64>, 使用中 %<PRIu64>, peak 使用 %<PRIu64>\n"
 
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[呼叫] 全部 re/malloc(): %<PRIu64>, 全部 free()': %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: 此行過長"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 記憶體不足! (嘗試配置 %<PRIu64> 位元組)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "呼叫 shell 執行: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: 缺少 colon"
-
-msgid "E546: Illegal mode"
-msgstr "E546: 不正確的模式"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: 不正確的滑鼠形狀"
-
-msgid "E548: digit expected"
-msgstr "E548: 應該要有數字"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: 不正確的百分比"
-
-msgid "Enter encryption key: "
-msgstr "輸入密碼: "
-
-msgid "Enter same key again: "
-msgstr "請再輸入一次: "
-
-msgid "Keys don't match!"
-msgstr "兩次輸入密碼不相同!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr "E343: 不正確的路徑: '**[number]' 必需要在路徑結尾或要接著 '%s'"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath 中沒有目錄 \"%s\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: 在路徑中找不到檔案 \"%s\""
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: 在路徑中找不到更多的檔案 \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: 在路徑中找不到更多的檔案 \"%s\""
-
-msgid "E550: Missing colon"
-msgstr "E550: 缺少 colon"
-
-msgid "E551: Illegal component"
-msgstr "E551: 不正確的模式"
-
-msgid "E552: digit expected"
-msgstr "E552: 應該要有數字"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "無法連接到 Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "無法連接到 Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans 連線資訊檔案: \"%s\" 存取模式不正確"
-
-msgid "read from Netbeans socket"
-msgstr "由 Netbeans socket 讀取"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: 緩衝區 %<PRId64> 與 NetBeans 的連線已中斷"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "注意: 你的終端機無法顯示高亮度"
-
-msgid "E348: No string under cursor"
-msgstr "E348: 游標處沒有字串"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: 游標處沒有識別字"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E221: 選項 'commentstring' 未設定"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "注意: 你的終端機無法顯示高亮度"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: 游標處沒有字串"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: 無法在目前的 'foldmethod' 下刪除 fold"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: 變更列表是空的"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: 已在變更列表的開頭"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "要離開 Vim 請輸入 :quit<Enter> "
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "一行 %s 過 一次"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "一行 %s 過 %d 次"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> 行 %s 過 一次"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> 行 %s 過 %d 次"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "縮排 %<PRId64> 行... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "一行已縮排"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "已縮排 %<PRId64> 行 "
 
+#: ../ops.c:938
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: 沒有前一個目錄"
+
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "無法剪下; 直接刪除"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr " 1 行 ~ed"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "已改變 %<PRId64> 行 "
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "釋放 %<PRId64> 行中 "
+#: ../ops.c:2521
+#, fuzzy
+msgid "block of 1 line yanked"
+msgstr "已複製 1 行 "
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "已複製 1 行 "
 
+#: ../ops.c:2525
+#, fuzzy, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr "已複製 %<PRId64> 行 "
+
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "已複製 %<PRId64> 行 "
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: 暫存器 %s 裡沒有東西"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3489,10 +4549,11 @@ msgstr ""
 "\n"
 "--- 暫存器 ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "不正確的暫存器名稱"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3500,153 +4561,195 @@ msgstr ""
 "\n"
 "# 暫存器:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的註冊型態: %d"
 
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: 暫存器名稱錯誤: '%s'"
-
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> 欄; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/%<PRId64> 字元(Bytes)"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/"
+"%<PRId64> 字元(Bytes)"
 
+#: ../ops.c:5105
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/"
+"%<PRId64> 字元(Bytes)"
+
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) %<PRId64>/%<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) "
+"%<PRId64>/%<PRId64>"
 
+#: ../ops.c:5133
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) "
+"%<PRId64>/%<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=第 %N 頁"
 
 # ? what's this for?
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "感謝您愛用 Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: 不正確的選項"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: 不支援該選項"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: 不能在 Modeline 裡出現"
 
-msgid ""
-"\n"
-"\tLast set from "
+#: ../option.c:2815
+msgid "E846: Key code not set"
 msgstr ""
-"\n"
-"\t上次設定: "
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = 後需要有數字"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Termcap 裡面找不到"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正確的字元 <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 無法設定 'term' 為空字串"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: 在圖型界面中無法切換 term"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: 輸入 \":gui\" 來啟動圖形界面"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' 跟 'patchmode' 是一樣的"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: 在圖型界面中無法切換 term"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: 缺少 colon"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: 零長度字串"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> 後缺少數字"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: 缺少逗號"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: 必需指定一個 ' 值"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: 內含無法顯示的字元"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: 不正確的字型"
-
-msgid "E597: can't select fontset"
-msgstr "E597: 無法使用字型集(Fontset)"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: 不正確的字型集(Fontset)"
-
-msgid "E533: can't select wide font"
-msgstr "E533: 無法使用設定的中文字型(Widefont)"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: 不正確的字型(Widefont)"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> 後有不正確的字元"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: 需要逗號"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' 必需是空白或包含 %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: 不支援滑鼠"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 沒有結束的運算式: "
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: 太多項目"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: 不對稱的 group"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: 預視的視窗已經存在了"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic 需要 UTF-8, 請執行 ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: 至少需要 %d 行 "
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: 至少需要 %d 欄"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: 不正確的選項: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: = 後需要有數字"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3654,6 +4757,7 @@ msgstr ""
 "\n"
 "--- 終端機碼 ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3661,6 +4765,7 @@ msgstr ""
 "\n"
 "--- Global 選項值 ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3668,6 +4773,7 @@ msgstr ""
 "\n"
 "--- Local 選項值 ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3675,129 +4781,21 @@ msgstr ""
 "\n"
 "--- 選項 ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp 錯誤"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': 找不到 %s 對應的字元"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': 分號後有多餘的字元: %s"
 
-msgid "cannot open "
-msgstr "不能開啟"
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: 無法開啟視窗!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "需要 Amigados 版本 2.04 以上\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "需要 %s 版本 %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "無法開啟 NIL:\n"
-
-msgid "Cannot create "
-msgstr "不能建立 "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim 結束傳回值: %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "無法切換主控台(console)模式 !?\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: 不是主控台(console)??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: 不能用 -f 選項執行 shell"
-
-msgid "Cannot execute "
-msgstr "不能執行 "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " 已返回\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE 太小"
-
-msgid "I/O ERROR"
-msgstr "I/O 錯誤"
-
-msgid "...(truncated)"
-msgstr "...(已切掉)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' 不是 80, 無法執行外部命令"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: 無法選擇此印表機"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "到 %s on %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: 不正確的印表機字型: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: 列印錯誤: %s"
-
-msgid "Unknown"
-msgstr "未知"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "列印中: '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: 字元集 \"%s\" 無法對應字型\"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: 不正確的字元 '%c' 出現在字型名稱 \"%s\" 內"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: 雙重signal, 離開中\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: CVim: 攔截到信號(signal) %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: 攔截到致命的信號(deadly signale)\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "開啟 X Window 耗時 %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X 錯誤\n"
-
-msgid "Testing the X display failed"
-msgstr "測試 X Window 失敗"
-
-msgid "Opening the X display timed out"
-msgstr "開啟 X Window 逾時"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -3805,13 +4803,7 @@ msgstr ""
 "\n"
 "不能執行 shell"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"不能執行 shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -3819,386 +4811,959 @@ msgstr ""
 "\n"
 "Shell 已返回"
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"不能建立 pipe 管線\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"不能 fork\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"命令已終結\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP 失去 ICE 連線"
-
-msgid "Opening the X display failed"
-msgstr "開啟 X Window 失敗"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP 正在處理自我儲存要求"
-
-msgid "XSMP opening connection"
-msgstr "開啟 XSMP 連線中"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE 連線監看失敗"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection 失敗: %s"
-
-msgid "At line"
-msgstr "在行號 "
-
-msgid "Could not allocate memory for command line."
-msgstr "無法為命令列配置記憶體。"
-
-msgid "VIM Error"
-msgstr "VIM 錯誤"
-
-msgid "Could not load vim32.dll!"
-msgstr "無法載入 vim32.dll！"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "不能修正函式指標到 DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "Shell 傳回值 %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: 攔截到 %s \n"
-
-msgid "close"
-msgstr "關閉"
-
-msgid "logoff"
-msgstr "登出"
-
-msgid "shutdown"
-msgstr "關機"
-
-msgid "E371: Command not found"
-msgstr "E371: 找不到命令"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
+msgid "dlerror = \"%s\""
 msgstr ""
-"在你的 $PATH 中找不到 VIMRUN.EXE.\n"
-"外部命令執行完畢後將不會暫停.\n"
-"進一步說明請執行 :help win32-vimrun "
 
-msgid "Vim Warning"
-msgstr "Vim 警告"
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: 在路徑中找不到檔案 \"%s\""
 
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: 格式化字串裡有太多 %%%c "
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: 格式化字串不應該出現 %%%c "
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: 格式化字串裡少了 ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: 格式化字串裡有不支援的 %%%c "
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: 格式化字串開頭裡有不正確的 %%%c "
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: 格式化字串裡有不正確的 %%%c "
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' 未設定"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: 找不到目錄名稱或是空的目錄名稱"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: 沒有其它項目"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d / %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (行已刪除)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Quickfix 堆疊結尾"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Quickfix 堆疊頂端"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "錯誤列表 %d/%d; 共有 %d 項錯誤"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: 無法寫入，'buftype' 選項已設定"
 
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "無法開啟檔案 %s"
+
+#: ../quickfix.c:3429
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "已釋放一個緩衝區"
+
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E548: 應該要有數字"
+
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: 不正確的項目： %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: 名字太長"
+#: ../regexp.c:374
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E69: %s%%[ 後缺少 ]"
 
-msgid "E50: Too many \\z("
-msgstr "E50: 太多 \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: 太多 %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: 無對應的 \\z("
-
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: 無對應的 %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: 無對應的 %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: 無對應的 %s)"
 
-#, c-format
-msgid "E56: %s* operand could be empty"
-msgstr "E56: %s* 運算元可以是空的"
-
-#, c-format
-msgid "E57: %s+ operand could be empty"
-msgstr "E57: %s+ 運算元可以是空的"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: 後面有不正確的字元: %s@"
-
-#, c-format
-msgid "E58: %s{ operand could be empty"
-msgstr "E58: %s{ 運算元可以是空的"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: 太多複雜的 %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: 巢狀 %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: 巢狀 %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: 不正確的使用 \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 沒有接東西"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: 不正確的反向參考"
-
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( 不能在此出現"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 et al. 不能在此出現"
 
-msgid "E68: Invalid character after \\z"
-msgstr "E68: 後面有不正確的字元: \\z"
-
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: %s%%[ 後缺少 ]"
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: 空的 %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: 名字太長"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: 太多 %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: 無對應的 \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: 後面有不正確的字元: %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: 太多複雜的 %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: 巢狀 %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: 巢狀 %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: 不正確的使用 \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 沒有接東西"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: 不正確的反向參考"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: 後面有不正確的字元: \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E71: 後面有不正確的字元: %s%%"
+
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: 後面有不正確的字元: %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: 語法錯誤: %s{...}"
 
-msgid "E361: Crash intercepted; regexp too complex?"
-msgstr "E361: 無法執行; regular expression 太複雜?"
-
-msgid "E363: pattern caused out-of-stack error"
-msgstr "E363: regular expression 造成堆疊用光的錯誤"
-
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "外部符合:\n"
 
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "+--已 fold %3ld 行 "
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: 太多 \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: 找不到寫入用的暫存檔"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-取代"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " 取代"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " 反轉"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " 插入"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (插入)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (取代)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-取代)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrew"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabic"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (語言)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (貼上)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " 選取"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " [行] "
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " [區塊] "
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " 選取"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " 選取行 "
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " 選取區塊"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "記錄中"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "已搜尋到檔案開頭；再從結尾繼續搜尋"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "已搜尋到檔案結尾；再從開頭繼續搜尋"
-
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: 錯誤的搜尋字串: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: 已搜尋到檔案開頭仍找不到 %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: 已搜尋到檔案結尾仍找不到 %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: 在 ';' 後面應該有 '?' 或 '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (包括前次列出符合項)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- 引入檔案 "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "找不到 "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (已列出)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  找不到"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "搜尋引入檔案: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "搜尋引入檔案: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: 目前所在行中有一匹配"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "所有引入檔案都已找到"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "沒有引入檔案"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: 找不到定義"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: 找不到 pattern"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "取代一組 "
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+#, fuzzy
+msgid "E759: Format error in spell file"
+msgstr "E297: 暫存檔寫入錯誤"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:955
+#, fuzzy
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "使用暫存檔 \"%s\""
+
+#: ../spell.c:2496
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s 看起來不像是 Vim 暫存檔"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: 暫存檔寫入錯誤"
+
+#: ../spell.c:3762
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "E519: 不支援該選項"
+
+#: ../spell.c:4550
+#, fuzzy, c-format
+msgid "Reading affix file %s ..."
+msgstr "搜尋 tag 檔案 \"%s\""
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "太多編輯參數"
+
+#: ../spell.c:5238
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "太多編輯參數"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, fuzzy, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "掃瞄字典: %s"
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "每一行都找不到: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, fuzzy, c-format
+msgid "Reading word file %s ..."
+msgstr "從標準輸入讀取..."
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "E573: 不正確的伺服器 id : %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "寫入 viminfo 檔案 \"%s\" 中"
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+#, fuzzy
+msgid "E754: Only up to 8 regions supported"
+msgstr "E519: 不支援該選項"
+
+#: ../spell.c:7846
+#, fuzzy, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E15: 不正確的運算式: %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, fuzzy, c-format
+msgid "Writing spell file %s ..."
+msgstr "寫入 viminfo 檔案 \"%s\" 中"
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, fuzzy, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "，範圍： %<PRId64> 行 "
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, fuzzy, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "將變動存儲至 \"%.*s\"?"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: 沒有前一個搜尋指令"
+
+#: ../spell.c:8925
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: [選單] 找不到 %s"
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s 看起來不像是 Vim 暫存檔"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: 讀取錯誤檔案失敗"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "這個緩衝區沒有定義任何語法"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 參數不正確: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: 無此 syntax cluster: \"%s\""
 
-msgid "No Syntax items defined for this buffer"
-msgstr "這個緩衝區沒有定義任何語法"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C語言式註解同步化中"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "沒有同步化"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "同步化開始"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr "行號超出範圍"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -4206,6 +5771,7 @@ msgstr ""
 "\n"
 "--- 語法同步物件 (Syntax sync items) ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -4213,6 +5779,7 @@ msgstr ""
 "\n"
 "同步化中:"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -4220,200 +5787,274 @@ msgstr ""
 "\n"
 "--- 語法項目 ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: 無此 syntax cluster: \"%s\""
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "最小"
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "最大"
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; 符合 "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr "斷行 "
 
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: 使用了不正確的參數"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: 不正確的參數"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: 使用了不正確的參數"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: 找不到 %s 的 region item"
 
-msgid "E395: contains argument not accepted here"
-msgstr "E395: 使用了不正確的參數"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: 使用了不正確的參數"
-
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: 需要檔案名稱"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 太多檔名"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: 缺少 \"=\": %s"
+
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: 缺少 \"=\": %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: syntax region %s 的引數太少"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 無此 syntax cluster: \"%s\""
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: 沒有指定的屬性"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: 找不到分隔符號: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: '%s' 後面的東西無法辨識"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: 語法同步: 連接行符號被指定了兩次"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: 參數不正確: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: 缺少相等符號: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: 空白參數: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s 不能在此出現"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s 必須是列表裡的第一個"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: 不正確的群組名稱: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: 不正確的 :syntax 子命令: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: 找不到 highlight group: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: 參數太少: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: 參數過多: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: 已設定群組, 忽略 highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: 不該有的等號: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: 缺少相等符號: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: 缺少參數: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: 不合法的值: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: 錯誤的前景顏色"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: 錯誤的背景顏色"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: 錯誤的顏色名稱或數值: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: 終端機碼太長: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: 參數不正確: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: 使用了過多相異的高亮度屬性"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 群組名稱中有無法列印的字元"
 
-#. This is an error, but since there previously was no check only
-#. * give a warning.
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: 群組名稱中有不正確的字元"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: 標籤(tag)堆疊結尾"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: 標籤(tag)堆疊開頭"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: 已經在最前面的標籤(tag)了"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: 找不到標籤(tag): %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "檔案\n"
 
-#.
-#. * Ask to select a tag from the list.
-#. * When using ":silent" assume that <CR> was entered.
-#.
-msgid "Enter nr of choice (<CR> to abort): "
-msgstr "輸入 nr 或選擇 (<CR> 離開): "
-
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: 只有此項符合"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: 己經在最後一個符合的 tag 了"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "檔案 \"%s\" 不存在"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "找到 tag: %d/%d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " 或更多"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  以不同大小寫來使用 tag!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: 檔案 \"%s\" 不存在"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -4421,59 +6062,79 @@ msgstr ""
 "\n"
 "  # 到 tag         從   行    在 檔案/文字"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "搜尋 tag 檔案 \"%s\""
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tag 檔案路徑被截斷為 %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "在 %<PRId64> 位元之前"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag 檔案未排序: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: 沒有 tag 檔"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: 找不到 tag"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: 找不到 tag, 用猜的!"
 
+#: ../tag.c:2797
+#, c-format
+msgid "Duplicate field name: %s"
+msgstr ""
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' 無法載入。可用的內建終端機形式有:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "預設: '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: 無法開啟 termcap 檔案"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: terminfo 中沒有終端機資料項"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: termcap 中沒有終端機資料項"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap 沒有 \"%s\" entry"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: 終端機需要 \"cm\" 的能力"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -4481,109 +6142,176 @@ msgstr ""
 "\n"
 "--- 終端機按鍵 ---"
 
-msgid "new shell started\n"
-msgstr "起動新 shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: 讀取輸入錯誤，離開中...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "無法還原；請繼續努力"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: 無法以寫入模式開啟"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "寫入 viminfo 檔案 \"%s\" 中"
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: 暫存檔寫入錯誤"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "讀取 viminfo 檔案 \"%s\"%s%s%s"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: 無法讀取 viminfo"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E484: 無法開啟檔案 %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: 無法開啟檔案 %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "結束執行 %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行號錯誤"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "還有一行 "
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "還有一行 "
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "少於一行 "
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "少了 %<PRId64> 行 "
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "一項改變"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "%<PRId64> 項改變"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "一項改變"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> 行 %s 過 %d 次"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "沒有這個 mapping 對應"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 欄; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s 不能在此出現"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: 復原列表損壞"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: 找不到要 undo 的行 "
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 Bit 圖型界面版本"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit 圖型界面版本"
-
-msgid " in Win32s mode"
-msgstr "Win32s 模式"
-
-msgid " with OLE support"
-msgstr "支援 OLE"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit console 版本"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit console 版本"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 Bit MS-DOS 版本"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 Bit MS-DOS 版本"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) 版本"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X 版本"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS 版本"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS 版本"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -4591,9 +6319,18 @@ msgstr ""
 "\n"
 "引入修正: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "外部符合:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "修改者為"
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -4601,9 +6338,11 @@ msgstr ""
 "\n"
 "編譯"
 
+#: ../version.c:649
 msgid "by "
 msgstr "者:"
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -4611,567 +6350,1477 @@ msgstr ""
 "\n"
 "超強版本 "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"大型版本 "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"一般版本 "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"簡易版本 "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"精簡版本 "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "不使用圖型界面。"
 
-msgid "with GTK2-GNOME GUI."
-msgstr "使用 GTK2-GNOME 圖型界面。"
-
-msgid "with GTK-GNOME GUI."
-msgstr "使用 GTK-GNOME 圖型界面。"
-
-msgid "with GTK2 GUI."
-msgstr "使用 GTK2 圖型界面。"
-
-msgid "with GTK GUI."
-msgstr "使用 GTK 圖型界面。"
-
-msgid "with X11-Motif GUI."
-msgstr "使用 X11-Motif 圖型界面。"
-
-msgid "with X11-neXtaw GUI."
-msgstr "使用 X11-neXtaw 圖型界面。"
-
-msgid "with X11-Athena GUI."
-msgstr "使用 X11-Athena 圖型界面。"
-
-msgid "with BeOS GUI."
-msgstr "使用 BeOS 圖型界面。"
-
-msgid "with Photon GUI."
-msgstr "使用Photon圖型界面。"
-
-msgid "with GUI."
-msgstr "使用圖型界面。"
-
-msgid "with Carbon GUI."
-msgstr "使用 Carbon 圖型界面。"
-
-msgid "with Cocoa GUI."
-msgstr "使用 Cocoa 圖型界面。"
-
-msgid "with (classic) GUI."
-msgstr "使用 (傳統) 圖型界面。"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr " 目前可使用(+)與不可使用(-)的模組列表:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "        系統 vimrc 設定檔: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "  使用者個人 vimrc 設定檔: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "    第二組個人 vimrc 檔案: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "    第三組個人 vimrc 檔案: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "   使用者個人 exrc 設定檔: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   第二組使用者 exrc 檔案: \""
 
-msgid "  system gvimrc file: \""
-msgstr "         系統 gvimrc 檔案: \""
-
-msgid "    user gvimrc file: \""
-msgstr "     使用者個人 gvimrc 檔: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "   第二組個人 gvimrc 檔案: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "   第三組個人 gvimrc 檔案: \""
-
-msgid "    system menu file: \""
-msgstr "           系統選單設定檔: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "              $VIM 預設值: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "       $VIMRUNTIME 預設值: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "編譯方式: "
 
-msgid "Compiler: "
-msgstr "編譯器: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "鏈結方式: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  除錯版本"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "版本   "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "維護者: Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim 為可自由散佈的開放原始碼軟體"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "請幫助烏干達的可憐孩童!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "進一步說明請輸入          :help iccf<Enter>"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "要離開請輸入                  :q<Enter>            "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "線上說明請輸入                :help<Enter>         "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "新版本資訊請輸入              :help version7<Enter>"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi 相容模式"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "如果要完全模擬傳統 Vi 請輸入 :set nocp<Enter>"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "如果需要對 Vi 相容模式的進一步說明請輸入 :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "進一步說明請選取選單的 輔助說明->拯救孤兒"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "執行 Modeless 模式，輸入的文字會自動插入"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "選取選單的「編輯」「全域設定」「切換插入模式」"
-
-msgid "                              for two modes      "
-msgstr "                              兩種模式           "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "選取選單的「編輯」「全域設定」「切換傳統Vi相容模式」"
-
-msgid "                              for Vim defaults   "
-msgstr "                              以得 Vim 預設值    "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "贊助 Vim 的開發與成長！"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "成為 Vim 的註冊使用者！"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "詳細說明請輸入          :help sponsor<Enter>"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "詳細說明請輸入          :help register<Enter> "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "詳細說明請選取選單的    輔助說明->贊助/註冊      "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "注意: 偵測到 Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "如果需要對 Windows 95 支援的更多資訊請輸入 :help windows95<Enter>"
-
-msgid "E441: There is no preview window"
-msgstr "E441: 沒有預覽視窗"
-
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: 不能同時分割視窗為左上和右下角"
-
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: 有其它分割視窗時無法旋轉"
-
-msgid "E444: Cannot close last window"
-msgstr "E444: 不能關閉最後一個視窗"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "已經只剩一個視窗了"
 
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: 沒有預覽視窗"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: 不能同時分割視窗為左上和右下角"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: 有其它分割視窗時無法旋轉"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: 其它視窗有更動資料"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: 游標處沒有檔名"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: 在路徑中找不到檔案 \"%s\""
+#~ msgid "[Error List]"
+#~ msgstr "[錯誤列表]"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: 無法重新載入程式庫 %s"
+#~ msgid "[No File]"
+#~ msgstr "[未命名]"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "抱歉, 此命令無法使用. 原因: 無法載入 Perl 程式庫(Library)"
+#~ msgid "Patch file"
+#~ msgstr "Patch 檔案"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: 在 sandbox 中無 Safe 模組時無法執行 Perl"
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: 未定義的變數: \"%s\""
 
-msgid "Edit with &multiple Vims"
-msgstr "使用多個 Vim session 編輯(&M)"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "確定(&O)\n"
+#~ "取消(&C)"
 
-msgid "Edit with single &Vim"
-msgstr "只使用同一個 Vim session 編輯(&V)"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: 沒有與 Vim Server 建立連線"
 
-msgid "&Diff with Vim"
-msgstr "使用 Vim 來比較(&Diff)"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 無法讀取伺服器的回應"
 
-msgid "Edit with &Vim"
-msgstr "使用 Vim 編輯此檔(&V)"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 無法傳送到 client"
 
-#. Now concatenate
-msgid "Edit with existing Vim - &"
-msgstr "使用執行中的 Vim session 編輯 - &"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: 無法傳送到 %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "使用 Vim 編輯已選取的檔案"
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: 函式 %s 尚未定義"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "無法執行程式: 請檢查 gvim 有沒有在你的 PATH 變數裡!"
+#~ msgid "Save As"
+#~ msgstr "另存新檔"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll 錯誤"
+#~ msgid "Edit File"
+#~ msgstr "編輯檔案"
 
-msgid "Path length too long!"
-msgstr "路徑長度太長!"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (找不到) "
 
-msgid "--No lines in buffer--"
-msgstr "--緩衝區無資料--"
+#~ msgid "Source Vim script"
+#~ msgstr "執行 Vim script"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: 命令被強制中斷執行 "
+#~ msgid "Edit File in new window"
+#~ msgstr "在新視窗編輯檔案"
 
-msgid "E471: Argument required"
-msgstr "E471: 需要指令參數"
+#~ msgid "Append File"
+#~ msgstr "附加檔案"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ 後面應該有 / ? 或 &"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "視窗位置: X %d, Y %d"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 不能在命令列視窗中使用。<CR>執行，CTRL-C 離開"
+#~ msgid "Save Redirection"
+#~ msgstr "儲存 Redirection"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: exrc/vimrc 裡的指令無法執行 "
+#~ msgid "Save View"
+#~ msgstr "儲存 View"
 
-msgid "E171: Missing :endif"
-msgstr "E171: 缺少 :endif"
+#~ msgid "Save Session"
+#~ msgstr "儲存 Session"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: 缺少 :endtry"
+#~ msgid "Save Setup"
+#~ msgstr "儲存設定"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: 缺少 :endwhile"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 本版本無複合字元(digraph)"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile 缺少對應的 :while"
+#~ msgid "[NL found]"
+#~ msgstr "[找到NL]"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
+#~ msgid "[crypted]"
+#~ msgstr "[已加密]"
 
-msgid "E472: Command failed"
-msgstr "E472: 命令執行失敗"
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "轉換錯誤"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: 不正確的字元集 (Fontset): %s"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans 不能寫出未修改的緩衝區"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: 不正確的字型名稱: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "部份內容無法寫入 Netbeans 緩衝區"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: \"%s\" 不是固定寬度字型"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resource fork 會消失 (請使用 ! 強制執行)"
 
-msgid "E473: Internal error"
-msgstr "E473: 內部錯誤"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: 無法啟動圖型界面"
 
-msgid "Interrupted"
-msgstr "已中斷"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: 無法讀取檔案 \"%s\""
 
-msgid "E14: Invalid address"
-msgstr "E14: 不正確的位址"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 無法啟動圖型界面，找不到可用的字型"
 
-msgid "E474: Invalid argument"
-msgstr "E474: 不正確的參數"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 不正確的 'guifontwide'"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 不正確的參數: %s"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 的值不正確"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 不正確的運算式: %s"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: 不能配置顏色 %s"
 
-msgid "E16: Invalid range"
-msgstr "E16: 不正確的範圍"
+#~ msgid "<cannot open> "
+#~ msgstr "<不能開啟>"
 
-msgid "E476: Invalid command"
-msgstr "E476: 不正確的命令"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 不能使用 %s 字型"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" 是目錄"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 無法回到目前目錄"
 
-msgid "E18: Unexpected characters before '='"
-msgstr "E18: '=' 前面出現了錯誤的字元"
+#~ msgid "Pathname:"
+#~ msgstr "路徑:"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 呼叫函式庫 \"%s\"() 失敗"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 無法取得目前目錄"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: 無法載入程式庫的函式 %s"
+#~ msgid "OK"
+#~ msgstr "確定"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 標記的行號錯誤"
+#~ msgid "Cancel"
+#~ msgstr "取消"
 
-msgid "E20: Mark not set"
-msgstr "E20: 沒有設定標記"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "捲動軸: 不能設定 thumb pixmap 的位置"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 因為 'modifiable' 選項是關閉的，所以不能修改"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim 對話盒"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 巢狀遞迴呼叫太多層"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: 不能對訊息與 callback 建立 BallonEval"
 
-msgid "E23: No alternate file"
-msgstr "E23: 沒有替代的檔案"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim 對話盒..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: 沒有這個 abbreviation 對應"
+#~ msgid "Input _Methods"
+#~ msgstr "輸入法"
 
-msgid "E477: No ! allowed"
-msgstr "E477: 不可使用 '!'"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 尋找與取代..."
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: 因為編譯時沒有加入圖型界面的程式碼，所以無法使用圖型界面"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 尋找..."
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: 因為編譯時沒有加入 Hebrew 的程式碼，所以無法使用 Hebrew\n"
+#~ msgid "Find what:"
+#~ msgstr "搜尋:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: 因為編譯時沒有加入 Farsi 的程式碼，所以無法使用 Farsi\n"
+#~ msgid "Replace with:"
+#~ msgstr "取代為:"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: 因為編譯時沒有加入 Arabic 的程式碼，所以無法使用\n"
+#~ msgid "Match whole word only"
+#~ msgstr "只搜尋完全相同的字"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 沒有名為 '%s' 的 highlight group"
+#~ msgid "Match case"
+#~ msgstr "符合大小寫"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: 還沒有插入文字過"
+#~ msgid "Direction"
+#~ msgstr "方向"
 
-msgid "E30: No previous command line"
-msgstr "E30: 沒有前一項命令"
+#~ msgid "Up"
+#~ msgstr "向上"
 
-msgid "E31: No such mapping"
-msgstr "E31: 沒有這個 mapping 對應"
+#~ msgid "Down"
+#~ msgstr "向下"
 
-msgid "E479: No match"
-msgstr "E479: 找不到"
+#~ msgid "Find Next"
+#~ msgstr "找下一個"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 找不到: %s"
+#~ msgid "Replace"
+#~ msgstr "取代"
 
-msgid "E32: No file name"
-msgstr "E32: 沒有檔名"
+#~ msgid "Replace All"
+#~ msgstr "取代全部"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 沒有前一個搜尋/取代的命令"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: 由 Session 管理員收到 \"die\" 要求\n"
 
-msgid "E34: No previous command"
-msgstr "E34: 沒有前一個命令"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: 主視窗爛掉\n"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: 沒有前一個搜尋指令"
+#~ msgid "Font Selection"
+#~ msgstr "字型選擇"
 
-msgid "E481: No range allowed"
-msgstr "E481: 不可使用範圍指令"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "使用 CUT_BUFFER0 來取代空選擇"
 
-msgid "E36: Not enough room"
-msgstr "E36: 沒有足夠的空間"
+#~ msgid "Filter"
+#~ msgstr "過濾器"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: 沒有註冊為 \"%s\" 的伺服器"
+#~ msgid "Directories"
+#~ msgstr "目錄"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: 不能建立檔案 %s"
+#~ msgid "Help"
+#~ msgstr "輔助說明"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: 無法得知暫存檔名"
+#~ msgid "Files"
+#~ msgstr "檔案"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: 無法開啟檔案 %s"
+#~ msgid "Selection"
+#~ msgstr "選擇"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: 無法讀取檔案 %s"
+#~ msgid "Undo"
+#~ msgstr "復原"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 已更改過檔案但尚未存檔 (可用 ! 強制執行)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: 找不到標題為 \"%s\" 的視窗"
 
-msgid "E38: Null argument"
-msgstr "E38: 空的 (Null) 參數"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 不支援參數 \"-%s\"。請用 OLE 版本。"
 
-msgid "E39: Number expected"
-msgstr "E39: 應該要有數字"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: 無法在 MDI 程式中開啟視窗"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 無法開啟錯誤檔案 %s"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "搜尋字串 (使用 '\\\\' 來表示 '\\')"
 
-msgid "E233: cannot open display"
-msgstr "E233: <不能開啟 X Server DISPLAY>"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "搜尋及取代字串 (使用 '\\\\' 來表示 '\\')"
 
-msgid "E41: Out of memory!"
-msgstr "E41: 記憶體不足!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 無法配置 color map 項目，有些顏色看起來會怪怪的"
 
-msgid "Pattern not found"
-msgstr "找不到"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Fontset %s 沒有設定正確的字型以供顯示這些字元集:"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 找不到 %s"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: 字型集(Fontset)名稱: %s"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: 參數應該是正數"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "'%s' 不是固定寬度字型"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 無法回到前一個目錄"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: 字型集(Fontset)名稱: %s\n"
 
-msgid "E42: No Errors"
-msgstr "E42: 沒有錯誤"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: 符合字串有問題"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: regexp 有問題"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "字型%<PRId64> 寬度不是 字型0 的兩倍\n"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 有設定 'readonly' 選項(唯讀) (可用 ! 強制執行)"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "字型0的寬度：%<PRId64>\n"
 
-#, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: 無法設定唯讀變數 \"%s\""
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "字型1寬度: %<PRId64>\n"
+#~ "\n"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 讀取錯誤檔案失敗"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata 錯誤"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: 不能在 sandbox 裡出現"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 錯誤"
 
-msgid "E523: Not allowed here"
-msgstr "E523: 這裡不可使用"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: 無法開啟 cscope 資料庫 %s"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 不支援設定螢幕模式"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: 無法取得 cscope 資料庫資訊"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: 錯誤的捲動大小"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: 已達到 cscope 最大連線數目"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'E71: 選項 'shell' 未設定"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr "E263: 抱歉，這個命令無法使用，Python 程式庫沒有載入。"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: 無法讀取 sign data!"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: 無法遞迴執行 Python "
 
-msgid "E72: Close error on swap file"
-msgstr "E72: 暫存檔關閉錯誤"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "無法刪除 OutputObject 屬性"
 
-msgid "E73: tag stack empty"
-msgstr "E73: 標籤堆疊已空"
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace 必需是整數"
 
-msgid "E74: Command too complex"
-msgstr "E74: 命令太複雜"
+#~ msgid "invalid attribute"
+#~ msgstr "不正確的屬性"
 
-msgid "E75: Name too long"
-msgstr "E75: 名字太長"
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() 需要 string list 當參數"
 
-msgid "E76: Too many ["
-msgstr "E76: 太多 ["
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: 無法初始 I/O 物件"
 
-msgid "E77: Too many file names"
-msgstr "E77: 太多檔名"
+#~ msgid "invalid expression"
+#~ msgstr "不正確的運算式"
 
-msgid "E488: Trailing characters"
-msgstr "E488: 你輸入了多餘的字元"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "因為編譯時沒有加入運算式(expression)的程式碼，所以無法使用運算式"
 
-msgid "E78: Unknown mark"
-msgstr "E78: 無法辦識的標記"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "試圖使用已被刪除的 buffer"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 無法展開萬用字元"
+#~ msgid "line number out of range"
+#~ msgstr "行號超出範圍"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' 不能比 'winminheight' 更少"
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffer 物件 (已刪除): %8lX>"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' 不能比 'winminwidth' 更少"
+#~ msgid "invalid mark name"
+#~ msgstr "標記名稱不正確"
 
-msgid "E80: Error while writing"
-msgstr "E80: 寫入錯誤"
+#~ msgid "no such buffer"
+#~ msgstr "無此 buffer"
 
-msgid "Zero count"
-msgstr "數到零 (?)"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "試圖使用已被刪除的視窗"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> 不能在 script 本文外使用."
+#~ msgid "readonly attribute"
+#~ msgstr "唯讀屬性"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: 收到不正確的運算式"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "游標定位在緩衝區之外"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: 區域被保護，無法修改"
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<視窗物件(已刪除): %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<視窗物件(未知): %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<視窗 %d>"
+
+#~ msgid "no such window"
+#~ msgstr "無此視窗"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "無法儲存復原資訊"
+
+#~ msgid "cannot delete line"
+#~ msgstr "不能刪除此行 "
+
+#~ msgid "cannot replace line"
+#~ msgstr "不能替代此行 "
+
+#~ msgid "cannot insert line"
+#~ msgstr "不能替代插入此行 "
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "字串無法包含新行 "
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: 此命令無法使用，無法載入 Ruby 程式庫(Library)"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知的 longjmp status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "切換實作/定義"
+
+#~ msgid "Show base class of"
+#~ msgstr "顯示 base class of:"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "顯示被 override 的 member function"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "讀取: 從檔案"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "讀取: 從物件"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "讀取: 從所有 project"
+
+#~ msgid "Retrieve"
+#~ msgstr "讀取"
+
+#~ msgid "Show source of"
+#~ msgstr "顯示原始碼: "
+
+#~ msgid "Find symbol"
+#~ msgstr "搜尋 symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "瀏覽 class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "顯示階層式的 class"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "顯示 restricted 階層式的 class"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref 參考到"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref 被誰參考:"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref 有"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref 被誰使用:"
+
+#~ msgid "Show docu of"
+#~ msgstr "顯示文件: "
+
+#~ msgid "Generate docu for"
+#~ msgstr "產生文件: "
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "無法連線到 SNiFF+。請檢查環境變數 ($PATH 裡必需可以找到 sniffemacs)\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 讀取錯誤. 取消連線"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ 目前"
+
+#~ msgid "not "
+#~ msgstr "未"
+
+#~ msgid "connected"
+#~ msgstr "連線中"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 不正確的 SNiff+ 呼叫: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: 連線到 SNiFF+ 失敗"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: 未連線到 SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 寫入錯誤。結束連線"
+
+#~ msgid "not implemented yet"
+#~ msgstr "尚未實作"
+
+#~ msgid "unknown option"
+#~ msgstr "不正確的選項"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "不能設定行 "
+
+#~ msgid "mark not set"
+#~ msgstr "沒有設定標記"
+
+#~ msgid "row %d column %d"
+#~ msgstr "列 %d 行 %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "不能插入或附加此行 "
+
+#~ msgid "unknown flag: "
+#~ msgstr "錯誤的旗標: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "不正確的 VIM 選項"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "鍵盤中斷"
+
+#~ msgid "vim error"
+#~ msgstr "vim 錯誤"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "無法建立緩衝區/視窗命令: 物件將會被刪除"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "無法註冊 callback 命令: 緩衝區/視窗已經被刪除了"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E280: TCL 嚴重錯誤: reflist 爛掉了!? 請報告給 to vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "無法註冊 callback 命令: 找不到緩衝區/視窗"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: 此命令無法使用, 因為無法載入 Tcl 程式庫(Library)"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr "E281: TCL 錯誤: 結束碼不是整數!? 請報告給 to vim-dev@vim.org"
+
+#~ msgid "cannot get line"
+#~ msgstr "不能取得此行 "
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "無法註冊命令伺服器名稱"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 無法送出命令到目的地程式"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 的 registry 設定項有誤。已刪除。"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "您的 Vim 編譯時沒有加入 diff 的能力"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t註冊 gvim 到 OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\t取消 OLE 中的 gvim 註冊"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\t使用圖形界面 (同 \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  或  --nofork\t前景: 起始圖形界面時不 fork"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose 等級"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t不使用 newcli 來開啟視窗"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\t使用 <device> 做輸出入"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t使用 <gvimrc> 取代任何 .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t編輯編碼過的檔案"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t將 vim 與指定的 X-server 連線"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\t不要連線到 X Server"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t編輯 Vim 伺服器上的 <files> 後離開"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  相同，但沒有伺服器時不警告"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  同 --remote, 但會等候檔案完成編輯"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  相同，但沒伺服器時不警告"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 伺服器並離開"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t在伺服器上執行 <expr> 並印出結果"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t列出可用的 Vim 伺服器名稱並離開"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t送至/成為 Vim 伺服器 <name>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (Motif 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (neXtaw 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (Athena 版):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t在視窗 <display> 執行 vim"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t啟動後圖示化(iconified)"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\t讀取 Resource 時把 vim 的名稱視為 <name>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (尚未實作)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t設定 <color> 為背景色 (也可用 -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t設定 <color> 為一般文字顏色 (也可用 -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t使用 <font> 為一般字型 (也可用 -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t使用 <font> 為粗體字型"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t使用 <font> 為斜體字型"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t使用<geom>為起始位置 (也可用 -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t使用寬度為 <width> 的邊框 (也可用 -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width>  設定捲動軸寬度為 <width> (也可用 -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t設定選單列的高度為 <height> (也可用 -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t使用反相顯示 (也可用 -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t不使用反相顯示 (也可用 +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t設定指定的 resource"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (RISC OS 版):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <number>\t視窗初始化寬度"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <number>\t視窗初始化高度"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (GTK+ 版):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t在 <display> 執行 vim (也可用 --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t設定獨特的角色(role)以區分主視窗"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t在另一個 GTK widget 內開啟 Vim"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\t在父程式中開啟 Vim"
+
+#~ msgid "No display"
+#~ msgstr "無顯示"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": 傳送失敗。\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": 送出失敗。試圖在本地執行\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "已編輯 %d/%d 個檔案"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "無 Display: 無法傳送運算式。\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 無法傳送運算式。\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 不正確的 codepage"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: 無法建立 input context"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: 無法開啟輸入法"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: 警告: 無法移除 IM 的 callback"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: 輸入法不支援任何 style"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: 輸入法不支援任何 style"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: over-the-spot 需要字型集(Fontset)"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: 你的 GTK+ 比 1.2.3 還舊。無法使用狀態區。"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: 沒有執行中的輸入法管理程式(Input Method Server)"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [無法在本版本的 Vim 上使用]"
+
+#~ msgid ""
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
+#~ msgstr ""
+#~ "以唯讀方式開啟(&O)\n"
+#~ "直接編輯(&E)\n"
+#~ "修復(&R)\n"
+#~ "離開(&Q)\n"
+#~ "跳出(&A)\n"
+#~ "刪除暫存檔(&D)"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "切下此選單"
+
+#~ msgid "[string too long]"
+#~ msgstr "[此行過長]"
+
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "請按 ENTER 繼續"
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: 向下/向上一行, 空白鍵/b: 一頁, d/u: 半頁, q: 離開)"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: 向下一行, 空白鍵: 一頁, d: 半頁, q: 離開)"
+
+#~ msgid "Save File dialog"
+#~ msgstr "存檔"
+
+#~ msgid "Open File dialog"
+#~ msgstr "開檔"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: 主控台(Console)模式時沒有檔案瀏覽器(file browser)"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: 保留檔案中...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 結束.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "錯誤: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] 全部 alloc-freed %<PRIu64>-%<PRIu64>, 使用中 %<PRIu64>, peak 使用 "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[呼叫] 全部 re/malloc(): %<PRIu64>, 全部 free()': %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: 此行過長"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 不正確的滑鼠形狀"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "輸入密碼: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "請再輸入一次: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "兩次輸入密碼不相同!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "無法連接到 Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "無法連接到 Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 連線資訊檔案: \"%s\" 存取模式不正確"
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "由 Netbeans socket 讀取"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 緩衝區 %<PRId64> 與 NetBeans 的連線已中斷"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "釋放 %<PRId64> 行中 "
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: 在圖型界面中無法切換 term"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: 輸入 \":gui\" 來啟動圖形界面"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: 在圖型界面中無法切換 term"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 無法使用字型集(Fontset)"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: 不正確的字型集(Fontset)"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: 無法使用設定的中文字型(Widefont)"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: 不正確的字型(Widefont)"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: 不支援滑鼠"
+
+#~ msgid "cannot open "
+#~ msgstr "不能開啟"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: 無法開啟視窗!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "需要 Amigados 版本 2.04 以上\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "需要 %s 版本 %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "無法開啟 NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "不能建立 "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim 結束傳回值: %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "無法切換主控台(console)模式 !?\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 不是主控台(console)??\n"
+
+#~ msgid "Cannot execute "
+#~ msgstr "不能執行 "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " 已返回\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE 太小"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 錯誤"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(已切掉)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' 不是 80, 無法執行外部命令"
+
+#~ msgid "to %s on %s"
+#~ msgstr "到 %s on %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: 不正確的印表機字型: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 列印錯誤: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "列印中: '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 字元集 \"%s\" 無法對應字型\"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 不正確的字元 '%c' 出現在字型名稱 \"%s\" 內"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 雙重signal, 離開中\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: CVim: 攔截到信號(signal) %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 攔截到致命的信號(deadly signale)\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "開啟 X Window 耗時 %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X 錯誤\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "測試 X Window 失敗"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "開啟 X Window 逾時"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "不能執行 shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "不能建立 pipe 管線\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "不能 fork\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "命令已終結\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP 失去 ICE 連線"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "開啟 X Window 失敗"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP 正在處理自我儲存要求"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "開啟 XSMP 連線中"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE 連線監看失敗"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection 失敗: %s"
+
+#~ msgid "At line"
+#~ msgstr "在行號 "
+
+#~ msgid "Could not allocate memory for command line."
+#~ msgstr "無法為命令列配置記憶體。"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM 錯誤"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "無法載入 vim32.dll！"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "不能修正函式指標到 DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "Shell 傳回值 %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: 攔截到 %s \n"
+
+#~ msgid "close"
+#~ msgstr "關閉"
+
+#~ msgid "logoff"
+#~ msgstr "登出"
+
+#~ msgid "shutdown"
+#~ msgstr "關機"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 找不到命令"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "在你的 $PATH 中找不到 VIMRUN.EXE.\n"
+#~ "外部命令執行完畢後將不會暫停.\n"
+#~ "進一步說明請執行 :help win32-vimrun "
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim 警告"
+
+#~ msgid "E56: %s* operand could be empty"
+#~ msgstr "E56: %s* 運算元可以是空的"
+
+#~ msgid "E57: %s+ operand could be empty"
+#~ msgstr "E57: %s+ 運算元可以是空的"
+
+#~ msgid "E58: %s{ operand could be empty"
+#~ msgstr "E58: %s{ 運算元可以是空的"
+
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr "E361: 無法執行; regular expression 太複雜?"
+
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: regular expression 造成堆疊用光的錯誤"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: 使用了不正確的參數"
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "輸入 nr 或選擇 (<CR> 離開): "
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag 檔案路徑被截斷為 %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "起動新 shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "無法還原；請繼續努力"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 Bit 圖型界面版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit 圖型界面版本"
+
+#~ msgid " in Win32s mode"
+#~ msgstr "Win32s 模式"
+
+#~ msgid " with OLE support"
+#~ msgstr "支援 OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit console 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit console 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 Bit MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 Bit MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "大型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "一般版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "簡易版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "精簡版本 "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "使用 GTK2-GNOME 圖型界面。"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "使用 GTK-GNOME 圖型界面。"
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "使用 GTK2 圖型界面。"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "使用 GTK 圖型界面。"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "使用 X11-Motif 圖型界面。"
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "使用 X11-neXtaw 圖型界面。"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "使用 X11-Athena 圖型界面。"
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "使用 BeOS 圖型界面。"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "使用Photon圖型界面。"
+
+#~ msgid "with GUI."
+#~ msgstr "使用圖型界面。"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "使用 Carbon 圖型界面。"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "使用 Cocoa 圖型界面。"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "使用 (傳統) 圖型界面。"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "         系統 gvimrc 檔案: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "     使用者個人 gvimrc 檔: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "   第二組個人 gvimrc 檔案: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "   第三組個人 gvimrc 檔案: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "           系統選單設定檔: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "編譯器: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "進一步說明請選取選單的 輔助說明->拯救孤兒"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "執行 Modeless 模式，輸入的文字會自動插入"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "選取選單的「編輯」「全域設定」「切換插入模式」"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              兩種模式           "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "選取選單的「編輯」「全域設定」「切換傳統Vi相容模式」"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              以得 Vim 預設值    "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "注意: 偵測到 Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "如果需要對 Windows 95 支援的更多資訊請輸入 :help windows95<Enter>"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: 無法重新載入程式庫 %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "抱歉, 此命令無法使用. 原因: 無法載入 Perl 程式庫(Library)"
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: 在 sandbox 中無 Safe 模組時無法執行 Perl"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "使用多個 Vim session 編輯(&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "只使用同一個 Vim session 編輯(&V)"
+
+#~ msgid "&Diff with Vim"
+#~ msgstr "使用 Vim 來比較(&Diff)"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "使用 Vim 編輯此檔(&V)"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "使用執行中的 Vim session 編輯 - &"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "使用 Vim 編輯已選取的檔案"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "無法執行程式: 請檢查 gvim 有沒有在你的 PATH 變數裡!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 錯誤"
+
+#~ msgid "Path length too long!"
+#~ msgstr "路徑長度太長!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: 不正確的字元集 (Fontset): %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: 不正確的字型名稱: %s"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: 無法載入程式庫的函式 %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: 因為編譯時沒有加入 Hebrew 的程式碼，所以無法使用 Hebrew\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: 因為編譯時沒有加入 Farsi 的程式碼，所以無法使用 Farsi\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: 因為編譯時沒有加入 Arabic 的程式碼，所以無法使用\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: 沒有註冊為 \"%s\" 的伺服器"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: <不能開啟 X Server DISPLAY>"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 區域被保護，無法修改"
 
 #~ msgid "E565: error reading cscope connection %d"
 #~ msgstr "E565: 讀取 cscope 連線 %d 錯誤"
@@ -5212,26 +7861,14 @@ msgstr "E463: 區域被保護，無法修改"
 #~ msgid "Run Macro"
 #~ msgstr "執行巨集"
 
-#~ msgid "E221: 'commentstring' is empty"
-#~ msgstr "E221: 選項 'commentstring' 未設定"
-
 #~ msgid "E242: Color name not recognized: %s"
 #~ msgstr "E242: %s 為無法識別的顏色名稱"
-
-#~ msgid "E242: Missing color: %s"
-#~ msgstr "E242: 找不到顏色: %s"
 
 #~ msgid "error reading cscope connection %d"
 #~ msgstr "讀取 cscope 連線 %d 時錯誤"
 
 #~ msgid "E249: couldn't read VIM instance registry property"
 #~ msgstr "E249: 無法讀取 VIM 的 registry 設定項"
-
-#~ msgid "Can't open file %s"
-#~ msgstr "無法開啟檔案 %s"
-
-#~ msgid "Unable to send reply"
-#~ msgstr "無法傳送回應訊息"
 
 #~ msgid "E241: Unable to send to Vim server"
 #~ msgstr "E241: 無法傳送到 Vim 伺服器"

--- a/src/nvim/po/zh_TW.po
+++ b/src/nvim/po/zh_TW.po
@@ -11,8 +11,7 @@
 # To update, search pattern:		/fuzzy\|^msgstr ""\(\n"\)\@!
 #
 # DO NOT USE WORDS WITH BACKSLASH ('\') AS SECOND BYTE OF BIG5 CHARS
-# EG: '¥\', # ³\¥\»\
-# [blacklist: À\¬\¾\¯\½\¶\²\Æ\°\Â\¿\Á\Å\§\ª\«\]
+# EG: '¥\', # ³\¥\»# [blacklist: À\¬\¾\¯\½\¶\²\Æ\°\Â\¿\Á\Å\§\ª\«\]
 # [blacklist: ®\±\Ã\Ä\´\µ\·\¹\º\¤\¦\­\á\ä\]
 # you can replace these characters with alternative words.
 # THIS WILL CAUSE INCOMPATIBLE ON gettext 0.10.36+
@@ -36,150 +35,216 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Traditional Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2005-01-27 19:00+0800\n"
+"POT-Creation-Date: 2014-05-26 14:21+0200\n"
 "PO-Revision-Date: Mon Feb 19 22:49:21 CST 2001\n"
 "Last-Translator: Hung-Te Lin <piaip@csie.ntu.edu.tw>\n"
 "Language-Team: Hung-Te Lin <piaip@csie.ntu.edu.tw>, Cecil Sheng "
 "<b7506022@csie.ntu.edu.tw>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=big5\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
+#: ../api/private/helpers.c:201
+#, fuzzy
+msgid "Unable to get option value"
+msgstr "µLªk¶Ç°e¦^À³°T®§"
+
+#: ../api/private/helpers.c:204
+msgid "internal error: unknown option type"
+msgstr ""
+
+#: ../buffer.c:92
+msgid "[Location List]"
+msgstr ""
+
+#: ../buffer.c:93
+msgid "[Quickfix List]"
+msgstr ""
+
+#: ../buffer.c:94
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: µLªk°t¸m¥ô¦ó½w½Ä°Ï¡AÂ÷¶}µ{¦¡..."
 
+#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: µLªk°t¸m½w½Ä°Ï¡A¨Ï¥Î¥t¤@­Ó½w½Ä°Ï...."
 
-#, c-format
+#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: ¨S¦³ÄÀ©ñ¥ô¦ó½w½Ä°Ï"
 
-#, c-format
+#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: ¨S¦³§R°£¥ô¦ó½w½Ä°Ï"
 
-#, c-format
+#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: ¨S¦³²M°£¥ô¦ó½w½Ä°Ï"
 
+#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "¤wÄÀ©ñ¤@­Ó½w½Ä°Ï"
 
+#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "¤wÄÀ©ñ %d ­Ó½w½Ä°Ï"
 
+#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "¤w§R°£¤@­Ó½w½Ä°Ï"
 
+#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "¤w§R°£ %d ­Ó½w½Ä°Ï"
 
+#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "¤w§R°£¤@­Ó½w½Ä°Ï"
 
+#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "¤w§R°£ %d ­Ó½w½Ä°Ï"
 
+#: ../buffer.c:806
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: µLªkÄÀ©ñ³Ì«á¤@­Ó½w½Ä°Ï"
+
+#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: ¨S¦³­×§ï¹Lªº½w½Ä°Ï"
 
 #. back where we started, didn't find anything.
+#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: ¨S¦³¦C¥Xªº½w½Ä°Ï"
 
+#: ../buffer.c:913
 #, c-format
 msgid "E86: Buffer %<PRId64> does not exist"
 msgstr "E86: ½w½Ä°Ï %<PRId64> ¤£¦s¦b"
 
+#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: µLªk¤Á´«¨ì§ó«á­±ªº½w½Ä°Ï"
 
+#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: µLªk¤Á´«¨ì§ó«e­±ªº½w½Ä°Ï"
 
+#: ../buffer.c:945
 #, c-format
-msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr "E89: ¤w§ó§ï¹L½w½Ä°Ï %<PRId64> ¦ý©|¥¼¦sÀÉ (¥i¥Î ! ±j¨î°õ¦æ)"
 
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: µLªkÄÀ©ñ³Ì«á¤@­Ó½w½Ä°Ï"
-
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1423
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Äµ§i: ÀÉ¦W¹L¦h"
 
+#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
 msgid "E92: Buffer %<PRId64> not found"
 msgstr "E92: §ä¤£¨ì²Ä %<PRId64> ­Ó½w½Ä°Ï"
 
+#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: §ä¨ì¤@­Ó¥H¤Wªº %s"
 
+#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: §ä¤£¨ì %s"
 
+#: ../buffer.c:2161
 #, c-format
 msgid "line %<PRId64>"
 msgstr "¦æ %<PRId64>"
 
+#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: ¤w¦³½w½Ä°Ï¨Ï¥Î³o­Ó¦W¦r"
 
+#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [¤w­×§ï]"
 
+#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[¥¼½s¿è]"
 
+#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[·sÀÉ®×]"
 
+#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Åª¨ú¿ù»~]"
 
+#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
+msgid "[RO]"
+msgstr "[°ßÅª]"
+
+#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[°ßÅª]"
 
+#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "¦æ¼Æ 1 --%d%%--"
 
+#: ../buffer.c:2526
 #, c-format
 msgid "%<PRId64> lines --%d%%--"
 msgstr "¦æ¼Æ %<PRId64> --%d%%--"
 
+#: ../buffer.c:2530
 #, c-format
 msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
 msgstr "¦æ %<PRId64>/%<PRId64> --%d%%-- Äæ "
 
-msgid "[No file]"
+#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
+#, fuzzy
+msgid "[No Name]"
 msgstr "[¥¼©R¦W]"
 
 #. must be a help buffer
+#: ../buffer.c:2667
 msgid "help"
 msgstr "[»²§U»¡©ú]"
 
-msgid "[help]"
+#: ../buffer.c:3225 ../screen.c:4883
+#, fuzzy
+msgid "[Help]"
 msgstr "[»²§U»¡©ú]"
 
+#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[¹wÄý]"
 
+#: ../buffer.c:3528
 msgid "All"
 msgstr "¥þ³¡"
 
+#: ../buffer.c:3528
 msgid "Bot"
 msgstr "©³ºÝ"
 
+#: ../buffer.c:3531
 msgid "Top"
 msgstr "³»ºÝ"
 
-#, c-format
+#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -187,12 +252,11 @@ msgstr ""
 "\n"
 "# ½w½Ä°Ï¦Cªí:\n"
 
-msgid "[Error List]"
-msgstr "[¿ù»~¦Cªí]"
+#: ../buffer.c:4289
+msgid "[Scratch]"
+msgstr ""
 
-msgid "[No File]"
-msgstr "[¥¼©R¦W]"
-
+#: ../buffer.c:4529
 msgid ""
 "\n"
 "--- Signs ---"
@@ -200,116 +264,206 @@ msgstr ""
 "\n"
 "--- ²Å¸¹ ---"
 
+#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "%s ªº²Å¸¹:"
 
+#: ../buffer.c:4543
 #, c-format
 msgid "    line=%<PRId64>  id=%d  name=%s"
 msgstr "    ¦æ=%<PRId64>  id=%d  ¦WºÙ=%s"
 
+#: ../cursor_shape.c:68
+msgid "E545: Missing colon"
+msgstr "E545: ¯Ê¤Ö colon"
+
+#: ../cursor_shape.c:70 ../cursor_shape.c:94
+msgid "E546: Illegal mode"
+msgstr "E546: ¤£¥¿½Tªº¼Ò¦¡"
+
+#: ../cursor_shape.c:134
+msgid "E548: digit expected"
+msgstr "E548: À³¸Ó­n¦³¼Æ¦r"
+
+#: ../cursor_shape.c:138
+msgid "E549: Illegal percentage"
+msgstr "E549: ¤£¥¿½Tªº¦Ê¤À¤ñ"
+
+#: ../diff.c:146
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: µLªk¤ñ¸û(diff) %<PRId64>­Ó¥H¤Wªº½w½Ä°Ï"
 
+#: ../diff.c:753
+#, fuzzy
+msgid "E810: Cannot read or write temp files"
+msgstr "E557: µLªk¶}±Ò termcap ÀÉ®×"
+
+#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: ¤£¯à«Ø¥ß "
 
-msgid "Patch file"
-msgstr "Patch ÀÉ®×"
+#: ../diff.c:966
+#, fuzzy
+msgid "E816: Cannot read patch output"
+msgstr "E98: µLªkÅª¨ú diff ªº¿é¥X"
 
+#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: µLªkÅª¨ú diff ªº¿é¥X"
 
+#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: ¥Ø«eªº½w½Ä°Ï¤£¬O¦b diff ¼Ò¦¡"
 
+#: ../diff.c:2100
+#, fuzzy
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E100: ¨S¦³½w½Ä°Ï¦b diff ¼Ò¦¡"
+
+#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: ¨S¦³½w½Ä°Ï¦b diff ¼Ò¦¡"
 
+#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: ¦³¨â­Ó¥H¤Wªº½w½Ä°Ï¦b diff ¼Ò¦¡¡AµLªk¨M©w­n¥Î­þ¤@­Ó"
 
+#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: §ä¤£¨ì½w½Ä°Ï: \"%s\""
 
+#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: ½w½Ä°Ï \"%s\" ¤£¬O¦b diff ¼Ò¦¡"
 
+#: ../diff.c:2193
+msgid "E787: Buffer changed unexpectedly"
+msgstr ""
+
+#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: ½Æ¦X¦r¤¸(digraph)¤¤¤£¯à¨Ï¥Î Escape"
 
+#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: §ä¤£¨ì keymap ÀÉ"
 
+#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: ¨Ï¥Î :loadkeymap "
 
+#: ../digraph.c:1821
+msgid "E791: Empty keymap entry"
+msgstr ""
+
+#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " ÃöÁä¦r¦Û°Ê§¹¦¨ (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-msgid " ^X mode (^E^Y^L^]^F^I^K^D^V^N^P)"
+#: ../edit.c:83
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X ¼Ò¦¡ (^E^Y^L^]^F^I^K^D^N^P)"
 
-#. Scroll has it's own msgs, in it's place there is the msg for local
-#. * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo
-msgid " Keyword Local completion (^N^P)"
-msgstr " °Ï°ìÃöÁä¦r¦Û°Ê§¹¦¨ (^N^P)"
-
+#: ../edit.c:85
 msgid " Whole line completion (^L^N^P)"
 msgstr " ¾ã¦æ¦Û°Ê§¹¦¨ (^L^N^P)"
 
+#: ../edit.c:86
 msgid " File name completion (^F^N^P)"
 msgstr " ÀÉ¦W¦Û°Ê§¹¦¨ (^F^N^P)"
 
+#: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
 msgstr " ¼ÐÅÒ¦Û°Ê§¹¦¨ (^]^N^P)"
 
+#: ../edit.c:88
 msgid " Path pattern completion (^N^P)"
 msgstr " ¸ô®|¦Û°Ê§¹¦¨ (^N^P)"
 
+#: ../edit.c:89
 msgid " Definition completion (^D^N^P)"
 msgstr " ©w¸q¦Û°Ê§¹¦¨ (^D^N^P)"
 
+#: ../edit.c:91
 msgid " Dictionary completion (^K^N^P)"
 msgstr " ¦r¨å¦Û°Ê§¹¦¨ (^K^N^P)"
 
+#: ../edit.c:92
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus ¦Û°Ê§¹¦¨ (^T^N^P)"
 
+#: ../edit.c:93
 msgid " Command-line completion (^V^N^P)"
 msgstr " ©R¥O¦C¦Û°Ê§¹¦¨ (^V^N^P)"
 
+#: ../edit.c:94
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " ¾ã¦æ¦Û°Ê§¹¦¨ (^L^N^P)"
+
+#: ../edit.c:95
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " ¼ÐÅÒ¦Û°Ê§¹¦¨ (^]^N^P)"
+
+#: ../edit.c:96
+#, fuzzy
+msgid " Spelling suggestion (s^N^P)"
+msgstr " ¾ã¦æ¦Û°Ê§¹¦¨ (^L^N^P)"
+
+#: ../edit.c:97
+msgid " Keyword Local completion (^N^P)"
+msgstr " °Ï°ìÃöÁä¦r¦Û°Ê§¹¦¨ (^N^P)"
+
+#: ../edit.c:100
 msgid "Hit end of paragraph"
 msgstr "¤w¨ì¬q¸¨µ²§À"
 
-msgid "'thesaurus' option is empty"
-msgstr "¿ï¶µ 'thesaurus' ¥¼³]©w"
+#: ../edit.c:101
+msgid "E839: Completion function changed window"
+msgstr ""
 
+#: ../edit.c:102
+msgid "E840: Completion function deleted text"
+msgstr ""
+
+#: ../edit.c:1847
 msgid "'dictionary' option is empty"
 msgstr "¿ï¶µ 'dictionary' ¥¼³]©w"
 
+#: ../edit.c:1848
+msgid "'thesaurus' option is empty"
+msgstr "¿ï¶µ 'thesaurus' ¥¼³]©w"
+
+#: ../edit.c:2655
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "±½ºË¦r¨å: %s"
 
+#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (´¡¤J) Scroll (^E/^Y)"
 
+#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (¨ú¥N) Scroll (^E/^Y)"
 
+#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "±½ºË¤¤: %s"
 
-#, c-format
+#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "±½ºË¼ÐÅÒ."
 
+#: ../edit.c:4519
 msgid " Adding"
 msgstr " ¼W¥["
 
@@ -317,201 +471,597 @@ msgstr " ¼W¥["
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
+#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- ·j´M¤¤..."
 
+#: ../edit.c:4618
 msgid "Back at original"
 msgstr "¦^¨ì°_ÂI"
 
+#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "±q§O¦æ¶}©lªº¦r (?)"
 
+#: ../edit.c:4624
 msgid "The only match"
 msgstr "¥u¦³¦¹¶µ²Å¦X"
 
+#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "§ä¨ì %d / %d"
 
+#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "²Å¦X %d"
 
-#. Skip further arguments but do continue to
-#. * search for a trailing command.
-#, c-format
-msgid "E106: Unknown variable: \"%s\""
-msgstr "E106: ¥¼©w¸qªºÅÜ¼Æ: \"%s\""
+#: ../eval.c:137
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: '=' «e­±¥X²{¤F¿ù»~ªº¦r¤¸"
 
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: ¯Ê¤Ö¹ïÀ³ªº¬A¸¹: %s"
+#: ../eval.c:138
+#, fuzzy, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E322: ¦æ¸¹¶W¥X½d³ò: %<PRId64> ¶W¹Lµ²§À"
 
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: µL¦¹ÅÜ¼Æ: \"%s\""
-
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: '?' «á¯Ê¤Ö ':'"
-
-msgid "E110: Missing ')'"
-msgstr "E110: ¯Ê¤Ö¹ïÀ³ªº \")\""
-
-msgid "E111: Missing ']'"
-msgstr "E111: ¯Ê¤Ö¹ïÀ³ªº \"]\""
-
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: ¯Ê¤Ö¿ï¶µ¦WºÙ: %s"
-
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: ¤£¥¿½Tªº¿ï¶µ: %s"
-
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: ¯Ê¤Ö¤Þ¸¹: %s"
-
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: ¯Ê¤Ö¤Þ¸¹: %s"
-
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: ¨ç¦¡ %s ªº¤Þ¼Æ¤£¥¿½T"
-
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: ¥¼©w¸qªº¨ç¦¡: %s"
-
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: ¨ç¦¡ %s ªº¤Þ¼Æ¹L¦h"
-
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: ¨ç¦¡ %s ªº¤Þ¼Æ¤Ó¤Ö"
-
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: <SID> ¤£¯à¦b script ¥»¤å¥~¨Ï¥Î: %s"
-
-#.
-#. * Yes this is ugly, I don't particularly like it either.  But doing it
-#. * this way has the compelling advantage that translations need not to
-#. * be touched at all.  See below what 'ok' and 'ync' are used for.
-#.
-msgid "&Ok"
-msgstr "½T©w(&O)"
-
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld ¦æ: "
-
-msgid ""
-"&OK\n"
-"&Cancel"
-msgstr ""
-"½T©w(&O)\n"
-"¨ú®ø(&C)"
-
-msgid "called inputrestore() more often than inputsave()"
-msgstr "©I¥s inputrestore() ªº¦¸¼Æ¤ñ inputsave() ÁÙ¦h"
-
-msgid "E655: Too many symbolic links (cycle?)"
-msgstr "E655: ¤Ó¦h¼hªº²Å¸¹Ãìµ²(symlink) (´`Àô?)"
-
-msgid "E240: No connection to Vim server"
-msgstr "E240: ¨S¦³»P Vim Server «Ø¥ß³s½u"
-
-msgid "E277: Unable to read a server reply"
-msgstr "E277: µLªkÅª¨ú¦øªA¾¹ªº¦^À³"
-
-msgid "E258: Unable to send to client"
-msgstr "E258: µLªk¶Ç°e¨ì client"
-
-#, c-format
-msgid "E241: Unable to send to %s"
-msgstr "E241: µLªk¶Ç°e¨ì %s"
-
-msgid "(Invalid)"
-msgstr "(¤£¥¿½T)"
-
+#: ../eval.c:139
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: ÅÜ¼Æ %s ©|¥¼©w¸q"
 
-#, c-format
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: ¤£¦XªkªºÅÜ¼Æ¦WºÙ: %s"
+#: ../eval.c:140
+msgid "E111: Missing ']'"
+msgstr "E111: ¯Ê¤Ö¹ïÀ³ªº \"]\""
 
+#: ../eval.c:141
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "E487: °Ñ¼ÆÀ³¸Ó¬O¥¿¼Æ"
+
+#: ../eval.c:143
+#, fuzzy, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E487: °Ñ¼ÆÀ³¸Ó¬O¥¿¼Æ"
+
+#: ../eval.c:144
+#, fuzzy
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E214: §ä¤£¨ì¼g¤J¥Îªº¼È¦sÀÉ"
+
+#: ../eval.c:145
+#, fuzzy
+msgid "E714: List required"
+msgstr "E471: »Ý­n«ü¥O°Ñ¼Æ"
+
+#: ../eval.c:146
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: »Ý­n¨ç¦¡¦WºÙ"
+
+#: ../eval.c:147
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: ¨ç¦¡ %s ªº¤Þ¼Æ¹L¦h"
+
+#: ../eval.c:148
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:150
 #, c-format
 msgid "E122: Function %s already exists, add ! to replace it"
 msgstr "E122: ¨ç¦¡ %s ¤w¸g¦s¦b, ½Ð¨Ï¥Î ! ±j¨î¨ú¥N"
 
+#: ../eval.c:151
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: ¤w¦³½w½Ä°Ï¨Ï¥Î³o­Ó¦W¦r"
+
+#: ../eval.c:152
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: »Ý­n¨ç¦¡¦WºÙ"
+
+#: ../eval.c:153
+#, fuzzy
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E360: ¤£¯à¥Î -f ¿ï¶µ°õ¦æ shell"
+
+#: ../eval.c:154
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr ""
+
+#: ../eval.c:155
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: ¥¼©w¸qªº¨ç¦¡: %s"
+
+#: ../eval.c:156
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: ¤£¦XªkªºÅÜ¼Æ¦WºÙ: %s"
+
+#: ../eval.c:157
+msgid "E806: using Float as a String"
+msgstr ""
+
+#: ../eval.c:1830
+msgid "E687: Less targets than List items"
+msgstr ""
+
+#: ../eval.c:1834
+msgid "E688: More targets than List items"
+msgstr ""
+
+#: ../eval.c:1906
+msgid "Double ; in list of variables"
+msgstr ""
+
+#: ../eval.c:2078
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E138: µLªk¼g¤J viminfo ÀÉ®× %s !"
+
+#: ../eval.c:2391
+msgid "E689: Can only index a List or Dictionary"
+msgstr ""
+
+#: ../eval.c:2396
+msgid "E708: [:] must come last"
+msgstr ""
+
+#: ../eval.c:2439
+msgid "E709: [:] requires a List value"
+msgstr ""
+
+#: ../eval.c:2674
+msgid "E710: List value has more items than target"
+msgstr ""
+
+#: ../eval.c:2678
+msgid "E711: List value has not enough items"
+msgstr ""
+
+#: ../eval.c:2867
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E69: %s%%[ «á¯Ê¤Ö ]"
+
+#: ../eval.c:3063
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: ¯Ê¤Ö¹ïÀ³ªº¬A¸¹: %s"
+
+#: ../eval.c:3263
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: µL¦¹ÅÜ¼Æ: \"%s\""
+
+#: ../eval.c:3333
+msgid "E743: variable nested too deep for (un)lock"
+msgstr ""
+
+#: ../eval.c:3630
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: '?' «á¯Ê¤Ö ':'"
+
+#: ../eval.c:3893
+msgid "E691: Can only compare List with List"
+msgstr ""
+
+#: ../eval.c:3895
+#, fuzzy
+msgid "E692: Invalid operation for Lists"
+msgstr "E449: ¦¬¨ì¤£¥¿½Tªº¹Bºâ¦¡"
+
+#: ../eval.c:3915
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr ""
+
+#: ../eval.c:3917
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: ¨ç¦¡ %s ªº¤Þ¼Æ¤£¥¿½T"
+
+#: ../eval.c:3932
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+
+#: ../eval.c:3934
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: ¨ç¦¡ %s ªº¤Þ¼Æ¤£¥¿½T"
+
+#: ../eval.c:4277
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: ¤£¯à¥Î -f ¿ï¶µ°õ¦æ shell"
+
+#: ../eval.c:4478
+msgid "E110: Missing ')'"
+msgstr "E110: ¯Ê¤Ö¹ïÀ³ªº \")\""
+
+#: ../eval.c:4609
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: µLªkÄÀ©ñ³Ì«á¤@­Ó½w½Ä°Ï"
+
+#: ../eval.c:4839
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: ¯Ê¤Ö¿ï¶µ¦WºÙ: %s"
+
+#: ../eval.c:4855
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: ¤£¥¿½Tªº¿ï¶µ: %s"
+
+#: ../eval.c:4904
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: ¯Ê¤Ö¤Þ¸¹: %s"
+
+#: ../eval.c:5020
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: ¯Ê¤Ö¤Þ¸¹: %s"
+
+#: ../eval.c:5084
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: ¯Ê¤Ö¬Ûµ¥²Å¸¹: %s"
+
+#: ../eval.c:5091
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: ¯Ê¤Ö \"=\": %s"
+
+#: ../eval.c:6475
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E242: §ä¤£¨ìÃC¦â: %s"
+
+#: ../eval.c:6499
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr ""
+
+#: ../eval.c:6517
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E242: §ä¤£¨ìÃC¦â: %s"
+
+#: ../eval.c:6524
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: ¯Ê¤Ö :endfunction"
+
+#: ../eval.c:6555
+#, fuzzy
+msgid "E724: variable nested too deep for displaying"
+msgstr "E22: ±_ª¬»¼°j©I¥s¤Ó¦h¼h"
+
+#: ../eval.c:7188
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: ¨ç¦¡ %s ªº¤Þ¼Æ¹L¦h"
+
+#: ../eval.c:7190
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: ¨ç¦¡ %s ªº¤Þ¼Æ¤£¥¿½T"
+
+#: ../eval.c:7377
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: ¥¼©w¸qªº¨ç¦¡: %s"
+
+#: ../eval.c:7383
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: ¨ç¦¡ %s ªº¤Þ¼Æ¤Ó¤Ö"
+
+#: ../eval.c:7387
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> ¤£¯à¦b script ¥»¤å¥~¨Ï¥Î: %s"
+
+#: ../eval.c:7391
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr ""
+
+#: ../eval.c:7453
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: = «á»Ý­n¦³¼Æ¦r"
+
+#: ../eval.c:7503
+#, fuzzy
+msgid "add() argument"
+msgstr "¤£¥¿½Tªº°Ñ¼Æ: "
+
+#: ../eval.c:7907
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "¤Ó¦h½s¿è°Ñ¼Æ"
+
+#: ../eval.c:8073
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: ¿ï³æ¥u¯à¦b¨ä¥¦¼Ò¦¡¤¤¨Ï¥Î"
+
+#: ../eval.c:8156
+msgid "&Ok"
+msgstr "½T©w(&O)"
+
+#: ../eval.c:8676
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: %s ªº mapping ¤w¸g¦s¦b"
+
+#: ../eval.c:8692
+msgid "extend() argument"
+msgstr ""
+
+#: ../eval.c:8915
+#, fuzzy
+msgid "map() argument"
+msgstr "vim [°Ñ¼Æ] "
+
+#: ../eval.c:8916
+msgid "filter() argument"
+msgstr ""
+
+#: ../eval.c:9229
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld ¦æ: "
+
+#: ../eval.c:9291
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: ¥¼©w¸qªº¨ç¦¡: %s"
+
+#: ../eval.c:10729
+msgid "called inputrestore() more often than inputsave()"
+msgstr "©I¥s inputrestore() ªº¦¸¼Æ¤ñ inputsave() ÁÙ¦h"
+
+#: ../eval.c:10771
+#, fuzzy
+msgid "insert() argument"
+msgstr "¤Ó¦h½s¿è°Ñ¼Æ"
+
+#: ../eval.c:10841
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E481: ¤£¥i¨Ï¥Î½d³ò«ü¥O"
+
+#: ../eval.c:11140
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E596: ¤£¥¿½Tªº¦r«¬"
+
+#: ../eval.c:11980
+msgid "E726: Stride is zero"
+msgstr ""
+
+#: ../eval.c:11982
+msgid "E727: Start past end"
+msgstr ""
+
+#: ../eval.c:12024 ../eval.c:15297
+msgid "<empty>"
+msgstr ""
+
+#: ../eval.c:12282
+msgid "remove() argument"
+msgstr ""
+
+#: ../eval.c:12466
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: ¤Ó¦h¼hªº²Å¸¹Ãìµ²(symlink) (´`Àô?)"
+
+#: ../eval.c:12593
+msgid "reverse() argument"
+msgstr ""
+
+#: ../eval.c:13721
+msgid "sort() argument"
+msgstr ""
+
+#: ../eval.c:13721
+#, fuzzy
+msgid "uniq() argument"
+msgstr "¤£¥¿½Tªº°Ñ¼Æ: "
+
+#: ../eval.c:13776
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: µLªk¿ï¾Ü¦¹¦Lªí¾÷"
+
+#: ../eval.c:13806
+msgid "E882: Uniq compare function failed"
+msgstr ""
+
+#: ../eval.c:14085
+msgid "(Invalid)"
+msgstr "(¤£¥¿½T)"
+
+#: ../eval.c:14590
+#, fuzzy
+msgid "E677: Error writing temp file"
+msgstr "E208: ¼g¤JÀÉ®× \"%s\" ¿ù»~"
+
+#: ../eval.c:16159
+msgid "E805: Using a Float as a Number"
+msgstr ""
+
+#: ../eval.c:16162
+msgid "E703: Using a Funcref as a Number"
+msgstr ""
+
+#: ../eval.c:16170
+msgid "E745: Using a List as a Number"
+msgstr ""
+
+#: ../eval.c:16173
+msgid "E728: Using a Dictionary as a Number"
+msgstr ""
+
+#: ../eval.c:16259
+msgid "E729: using Funcref as a String"
+msgstr ""
+
+#: ../eval.c:16262
+#, fuzzy
+msgid "E730: using List as a String"
+msgstr "E374: ®æ¦¡¤Æ¦r¦ê¸Ì¤Ö¤F ]"
+
+#: ../eval.c:16265
+msgid "E731: using Dictionary as a String"
+msgstr ""
+
+#: ../eval.c:16619
+#, fuzzy, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E93: §ä¨ì¤@­Ó¥H¤Wªº %s"
+
+#: ../eval.c:16705
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E46: µLªk³]©w°ßÅªÅÜ¼Æ \"%s\""
+
+#: ../eval.c:16724
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: ¨ç¦¡¦WºÙ²Ä¤@­Ó¦r¥À¥²¶·¤j¼g: %s"
+
+#: ../eval.c:16732
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr ""
+
+#: ../eval.c:16763
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr ""
+
+#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
+msgid "Unknown"
+msgstr "¥¼ª¾"
+
+#: ../eval.c:16768
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E284: ¤£¯à³]©w IC ¼Æ­È"
+
+#: ../eval.c:16838
+msgid "E698: variable nested too deep for making a copy"
+msgstr ""
+
+#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: ¨ç¦¡ %s ©|¥¼©w¸q"
 
+#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: ¯Ê¤Ö \"(\": %s"
 
+#: ../eval.c:17293
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: ¤£¯à³]©w IC ¼Æ­È"
+
+#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: °Ñ¼Æ¤£¥¿½T: %s"
 
+#: ../eval.c:17323
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: ¼ÐÅÒ(tag) \"%s\" ¦bÀÉ®× %s ¸Ì­«½Æ¥X²{¦h¦¸"
+
+#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: ¯Ê¤Ö :endfunction"
 
+#: ../eval.c:17537
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: ¨ç¦¡¦WºÙ²Ä¤@­Ó¦r¥À¥²¶·¤j¼g: %s"
+
+#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: ¨ç¦¡ %s ¥¿¦b¨Ï¥Î¤¤¡AµLªk­«·s©w¸q"
 
+#: ../eval.c:17604
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E128: ¨ç¦¡¦WºÙ²Ä¤@­Ó¦r¥À¥²¶·¤j¼g: %s"
+
+#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: »Ý­n¨ç¦¡¦WºÙ"
 
-#, c-format
-msgid "E128: Function name must start with a capital: %s"
+#: ../eval.c:17824
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr "E128: ¨ç¦¡¦WºÙ²Ä¤@­Ó¦r¥À¥²¶·¤j¼g: %s"
 
-#, c-format
-msgid "E130: Undefined function: %s"
-msgstr "E130: ¨ç¦¡ %s ©|¥¼©w¸q"
+#: ../eval.c:17833
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: ¨ç¦¡¦WºÙ²Ä¤@­Ó¦r¥À¥²¶·¤j¼g: %s"
 
+#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: ¨ç¦¡ %s ¥¿¦b¨Ï¥Î¤¤¡AµLªk§R°£"
 
+#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: ¨ç¦¡»¼°j©I¥s¼h¼Æ¶W¹L 'maxfuncdepth'"
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "©I¥s %s"
 
+#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s ³Q±j¨î¤¤Â_°õ¦æ "
 
+#: ../eval.c:18653
 #, c-format
 msgid "%s returning #%<PRId64>"
 msgstr "%s ¶Ç¦^­È #%<PRId64> "
 
-#, c-format
-msgid "%s returning \"%s\""
+#: ../eval.c:18670
+#, fuzzy, c-format
+msgid "%s returning %s"
 msgstr "%s ¶Ç¦^­È \"%s\""
 
-#. always scroll up, don't overwrite
+#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "Ä~Äò: %s"
 
+#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: :return ¥²¶·¦b¨ç¦¡¸Ì¨Ï¥Î"
 
-#, c-format
+#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -519,76 +1069,114 @@ msgstr ""
 "\n"
 "# ¥þ°ìÅÜ¼Æ:\n"
 
+#: ../eval.c:19254
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+"\n"
+"\t¤W¦¸³]©w: "
+
+#: ../eval.c:19272
+#, fuzzy
+msgid "No old files"
+msgstr "¨S¦³¤Þ¤JÀÉ®×"
+
+#: ../ex_cmds.c:122
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  ¤Q¤»¶i¦ì %02x,  ¤K¶i¦ì %03o"
 
+#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, ¤Q¤»¶i¦ì %04x, ¤K¶i¦ì %o"
 
+#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, ¤Q¤»¶i¦ì %08x,  ¤K¶i¦ì %o"
 
+#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: µLªk§â¦æ²¾¨ì¥¦¦Û¤w¤º"
 
+#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "¤w·h²¾ 1 ¦æ "
 
+#: ../ex_cmds.c:749
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "¤w·h²¾ %<PRId64> ¦æ "
 
+#: ../ex_cmds.c:1175
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "¤w³B²z %<PRId64> ¦æ "
 
+#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autocommand ¤£¥i¥H§ó§ï½w½Ä°Ïªº¤º®e"
 
+#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[§ó·s«á©|¥¼Àx¦s]\n"
 
+#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s ¦b¦æ¤¤: "
 
+#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: ¹L¦h¿ù»~, ©¿²¤ÀÉ®×¨ä¾l³¡¤À"
 
+#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Åª¨ú viminfo ÀÉ®× \"%s\"%s%s%s"
 
+#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " °T®§"
 
+#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " ¼Ð°O"
 
+#: ../ex_cmds.c:1462
+#, fuzzy
+msgid " oldfiles"
+msgstr "¨S¦³¤Þ¤JÀÉ®×"
+
+#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " ¥¢±Ñ"
 
+#. avoid a wait_return for this message, it's annoying
+#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo ÀÉ®×µLªk¼g¤J: %s"
 
+#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: µLªk¼g¤J viminfo ÀÉ®× %s !"
 
+#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "¼g¤J viminfo ÀÉ®× \"%s\" ¤¤"
 
 #. Write the info:
+#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# ¥» viminfo ÀÉ®×¬O¥Ñ Vim %s ©Ò²£¥Í.\n"
 
-#, c-format
+#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -596,94 +1184,141 @@ msgstr ""
 "# ¦pªG·Q­n¦Û¦æ­×§ï½Ð¯S§O¤p¤ß¡I\n"
 "\n"
 
-#, c-format
+#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# 'encoding' ¦b¦¹ÀÉ«Ø¥ß®Éªº­È\n"
 
+#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "µL®Äªº°_©l¦r¤¸"
 
-msgid "Save As"
-msgstr "¥t¦s·sÀÉ"
-
-#. Overwriting a file that is loaded in another buffer is not a
-#. * good idea.
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: ±z¦b¥t¤@­Ó½w½Ä°Ï¤]¸ü¤J¤F³o­ÓÀÉ®×"
-
+#: ../ex_cmds.c:2162
 msgid "Write partial file?"
 msgstr "­n¼g¤J³¡¤ÀÀÉ®×¶Ü¡H"
 
+#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: ½Ð¨Ï¥Î ! ¥H¼g¤J³¡¤À½w½Ä°Ï"
 
-#, c-format
-msgid "Overwrite existing file \"%.*s\"?"
+#: ../ex_cmds.c:2281
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
 msgstr "­nÂÐ¼g¤w¦s¦bªºÀÉ®× \"%.*s\"¡H"
 
+#: ../ex_cmds.c:2317
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr ""
+
+#: ../ex_cmds.c:2326
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: ÀÉ®×¤w¸g¦s¦b (¥i¥Î ! ±j¨î¨ú¥N)"
+
+#: ../ex_cmds.c:2381
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: ½w½Ä°Ï %<PRId64> ¨S¦³ÀÉ®×¦WºÙ"
 
+#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ÀÉ®×¥¼¼g¤J¡A¦]¬° 'write' ¿ï¶µ³QÃö³¬"
 
-#, c-format
+#: ../ex_cmds.c:2434
+#, fuzzy, c-format
 msgid ""
-"'readonly' option is set for \"%.*s\".\n"
+"'readonly' option is set for \"%s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "\"%.*s\" ¤w³]©w 'readonly' ¿ï¶µ.\n"
 "½T©w­nÂÐ¼g¶Ü¡H"
 
-msgid "Edit File"
-msgstr "½s¿èÀÉ®×"
+#: ../ex_cmds.c:2439
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
 
+#: ../ex_cmds.c:2451
+#, fuzzy, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "¬O°ßÅªÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
+
+#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autocommands ·N¥~¦a§R°£·s½w½Ä°Ï %s"
 
+#: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z ¤£±µ¨ü«D¼Æ¦rªº°Ñ¼Æ"
 
+#: ../ex_cmds.c:3404
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: rvim ¤¤¸T¤î¨Ï¥Î shell ©R¥O"
 
+#: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regular expression µLªk¥Î¦r¥À¤À¹j (?)"
 
+#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "¨ú¥N¬° %s (y/n/a/q/^E/^Y)?"
 
+#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(¤w¤¤Â_) "
 
+#: ../ex_cmds.c:4384
+#, fuzzy
+msgid "1 match"
+msgstr "; ²Å¦X "
+
+#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "¨ú¥N¤@²Õ "
 
+#: ../ex_cmds.c:4387
+#, fuzzy, c-format
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> ¶µ§ïÅÜ"
+
+#: ../ex_cmds.c:4388
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "¨ú¥N %<PRId64> ²Õ "
 
+#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr "¡A½d³ò¡G¤@¦æ "
 
+#: ../ex_cmds.c:4395
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr "¡A½d³ò¡G %<PRId64> ¦æ "
 
+#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global µLªk»¼°j°õ¦æ "
 
+#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: ¨S¦³¨Ï¥Î¹L Regular expression (?)"
 
+#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "¨C¤@¦æ³£§ä¤£¨ì: %s"
 
-#, c-format
+#: ../ex_cmds.c:4510
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "§ä¤£¨ì"
+
+#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -693,319 +1328,338 @@ msgstr ""
 "# «e¤@²Õ´À¥N¦r¦ê:\n"
 "$"
 
+#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: ¤£­nÅå·W!"
 
+#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: ©êºp, ¨S¦³Ãö©ó %s-%s ªº»¡©ú"
 
+#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: ©êºp, ¨S¦³ %s ªº»¡©ú"
 
+#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "©êºp, §ä¤£¨ì»¡©úÀÉ \"%s\""
 
+#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s ¤£¬O¥Ø¿ý"
 
+#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: µLªk¥H¼g¤J¼Ò¦¡¶}±Ò \"%s\""
 
+#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: µLªkÅª¨úÀÉ®×: %s"
 
+#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr "E670: ¦P¤@»y¨¥ (%s) ¤¤¦³²V¦X¤£¦P¦r¤¸½s½Xªº»¡©úÀÉ"
 
-#, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s"
+#: ../ex_cmds.c:5565
+#, fuzzy, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: ¼ÐÅÒ(tag) \"%s\" ¦bÀÉ®× %s ¸Ì­«½Æ¥X²{¦h¦¸"
 
+#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: ¥¼©w¸qªº sign command: %s"
 
+#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: ¯Ê¤Ö sign ¦WºÙ"
 
+#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: ¤w©w¸q¤Ó¦h signs"
 
+#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: ¤£¥¿½Tªº sign ¤å¦r: %s"
 
+#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: ¤£¥¿½Tªº sign: %s"
 
+#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: ¯Ê¤Ö sign number"
 
+#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: ½w½Ä°Ï¦WºÙ¿ù»~: %s"
 
+#: ../ex_cmds.c:6008
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Sign ID ¿ù»~: %<PRId64>"
 
-msgid " (NOT FOUND)"
-msgstr " (§ä¤£¨ì) "
-
+#: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (¤£¤ä´©) "
 
+#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[¤w§R°£]"
 
+#: ../ex_cmds2.c:139
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "¶i¤J°£¿ù¼Ò¦¡. ¿é¤J \"cont\" ¥H¦^¨ì¥¿±`¼Ò¦¡."
 
+#: ../ex_cmds2.c:143 ../ex_docmd.c:759
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "¦æ %<PRId64>: %s"
 
+#: ../ex_cmds2.c:145
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
+#: ../ex_cmds2.c:322
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "\"%s%s\" ¤¤Â_ÂI: ²Ä %<PRId64> ¦æ "
 
+#: ../ex_cmds2.c:581
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: §ä¤£¨ì¤¤Â_ÂI: %s"
 
+#: ../ex_cmds2.c:611
 msgid "No breakpoints defined"
 msgstr "¨S¦³©w¸q¤¤Â_ÂI"
 
+#: ../ex_cmds2.c:617
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  ²Ä %<PRId64> ¦æ "
 
-#, c-format
-msgid "Save changes to \"%.*s\"?"
+#: ../ex_cmds2.c:942
+msgid "E750: First use \":profile start {fname}\""
+msgstr ""
+
+#: ../ex_cmds2.c:1269
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
 msgstr "±NÅÜ°Ê¦sÀx¦Ü \"%.*s\"?"
 
+#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
 msgid "Untitled"
 msgstr "¥¼©R¦W"
 
+#: ../ex_cmds2.c:1421
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: ¤w§ó§ï¹L½w½Ä°Ï \"%s\" ¦ý©|¥¼¦sÀÉ (¥i¥Î ! ±j¨î°õ¦æ)"
 
+#: ../ex_cmds2.c:1480
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr "ª`·N: ¤w¤Á´«¨ì¨ä¥¦½w½Ä°Ï (½ÐÀË¬d Autocommands ¦³µL¿ù»~)"
 
+#: ../ex_cmds2.c:1826
 msgid "E163: There is only one file to edit"
 msgstr "E163: ¥u¦³¤@­ÓÀÉ®×¥i½s¿è"
 
+#: ../ex_cmds2.c:1828
 msgid "E164: Cannot go before first file"
 msgstr "E164: ¤w¸g¦b²Ä¤@­ÓÀÉ®×¤F"
 
+#: ../ex_cmds2.c:1830
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: ¤w¸g¦b³Ì«á¤@­ÓÀÉ®×¤F"
 
+#: ../ex_cmds2.c:2175
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: ½sÄ¶¾¹¤£¤ä´©: %s"
 
+#: ../ex_cmds2.c:2257
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "·j´M¤¤: \"%s\" -- \"%s\""
 
+#: ../ex_cmds2.c:2284
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "·j´M¤¤: \"%s\""
 
+#: ../ex_cmds2.c:2307
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "¦b 'runtimepath' ¸Ì§ä¤£¨ì \"%s\""
 
-msgid "Source Vim script"
-msgstr "°õ¦æ Vim script"
-
+#: ../ex_cmds2.c:2472
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "µLªk°õ¦æ¥Ø¿ý¡G \"%s\""
 
+#: ../ex_cmds2.c:2518
 #, c-format
 msgid "could not source \"%s\""
 msgstr "µLªk°õ¦æ \"%s\""
 
+#: ../ex_cmds2.c:2520
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "²Ä %<PRId64> ¦æ: µLªk°õ¦æ \"%s\""
 
+#: ../ex_cmds2.c:2535
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "°õ¦æ \"%s\" ¤¤"
 
+#: ../ex_cmds2.c:2537
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "²Ä %<PRId64> ¦æ: µ²§ô°õ¦æ %s"
 
+#: ../ex_cmds2.c:2693
 #, c-format
 msgid "finished sourcing %s"
 msgstr "µ²§ô°õ¦æ %s"
 
+#: ../ex_cmds2.c:2765
+#, fuzzy
+msgid "modeline"
+msgstr "ÁÙ¦³¤@¦æ "
+
+#: ../ex_cmds2.c:2767
+#, fuzzy
+msgid "--cmd argument"
+msgstr "vim [°Ñ¼Æ] "
+
+#: ../ex_cmds2.c:2769
+#, fuzzy
+msgid "-c argument"
+msgstr "vim [°Ñ¼Æ] "
+
+#: ../ex_cmds2.c:2771
+msgid "environment variable"
+msgstr ""
+
+#: ../ex_cmds2.c:2773
+#, fuzzy
+msgid "error handler"
+msgstr "¿ù»~»P¤¤Â_"
+
+#: ../ex_cmds2.c:3020
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: ª`·N: ¿ù»~ªº¦æ¤À¹j¦r¤¸¡A¥i¯à¬O¤Ö¤F ^M"
 
+#: ../ex_cmds2.c:3139
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: ¦b°õ¦æ script ÀÉ®×¥~¤£¥i¨Ï¥Î :scriptencoding"
 
+#: ../ex_cmds2.c:3166
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: ¦b°õ¦æ script ÀÉ®×¥~¤£¥i¨Ï¥Î :finish"
 
-#, c-format
-msgid "Page %d"
-msgstr "²Ä %d ­¶"
-
-msgid "No text to be printed"
-msgstr "¨S¦³­n¦C¦Lªº¤å¦r"
-
-#, c-format
-msgid "Printing page %d (%d%%)"
-msgstr "¦C¦L¤¤: ²Ä %d ­¶ (%d%%)"
-
-#, c-format
-msgid " Copy %d of %d"
-msgstr "½Æ»s %d / %d"
-
-#, c-format
-msgid "Printed: %s"
-msgstr "¤w¦C¦L: %s"
-
-#, c-format
-msgid "Printing aborted"
-msgstr "¤w¨ú®ø¦C¦L"
-
-msgid "E455: Error writing to PostScript output file"
-msgstr "E455: µLªk¼g¤J PostScript ¿é¥XÀÉ"
-
-#, c-format
-msgid "E624: Can't open file \"%s\""
-msgstr "E624: µLªk¶}±ÒÀÉ®× \"%s\""
-
-#, c-format
-msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"%s\""
-
-#, c-format
-msgid "E618: file \"%s\" is not a PostScript resource file"
-msgstr "E618: ÀÉ®× \"%s\" ¤£¬O PostScript ¸ê·½ÀÉ "
-
-#, c-format
-msgid "E619: file \"%s\" is not a supported PostScript resource file"
-msgstr "E619: ¤£¤ä´© PostScript ¸ê·½ÀÉ \"%s\""
-
-#, c-format
-msgid "E621: \"%s\" resource file has wrong version"
-msgstr "E621: \"%s\" ¸ê·½ÀÉª©¥»¿ù»~"
-
-msgid "E324: Can't open PostScript output file"
-msgstr "E324: µLªk¶}±Ò PostScript ¿é¥XÀÉ"
-
-#, c-format
-msgid "E456: Can't open file \"%s\""
-msgstr "E456: µLªk¶}±ÒÀÉ®× \"%s\""
-
-msgid "E456: Can't find PostScript resource file \"prolog.ps\""
-msgstr "E456: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"prolog.ps\""
-
-#, c-format
-msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"%s.ps\""
-
-#, c-format
-msgid "E620: Unable to convert from multi-byte to \"%s\" encoding"
-msgstr "E620:µLªkÂà´«¦Ü \"%s\" ¦r¤¸½s½X"
-
-msgid "Sending to printer..."
-msgstr "¶Ç°e¸ê®Æ¨ì¦Lªí¾÷..."
-
-msgid "E365: Failed to print PostScript file"
-msgstr "E365: µLªk¦C¦L PostScript ÀÉ®×"
-
-msgid "Print job sent."
-msgstr "¤w°e¥X¦C¦L¤u§@¡C"
-
+#: ../ex_cmds2.c:3389
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "¥Ø«eªº %s»y¨¥: \"%s\""
 
+#: ../ex_cmds2.c:3404
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: ¤£¯à³]©w»y¨¥¦¨ \"%s\""
 
+#. don't redisplay the window
+#. don't wait for return
+#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr "¶i¤J Ex ¼Ò¦¡. ¿é¤J \"visua\" ¥H¦^¨ì¥¿±`¼Ò¦¡."
 
-#. must be at EOF
+#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: ¤w¨ìÀÉ®×µ²§À"
 
+#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: ©R¥O»¼°j¼h¼Æ¹L¦h"
 
+#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: ¥¼ÄdºIªº¨Ò¥~¡G %s"
 
+#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "©R¥OÀÉµ²§ô"
 
+#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "¨ç¦¡µ²§À"
 
+#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: ¨Ï¥ÎªÌ©w¸qªº©R¥O·|²V²c"
 
+#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: ¤£¬O½s¿è¾¹ªº©R¥O"
 
+#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: «ü©w¤F¦V«e°Ñ¦Òªº½d³ò"
 
+#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "«ü©w¤F¦V«e°Ñ¦Òªº½d³ò¡AOK to swap"
 
+#. append
+#. typed wrong
+#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: ½Ð¨Ï¥Î w ©Î w>>"
 
+#: ../ex_docmd.c:3454
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: ©êºp, ¥»©R¥O¦b¦¹ª©¥»¤¤¨S¦³¹ê§@"
 
+#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: ¥u¯à¦³¤@­ÓÀÉ"
 
+#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "ÁÙ¦³¤@­ÓÀÉ®×¥¼½s¿è. ½T©w­nÂ÷¶}¡H"
 
+#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "ÁÙ¦³ %d ­ÓÀÉ®×¥¼½s¿è. ½T©w­nÂ÷¶}¡H"
 
+#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: ÁÙ¦³¤@­ÓÀÉ®×¥¼½s¿è "
 
+#: ../ex_docmd.c:4250
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: ÁÙ¦³ %<PRId64> ­ÓÀÉ®×¥¼½s¿è"
 
+#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: ©R¥O¤w¸g¦s¦b, ½Ð¨Ï¥Î ! ±j¨î­«·s©w¸q"
 
+#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1013,248 +1667,348 @@ msgstr ""
 "\n"
 "    ¦WºÙ        °Ñ¼Æ ½d³ò  §¹¾ã      ©w¸q      "
 
+#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "§ä¤£¨ì¨Ï¥ÎªÌ©w¸qªº©R¥O"
 
+#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: ¨S¦³«ü©wªºÄÝ©Ê"
 
+#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: ¤£¥¿½Tªº°Ñ¼Æ¼Æ¥Ø"
 
+#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: ¤£¯à«ü©w¨â¦¸¼Æ¥Ø"
 
+#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: ¼Æ¥Øªº¹w³]°Ñ¼Æ¤£¥¿½T"
 
-msgid "E179: argument required for complete"
+#: ../ex_docmd.c:4625
+#, fuzzy
+msgid "E179: argument required for -complete"
 msgstr "E179: «ü¥O»Ý­n°Ñ¼Æ¤~¯à§¹¦¨"
 
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: ¤£§¹¾ãªº­È: '%s'"
-
-msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: ¦Û­q¸É§¹®É¤~¥i¸É§¹°Ñ¼Æ"
-
-msgid "E467: Custom completion requires a function argument"
-msgstr "E467: ¦Û­q¸É§¹»Ý­n¨ç¦¡¬°°Ñ¼Æ"
-
+#: ../ex_docmd.c:4635
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: ¤£¥¿½TªºÄÝ©Ê: %s"
 
+#: ../ex_docmd.c:4678
 msgid "E182: Invalid command name"
 msgstr "E182: «ü¥O¦WºÙ¤£¥¿½T"
 
+#: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: ¨Ï¥ÎªÌ¦Û©w«ü¥O¥²¶·¥H¤j¼g¦r¥À¶}©l"
 
+#: ../ex_docmd.c:4696
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: ¨Ï¥ÎªÌ©w¸qªº©R¥O·|²V²c"
+
+#: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: ¨S¦³¨Ï¥ÎªÌ¦Û©wªº©R¥O¡G %s"
 
+#: ../ex_docmd.c:5219
 #, c-format
-msgid "E185: Cannot find color scheme %s"
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: ¤£§¹¾ãªº­È: '%s'"
+
+#: ../ex_docmd.c:5225
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr "E468: ¦Û­q¸É§¹®É¤~¥i¸É§¹°Ñ¼Æ"
+
+#: ../ex_docmd.c:5231
+msgid "E467: Custom completion requires a function argument"
+msgstr "E467: ¦Û­q¸É§¹»Ý­n¨ç¦¡¬°°Ñ¼Æ"
+
+#: ../ex_docmd.c:5257
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: §ä¤£¨ìÃC¦â¼Ë¦¡ %s"
 
+#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "¶Ù, Vim ¨Ï¥ÎªÌ¡I"
 
-msgid "Edit File in new window"
-msgstr "¦b·sµøµ¡½s¿èÀÉ®×"
+#: ../ex_docmd.c:5431
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: ¤£¯àÃö³¬³Ì«á¤@­Óµøµ¡"
 
+#: ../ex_docmd.c:5462
+#, fuzzy
+msgid "Already only one tab page"
+msgstr "¤w¸g¥u³Ñ¤@­Óµøµ¡¤F"
+
+#: ../ex_docmd.c:6004
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "²Ä %d ­¶"
+
+#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "µL¼È¦sÀÉ"
 
-msgid "Append File"
-msgstr "ªþ¥[ÀÉ®×"
+#: ../ex_docmd.c:6478
+#, fuzzy
+msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
+msgstr "E509: µLªk«Ø¥ß³Æ¥÷ÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
+#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: ¨S¦³«e¤@­Ó¥Ø¿ý"
 
+#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: µLªk¿ìÃÑªº¼Ð°O"
 
+#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize »Ý­n¨â­Ó°Ñ¼Æ"
 
-#, c-format
-msgid "Window position: X %d, Y %d"
-msgstr "µøµ¡¦ì¸m: X %d, Y %d"
-
+#: ../ex_docmd.c:6655
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: ¦b±zªº¥­¥x¤WµLªkÀò±oµøµ¡¦ì¸m"
 
+#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos »Ý­n¨â­Ó°Ñ¼Æ"
 
-msgid "Save Redirection"
-msgstr "Àx¦s Redirection"
+#: ../ex_docmd.c:7241
+#, fuzzy, c-format
+msgid "E739: Cannot create directory: %s"
+msgstr "µLªk°õ¦æ¥Ø¿ý¡G \"%s\""
 
-msgid "Save View"
-msgstr "Àx¦s View"
-
-msgid "Save Session"
-msgstr "Àx¦s Session"
-
-msgid "Save Setup"
-msgstr "Àx¦s³]©w"
-
+#: ../ex_docmd.c:7268
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" ¤w¦s¦b (½Ð¥Î ! ±j¨î°õ¦æ)"
 
+#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: µLªk¥H¼g¤J¼Ò¦¡¶}±Ò \"%s\""
 
 #. set mark
+#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: °Ñ¼Æ¥²¶·¬O­^¤å¦r¥À©Î¦V«e/«áªº¤Þ¸¹"
 
+#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: :normal »¼°j¼h¼Æ¹L²`"
 
+#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: ¨S¦³ '#' ¥i´À¥NªºÀÉ¦W"
 
+#: ../ex_docmd.c:7841
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: ¨S¦³ Autocommand ÀÉ¦W¥H¨ú¥N \"<afile>\""
 
+#: ../ex_docmd.c:7850
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: ¨S¦³ Autocommand ½w½Ä°Ï¦WºÙ¥H¨ú¥N \"<abuf>\""
 
+#: ../ex_docmd.c:7861
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: ¨S¦³ Autocommand ²Å¦X¦WºÙ¥H¨ú¥N \"<amatch>\""
 
+#: ../ex_docmd.c:7870
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: ¨S¦³ :source ÀÉ¦W¥H¨ú¥N \"<sfile>\""
 
-#, no-c-format
+#: ../ex_docmd.c:7876
+#, fuzzy
+msgid "E842: no line number to use for \"<slnum>\""
+msgstr "E498: ¨S¦³ :source ÀÉ¦W¥H¨ú¥N \"<sfile>\""
+
+#: ../ex_docmd.c:7903
+#, fuzzy, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: '%' ©Î '#' «ü¦VªÅÀÉ¦W¡A¥u¯à¥Î©ó \":p:h\""
 
+#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: ¿é¤J¬°ªÅ¦r¦ê"
 
+#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: µLªkÅª¨ú viminfo"
 
-msgid "E196: No digraphs in this version"
-msgstr "E196: ¥»ª©¥»µL½Æ¦X¦r¤¸(digraph)"
-
+#: ../ex_eval.c:464
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: ¤£¯à :throw ¥Î 'Vim' ¶}ÀYªº¨Ò¥~"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "¥á¥X¨Ò¥~¡G %s"
 
+#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "¨Ò¥~µ²§ô¡G %s"
 
+#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "¤w¥á±ó¨Ò¥~¡G %s"
 
+#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, ¦æ %<PRId64>"
 
 #. always scroll up, don't overwrite
+#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "µo¥Í¨Ò¥~¡G%s"
 
+#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s ³y¦¨ pending"
 
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s ¤w¦^´_"
 
+#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s ¤w¥á±ó"
 
+#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "¨Ò¥~"
 
+#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "¿ù»~»P¤¤Â_"
 
+#: ../ex_eval.c:715
 msgid "Error"
 msgstr "¿ù»~"
 
 #. if (pending & CSTP_INTERRUPT)
+#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "¤¤Â_"
 
+#: ../ex_eval.c:795
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if ¼h¼Æ¹L²`"
 
+#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif ¯Ê¤Ö¹ïÀ³ªº :if"
 
+#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else ¯Ê¤Ö¹ïÀ³ªº :if"
 
+#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif ¯Ê¤Ö¹ïÀ³ªº :if"
 
+#: ../ex_eval.c:880
 msgid "E583: multiple :else"
 msgstr "E583: ¦h­« :else"
 
+#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif ¦b :else ¤§«á"
 
-msgid "E585: :while nesting too deep"
+#: ../ex_eval.c:941
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while ¼h¼Æ¹L²`"
 
-msgid "E586: :continue without :while"
+#: ../ex_eval.c:1028
+#, fuzzy
+msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue ¯Ê¤Ö¹ïÀ³ªº :while"
 
-msgid "E587: :break without :while"
+#: ../ex_eval.c:1061
+#, fuzzy
+msgid "E587: :break without :while or :for"
 msgstr "E587: :break ¯Ê¤Ö¹ïÀ³ªº :while"
 
+#: ../ex_eval.c:1102
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: ¯Ê¤Ö :endwhile"
+
+#: ../ex_eval.c:1104
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: ¯Ê¤Ö :endwhile"
+
+#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :if ¼h¼Æ¹L²`"
 
+#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch ¨S¦³ :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
+#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch ¦b :finally ¤§«á"
 
+#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally ¨S¦³ :try"
 
 #. Give up for a multiple ":finally" and ignore it.
+#: ../ex_eval.c:1467
 msgid "E607: multiple :finally"
 msgstr "E607: ¦h­« :finally"
 
+#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endif ¯Ê¤Ö¹ïÀ³ªº :if"
 
+#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction ¥²¶·¦b¨ç¦¡¤º³¡¨Ï¥Î"
 
+#: ../ex_getln.c:1643
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: ¤£¯à¦b sandbox ¸Ì¥X²{"
+
+#: ../ex_getln.c:1656
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: §ä¤£¨ì %s"
+
+#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "¼ÐÅÒ¦WºÙ"
 
+#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr "ÃþÀÉ®×\n"
 
+#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "¿ï¶µ 'history' ¬O¹s"
 
+#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1263,194 +2017,302 @@ msgstr ""
 "\n"
 "# %s ¾ú¥v°O¿ý (·s¨ìÂÂ):\n"
 
+#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "©R¥O¦C"
 
+#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "·j´M¦r¦ê"
 
+#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "¹Bºâ¦¡"
 
+#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "¿é¤J¦æ "
 
+#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar ¶W¹L©R¥Oªø«×"
 
+#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: ¤w§R°£±¼§@¥Î¤¤ªºµøµ¡©Î¼È¦s°Ï"
 
+#: ../file_search.c:203
+msgid "E854: path too long for completion"
+msgstr ""
+
+#: ../file_search.c:446
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr "E343: ¤£¥¿½Tªº¸ô®|: '**[number]' ¥²»Ý­n¦b¸ô®|µ²§À©Î­n±µµÛ '%s'"
+
+#: ../file_search.c:1505
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath ¤¤¨S¦³¥Ø¿ý \"%s\""
+
+#: ../file_search.c:1508
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: ¦b¸ô®|¤¤§ä¤£¨ìÀÉ®× \"%s\""
+
+#: ../file_search.c:1512
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: ¦b¸ô®|¤¤§ä¤£¨ì§ó¦hªºÀÉ®× \"%s\""
+
+#: ../file_search.c:1515
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: ¦b¸ô®|¤¤§ä¤£¨ì§ó¦hªºÀÉ®× \"%s\""
+
+#: ../fileio.c:137
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* Autocommand ¤£¥i¥H§ó§ï½w½Ä°Ïªº¤º®e"
+
+#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "¤£¥¿½TªºÀÉ¦W"
 
+#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "¬O¥Ø¿ý"
 
+#: ../fileio.c:397
 msgid "is not a file"
 msgstr "¤£¬OÀÉ®×"
 
+#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[¥¼©R¦W]"
 
+#: ../fileio.c:511
+msgid "[New DIRECTORY]"
+msgstr ""
+
+#: ../fileio.c:529 ../fileio.c:532
+msgid "[File too big]"
+msgstr ""
+
+#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Åv­­¤£¨¬]"
 
+#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre Autocommand ¨Ïµ{¦¡µLªkÅª¨ú¦¹ÀÉ"
 
+#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *Filter* Autocommand ¤£¥i¥H§ó§ï½w½Ä°Ïªº¤º®e"
 
+#: ../fileio.c:672
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: ±q¼Ð·Ç¿é¤JÅª¨ú...\n"
 
-msgid "Reading from stdin..."
-msgstr "±q¼Ð·Ç¿é¤JÅª¨ú..."
-
 #. Re-opening the original file failed!
+#: ../fileio.c:909
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Âà´«¿ù»~"
 
+#. fifo or socket
+#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
+#. fifo
+#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
+#. or socket
+#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-msgid "[RO]"
-msgstr "[°ßÅª]"
+#. or character special
+#: ../fileio.c:1801
+#, fuzzy
+msgid "[character special]"
+msgstr "¤@­Ó¦r¤¸"
 
+#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[¯Ê¤ÖCR]'"
 
-msgid "[NL found]"
-msgstr "[§ä¨ìNL]"
-
+#: ../fileio.c:1819
 msgid "[long lines split]"
 msgstr "[¤À³Î¹Lªø¦æ]"
 
+#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[¥¼Âà´«]"
 
+#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[¤wÂà´«]"
 
-msgid "[crypted]"
-msgstr "[¤w¥[±K]"
+#: ../fileio.c:1831
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[¦æ %<PRId64> ¦³¤£¥¿½Tªº¦ì¤¸]"
 
-msgid "[CONVERSION ERROR]"
-msgstr "Âà´«¿ù»~"
-
+#: ../fileio.c:1835
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[¦æ %<PRId64> ¦³¤£¥¿½Tªº¦ì¤¸]"
 
+#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[Åª¨ú¿ù»~]"
 
+#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "§ä¤£¨ìÂà´«¥Îªº¼È¦sÀÉ"
 
+#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "¦r¤¸¶°Âà´«¿ù»~"
 
+#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "µLªkÅª¨ú 'charconvert' ªº¿é¥X"
 
+#: ../fileio.c:2437
+#, fuzzy
+msgid "E676: No matching autocommands for acwrite buffer"
+msgstr "§ä¤£¨ì¹ïÀ³ªº autocommand"
+
+#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Autocommand §R°£©ÎÄÀ©ñ¤F­n¼g¤Jªº½w½Ä°Ï"
 
+#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Autocommand ·N¥~¦a§ïÅÜ¤F¦æ¸¹"
 
-msgid "NetBeans disallows writes of unmodified buffers"
-msgstr "NetBeans ¤£¯à¼g¥X¥¼­×§ïªº½w½Ä°Ï"
-
-msgid "Partial writes disallowed for NetBeans buffers"
-msgstr "³¡¥÷¤º®eµLªk¼g¤J Netbeans ½w½Ä°Ï"
-
+#: ../fileio.c:2548 ../fileio.c:2565
 msgid "is not a file or writable device"
 msgstr "¤£¬OÀÉ®×©Î¥i¼g¤Jªº¸Ë¸m"
 
+#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "¬O°ßÅªÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
+#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: µLªk¼g¤J³Æ¥÷ÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
+#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: µLªkÃö³¬³Æ¥÷ÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
+#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: µLªkÅª¨úÀÉ®×¥H¨Ñ³Æ¥÷ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
+#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: µLªk«Ø¥ß³Æ¥÷ÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
+#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: µLªk»s§@³Æ¥÷ÀÉ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
-msgid "E460: The resource fork would be lost (add ! to override)"
-msgstr "E460: Resource fork ·|®ø¥¢ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
-
+#. Can't write without a tempfile!
+#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: §ä¤£¨ì¼g¤J¥Îªº¼È¦sÀÉ"
 
+#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: µLªkÂà´« (½Ð¨Ï¥Î ! ±j¨î¤£Âà´«¼g¤J)"
 
+#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: µLªk¥H¼g¤J¼Ò¦¡¶}±Ò³sµ²ÀÉ®×"
 
+#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: µLªk¥H¼g¤J¼Ò¦¡¶}±Ò"
 
+#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync ©R¥O°õ¦æ¥¢±Ñ"
 
+#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Ãö³¬¥¢±Ñ"
 
-msgid "E513: write error, conversion failed"
+#: ../fileio.c:3436
+#, fuzzy
+msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: µLªk¼g¤J -- Âà´«¥¢±Ñ"
 
+#: ../fileio.c:3441
+#, c-format
+msgid ""
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
+"override)"
+msgstr ""
+
+#: ../fileio.c:3448
 msgid "E514: write error (file system full?)"
 msgstr "E514: ¼g¤J¿ù»~ (ÀÉ®×¨t²Î¤wº¡¡H)"
 
+#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr "Âà´«¿ù»~"
 
+#: ../fileio.c:3509
+#, fuzzy, c-format
+msgid " in line %<PRId64>;"
+msgstr "¦æ %<PRId64>"
+
+#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[¸Ë¸m]"
 
+#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[·s]"
 
+#: ../fileio.c:3535
 msgid " [a]"
 msgstr "[a]"
 
+#: ../fileio.c:3535
 msgid " appended"
 msgstr " ¤wªþ¥["
 
+#: ../fileio.c:3537
 msgid " [w]"
 msgstr "[w]"
 
+#: ../fileio.c:3537
 msgid " written"
 msgstr " ¤w¼g¤J"
 
+#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patch ¼Ò¦¡: µLªkÀx¦s­ì©lÀÉ®×"
 
+#: ../fileio.c:3602
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: Patch ¼Ò¦¡: µLªkÅÜ§óªÅªº­ì©lÀÉ®×"
 
+#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: µLªk§R°£³Æ¥÷ÀÉ"
 
+#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -1458,100 +2320,137 @@ msgstr ""
 "\n"
 "Äµ§i: ­ì©lÀÉ®×¬y¥¢©Î·lÃa\n"
 
+#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "¦bÀÉ®×¥¿½T¼g¤J«e½Ð¤ÅÂ÷¶}½s¿è¾¹!"
 
+#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
+#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[dos ®æ¦¡]"
 
+#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
+#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[mac ®æ¦¡]"
 
+#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
+#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[unix ®æ¦¡]"
 
+#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 ¦æ, "
 
+#: ../fileio.c:3833
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> ¦æ, "
 
+#: ../fileio.c:3836
 msgid "1 character"
 msgstr "¤@­Ó¦r¤¸"
 
+#: ../fileio.c:3838
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64>­Ó¦r¤¸"
 
+#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
+#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[µ²§À¦æ¤£§¹¾ã]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
+#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "Äµ§i: ¥»ÀÉ®×¦Û¤W¦¸Åª¤J«á¤wÅÜ°Ê!!!"
 
+#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "½T©w­n¼g¤J¶Ü"
 
+#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: ¼g¤JÀÉ®× \"%s\" ¿ù»~"
 
+#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Ãö³¬ÀÉ®× \"%s\" ¿ù»~"
 
+#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Åª¨úÀÉ®× \"%s\" ¿ù»~"
 
+#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell autocommand §R°£½w½Ä°Ï"
 
-#, c-format
-msgid "E211: Warning: File \"%s\" no longer available"
+#: ../fileio.c:4894
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Äµ§i: ÀÉ®× \"%s\" ¤w¸g¤£¦s¦b"
 
+#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
 "well"
 msgstr "W12: Äµ§i: ÀÉ®× \"%s\" ¦Û¤W¦¸Åª¤J«á¤wÅÜ°Ê, ¦Ó¥B½s¿è¤¤ªº½w½Ä°Ï¤]§ó°Ê¤F"
 
+#: ../fileio.c:4907
+#, fuzzy
+msgid "See \":help W12\" for more info."
+msgstr "¶i¤@¨B»¡©ú½Ð¨£ \":help W11\"¡C"
+
+#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr "W11: Äµ§i: ÀÉ®× \"%s\" ¦Û¤W¦¸Åª¤J«á¤wÅÜ°Ê"
 
+#: ../fileio.c:4911
+msgid "See \":help W11\" for more info."
+msgstr "¶i¤@¨B»¡©ú½Ð¨£ \":help W11\"¡C"
+
+#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr "W16: Äµ§i: ÀÉ®× \"%s\" ªºÅv­­»P¤W¦¸Åª¤J®É¤£¤@¼Ë (¦³ÅÜ°Ê¹L)"
 
+#: ../fileio.c:4915
+#, fuzzy
+msgid "See \":help W16\" for more info."
+msgstr "¶i¤@¨B»¡©ú½Ð¨£ \":help W11\"¡C"
+
 # 'mode' seems better as translated to 'permission'?
+#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr "W13: Äµ§i: ÀÉ®× \"%s\" ¦b¶}©l½s¿è«á¤S³Q«Ø¥ß¤F"
 
-msgid "See \":help W11\" for more info."
-msgstr "¶i¤@¨B»¡©ú½Ð¨£ \":help W11\"¡C"
-
+#: ../fileio.c:4947
 msgid "Warning"
 msgstr "Äµ§i"
 
+#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -1559,35 +2458,48 @@ msgstr ""
 "½T©w(&O)\n"
 "¸ü¤JÀÉ®×(&L)"
 
+#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: µLªk·Ç³Æ­«·s¸ü¤J \"%s\""
 
+#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: µLªk­«·s¸ü¤J \"%s\""
 
+#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--¤w§R°£--"
 
+#: ../fileio.c:5732
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr ""
+
 #. the group doesn't exist
+#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: µL¦¹¸s²Õ: \"%s\""
 
+#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: * «á­±¦³¤£¥¿½Tªº¦r¤¸: %s"
 
+#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: µL¦¹¨Æ¥ó: %s"
 
+#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: µL¦¹¸s²Õ©Î¨Æ¥ó: %s"
 
 #. Highlight title
+#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -1595,390 +2507,802 @@ msgstr ""
 "\n"
 "--- Auto-Commands ---"
 
+#: ../fileio.c:6293
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number "
+msgstr "½w½Ä°Ï¸¹½X¿ù»~"
+
+#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: µLªk¹ï©Ò¦³¨Æ¥ó°õ¦æ autocommand"
 
+#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "§ä¤£¨ì¹ïÀ³ªº autocommand"
 
+#: ../fileio.c:6831
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: autocommand ¼h¼Æ¹L²`"
 
+#: ../fileio.c:7143
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Auto commands: \"%s\""
 
+#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "°õ¦æ %s"
 
-#. always scroll up, don't overwrite
+#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "autocommand %s"
 
+#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: ¯Ê¤Ö {."
 
+#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: ¯Ê¤Ö }."
 
+#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: §ä¤£¨ì¥ô¦ó fold"
 
+#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr "E350: µLªk¦b¥Ø«eªº 'foldmethod' ¤U«Ø¥ß fold"
 
+#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr "E351: µLªk¦b¥Ø«eªº 'foldmethod' ¤U§R°£ fold"
 
+#: ../fold.c:1784
+#, c-format
+msgid "+--%3ld lines folded "
+msgstr "+--¤w fold %3ld ¦æ "
+
+#. buffer has already been read
+#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: ¥[¤JÅª¨ú½w½Ä°Ï¤¤"
 
+#: ../getchar.c:2040
 msgid "E223: recursive mapping"
 msgstr "E223: »¼°j mapping"
 
+#: ../getchar.c:2849
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: %s ¤w¸g¦³¥þ°ì abbreviation ¤F"
 
+#: ../getchar.c:2852
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: %s ¤w¸g¦³¥þ°ì mapping ¤F"
 
+#: ../getchar.c:2952
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: %s ¤w¸g¦³ abbreviation ¤F"
 
+#: ../getchar.c:2955
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: %s ªº mapping ¤w¸g¦s¦b"
 
+#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "§ä¤£¨ì abbreviation"
 
+#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "¨S¦³³o­Ó mapping ¹ïÀ³"
 
+#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: ¤£¥¿½Tªº¼Ò¦¡"
 
-msgid "E229: Cannot start the GUI"
-msgstr "E229: µLªk±Ò°Ê¹Ï«¬¬É­±"
+#. key value of 'cedit' option
+#. type of cmdline window or 0
+#. result of cmdline window or 0
+#: ../globals.h:924
+msgid "--No lines in buffer--"
+msgstr "--½w½Ä°ÏµL¸ê®Æ--"
 
+#.
+#. * The error messages that can be shared are included here.
+#. * Excluded are errors that are only used once and debugging messages.
+#.
+#: ../globals.h:996
+msgid "E470: Command aborted"
+msgstr "E470: ©R¥O³Q±j¨î¤¤Â_°õ¦æ "
+
+#: ../globals.h:997
+msgid "E471: Argument required"
+msgstr "E471: »Ý­n«ü¥O°Ñ¼Æ"
+
+#: ../globals.h:998
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ «á­±À³¸Ó¦³ / ? ©Î &"
+
+#: ../globals.h:1000
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: ¤£¯à¦b©R¥O¦Cµøµ¡¤¤¨Ï¥Î¡C<CR>°õ¦æ¡ACTRL-C Â÷¶}"
+
+#: ../globals.h:1002
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr "E12: exrc/vimrc ¸Ìªº«ü¥OµLªk°õ¦æ "
+
+#: ../globals.h:1003
+msgid "E171: Missing :endif"
+msgstr "E171: ¯Ê¤Ö :endif"
+
+#: ../globals.h:1004
+msgid "E600: Missing :endtry"
+msgstr "E600: ¯Ê¤Ö :endtry"
+
+#: ../globals.h:1005
+msgid "E170: Missing :endwhile"
+msgstr "E170: ¯Ê¤Ö :endwhile"
+
+#: ../globals.h:1006
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: ¯Ê¤Ö :endif"
+
+#: ../globals.h:1007
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile ¯Ê¤Ö¹ïÀ³ªº :while"
+
+#: ../globals.h:1008
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr "E580: :endif ¯Ê¤Ö¹ïÀ³ªº :if"
+
+#: ../globals.h:1009
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: ÀÉ®×¤w¸g¦s¦b (¥i¥Î ! ±j¨î¨ú¥N)"
+
+#: ../globals.h:1010
+msgid "E472: Command failed"
+msgstr "E472: ©R¥O°õ¦æ¥¢±Ñ"
+
+#: ../globals.h:1011
+msgid "E473: Internal error"
+msgstr "E473: ¤º³¡¿ù»~"
+
+#: ../globals.h:1012
+msgid "Interrupted"
+msgstr "¤w¤¤Â_"
+
+#: ../globals.h:1013
+msgid "E14: Invalid address"
+msgstr "E14: ¤£¥¿½Tªº¦ì§}"
+
+#: ../globals.h:1014
+msgid "E474: Invalid argument"
+msgstr "E474: ¤£¥¿½Tªº°Ñ¼Æ"
+
+#: ../globals.h:1015
 #, c-format
-msgid "E230: Cannot read from \"%s\""
-msgstr "E230: µLªkÅª¨úÀÉ®× \"%s\""
+msgid "E475: Invalid argument: %s"
+msgstr "E475: ¤£¥¿½Tªº°Ñ¼Æ: %s"
 
-msgid "E665: Cannot start GUI, no valid font found"
-msgstr "E665: µLªk±Ò°Ê¹Ï«¬¬É­±¡A§ä¤£¨ì¥i¥Îªº¦r«¬"
-
-msgid "E231: 'guifontwide' invalid"
-msgstr "E231: ¤£¥¿½Tªº 'guifontwide'"
-
-msgid "E599: Value of 'imactivatekey' is invalid"
-msgstr "E599: 'imactivatekey' ªº­È¤£¥¿½T"
-
+#: ../globals.h:1016
 #, c-format
-msgid "E254: Cannot allocate color %s"
-msgstr "E254: ¤£¯à°t¸mÃC¦â %s"
+msgid "E15: Invalid expression: %s"
+msgstr "E15: ¤£¥¿½Tªº¹Bºâ¦¡: %s"
 
-msgid "<cannot open> "
-msgstr "<¤£¯à¶}±Ò>"
+#: ../globals.h:1017
+msgid "E16: Invalid range"
+msgstr "E16: ¤£¥¿½Tªº½d³ò"
 
+#: ../globals.h:1018
+msgid "E476: Invalid command"
+msgstr "E476: ¤£¥¿½Tªº©R¥O"
+
+#: ../globals.h:1019
 #, c-format
-msgid "E616: vim_SelFile: can't get font %s"
-msgstr "E616: vim_SelFile: ¤£¯à¨Ï¥Î %s ¦r«¬"
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" ¬O¥Ø¿ý"
 
-msgid "E614: vim_SelFile: can't return to current directory"
-msgstr "E614: vim_SelFile: µLªk¦^¨ì¥Ø«e¥Ø¿ý"
+#: ../globals.h:1020
+#, fuzzy
+msgid "E900: Invalid job id"
+msgstr "E49: ¿ù»~ªº±²°Ê¤j¤p"
 
-msgid "Pathname:"
-msgstr "¸ô®|:"
-
-msgid "E615: vim_SelFile: can't get current directory"
-msgstr "E615: vim_SelFile: µLªk¨ú±o¥Ø«e¥Ø¿ý"
-
-msgid "OK"
-msgstr "½T©w"
-
-msgid "Cancel"
-msgstr "¨ú®ø"
-
-msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "±²°Ê¶b: ¤£¯à³]©w thumb pixmap ªº¦ì¸m"
-
-msgid "Vim dialog"
-msgstr "Vim ¹ï¸Ü²°"
-
-msgid "E232: Cannot create BalloonEval with both message and callback"
-msgstr "E232: ¤£¯à¹ï°T®§»P callback «Ø¥ß BallonEval"
-
-msgid "Vim dialog..."
-msgstr "Vim ¹ï¸Ü²°..."
-
-msgid ""
-"&Yes\n"
-"&No\n"
-"&Cancel"
+#: ../globals.h:1021
+msgid "E901: Job table is full"
 msgstr ""
-"&Y¬O\n"
-"&N§_\n"
-"&C¨ú®ø"
 
-msgid "Input _Methods"
-msgstr "¿é¤Jªk"
-
-msgid "VIM - Search and Replace..."
-msgstr "VIM - ´M§ä»P¨ú¥N..."
-
-msgid "VIM - Search..."
-msgstr "VIM - ´M§ä..."
-
-msgid "Find what:"
-msgstr "·j´M:"
-
-msgid "Replace with:"
-msgstr "¨ú¥N¬°:"
-
-#. whole word only button
-msgid "Match whole word only"
-msgstr "¥u·j´M§¹¥þ¬Û¦Pªº¦r"
-
-#. match case button
-msgid "Match case"
-msgstr "²Å¦X¤j¤p¼g"
-
-msgid "Direction"
-msgstr "¤è¦V"
-
-#. 'Up' and 'Down' buttons
-msgid "Up"
-msgstr "¦V¤W"
-
-msgid "Down"
-msgstr "¦V¤U"
-
-msgid "Find Next"
-msgstr "§ä¤U¤@­Ó"
-
-msgid "Replace"
-msgstr "¨ú¥N"
-
-msgid "Replace All"
-msgstr "¨ú¥N¥þ³¡"
-
-msgid "Vim: Received \"die\" request from session manager\n"
-msgstr "Vim: ¥Ñ Session ºÞ²z­û¦¬¨ì \"die\" ­n¨D\n"
-
-msgid "Vim: Main window unexpectedly destroyed\n"
-msgstr "Vim: ¥Dµøµ¡Äê±¼\n"
-
-msgid "Font Selection"
-msgstr "¦r«¬¿ï¾Ü"
-
-msgid "Used CUT_BUFFER0 instead of empty selection"
-msgstr "¨Ï¥Î CUT_BUFFER0 ¨Ó¨ú¥NªÅ¿ï¾Ü"
-
-msgid "Filter"
-msgstr "¹LÂo¾¹"
-
-msgid "Directories"
-msgstr "¥Ø¿ý"
-
-msgid "Help"
-msgstr "»²§U»¡©ú"
-
-msgid "Files"
-msgstr "ÀÉ®×"
-
-msgid "Selection"
-msgstr "¿ï¾Ü"
-
-msgid "Undo"
-msgstr "´_­ì"
-
+#: ../globals.h:1022
 #, c-format
-msgid "E671: Cannot find window title \"%s\""
-msgstr "E671: §ä¤£¨ì¼ÐÃD¬° \"%s\" ªºµøµ¡"
-
-#, c-format
-msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: ¤£¤ä´©°Ñ¼Æ \"-%s\"¡C½Ð¥Î OLE ª©¥»¡C"
-
-msgid "E672: Unable to open window inside MDI application"
-msgstr "E672: µLªk¦b MDI µ{¦¡¤¤¶}±Òµøµ¡"
-
-msgid "Find string (use '\\\\' to find  a '\\')"
-msgstr "·j´M¦r¦ê (¨Ï¥Î '\\\\' ¨Óªí¥Ü '\\')"
-
-msgid "Find & Replace (use '\\\\' to find  a '\\')"
-msgstr "·j´M¤Î¨ú¥N¦r¦ê (¨Ï¥Î '\\\\' ¨Óªí¥Ü '\\')"
-
-msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-msgstr "Vim E458: µLªk°t¸m color map ¶µ¥Ø¡A¦³¨ÇÃC¦â¬Ý°_¨Ó·|©Ç©Çªº"
-
-#, c-format
-msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-msgstr "E250: Fontset %s ¨S¦³³]©w¥¿½Tªº¦r«¬¥H¨ÑÅã¥Ü³o¨Ç¦r¤¸¶°:"
-
-#, c-format
-msgid "E252: Fontset name: %s"
-msgstr "E252: ¦r«¬¶°(Fontset)¦WºÙ: %s"
-
-#, c-format
-msgid "Font '%s' is not fixed-width"
-msgstr "'%s' ¤£¬O©T©w¼e«×¦r«¬"
-
-#, c-format
-msgid "E253: Fontset name: %s\n"
-msgstr "E253: ¦r«¬¶°(Fontset)¦WºÙ: %s\n"
-
-#, c-format
-msgid "Font0: %s\n"
-msgstr "Font0: %s\n"
-
-#, c-format
-msgid "Font1: %s\n"
-msgstr "Font1: %s\n"
-
-#, c-format
-msgid "Font%<PRId64> width is not twice that of font0\n"
-msgstr "¦r«¬%<PRId64> ¼e«×¤£¬O ¦r«¬0 ªº¨â­¿\n"
-
-#, c-format
-msgid "Font0 width: %<PRId64>\n"
-msgstr "¦r«¬0ªº¼e«×¡G%<PRId64>\n"
-
-#, c-format
-msgid ""
-"Font1 width: %<PRId64>\n"
-"\n"
+msgid "E902: \"%s\" is not an executable"
 msgstr ""
-"¦r«¬1¼e«×: %<PRId64>\n"
-"\n"
 
-msgid "E256: Hangul automata ERROR"
-msgstr "E256: Hangul automata ¿ù»~"
+#: ../globals.h:1024
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: ©I¥s¨ç¦¡®w \"%s\"() ¥¢±Ñ"
 
+#: ../globals.h:1026
+msgid "E19: Mark has invalid line number"
+msgstr "E19: ¼Ð°Oªº¦æ¸¹¿ù»~"
+
+#: ../globals.h:1027
+msgid "E20: Mark not set"
+msgstr "E20: ¨S¦³³]©w¼Ð°O"
+
+#: ../globals.h:1029
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: ¦]¬° 'modifiable' ¿ï¶µ¬OÃö³¬ªº¡A©Ò¥H¤£¯à­×§ï"
+
+#: ../globals.h:1030
+msgid "E22: Scripts nested too deep"
+msgstr "E22: ±_ª¬»¼°j©I¥s¤Ó¦h¼h"
+
+#: ../globals.h:1031
+msgid "E23: No alternate file"
+msgstr "E23: ¨S¦³´À¥NªºÀÉ®×"
+
+#: ../globals.h:1032
+msgid "E24: No such abbreviation"
+msgstr "E24: ¨S¦³³o­Ó abbreviation ¹ïÀ³"
+
+#: ../globals.h:1033
+msgid "E477: No ! allowed"
+msgstr "E477: ¤£¥i¨Ï¥Î '!'"
+
+#: ../globals.h:1035
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: ¦]¬°½sÄ¶®É¨S¦³¥[¤J¹Ï«¬¬É­±ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î¹Ï«¬¬É­±"
+
+#: ../globals.h:1036
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: ¨S¦³¦W¬° '%s' ªº highlight group"
+
+#: ../globals.h:1037
+msgid "E29: No inserted text yet"
+msgstr "E29: ÁÙ¨S¦³´¡¤J¤å¦r¹L"
+
+#: ../globals.h:1038
+msgid "E30: No previous command line"
+msgstr "E30: ¨S¦³«e¤@¶µ©R¥O"
+
+#: ../globals.h:1039
+msgid "E31: No such mapping"
+msgstr "E31: ¨S¦³³o­Ó mapping ¹ïÀ³"
+
+#: ../globals.h:1040
+msgid "E479: No match"
+msgstr "E479: §ä¤£¨ì"
+
+#: ../globals.h:1041
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: §ä¤£¨ì: %s"
+
+#: ../globals.h:1042
+msgid "E32: No file name"
+msgstr "E32: ¨S¦³ÀÉ¦W"
+
+#: ../globals.h:1044
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: ¨S¦³«e¤@­Ó·j´M/¨ú¥Nªº©R¥O"
+
+#: ../globals.h:1045
+msgid "E34: No previous command"
+msgstr "E34: ¨S¦³«e¤@­Ó©R¥O"
+
+#: ../globals.h:1046
+msgid "E35: No previous regular expression"
+msgstr "E35: ¨S¦³«e¤@­Ó·j´M«ü¥O"
+
+#: ../globals.h:1047
+msgid "E481: No range allowed"
+msgstr "E481: ¤£¥i¨Ï¥Î½d³ò«ü¥O"
+
+#: ../globals.h:1048
+msgid "E36: Not enough room"
+msgstr "E36: ¨S¦³¨¬°÷ªºªÅ¶¡"
+
+#: ../globals.h:1049
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: ¤£¯à«Ø¥ßÀÉ®× %s"
+
+#: ../globals.h:1050
+msgid "E483: Can't get temp file name"
+msgstr "E483: µLªk±oª¾¼È¦sÀÉ¦W"
+
+#: ../globals.h:1051
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: µLªk¶}±ÒÀÉ®× %s"
+
+#: ../globals.h:1052
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: µLªkÅª¨úÀÉ®× %s"
+
+#: ../globals.h:1054
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: ¤w§ó§ï¹LÀÉ®×¦ý©|¥¼¦sÀÉ (¥i¥Î ! ±j¨î°õ¦æ)"
+
+#: ../globals.h:1055
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[§ó·s«á©|¥¼Àx¦s]\n"
+
+#: ../globals.h:1056
+msgid "E38: Null argument"
+msgstr "E38: ªÅªº (Null) °Ñ¼Æ"
+
+#: ../globals.h:1057
+msgid "E39: Number expected"
+msgstr "E39: À³¸Ó­n¦³¼Æ¦r"
+
+#: ../globals.h:1058
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: µLªk¶}±Ò¿ù»~ÀÉ®× %s"
+
+#: ../globals.h:1059
+msgid "E41: Out of memory!"
+msgstr "E41: °O¾ÐÅé¤£¨¬!"
+
+#: ../globals.h:1060
+msgid "Pattern not found"
+msgstr "§ä¤£¨ì"
+
+#: ../globals.h:1061
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: §ä¤£¨ì %s"
+
+#: ../globals.h:1062
+msgid "E487: Argument must be positive"
+msgstr "E487: °Ñ¼ÆÀ³¸Ó¬O¥¿¼Æ"
+
+#: ../globals.h:1064
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: µLªk¦^¨ì«e¤@­Ó¥Ø¿ý"
+
+#: ../globals.h:1066
+msgid "E42: No Errors"
+msgstr "E42: ¨S¦³¿ù»~"
+
+#: ../globals.h:1067
+msgid "E776: No location list"
+msgstr ""
+
+#: ../globals.h:1068
+msgid "E43: Damaged match string"
+msgstr "E43: ²Å¦X¦r¦ê¦³°ÝÃD"
+
+#: ../globals.h:1069
+msgid "E44: Corrupted regexp program"
+msgstr "E44: regexp ¦³°ÝÃD"
+
+#: ../globals.h:1071
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: ¦³³]©w 'readonly' ¿ï¶µ(°ßÅª) (¥i¥Î ! ±j¨î°õ¦æ)"
+
+#: ../globals.h:1073
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%s\""
+msgstr "E46: µLªk³]©w°ßÅªÅÜ¼Æ \"%s\""
+
+#: ../globals.h:1075
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%s\""
+msgstr "E46: µLªk³]©w°ßÅªÅÜ¼Æ \"%s\""
+
+#: ../globals.h:1076
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Åª¨ú¿ù»~ÀÉ®×¥¢±Ñ"
+
+#: ../globals.h:1078
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: ¤£¯à¦b sandbox ¸Ì¥X²{"
+
+#: ../globals.h:1080
+msgid "E523: Not allowed here"
+msgstr "E523: ³o¸Ì¤£¥i¨Ï¥Î"
+
+#: ../globals.h:1082
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: ¤£¤ä´©³]©w¿Ã¹õ¼Ò¦¡"
+
+#: ../globals.h:1083
+msgid "E49: Invalid scroll size"
+msgstr "E49: ¿ù»~ªº±²°Ê¤j¤p"
+
+#: ../globals.h:1084
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'E71: ¿ï¶µ 'shell' ¥¼³]©w"
+
+#: ../globals.h:1085
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: µLªkÅª¨ú sign data!"
+
+#: ../globals.h:1086
+msgid "E72: Close error on swap file"
+msgstr "E72: ¼È¦sÀÉÃö³¬¿ù»~"
+
+#: ../globals.h:1087
+msgid "E73: tag stack empty"
+msgstr "E73: ¼ÐÅÒ°ïÅ|¤wªÅ"
+
+#: ../globals.h:1088
+msgid "E74: Command too complex"
+msgstr "E74: ©R¥O¤Ó½ÆÂø"
+
+#: ../globals.h:1089
+msgid "E75: Name too long"
+msgstr "E75: ¦W¦r¤Óªø"
+
+#: ../globals.h:1090
+msgid "E76: Too many ["
+msgstr "E76: ¤Ó¦h ["
+
+#: ../globals.h:1091
+msgid "E77: Too many file names"
+msgstr "E77: ¤Ó¦hÀÉ¦W"
+
+#: ../globals.h:1092
+msgid "E488: Trailing characters"
+msgstr "E488: §A¿é¤J¤F¦h¾lªº¦r¤¸"
+
+#: ../globals.h:1093
+msgid "E78: Unknown mark"
+msgstr "E78: µLªk¿ìÃÑªº¼Ð°O"
+
+#: ../globals.h:1094
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: µLªk®i¶}¸U¥Î¦r¤¸"
+
+#: ../globals.h:1096
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' ¤£¯à¤ñ 'winminheight' §ó¤Ö"
+
+#: ../globals.h:1098
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' ¤£¯à¤ñ 'winminwidth' §ó¤Ö"
+
+#: ../globals.h:1099
+msgid "E80: Error while writing"
+msgstr "E80: ¼g¤J¿ù»~"
+
+#: ../globals.h:1100
+msgid "Zero count"
+msgstr "¼Æ¨ì¹s (?)"
+
+#: ../globals.h:1101
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> ¤£¯à¦b script ¥»¤å¥~¨Ï¥Î."
+
+#: ../globals.h:1102
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "E473: ¤º³¡¿ù»~"
+
+#: ../globals.h:1104
+msgid "E363: pattern uses more memory than 'maxmempattern'"
+msgstr ""
+
+#: ../globals.h:1105
+#, fuzzy
+msgid "E749: empty buffer"
+msgstr "E279: ¤£¬O SNiFF+ ªº½w½Ä°Ï"
+
+#: ../globals.h:1108
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: ¿ù»~ªº·j´M¦r¦ê: %s"
+
+#: ../globals.h:1109
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: ±z¦b¥t¤@­Ó½w½Ä°Ï¤]¸ü¤J¤F³o­ÓÀÉ®×"
+
+#: ../globals.h:1110
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: \"%s\" ¤£¬O©T©w¼e«×¦r«¬"
+
+#: ../globals.h:1111
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: ¼È¦s¾¹¦WºÙ¿ù»~: '%s'"
+
+#: ../globals.h:1114
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "¤w·j´M¨ìÀÉ®×¶}ÀY¡F¦A±qµ²§ÀÄ~Äò·j´M"
+
+#: ../globals.h:1115
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "¤w·j´M¨ìÀÉ®×µ²§À¡F¦A±q¶}ÀYÄ~Äò·j´M"
+
+#: ../hardcopy.c:240
+msgid "E550: Missing colon"
+msgstr "E550: ¯Ê¤Ö colon"
+
+#: ../hardcopy.c:252
+msgid "E551: Illegal component"
+msgstr "E551: ¤£¥¿½Tªº¼Ò¦¡"
+
+#: ../hardcopy.c:259
+msgid "E552: digit expected"
+msgstr "E552: À³¸Ó­n¦³¼Æ¦r"
+
+#: ../hardcopy.c:473
+#, c-format
+msgid "Page %d"
+msgstr "²Ä %d ­¶"
+
+#: ../hardcopy.c:597
+msgid "No text to be printed"
+msgstr "¨S¦³­n¦C¦Lªº¤å¦r"
+
+#: ../hardcopy.c:668
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "¦C¦L¤¤: ²Ä %d ­¶ (%d%%)"
+
+#: ../hardcopy.c:680
+#, c-format
+msgid " Copy %d of %d"
+msgstr "½Æ»s %d / %d"
+
+#: ../hardcopy.c:733
+#, c-format
+msgid "Printed: %s"
+msgstr "¤w¦C¦L: %s"
+
+#: ../hardcopy.c:740
+msgid "Printing aborted"
+msgstr "¤w¨ú®ø¦C¦L"
+
+#: ../hardcopy.c:1365
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: µLªk¼g¤J PostScript ¿é¥XÀÉ"
+
+#: ../hardcopy.c:1747
+#, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E624: µLªk¶}±ÒÀÉ®× \"%s\""
+
+#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"%s\""
+
+#: ../hardcopy.c:1772
+#, c-format
+msgid "E618: file \"%s\" is not a PostScript resource file"
+msgstr "E618: ÀÉ®× \"%s\" ¤£¬O PostScript ¸ê·½ÀÉ "
+
+#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#, c-format
+msgid "E619: file \"%s\" is not a supported PostScript resource file"
+msgstr "E619: ¤£¤ä´© PostScript ¸ê·½ÀÉ \"%s\""
+
+#: ../hardcopy.c:1856
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr "E621: \"%s\" ¸ê·½ÀÉª©¥»¿ù»~"
+
+#: ../hardcopy.c:2225
+msgid "E673: Incompatible multi-byte encoding and character set."
+msgstr ""
+
+#: ../hardcopy.c:2238
+msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
+msgstr ""
+
+#: ../hardcopy.c:2254
+msgid "E675: No default font specified for multi-byte printing."
+msgstr ""
+
+#: ../hardcopy.c:2426
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: µLªk¶}±Ò PostScript ¿é¥XÀÉ"
+
+#: ../hardcopy.c:2458
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: µLªk¶}±ÒÀÉ®× \"%s\""
+
+#: ../hardcopy.c:2583
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E456: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"prolog.ps\""
+
+#: ../hardcopy.c:2593
+#, fuzzy
+msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
+msgstr "E456: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"%s.ps\""
+
+#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E456: µLªkÅª¨ú PostScript ¸ê·½ÀÉ \"%s.ps\""
+
+#: ../hardcopy.c:2654
+#, fuzzy, c-format
+msgid "E620: Unable to convert to print encoding \"%s\""
+msgstr "E620:µLªkÂà´«¦Ü \"%s\" ¦r¤¸½s½X"
+
+#: ../hardcopy.c:2877
+msgid "Sending to printer..."
+msgstr "¶Ç°e¸ê®Æ¨ì¦Lªí¾÷..."
+
+#: ../hardcopy.c:2881
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: µLªk¦C¦L PostScript ÀÉ®×"
+
+#: ../hardcopy.c:2883
+msgid "Print job sent."
+msgstr "¤w°e¥X¦C¦L¤u§@¡C"
+
+#: ../if_cscope.c:85
 msgid "Add a new database"
 msgstr "·s¼W¸ê®Æ®w"
 
+#: ../if_cscope.c:87
 msgid "Query for a pattern"
 msgstr "¿é¤J pattern"
 
+#: ../if_cscope.c:89
 msgid "Show this message"
 msgstr "Åã¥Ü¦¹°T®§"
 
+#: ../if_cscope.c:91
 msgid "Kill a connection"
 msgstr "µ²§ô³s½u"
 
+#: ../if_cscope.c:93
 msgid "Reinit all connections"
 msgstr "­«³]©Ò¦³³s½u"
 
+#: ../if_cscope.c:95
 msgid "Show connections"
 msgstr "Åã¥Ü³s½u"
 
+#: ../if_cscope.c:101
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: ¥Îªk: cs[cope] %s"
 
+#: ../if_cscope.c:225
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "³o­Ó cscope ©R¥O¤£¤ä´©¤À³Î¿Ã¹õ\n"
 
+#: ../if_cscope.c:266
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: ¥Îªk: cstag <ÃÑ§O¦rident>"
 
+#: ../if_cscope.c:313
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: §ä¤£¨ì tag"
 
+#: ../if_cscope.c:461
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) ¿ù»~: %d"
 
-msgid "E563: stat error"
-msgstr "E563: stat ¿ù»~"
-
+#: ../if_cscope.c:551
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s ¤£¬O¥Ø¿ý©Î cscope ¸ê®Æ®w"
 
+#: ../if_cscope.c:566
 #, c-format
 msgid "Added cscope database %s"
 msgstr "·s¼W cscope ¸ê®Æ®w %s"
 
+#: ../if_cscope.c:616
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Åª¨ú cscope ³s½u %<PRId64> ¿ù»~"
 
+#: ../if_cscope.c:711
 msgid "E561: unknown cscope search type"
 msgstr "E561: ¥¼ª¾ªº cscope ·j´M§ÎºA"
 
+#: ../if_cscope.c:752 ../if_cscope.c:789
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: µLªk«Ø¥ß»P cscope ªº pipe ³s½u"
 
+#: ../if_cscope.c:767
 msgid "E622: Could not fork for cscope"
 msgstr "E622: µLªk fork ¥H°õ¦æ cscope "
 
+#: ../if_cscope.c:849
+#, fuzzy
+msgid "cs_create_connection setpgid failed"
+msgstr "cs_create_connection °õ¦æ¥¢±Ñ"
+
+#: ../if_cscope.c:853 ../if_cscope.c:889
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection °õ¦æ¥¢±Ñ"
 
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: µLªk°õ¦æ cscope "
-
+#: ../if_cscope.c:863 ../if_cscope.c:902
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen ¥¢±Ñ (to_fp)"
 
+#: ../if_cscope.c:865 ../if_cscope.c:906
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen ¥¢±Ñ (fr_fp)"
 
+#: ../if_cscope.c:890
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: µLªk°õ¦æ cscope "
+
+#: ../if_cscope.c:932
 msgid "E567: no cscope connections"
 msgstr "E567: ¨S¦³ cscope ³s½u"
 
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: §ä¤£¨ì²Å¦X cscope ªº·j´M %s / %s"
-
+#: ../if_cscope.c:1009
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: cscopequickfix ªº flac %c (%c) ¤£¥¿½T"
 
+#: ../if_cscope.c:1058
+#, c-format
+msgid "E259: no matches found for cscope query %s of %s"
+msgstr "E259: §ä¤£¨ì²Å¦X cscope ªº·j´M %s / %s"
+
+#: ../if_cscope.c:1142
 msgid "cscope commands:\n"
 msgstr "cscope ©R¥O:\n"
 
-#, c-format
-msgid "%-5s: %-30s (Usage: %s)"
+#: ../if_cscope.c:1150
+#, fuzzy, c-format
+msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (¥Îªk: %s)"
 
-#, c-format
-msgid "E625: cannot open cscope database: %s"
-msgstr "E625: µLªk¶}±Ò cscope ¸ê®Æ®w %s"
+#: ../if_cscope.c:1155
+msgid ""
+"\n"
+"       c: Find functions calling this function\n"
+"       d: Find functions called by this function\n"
+"       e: Find this egrep pattern\n"
+"       f: Find this file\n"
+"       g: Find this definition\n"
+"       i: Find files #including this file\n"
+"       s: Find this C symbol\n"
+"       t: Find this text string\n"
+msgstr ""
 
-msgid "E626: cannot get cscope database information"
-msgstr "E626: µLªk¨ú±o cscope ¸ê®Æ®w¸ê°T"
-
+#: ../if_cscope.c:1226
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: ­«½Æªº cscope ¸ê®Æ®w¥¼³Q¥[¤J"
 
-msgid "E569: maximum number of cscope connections reached"
-msgstr "E569: ¤w¹F¨ì cscope ³Ì¤j³s½u¼Æ¥Ø"
-
+#: ../if_cscope.c:1335
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: §ä¤£¨ì cscope ³s½u %s"
 
+#: ../if_cscope.c:1364
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope ³s½u %s ¤wÃö³¬"
 
 #. should not reach here
+#: ../if_cscope.c:1486
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: cs_manage_matches ÄY­«¿ù»~"
 
+#: ../if_cscope.c:1693
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope ¼ÐÅÒ(tag): %s"
 
+#: ../if_cscope.c:1711
 msgid ""
 "\n"
 "   #   line"
@@ -1986,324 +3310,89 @@ msgstr ""
 "\n"
 "   #   ¦æ  "
 
+#: ../if_cscope.c:1713
 msgid "filename / context / line\n"
 msgstr "ÀÉ¦W     / ¤º¤å    / ¦æ¸¹\n"
 
+#: ../if_cscope.c:1809
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Csope ¿ù»~: %s"
 
+#: ../if_cscope.c:2053
 msgid "All cscope databases reset"
 msgstr "­«³]©Ò¦³ cscope ¸ê®Æ®w"
 
+#: ../if_cscope.c:2123
 msgid "no cscope connections\n"
 msgstr "¨S¦³ cscope ³s½u\n"
 
+#: ../if_cscope.c:2126
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid    ¸ê®Æ®w¦WºÙ                          prepend path\n"
 
-msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr "E263: ©êºp¡A³o­Ó©R¥OµLªk¨Ï¥Î¡APython µ{¦¡®w¨S¦³¸ü¤J¡C"
-
-msgid "E659: Cannot invoke Python recursively"
-msgstr "E659: µLªk»¼°j°õ¦æ Python "
-
-msgid "can't delete OutputObject attributes"
-msgstr "µLªk§R°£ OutputObject ÄÝ©Ê"
-
-msgid "softspace must be an integer"
-msgstr "softspace ¥²»Ý¬O¾ã¼Æ"
-
-msgid "invalid attribute"
-msgstr "¤£¥¿½TªºÄÝ©Ê"
-
-msgid "writelines() requires list of strings"
-msgstr "writelines() »Ý­n string list ·í°Ñ¼Æ"
-
-msgid "E264: Python: Error initialising I/O objects"
-msgstr "E264: Python: µLªkªì©l I/O ª«¥ó"
-
-msgid "invalid expression"
-msgstr "¤£¥¿½Tªº¹Bºâ¦¡"
-
-msgid "expressions disabled at compile time"
-msgstr "¦]¬°½sÄ¶®É¨S¦³¥[¤J¹Bºâ¦¡(expression)ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î¹Bºâ¦¡"
-
-msgid "attempt to refer to deleted buffer"
-msgstr "¸Õ¹Ï¨Ï¥Î¤w³Q§R°£ªº buffer"
-
-msgid "line number out of range"
-msgstr "¦æ¸¹¶W¥X½d³ò"
-
-#, c-format
-msgid "<buffer object (deleted) at %8lX>"
-msgstr "<buffer ª«¥ó (¤w§R°£): %8lX>"
-
-msgid "invalid mark name"
-msgstr "¼Ð°O¦WºÙ¤£¥¿½T"
-
-msgid "no such buffer"
-msgstr "µL¦¹ buffer"
-
-msgid "attempt to refer to deleted window"
-msgstr "¸Õ¹Ï¨Ï¥Î¤w³Q§R°£ªºµøµ¡"
-
-msgid "readonly attribute"
-msgstr "°ßÅªÄÝ©Ê"
-
-msgid "cursor position outside buffer"
-msgstr "´å¼Ð©w¦ì¦b½w½Ä°Ï¤§¥~"
-
-#, c-format
-msgid "<window object (deleted) at %.8lX>"
-msgstr "<µøµ¡ª«¥ó(¤w§R°£): %.8lX>"
-
-#, c-format
-msgid "<window object (unknown) at %.8lX>"
-msgstr "<µøµ¡ª«¥ó(¥¼ª¾): %.8lX>"
-
-#, c-format
-msgid "<window %d>"
-msgstr "<µøµ¡ %d>"
-
-msgid "no such window"
-msgstr "µL¦¹µøµ¡"
-
-msgid "cannot save undo information"
-msgstr "µLªkÀx¦s´_­ì¸ê°T"
-
-msgid "cannot delete line"
-msgstr "¤£¯à§R°£¦¹¦æ "
-
-msgid "cannot replace line"
-msgstr "¤£¯à´À¥N¦¹¦æ "
-
-msgid "cannot insert line"
-msgstr "¤£¯à´À¥N´¡¤J¦¹¦æ "
-
-msgid "string cannot contain newlines"
-msgstr "¦r¦êµLªk¥]§t·s¦æ "
-
-msgid ""
-"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: ¦¹©R¥OµLªk¨Ï¥Î¡AµLªk¸ü¤J Ruby µ{¦¡®w(Library)"
-
-#, c-format
-msgid "E273: unknown longjmp status %d"
-msgstr "E273: ¥¼ª¾ªº longjmp status %d"
-
-msgid "Toggle implementation/definition"
-msgstr "¤Á´«¹ê§@/©w¸q"
-
-msgid "Show base class of"
-msgstr "Åã¥Ü base class of:"
-
-msgid "Show overridden member function"
-msgstr "Åã¥Ü³Q override ªº member function"
-
-msgid "Retrieve from file"
-msgstr "Åª¨ú: ±qÀÉ®×"
-
-msgid "Retrieve from project"
-msgstr "Åª¨ú: ±qª«¥ó"
-
-msgid "Retrieve from all projects"
-msgstr "Åª¨ú: ±q©Ò¦³ project"
-
-msgid "Retrieve"
-msgstr "Åª¨ú"
-
-msgid "Show source of"
-msgstr "Åã¥Ü­ì©l½X: "
-
-msgid "Find symbol"
-msgstr "·j´M symbol"
-
-msgid "Browse class"
-msgstr "ÂsÄý class"
-
-msgid "Show class in hierarchy"
-msgstr "Åã¥Ü¶¥¼h¦¡ªº class"
-
-msgid "Show class in restricted hierarchy"
-msgstr "Åã¥Ü restricted ¶¥¼h¦¡ªº class"
-
-msgid "Xref refers to"
-msgstr "Xref °Ñ¦Ò¨ì"
-
-msgid "Xref referred by"
-msgstr "Xref ³Q½Ö°Ñ¦Ò:"
-
-msgid "Xref has a"
-msgstr "Xref ¦³"
-
-msgid "Xref used by"
-msgstr "Xref ³Q½Ö¨Ï¥Î:"
-
-msgid "Show docu of"
-msgstr "Åã¥Ü¤å¥ó: "
-
-msgid "Generate docu for"
-msgstr "²£¥Í¤å¥ó: "
-
-msgid ""
-"Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-"$PATH).\n"
-msgstr "µLªk³s½u¨ì SNiFF+¡C½ÐÀË¬dÀô¹ÒÅÜ¼Æ ($PATH ¸Ì¥²»Ý¥i¥H§ä¨ì sniffemacs)\n"
-
-msgid "E274: Sniff: Error during read. Disconnected"
-msgstr "E274: Sniff: Åª¨ú¿ù»~. ¨ú®ø³s½u"
-
-msgid "SNiFF+ is currently "
-msgstr "SNiFF+ ¥Ø«e"
-
-msgid "not "
-msgstr "¥¼"
-
-msgid "connected"
-msgstr "³s½u¤¤"
-
-#, c-format
-msgid "E275: Unknown SNiFF+ request: %s"
-msgstr "E275: ¤£¥¿½Tªº SNiff+ ©I¥s: %s"
-
-msgid "E276: Error connecting to SNiFF+"
-msgstr "E276: ³s½u¨ì SNiFF+ ¥¢±Ñ"
-
-msgid "E278: SNiFF+ not connected"
-msgstr "E278: ¥¼³s½u¨ì SNiFF+"
-
-msgid "E279: Not a SNiFF+ buffer"
-msgstr "E279: ¤£¬O SNiFF+ ªº½w½Ä°Ï"
-
-msgid "Sniff: Error during write. Disconnected"
-msgstr "Sniff: ¼g¤J¿ù»~¡Cµ²§ô³s½u"
-
-msgid "invalid buffer number"
-msgstr "½w½Ä°Ï¸¹½X¿ù»~"
-
-msgid "not implemented yet"
-msgstr "©|¥¼¹ê§@"
-
-msgid "unknown option"
+#: ../main.c:144
+#, fuzzy
+msgid "Unknown option argument"
 msgstr "¤£¥¿½Tªº¿ï¶µ"
 
-#. ???
-msgid "cannot set line(s)"
-msgstr "¤£¯à³]©w¦æ "
-
-msgid "mark not set"
-msgstr "¨S¦³³]©w¼Ð°O"
-
-#, c-format
-msgid "row %d column %d"
-msgstr "¦C %d ¦æ %d"
-
-msgid "cannot insert/append line"
-msgstr "¤£¯à´¡¤J©Îªþ¥[¦¹¦æ "
-
-msgid "unknown flag: "
-msgstr "¿ù»~ªººX¼Ð: "
-
-msgid "unknown vimOption"
-msgstr "¤£¥¿½Tªº VIM ¿ï¶µ"
-
-msgid "keyboard interrupt"
-msgstr "Áä½L¤¤Â_"
-
-msgid "vim error"
-msgstr "vim ¿ù»~"
-
-msgid "cannot create buffer/window command: object is being deleted"
-msgstr "µLªk«Ø¥ß½w½Ä°Ï/µøµ¡©R¥O: ª«¥ó±N·|³Q§R°£"
-
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
-msgstr "µLªkµù¥U callback ©R¥O: ½w½Ä°Ï/µøµ¡¤w¸g³Q§R°£¤F"
-
-#. This should never happen.  Famous last word?
-msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
-msgstr "E280: TCL ÄY­«¿ù»~: reflist Äê±¼¤F!? ½Ð³ø§iµ¹ to vim-dev@vim.org"
-
-msgid "cannot register callback command: buffer/window reference not found"
-msgstr "µLªkµù¥U callback ©R¥O: §ä¤£¨ì½w½Ä°Ï/µøµ¡"
-
-msgid ""
-"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: ¦¹©R¥OµLªk¨Ï¥Î, ¦]¬°µLªk¸ü¤J Tcl µ{¦¡®w(Library)"
-
-msgid ""
-"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
-msgstr "E281: TCL ¿ù»~: µ²§ô½X¤£¬O¾ã¼Æ!? ½Ð³ø§iµ¹ to vim-dev@vim.org"
-
-msgid "cannot get line"
-msgstr "¤£¯à¨ú±o¦¹¦æ "
-
-msgid "Unable to register a command server name"
-msgstr "µLªkµù¥U©R¥O¦øªA¾¹¦WºÙ"
-
-msgid "E248: Failed to send command to the destination program"
-msgstr "E248: µLªk°e¥X©R¥O¨ì¥Øªº¦aµ{¦¡"
-
-#, c-format
-msgid "E573: Invalid server id used: %s"
-msgstr "E573: ¤£¥¿½Tªº¦øªA¾¹ id : %s"
-
-msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIM ªº registry ³]©w¶µ¦³»~¡C¤w§R°£¡C"
-
-msgid "Unknown option"
-msgstr "¤£¥¿½Tªº¿ï¶µ"
-
+#: ../main.c:146
 msgid "Too many edit arguments"
 msgstr "¤Ó¦h½s¿è°Ñ¼Æ"
 
+#: ../main.c:148
 msgid "Argument missing after"
 msgstr "¯Ê¤Ö¥²­nªº°Ñ¼Æ:"
 
-msgid "Garbage after option"
+#: ../main.c:150
+#, fuzzy
+msgid "Garbage after option argument"
 msgstr "µLªk¿ë»{¦¹¿ï¶µ«áªº©R¥O: "
 
+#: ../main.c:152
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "¤Ó¦h \"+command\" ¡B \"-c command\" ©Î \"--cmd command\" °Ñ¼Æ"
 
+#: ../main.c:154
 msgid "Invalid argument for"
 msgstr "¤£¥¿½Tªº°Ñ¼Æ: "
 
-msgid "This Vim was not compiled with the diff feature."
-msgstr "±zªº Vim ½sÄ¶®É¨S¦³¥[¤J diff ªº¯à¤O"
-
-msgid "Attempt to open script file again: \""
-msgstr "¸Õ¹Ï¦A¦¸¶}±Ò script ÀÉ: \""
-
-msgid "Cannot open for reading: \""
-msgstr "µLªk¶}±Ò¥HÅª¨ú: \""
-
-msgid "Cannot open for script output: \""
-msgstr "µLªk¶}±Ò¬° script ¿é¥X: \""
-
+#: ../main.c:294
 #, c-format
 msgid "%d files to edit\n"
 msgstr "ÁÙ¦³ %d ­ÓÀÉ®×µ¥«Ý½s¿è\n"
 
+#: ../main.c:1342
+msgid "Attempt to open script file again: \""
+msgstr "¸Õ¹Ï¦A¦¸¶}±Ò script ÀÉ: \""
+
+#: ../main.c:1350
+msgid "Cannot open for reading: \""
+msgstr "µLªk¶}±Ò¥HÅª¨ú: \""
+
+#: ../main.c:1393
+msgid "Cannot open for script output: \""
+msgstr "µLªk¶}±Ò¬° script ¿é¥X: \""
+
+#: ../main.c:1622
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: ª`·N: ¿é¥X¤£¬O²×ºÝ¾÷(¿Ã¹õ)\n"
 
+#: ../main.c:1624
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: ª`·N: ¿é¤J¤£¬O²×ºÝ¾÷(Áä½L)\n"
 
 #. just in case..
+#: ../main.c:1891
 msgid "pre-vimrc command line"
 msgstr "vimrc «e©R¥O¦C"
 
+#: ../main.c:1964
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: µLªkÅª¨úÀÉ®× \"%s\""
 
+#: ../main.c:2149
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -2311,18 +3400,23 @@ msgstr ""
 "\n"
 "¬d¸ß§ó¦h¸ê°T½Ð°õ¦æ: \"vim -h\"\n"
 
+#: ../main.c:2178
 msgid "[file ..]       edit specified file(s)"
 msgstr "[ÀÉ®× ..]       ½s¿è«ü©wªºÀÉ®×"
 
+#: ../main.c:2179
 msgid "-               read text from stdin"
 msgstr "-               ±q¼Ð·Ç¿é¤J(stdin)Åª¨úÀÉ®×"
 
+#: ../main.c:2180
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          ½s¿è®É¨Ï¥Î«ü©wªº tag"
 
+#: ../main.c:2181
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [errorfile]  ½s¿è®É¸ü¤J²Ä¤@­Ó¿ù»~"
 
+#: ../main.c:2187
 msgid ""
 "\n"
 "\n"
@@ -2332,9 +3426,11 @@ msgstr ""
 "\n"
 " ¥Îªk:"
 
+#: ../main.c:2189
 msgid " vim [arguments] "
 msgstr "vim [°Ñ¼Æ] "
 
+#: ../main.c:2193
 msgid ""
 "\n"
 "   or:"
@@ -2342,6 +3438,7 @@ msgstr ""
 "\n"
 "   ©Î:"
 
+#: ../main.c:2196
 msgid ""
 "\n"
 "\n"
@@ -2351,312 +3448,190 @@ msgstr ""
 "\n"
 "°Ñ¼Æ:\n"
 
+#: ../main.c:2197
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\t¥u¦³¦b³o¤§«áªºÀÉ®×"
 
+#: ../main.c:2199
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\t¤£®i¶}¸U¥Î¦r¤¸"
 
-msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\tµù¥U gvim ¨ì OLE"
-
-msgid "-unregister\t\tUnregister gvim for OLE"
-msgstr "-unregister\t\t¨ú®ø OLE ¤¤ªº gvim µù¥U"
-
-msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-msgstr "-g\t\t\t¨Ï¥Î¹Ï§Î¬É­± (¦P \"gvim\")"
-
-msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-msgstr "-f  ©Î  --nofork\t«e´º: °_©l¹Ï§Î¬É­±®É¤£ fork"
-
+#: ../main.c:2201
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi ¼Ò¦¡ (¦P \"vi\")"
 
+#: ../main.c:2202
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx ¼Ò¦¡ (¦P \"ex\")"
 
+#: ../main.c:2203
+msgid "-E\t\t\tImproved Ex mode"
+msgstr ""
+
+#: ../main.c:2204
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\t¦wÀR (batch) ¼Ò¦¡ (¥u¯à»P \"ex\" ¤@°_¨Ï¥Î)"
 
+#: ../main.c:2205
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff ¼Ò¦¡ (¦P \"vimdiff\", ¥i¨³³t¤ñ¸û¨âÀÉ®×¤£¦P³B)"
 
+#: ../main.c:2206
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tÂ²©ö¼Ò¦¡ (¦P \"evim\", modeless)"
 
+#: ../main.c:2207
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t°ßÅª¼Ò¦¡ (¦P \"view\")"
 
+#: ../main.c:2208
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\t­­¨î¼Ò¦¡ (¦P \"rvim\")"
 
+#: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t¤£¥i­×§ï (¼g¤JÀÉ®×)"
 
+#: ../main.c:2210
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\t¤£¥i­×§ï¤å¦r"
 
+#: ../main.c:2211
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\t¤G¶i¦ì¼Ò¦¡"
 
+#: ../main.c:2212
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp ¼Ò¦¡"
 
+#: ../main.c:2213
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\t'compatible' ¶Ç²Î Vi ¬Û®e¼Ò¦¡"
 
+#: ../main.c:2214
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\t'nocompatible' ¤£§¹¥þ»P¶Ç²Î Vi ¬Û®e¡A¥i¨Ï¥Î Vim ¥[±j¯à¤O"
 
-msgid "-V[N]\t\tVerbose level"
-msgstr "-V[N]\t\tVerbose µ¥¯Å"
+#: ../main.c:2215
+msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+msgstr ""
 
+#: ../main.c:2216
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\t°£¿ù¼Ò¦¡"
 
+#: ../main.c:2217
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\t¤£¨Ï¥Î¼È¦sÀÉ, ¥u¨Ï¥Î°O¾ÐÅé"
 
+#: ../main.c:2218
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\t¦C¥X¼È¦sÀÉ«áÂ÷¶}"
 
+#: ../main.c:2219
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (¥[ÀÉ¦W)       \t­×´_¤W¦¸·l·´ªº¸ê®Æ(Recover crashed session)"
 
+#: ../main.c:2220
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\t¦P -r"
 
-msgid "-f\t\t\tDon't use newcli to open window"
-msgstr "-f\t\t\t¤£¨Ï¥Î newcli ¨Ó¶}±Òµøµ¡"
-
-msgid "-dev <device>\t\tUse <device> for I/O"
-msgstr "-dev <device>\t\t¨Ï¥Î <device> °µ¿é¥X¤J"
-
+#: ../main.c:2221
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\t±Ò°Ê¬° Arabic ¼Ò¦¡"
 
+#: ../main.c:2222
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\t±Ò°Ê¬° Hebrew ¼Ò¦¡"
 
+#: ../main.c:2223
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\t±Ò°Ê¬° Farsi ¼Ò¦¡"
 
+#: ../main.c:2224
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\t³]©w²×ºÝ¾÷¬° <terminal>"
 
+#: ../main.c:2225
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\t¨Ï¥Î <vimrc> ¨ú¥N¥ô¦ó .vimrc"
 
-msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-msgstr "-U <gvimrc>\t\t¨Ï¥Î <gvimrc> ¨ú¥N¥ô¦ó .gvimrc"
-
+#: ../main.c:2226
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\t¤£¸ü¤J¥ô¦ó plugin"
 
+#: ../main.c:2227
+#, fuzzy
+msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
+msgstr "-o[N]\t\t¶}±Ò N ­Óµøµ¡ (¹w³]¬O¨C­ÓÀÉ®×¤@­Ó)"
+
+#: ../main.c:2228
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\t¶}±Ò N ­Óµøµ¡ (¹w³]¬O¨C­ÓÀÉ®×¤@­Ó)"
 
+#: ../main.c:2229
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\t¦P -o ¦ý¨Ï¥Î««ª½¤À³Î"
 
+#: ../main.c:2230
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\t±Ò°Ê«á¸õ¨ìÀÉ®×µ²§À"
 
+#: ../main.c:2231
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\t±Ò°Ê«á¸õ¨ì²Ä <lnum> ¦æ "
 
+#: ../main.c:2232
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <command>\t¸ü¤J¥ô¦ó vimrc «e°õ¦æ <command>"
 
+#: ../main.c:2233
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <command>\t\t¸ü¤J²Ä¤@­ÓÀÉ®×«á°õ¦æ <command>"
 
+#: ../main.c:2235
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\t¸ü¤J²Ä¤@­ÓÀÉ®×«á¸ü¤J Session ÀÉ <session>"
 
+#: ../main.c:2236
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr "-s <scriptin>\t±q <scriptin> Åª¤J¤@¯ë¼Ò¦¡©R¥O"
 
+#: ../main.c:2237
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\t¹ïÀÉ®× <scriptout> ªþ¥[(append)©Ò¦³¿é¤Jªº©R¥O"
 
+#: ../main.c:2238
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\t¹ïÀÉ®× <scriptout> ¼g¤J©Ò¦³¿é¤Jªº©R¥O"
 
-msgid "-x\t\t\tEdit encrypted files"
-msgstr "-x\t\t\t½s¿è½s½X¹LªºÀÉ®×"
+#: ../main.c:2240
+msgid "--startuptime <file>\tWrite startup timing messages to <file>"
+msgstr ""
 
-msgid "-display <display>\tConnect vim to this particular X-server"
-msgstr "-display <display>\t±N vim »P«ü©wªº X-server ³s½u"
-
-msgid "-X\t\t\tDo not connect to X server"
-msgstr "-X\t\t\t¤£­n³s½u¨ì X Server"
-
-msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-msgstr "--remote <files>\t½s¿è Vim ¦øªA¾¹¤Wªº <files> «áÂ÷¶}"
-
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-silent <files>  ¬Û¦P¡A¦ý¨S¦³¦øªA¾¹®É¤£Äµ§i"
-
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
-msgstr "--remote-wait <files>  ¦P --remote, ¦ý·|µ¥­ÔÀÉ®×§¹¦¨½s¿è"
-
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
-msgstr "--remote-wait-silent <files>  ¬Û¦P¡A¦ý¨S¦øªA¾¹®É¤£Äµ§i"
-
-msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-msgstr "--remote-send <keys>\t°e¥X <keys> ¨ì Vim ¦øªA¾¹¨ÃÂ÷¶}"
-
-msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-msgstr "--remote-expr <expr>\t¦b¦øªA¾¹¤W°õ¦æ <expr> ¨Ã¦L¥Xµ²ªG"
-
-msgid "--serverlist\t\tList available Vim server names and exit"
-msgstr "--serverlist\t\t¦C¥X¥i¥Îªº Vim ¦øªA¾¹¦WºÙ¨ÃÂ÷¶}"
-
-msgid "--servername <name>\tSend to/become the Vim server <name>"
-msgstr "--servername <name>\t°e¦Ü/¦¨¬° Vim ¦øªA¾¹ <name>"
-
+#: ../main.c:2242
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t¨Ï¥Î <viminfo> ¦Ó«D .viminfo"
 
+#: ../main.c:2243
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  ©Î  --help\t¦L¥X»¡©ú(¤]´N¬O¥»°T®§)«áÂ÷¶}"
 
+#: ../main.c:2244
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\t¦L¥Xª©¥»¸ê°T«áÂ÷¶}"
 
-msgid ""
-"\n"
-"Arguments recognised by gvim (Motif version):\n"
-msgstr ""
-"\n"
-"gvim »{±oªº°Ñ¼Æ (Motif ª©):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (neXtaw version):\n"
-msgstr ""
-"\n"
-"gvim »{±oªº°Ñ¼Æ (neXtaw ª©):\n"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (Athena version):\n"
-msgstr ""
-"\n"
-"gvim »{±oªº°Ñ¼Æ (Athena ª©):\n"
-
-msgid "-display <display>\tRun vim on <display>"
-msgstr "-display <display>\t¦bµøµ¡ <display> °õ¦æ vim"
-
-msgid "-iconic\t\tStart vim iconified"
-msgstr "-iconic\t\t±Ò°Ê«á¹Ï¥Ü¤Æ(iconified)"
-
-msgid "-name <name>\t\tUse resource as if vim was <name>"
-msgstr "-name <name>\t\tÅª¨ú Resource ®É§â vim ªº¦WºÙµø¬° <name>"
-
-msgid "\t\t\t  (Unimplemented)\n"
-msgstr "\t\t\t  (©|¥¼¹ê§@)\n"
-
-msgid "-background <color>\tUse <color> for the background (also: -bg)"
-msgstr "-background <color>\t³]©w <color> ¬°­I´º¦â (¤]¥i¥Î -bg)"
-
-msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-msgstr "-foreground <color>\t³]©w <color> ¬°¤@¯ë¤å¦rÃC¦â (¤]¥i¥Î -fg)"
-
-msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-msgstr "-font <font>\t¨Ï¥Î <font> ¬°¤@¯ë¦r«¬ (¤]¥i¥Î -fn)"
-
-msgid "-boldfont <font>\tUse <font> for bold text"
-msgstr "-boldfont <font>\t¨Ï¥Î <font> ¬°²ÊÅé¦r«¬"
-
-msgid "-italicfont <font>\tUse <font> for italic text"
-msgstr "-italicfont <font>\t¨Ï¥Î <font> ¬°±×Åé¦r«¬"
-
-msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr "-geometry <geom>\t¨Ï¥Î<geom>¬°°_©l¦ì¸m (¤]¥i¥Î -geom)"
-
-msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidth <width>\t¨Ï¥Î¼e«×¬° <width> ªºÃä®Ø (¤]¥i¥Î -bw)"
-
-msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr "-scrollbarwidth <width>  ³]©w±²°Ê¶b¼e«×¬° <width> (¤]¥i¥Î -sw)"
-
-msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-msgstr "-menuheight <height>\t³]©w¿ï³æ¦Cªº°ª«×¬° <height> (¤]¥i¥Î -mh)"
-
-msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\t¨Ï¥Î¤Ï¬ÛÅã¥Ü (¤]¥i¥Î -rv)"
-
-msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-msgstr "+reverse\t\t¤£¨Ï¥Î¤Ï¬ÛÅã¥Ü (¤]¥i¥Î +rv)"
-
-msgid "-xrm <resource>\tSet the specified resource"
-msgstr "-xrm <resource>\t³]©w«ü©wªº resource"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (RISC OS version):\n"
-msgstr ""
-"\n"
-"gvim »{±oªº°Ñ¼Æ (RISC OS ª©):\n"
-
-msgid "--columns <number>\tInitial width of window in columns"
-msgstr "--columns <number>\tµøµ¡ªì©l¤Æ¼e«×"
-
-msgid "--rows <number>\tInitial height of window in rows"
-msgstr "--rows <number>\tµøµ¡ªì©l¤Æ°ª«×"
-
-msgid ""
-"\n"
-"Arguments recognised by gvim (GTK+ version):\n"
-msgstr ""
-"\n"
-"gvim »{±oªº°Ñ¼Æ (GTK+ ª©):\n"
-
-msgid "-display <display>\tRun vim on <display> (also: --display)"
-msgstr "-display <display>\t¦b <display> °õ¦æ vim (¤]¥i¥Î --display)"
-
-msgid "--role <role>\tSet a unique role to identify the main window"
-msgstr "--role <role>\t³]©w¿W¯Sªº¨¤¦â(role)¥H°Ï¤À¥Dµøµ¡"
-
-msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\t¦b¥t¤@­Ó GTK widget ¤º¶}±Ò Vim"
-
-msgid "-P <parent title>\tOpen Vim inside parent application"
-msgstr "-P <parent title>\t¦b¤÷µ{¦¡¤¤¶}±Ò Vim"
-
-msgid "No display"
-msgstr "µLÅã¥Ü"
-
-#. Failed to send, abort.
-msgid ": Send failed.\n"
-msgstr ": ¶Ç°e¥¢±Ñ¡C\n"
-
-#. Let vim start normally.
-msgid ": Send failed. Trying to execute locally\n"
-msgstr ": °e¥X¥¢±Ñ¡C¸Õ¹Ï¦b¥»¦a°õ¦æ\n"
-
-#, c-format
-msgid "%d of %d edited"
-msgstr "¤w½s¿è %d/%d ­ÓÀÉ®×"
-
-msgid "No display: Send expression failed.\n"
-msgstr "µL Display: µLªk¶Ç°e¹Bºâ¦¡¡C\n"
-
-msgid ": Send expression failed.\n"
-msgstr ": µLªk¶Ç°e¹Bºâ¦¡¡C\n"
-
+#: ../mark.c:676
 msgid "No marks set"
 msgstr "¨S¦³³]©w¼Ð°O (mark)"
 
+#: ../mark.c:678
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: §ä¤£¨ì²Å¦X \"%s\" ªº¼Ð°O(mark)"
 
 #. Highlight title
+#: ../mark.c:687
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -2665,6 +3640,7 @@ msgstr ""
 "¼Ð°O ¦æ¸¹  Äæ  ÀÉ®×/¤å¦r"
 
 #. Highlight title
+#: ../mark.c:789
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -2673,6 +3649,7 @@ msgstr ""
 " jump ¦æ¸¹  Äæ  ÀÉ®×/¤å¦r"
 
 #. Highlight title
+#: ../mark.c:831
 msgid ""
 "\n"
 "change line  col text"
@@ -2680,7 +3657,7 @@ msgstr ""
 "\n"
 "§ïÅÜ   ¦æ¸¹  Äæ  ¤å¦r"
 
-#, c-format
+#: ../mark.c:1238
 msgid ""
 "\n"
 "# File marks:\n"
@@ -2689,7 +3666,7 @@ msgstr ""
 "# ÀÉ®×¼Ð°O:\n"
 
 #. Write the jumplist with -'
-#, c-format
+#: ../mark.c:1271
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -2697,7 +3674,7 @@ msgstr ""
 "\n"
 "# Jumplist (¥Ñ·s¨ìÂÂ):\n"
 
-#, c-format
+#: ../mark.c:1352
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -2705,94 +3682,85 @@ msgstr ""
 "\n"
 "# ÀÉ®×¤º Mark °O¿ý (¥Ñ·s¨ìÂÂ):\n"
 
+#: ../mark.c:1431
 msgid "Missing '>'"
 msgstr "¯Ê¤Ö¹ïÀ³ªº '>'"
 
-msgid "E543: Not a valid codepage"
-msgstr "E543: ¤£¥¿½Tªº codepage"
-
-msgid "E284: Cannot set IC values"
-msgstr "E284: ¤£¯à³]©w IC ¼Æ­È"
-
-msgid "E285: Failed to create input context"
-msgstr "E285: µLªk«Ø¥ß input context"
-
-msgid "E286: Failed to open input method"
-msgstr "E286: µLªk¶}±Ò¿é¤Jªk"
-
-msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr "E287: Äµ§i: µLªk²¾°£ IM ªº callback"
-
-msgid "E288: input method doesn't support any style"
-msgstr "E288: ¿é¤Jªk¤£¤ä´©¥ô¦ó style"
-
-msgid "E289: input method doesn't support my preedit type"
-msgstr "E289: ¿é¤Jªk¤£¤ä´©¥ô¦ó style"
-
-msgid "E290: over-the-spot style requires fontset"
-msgstr "E290: over-the-spot »Ý­n¦r«¬¶°(Fontset)"
-
-msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-msgstr "E291: §Aªº GTK+ ¤ñ 1.2.3 ÁÙÂÂ¡CµLªk¨Ï¥Îª¬ºA°Ï¡C"
-
-msgid "E292: Input Method Server is not running"
-msgstr "E292: ¨S¦³°õ¦æ¤¤ªº¿é¤JªkºÞ²zµ{¦¡(Input Method Server)"
-
+#: ../memfile.c:426
 msgid "E293: block was not locked"
 msgstr "E293: °Ï¶ô¥¼³QÂê©w"
 
+#: ../memfile.c:799
 msgid "E294: Seek error in swap file read"
 msgstr "E294: ¼È¦sÀÉÅª¨ú¿ù»~"
 
+#: ../memfile.c:803
 msgid "E295: Read error in swap file"
 msgstr "E295: ¼È¦sÀÉÅª¨ú¿ù»~"
 
+#: ../memfile.c:849
 msgid "E296: Seek error in swap file write"
 msgstr "E296: ¼È¦sÀÉ¼g¤J¿ù»~"
 
+#: ../memfile.c:865
 msgid "E297: Write error in swap file"
 msgstr "E297: ¼È¦sÀÉ¼g¤J¿ù»~"
 
+#: ../memfile.c:1036
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: ¼È¦sÀÉ¤w¸g¦s¦b! (¤p¤ß²Å¸¹³sµ²ªº¦w¥þº|¬}!?)"
 
+#: ../memline.c:318
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: §ä¤£¨ì°Ï¶ô 0?"
 
+#: ../memline.c:361
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: §ä¤£¨ì°Ï¶ô 1?"
 
+#: ../memline.c:377
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: §ä¤£¨ì°Ï¶ô 2?"
 
 #. could not (re)open the swap file, what can we do????
+#: ../memline.c:465
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: ¾¾¾¾, ¼È¦sÀÉ¤£¨£¤F!!!"
 
+#: ../memline.c:477
 msgid "E302: Could not rename swap file"
 msgstr "E302: µLªk§ïÅÜ¼È¦sÀÉªº¦WºÙ"
 
+#: ../memline.c:554
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr "E303: µLªk¶}±Ò¼È¦sÀÉ \"%s\", ¤£¥i¯à­×´_¤F"
 
-msgid "E304: ml_timestamp: Didn't get block 0??"
+#: ../memline.c:666
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_timestamp: §ä¤£¨ì°Ï¶ô 0??"
 
+#. no swap files found
+#: ../memline.c:830
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: §ä¤£¨ì %s ªº¼È¦sÀÉ"
 
+#: ../memline.c:839
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr "½Ð¿ï¾Ü§A­n¨Ï¥Îªº¼È¦sÀÉ («ö0 Â÷¶}): "
 
+#: ../memline.c:879
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: µLªk¶}±Ò %s"
 
+#: ../memline.c:897
 msgid "Unable to read block 0 from "
 msgstr "µLªkÅª¨ú°Ï¶ô 0:"
 
+#: ../memline.c:900
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -2800,22 +3768,28 @@ msgstr ""
 "\n"
 "¥i¯à¬O§A¨S°µ¹L¥ô¦ó­×§ï©Î¬O Vim ÁÙ¨Ó¤£¤Î§ó·s¼È¦sÀÉ."
 
+#: ../memline.c:909
 msgid " cannot be used with this version of Vim.\n"
 msgstr " µLªk¦b¥»ª©¥»ªº Vim ¤¤¨Ï¥Î.\n"
 
+#: ../memline.c:911
 msgid "Use Vim version 3.0.\n"
 msgstr "¨Ï¥Î Vim 3.0¡C\n"
 
+#: ../memline.c:916
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s ¬Ý°_¨Ó¤£¹³¬O Vim ¼È¦sÀÉ"
 
+#: ../memline.c:922
 msgid " cannot be used on this computer.\n"
 msgstr " µLªk¦b³o»O¹q¸£¤W¨Ï¥Î.\n"
 
+#: ../memline.c:924
 msgid "The file was created on "
 msgstr "¥»ÀÉ®×«Ø¥ß©ó "
 
+#: ../memline.c:928
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -2823,63 +3797,85 @@ msgstr ""
 ",\n"
 "©Î¬O³oÀÉ®×¤w¸g·l·´¡C"
 
+#: ../memline.c:945
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr ""
+
+#: ../memline.c:974
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "¨Ï¥Î¼È¦sÀÉ \"%s\""
 
+#: ../memline.c:980
 #, c-format
 msgid "Original file \"%s\""
 msgstr "­ì©lÀÉ \"%s\""
 
+#: ../memline.c:995
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Äµ§i: ­ì©lÀÉ®×¥i¯à¤w¸g­×§ï¹L¤F"
 
+#: ../memline.c:1061
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: µLªk±q %s Åª¨ú°Ï¶ô 1"
 
+#: ../memline.c:1065
 msgid "???MANY LINES MISSING"
 msgstr "???¯Ê¤Ö¤Ó¦h¦æ "
 
+#: ../memline.c:1076
 msgid "???LINE COUNT WRONG"
 msgstr "???¦æ¸¹¿ù»~"
 
+#: ../memline.c:1082
 msgid "???EMPTY BLOCK"
 msgstr "???ªÅªº BLOCK"
 
+#: ../memline.c:1103
 msgid "???LINES MISSING"
 msgstr "???§ä¤£¨ì¤@¨Ç¦æ "
 
+#: ../memline.c:1128
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: °Ï¶ô 1 ID ¿ù»~ (%s ¤£¬O¼È¦sÀÉ?)"
 
+#: ../memline.c:1133
 msgid "???BLOCK MISSING"
 msgstr "???§ä¤£¨ìBLOCK"
 
+#: ../memline.c:1147
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? ±q³o¸Ì¨ì ???END ªº¤º®e¥i¯à¦³°ÝÃD"
 
+#: ../memline.c:1164
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? ±q³o¸Ì¨ì ???END ªº¤º®e¥i¯à³Q§R°£/´¡¤J¹L"
 
 # do not translate
+#: ../memline.c:1181
 msgid "???END"
 msgstr "???END"
 
+#: ../memline.c:1238
 msgid "E311: Recovery Interrupted"
 msgstr "E311: ­×´_¤w¤¤Â_"
 
+#: ../memline.c:1243
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: ­×´_®Éµo¥Í¿ù»~; ½Ðª`·N¶}ÀY¬° ??? ªº¦æ "
 
+#: ../memline.c:1245
 msgid "See \":help E312\" for more information."
 msgstr "¸Ô²Ó»¡©ú½Ð¨£ \":help E312\""
 
+#: ../memline.c:1249
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "´_­ì§¹¦¨. ½Ð½T©w¤@¤Á¥¿±`."
 
+#: ../memline.c:1251
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -2887,50 +3883,71 @@ msgstr ""
 "\n"
 "(§A¥i¯à·|·Q­n§â³o­ÓÀÉ®×¥t¦s§OªºÀÉ¦W¡A\n"
 
-msgid "and run diff with the original file to check for changes)\n"
+#: ../memline.c:1252
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
 msgstr "¦A°õ¦æ diff »P­ìÀÉ®×¤ñ¸û¥HÀË¬d¬O§_¦³§ïÅÜ)\n"
 
+#: ../memline.c:1254
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr ""
+
+#: ../memline.c:1255
+#, fuzzy
 msgid ""
-"Delete the .swp file afterwards.\n"
+"\n"
+"You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
 "(D)ª½±µ§R°£ .swp ¼È¦sÀÉ\n"
 "\n"
 
 #. use msg() to start the scrolling properly
+#: ../memline.c:1327
 msgid "Swap files found:"
 msgstr "§ä¨ì¥H¤Uªº¼È¦sÀÉ:"
 
+#: ../memline.c:1446
 msgid "   In current directory:\n"
 msgstr "   ¦b¥Ø«eªº¥Ø¿ý:\n"
 
+#: ../memline.c:1448
 msgid "   Using specified name:\n"
 msgstr "   Using specified name:\n"
 
+#: ../memline.c:1450
 msgid "   In directory "
 msgstr "   ¦b¥Ø¿ý "
 
+#: ../memline.c:1465
 msgid "      -- none --\n"
 msgstr "      -- µL --\n"
 
+#: ../memline.c:1527
 msgid "          owned by: "
 msgstr "            ¾Ö¦³ªÌ: "
 
+#: ../memline.c:1529
 msgid "   dated: "
 msgstr "    ¤é´Á: "
 
+#: ../memline.c:1532 ../memline.c:3231
 msgid "             dated: "
 msgstr "              ¤é´Á: "
 
+#: ../memline.c:1548
 msgid "         [from Vim version 3.0]"
 msgstr "              [±q Vim ª©¥» 3.0]"
 
+#: ../memline.c:1550
 msgid "         [does not look like a Vim swap file]"
 msgstr "                          [¤£¹³ Vim ªº¼È¦sÀÉ]"
 
+#: ../memline.c:1552
 msgid "         file name: "
 msgstr "              ÀÉ¦W: "
 
+#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -2938,12 +3955,15 @@ msgstr ""
 "\n"
 "            ­×§ï¹L: "
 
+#: ../memline.c:1559
 msgid "YES"
 msgstr "¬O"
 
+#: ../memline.c:1559
 msgid "no"
 msgstr "§_"
 
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         user name: "
@@ -2951,9 +3971,11 @@ msgstr ""
 "\n"
 "            ¨Ï¥ÎªÌ: "
 
+#: ../memline.c:1568
 msgid "   host name: "
 msgstr "    ¥D¾÷¦WºÙ: "
 
+#: ../memline.c:1570
 msgid ""
 "\n"
 "         host name: "
@@ -2961,6 +3983,7 @@ msgstr ""
 "\n"
 "          ¥D¾÷¦WºÙ: "
 
+#: ../memline.c:1575
 msgid ""
 "\n"
 "        process ID: "
@@ -2968,16 +3991,11 @@ msgstr ""
 "\n"
 "        process ID: "
 
+#: ../memline.c:1579
 msgid " (still running)"
 msgstr " (°õ¦æ¤¤)"
 
-msgid ""
-"\n"
-"         [not usable with this version of Vim]"
-msgstr ""
-"\n"
-"         [µLªk¦b¥»ª©¥»ªº Vim ¤W¨Ï¥Î]"
-
+#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -2985,71 +4003,97 @@ msgstr ""
 "\n"
 "         [µLªk¦b¥»¹q¸£¤W¨Ï¥Î]"
 
+#: ../memline.c:1590
 msgid "         [cannot be read]"
 msgstr "         [µLªkÅª¨ú]"
 
+#: ../memline.c:1593
 msgid "         [cannot be opened]"
 msgstr "         [µLªk¶}±Ò]"
 
+#: ../memline.c:1698
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: µLªk«O¯d, ¤£¨Ï¥Î¼È¦sÀÉ"
 
+#: ../memline.c:1747
 msgid "File preserved"
 msgstr "ÀÉ®×¤w«O¯d"
 
+#: ../memline.c:1749
 msgid "E314: Preserve failed"
 msgstr "E314: «O¯d¥¢±Ñ"
 
+#: ../memline.c:1819
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: ¿ù»~ªº lnum: %<PRId64>"
 
+#: ../memline.c:1851
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: §ä¤£¨ì²Ä %<PRId64> ¦æ "
 
+#: ../memline.c:2236
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: «ü¼Ð°Ï¶ô id ¿ù»~ 3"
 
+#: ../memline.c:2311
 msgid "stack_idx should be 0"
 msgstr "stack_idx À³¸Ó¬O 0"
 
+#: ../memline.c:2369
 msgid "E318: Updated too many blocks?"
 msgstr "E318: §ó·s¤Ó¦h°Ï¶ô?"
 
+#: ../memline.c:2511
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: «ü¼Ð°Ï¶ô id ¿ù»~ 4"
 
+#: ../memline.c:2536
 msgid "deleted block 1?"
 msgstr "§R°£°Ï¶ô 1?"
 
+#: ../memline.c:2707
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: §ä¤£¨ì²Ä %<PRId64> ¦æ "
 
+#: ../memline.c:2916
 msgid "E317: pointer block id wrong"
 msgstr "E317: «ü¼Ð°Ï¶ô id ¿ù»~"
 
+#: ../memline.c:2930
 msgid "pe_line_count is zero"
 msgstr "pe_line_count ¬°¹s"
 
+#: ../memline.c:2955
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr "E322: ¦æ¸¹¶W¥X½d³ò: %<PRId64> ¶W¹Lµ²§À"
 
+#: ../memline.c:2959
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: °Ï¶ô %<PRId64> ¦æ¼Æ¿ù»~"
 
+#: ../memline.c:2999
 msgid "Stack size increases"
 msgstr "°ïÅ|¤j¤p¼W¥["
 
+#: ../memline.c:3038
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: «ü¼Ð°Ï¶ô id ¿ù 2"
 
+#: ../memline.c:3070
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr ""
+
+#: ../memline.c:3221
 msgid "E325: ATTENTION"
 msgstr "E325: ª`·N"
 
+#: ../memline.c:3222
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -3057,37 +4101,43 @@ msgstr ""
 "\n"
 "§ä¨ì¼È¦sÀÉ \""
 
+#: ../memline.c:3226
 msgid "While opening file \""
 msgstr "¦b¶}±ÒÀÉ®× \""
 
+#: ../memline.c:3239
 msgid "      NEWER than swap file!\n"
 msgstr "      ¤ñ¼È¦sÀÉ§ó·s!\n"
 
-#. Some of these messages are long to allow translation to
-#. * other languages.
+#: ../memline.c:3244
+#, fuzzy
 msgid ""
 "\n"
-"(1) Another program may be editing the same file.\n"
-"    If this is the case, be careful not to end up with two\n"
-"    different instances of the same file when making changes.\n"
+"(1) Another program may be editing the same file.  If this is the case,\n"
+"    be careful not to end up with two different instances of the same\n"
+"    file when making changes."
 msgstr ""
 "\n"
 "(1) ¥i¯à¦³¥t¤@­Óµ{¦¡¤]¦b½s¿è¦P¤@­ÓÀÉ®×.\n"
 "    ¦pªG¬O³o¼Ë¡A½Ð¤p¤ß¤£­n¨âÃä¤@°_¼g¤J¡A¤£µM§Aªº§V¤O³£·|­t½Ñ¬y¤ô¡C\n"
 
-msgid "    Quit, or continue with caution.\n"
+#: ../memline.c:3245
+#, fuzzy
+msgid "  Quit, or continue with caution.\n"
 msgstr "    Â÷¶}¡A©Î¬OÄ~Äò½s¿è¡C\n"
 
-msgid ""
-"\n"
-"(2) An edit session for this file crashed.\n"
+#: ../memline.c:3246
+#, fuzzy
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) «e¦¸½s¿è¦¹ÀÉ®É·í¾÷\n"
 
+#: ../memline.c:3247
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr "    ¦pªG¬O³o¼Ë, ½Ð¥Î \":recover\" ©Î \"vim -r"
 
+#: ../memline.c:3249
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -3095,9 +4145,11 @@ msgstr ""
 "\"\n"
 "    ¨Ó±Ï¦^­×§ï¸ê®Æ (¸Ô²Ó»¡©ú½Ð¬Ý \":help recovery\").\n"
 
+#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    ¦pªG¸Ó±Ïªº³£¤w¸g±Ï¤F, ½Ðª½±µ§R°£¦¹¼È¦sÀÉ \""
 
+#: ../memline.c:3252
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -3105,18 +4157,23 @@ msgstr ""
 "\"\n"
 "    ¥HÁ×§K¦A¬Ý¨ì¦¹°T®§.\n"
 
+#: ../memline.c:3450 ../memline.c:3452
 msgid "Swap file \""
 msgstr "¼È¦sÀÉ \""
 
+#: ../memline.c:3451 ../memline.c:3455
 msgid "\" already exists!"
 msgstr "\" ¤w¸g¦s¦b¤F!"
 
+#: ../memline.c:3457
 msgid "VIM - ATTENTION"
 msgstr "VIM - ª`·N"
 
+#: ../memline.c:3459
 msgid "Swap file already exists!"
 msgstr "¼È¦sÀÉ¤w¸g¦s¦b!"
 
+#: ../memline.c:3464
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -3130,44 +4187,72 @@ msgstr ""
 "Â÷¶}(&Q)\n"
 "¸õ¥X(&A)"
 
+#: ../memline.c:3467
+#, fuzzy
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
 "&Recover\n"
+"&Delete it\n"
 "&Quit\n"
-"&Abort\n"
-"&Delete it"
+"&Abort"
 msgstr ""
 "¥H°ßÅª¤è¦¡¶}±Ò(&O)\n"
 "ª½±µ½s¿è(&E)\n"
 "­×´_(&R)\n"
 "Â÷¶}(&Q)\n"
-"¸õ¥X(&A)\n"
-"§R°£¼È¦sÀÉ(&D)"
+"¸õ¥X(&A)"
 
+#.
+#. * Change the ".swp" extension to find another file that can be used.
+#. * First decrement the last char: ".swo", ".swn", etc.
+#. * If that still isn't enough decrement the last but one char: ".svz"
+#. * Can happen when editing many "No Name" buffers.
+#.
+#. ".s?a"
+#. ".saa": tried enough, give up
+#: ../memline.c:3528
 msgid "E326: Too many swap files found"
 msgstr "E326: §ä¨ì¤Ó¦h¼È¦sÀÉ"
 
+#: ../memory.c:227
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: °O¾ÐÅé¤£¨¬! (¹Á¸Õ°t¸m %<PRIu64> ¦ì¤¸²Õ)"
+
+#: ../menu.c:62
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: ³¡¥÷¿ï¶µ¸ô®|¤£¬O¤l¿ï³æ"
 
+#: ../menu.c:63
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: ¿ï³æ¥u¯à¦b¨ä¥¦¼Ò¦¡¤¤¨Ï¥Î"
 
-msgid "E329: No menu of that name"
+#: ../menu.c:64
+#, fuzzy, c-format
+msgid "E329: No menu \"%s\""
 msgstr "E329: ¨S¦³¨º¼Ëªº¿ï³æ"
 
+#. Only a mnemonic or accelerator is not valid.
+#: ../menu.c:329
+msgid "E792: Empty menu name"
+msgstr ""
+
+#: ../menu.c:340
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: ¿ï³æ¸ô®|¤£¯à«ü¦V¤l¿ï³æ"
 
+#: ../menu.c:365
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: ¤£¯àª½±µ§â¿ï¶µ¥[¨ì¿ï³æ¦C¤¤"
 
+#: ../menu.c:370
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: ¤À¹j½u¤£¯à¬O¿ï³æ¸ô®|ªº¤@³¡¥÷"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
+#: ../menu.c:762
 msgid ""
 "\n"
 "--- Menus ---"
@@ -3175,63 +4260,76 @@ msgstr ""
 "\n"
 "--- ¿ï³æ ---"
 
-msgid "Tear off this menu"
-msgstr "¤Á¤U¦¹¿ï³æ"
-
+#: ../menu.c:1313
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: ¿ï³æ¸ô®|¥²»Ý«ü¦V¤@­Ó¿ï¶µ"
 
+#: ../menu.c:1330
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: [¿ï³æ] §ä¤£¨ì %s"
 
+#: ../menu.c:1396
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: %s ¼Ò¦¡¥¼©w¸q¿ï³æ"
 
+#: ../menu.c:1426
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: ¿ï³æ¸ô®|¥²»Ý«ü¦V¤l¿ï³æ"
 
+#: ../menu.c:1447
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: §ä¤£¨ì¿ï³æ - ½ÐÀË¬d¿ï³æ¦WºÙ"
 
+#: ../message.c:423
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "³B²z %s ®Éµo¥Í¿ù»~:"
 
+#: ../message.c:445
 #, c-format
 msgid "line %4ld:"
 msgstr "¦æ %4ld:"
 
-msgid "[string too long]"
-msgstr "[¦¹¦æ¹Lªø]"
+#: ../message.c:617
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: ¼È¦s¾¹¦WºÙ¿ù»~: '%s'"
 
+#: ../message.c:745
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr ""
 "¥¿Åé¤¤¤å°T®§ºûÅ@ªÌ: Francis S.Lin <piaip@csie.ntu.edu."
 "tw>,                                 Cecil Sheng   <b7506022@csie.ntu.edu.tw>"
 
+#: ../message.c:986
 msgid "Interrupt: "
 msgstr "¤w¤¤Â_: "
 
-msgid "Hit ENTER to continue"
-msgstr "½Ð«ö ENTER Ä~Äò"
-
-msgid "Hit ENTER or type command to continue"
+#: ../message.c:988
+#, fuzzy
+msgid "Press ENTER or type command to continue"
 msgstr "½Ð«ö ENTER ©Î¨ä¥¦©R¥O¥HÄ~Äò"
 
+#: ../message.c:1843
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, ¦æ %<PRId64>"
+
+#: ../message.c:2392
 msgid "-- More --"
 msgstr "-- ©|¦³ --"
 
-msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-msgstr " (RET/BS: ¦V¤U/¦V¤W¤@¦æ, ªÅ¥ÕÁä/b: ¤@­¶, d/u: ¥b­¶, q: Â÷¶})"
+#: ../message.c:2398
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr ""
 
-msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-msgstr " (RET: ¦V¤U¤@¦æ, ªÅ¥ÕÁä: ¤@­¶, d: ¥b­¶, q: Â÷¶})"
-
+#: ../message.c:3021 ../message.c:3031
 msgid "Question"
 msgstr "°ÝÃD"
 
+#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -3239,6 +4337,17 @@ msgstr ""
 "&Y¬O\n"
 "&N§_"
 
+#: ../message.c:3033
+msgid ""
+"&Yes\n"
+"&No\n"
+"&Cancel"
+msgstr ""
+"&Y¬O\n"
+"&N§_\n"
+"&C¨ú®ø"
+
+#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -3252,229 +4361,179 @@ msgstr ""
 "&D¥þ³¡¤£¦s\n"
 "&C¨ú®ø"
 
-msgid "Save File dialog"
-msgstr "¦sÀÉ"
+#: ../message.c:3058
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: ¨ç¦¡ %s ªº¤Þ¼Æ¤£¥¿½T"
 
-msgid "Open File dialog"
-msgstr "¶}ÀÉ"
+#: ../message.c:3119
+msgid "E807: Expected Float argument for printf()"
+msgstr ""
 
-#. TODO: non-GUI file selector here
-msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: ¥D±±¥x(Console)¼Ò¦¡®É¨S¦³ÀÉ®×ÂsÄý¾¹(file browser)"
+#: ../message.c:3873
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: ¨ç¦¡ %s ªº¤Þ¼Æ¹L¦h"
 
+#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: ª`·N: §A¥¿¦b­×§ï¤@­Ó°ßÅªÀÉ"
 
+#: ../misc1.c:2537
+msgid "Type number and <Enter> or click with mouse (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2539
+msgid "Type number and <Enter> (empty cancels): "
+msgstr ""
+
+#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "ÁÙ¦³¤@¦æ "
 
+#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "¤Ö©ó¤@¦æ "
 
+#: ../misc1.c:2593
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "ÁÙ¦³ %<PRId64> ¦æ "
 
+#: ../misc1.c:2596
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "¥u³Ñ %<PRId64> ¦æ "
 
+#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (¤w¤¤Â_)"
 
-msgid "Vim: preserving files...\n"
-msgstr "Vim: «O¯dÀÉ®×¤¤...\n"
-
-#. close all memfiles, without deleting
-msgid "Vim: Finished.\n"
-msgstr "Vim: µ²§ô.\n"
-
-#, c-format
-msgid "ERROR: "
-msgstr "¿ù»~: "
-
-#, c-format
-msgid ""
-"\n"
-"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
+#: ../misc1.c:2635
+msgid "Beep!"
 msgstr ""
-"\n"
-"[bytes] ¥þ³¡ alloc-freed %<PRIu64>-%<PRIu64>, ¨Ï¥Î¤¤ %<PRIu64>, peak ¨Ï¥Î %<PRIu64>\n"
 
-#, c-format
-msgid ""
-"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-"\n"
-msgstr ""
-"[©I¥s] ¥þ³¡ re/malloc(): %<PRIu64>, ¥þ³¡ free()': %<PRIu64>\n"
-"\n"
-
-msgid "E340: Line is becoming too long"
-msgstr "E340: ¦¹¦æ¹Lªø"
-
-#, c-format
-msgid "E341: Internal error: lalloc(%<PRId64>, )"
-msgstr "E341: ¤º³¡¿ù»~: lalloc(%<PRId64>, )"
-
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: °O¾ÐÅé¤£¨¬! (¹Á¸Õ°t¸m %<PRIu64> ¦ì¤¸²Õ)"
-
+#: ../misc2.c:738
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "©I¥s shell °õ¦æ: \"%s\""
 
-msgid "E545: Missing colon"
-msgstr "E545: ¯Ê¤Ö colon"
-
-msgid "E546: Illegal mode"
-msgstr "E546: ¤£¥¿½Tªº¼Ò¦¡"
-
-msgid "E547: Illegal mouseshape"
-msgstr "E547: ¤£¥¿½Tªº·Æ¹«§Îª¬"
-
-msgid "E548: digit expected"
-msgstr "E548: À³¸Ó­n¦³¼Æ¦r"
-
-msgid "E549: Illegal percentage"
-msgstr "E549: ¤£¥¿½Tªº¦Ê¤À¤ñ"
-
-msgid "Enter encryption key: "
-msgstr "¿é¤J±K½X: "
-
-msgid "Enter same key again: "
-msgstr "½Ð¦A¿é¤J¤@¦¸: "
-
-msgid "Keys don't match!"
-msgstr "¨â¦¸¿é¤J±K½X¤£¬Û¦P!"
-
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr "E343: ¤£¥¿½Tªº¸ô®|: '**[number]' ¥²»Ý­n¦b¸ô®|µ²§À©Î­n±µµÛ '%s'"
-
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath ¤¤¨S¦³¥Ø¿ý \"%s\""
-
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: ¦b¸ô®|¤¤§ä¤£¨ìÀÉ®× \"%s\""
-
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: ¦b¸ô®|¤¤§ä¤£¨ì§ó¦hªºÀÉ®× \"%s\""
-
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: ¦b¸ô®|¤¤§ä¤£¨ì§ó¦hªºÀÉ®× \"%s\""
-
-msgid "E550: Missing colon"
-msgstr "E550: ¯Ê¤Ö colon"
-
-msgid "E551: Illegal component"
-msgstr "E551: ¤£¥¿½Tªº¼Ò¦¡"
-
-msgid "E552: digit expected"
-msgstr "E552: À³¸Ó­n¦³¼Æ¦r"
-
-#. Get here when the server can't be found.
-msgid "Cannot connect to Netbeans #2"
-msgstr "µLªk³s±µ¨ì Netbeans #2"
-
-msgid "Cannot connect to Netbeans"
-msgstr "µLªk³s±µ¨ì Netbeans"
-
-#, c-format
-msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-msgstr "E668: NetBeans ³s½u¸ê°TÀÉ®×: \"%s\" ¦s¨ú¼Ò¦¡¤£¥¿½T"
-
-msgid "read from Netbeans socket"
-msgstr "¥Ñ Netbeans socket Åª¨ú"
-
-#, c-format
-msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-msgstr "E658: ½w½Ä°Ï %<PRId64> »P NetBeans ªº³s½u¤w¤¤Â_"
-
-msgid "Warning: terminal cannot highlight"
-msgstr "ª`·N: §Aªº²×ºÝ¾÷µLªkÅã¥Ü°ª«G«×"
-
-msgid "E348: No string under cursor"
-msgstr "E348: ´å¼Ð³B¨S¦³¦r¦ê"
-
+#: ../normal.c:183
 msgid "E349: No identifier under cursor"
 msgstr "E349: ´å¼Ð³B¨S¦³ÃÑ§O¦r"
 
+#: ../normal.c:1866
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E221: ¿ï¶µ 'commentstring' ¥¼³]©w"
+
+#: ../normal.c:2637
+msgid "Warning: terminal cannot highlight"
+msgstr "ª`·N: §Aªº²×ºÝ¾÷µLªkÅã¥Ü°ª«G«×"
+
+#: ../normal.c:2807
+msgid "E348: No string under cursor"
+msgstr "E348: ´å¼Ð³B¨S¦³¦r¦ê"
+
+#: ../normal.c:3937
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr "E352: µLªk¦b¥Ø«eªº 'foldmethod' ¤U§R°£ fold"
 
+#: ../normal.c:5897
 msgid "E664: changelist is empty"
 msgstr "E664: ÅÜ§ó¦Cªí¬OªÅªº"
 
+#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: ¤w¦bÅÜ§ó¦Cªíªº¶}ÀY"
 
+#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: ¤w¦bÅÜ§ó¦Cªíªºµ²§À"
 
+#: ../normal.c:7053
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "­nÂ÷¶} Vim ½Ð¿é¤J :quit<Enter> "
 
+#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "¤@¦æ %s ¹L ¤@¦¸"
 
+#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "¤@¦æ %s ¹L %d ¦¸"
 
+#: ../ops.c:253
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> ¦æ %s ¹L ¤@¦¸"
 
+#: ../ops.c:256
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> ¦æ %s ¹L %d ¦¸"
 
+#: ../ops.c:592
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "ÁY±Æ %<PRId64> ¦æ... "
 
+#: ../ops.c:634
 msgid "1 line indented "
 msgstr "¤@¦æ¤wÁY±Æ"
 
+#: ../ops.c:636
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "¤wÁY±Æ %<PRId64> ¦æ "
 
+#: ../ops.c:938
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: ¨S¦³«e¤@­Ó¥Ø¿ý"
+
 #. must display the prompt
+#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "µLªk°Å¤U; ª½±µ§R°£"
 
+#: ../ops.c:1929
 msgid "1 line changed"
 msgstr " 1 ¦æ ~ed"
 
+#: ../ops.c:1931
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "¤w§ïÅÜ %<PRId64> ¦æ "
 
-#, c-format
-msgid "freeing %<PRId64> lines"
-msgstr "ÄÀ©ñ %<PRId64> ¦æ¤¤ "
+#: ../ops.c:2521
+#, fuzzy
+msgid "block of 1 line yanked"
+msgstr "¤w½Æ»s 1 ¦æ "
 
+#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "¤w½Æ»s 1 ¦æ "
 
+#: ../ops.c:2525
+#, fuzzy, c-format
+msgid "block of %<PRId64> lines yanked"
+msgstr "¤w½Æ»s %<PRId64> ¦æ "
+
+#: ../ops.c:2528
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "¤w½Æ»s %<PRId64> ¦æ "
 
+#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: ¼È¦s¾¹ %s ¸Ì¨S¦³ªF¦è"
 
 #. Highlight title
+#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -3482,10 +4541,11 @@ msgstr ""
 "\n"
 "--- ¼È¦s¾¹ ---"
 
+#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "¤£¥¿½Tªº¼È¦s¾¹¦WºÙ"
 
-#, c-format
+#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -3493,153 +4553,195 @@ msgstr ""
 "\n"
 "# ¼È¦s¾¹:\n"
 
+#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: ¥¼ª¾ªºµù¥U«¬ºA: %d"
 
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: ¼È¦s¾¹¦WºÙ¿ù»~: '%s'"
-
+#: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Äæ; "
 
+#: ../ops.c:5097
 #, c-format
-msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
-msgstr "¿ï¾Ü¤F %s%<PRId64>/%<PRId64> ¦æ; %<PRId64>/%<PRId64> ¦r(Word); %<PRId64>/%<PRId64> ¦r¤¸(Bytes)"
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"¿ï¾Ü¤F %s%<PRId64>/%<PRId64> ¦æ; %<PRId64>/%<PRId64> ¦r(Word); %<PRId64>/"
+"%<PRId64> ¦r¤¸(Bytes)"
 
+#: ../ops.c:5105
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"¿ï¾Ü¤F %s%<PRId64>/%<PRId64> ¦æ; %<PRId64>/%<PRId64> ¦r(Word); %<PRId64>/"
+"%<PRId64> ¦r¤¸(Bytes)"
+
+#: ../ops.c:5123
 #, c-format
-msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr "Äæ %s/%s; ¦æ %<PRId64>/%<PRId64>; ¦r(Word) %<PRId64>/%<PRId64>; ¦r¤¸(Byte) %<PRId64>/%<PRId64>"
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"Äæ %s/%s; ¦æ %<PRId64>/%<PRId64>; ¦r(Word) %<PRId64>/%<PRId64>; ¦r¤¸(Byte) "
+"%<PRId64>/%<PRId64>"
 
+#: ../ops.c:5133
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"Äæ %s/%s; ¦æ %<PRId64>/%<PRId64>; ¦r(Word) %<PRId64>/%<PRId64>; ¦r¤¸(Byte) "
+"%<PRId64>/%<PRId64>"
+
+#: ../ops.c:5146
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> for BOM)"
 
+#: ../option.c:1238
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=²Ä %N ­¶"
 
 # ? what's this for?
+#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "·PÁÂ±z·R¥Î Vim"
 
+#. found a mismatch: skip
+#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: ¤£¥¿½Tªº¿ï¶µ"
 
+#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: ¤£¤ä´©¸Ó¿ï¶µ"
 
+#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: ¤£¯à¦b Modeline ¸Ì¥X²{"
 
-msgid ""
-"\n"
-"\tLast set from "
+#: ../option.c:2815
+msgid "E846: Key code not set"
 msgstr ""
-"\n"
-"\t¤W¦¸³]©w: "
 
+#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: = «á»Ý­n¦³¼Æ¦r"
 
+#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Termcap ¸Ì­±§ä¤£¨ì"
 
+#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: ¤£¥¿½Tªº¦r¤¸ <%s>"
 
+#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: µLªk³]©w 'term' ¬°ªÅ¦r¦ê"
 
-msgid "E530: Cannot change term in GUI"
-msgstr "E530: ¦b¹Ï«¬¬É­±¤¤µLªk¤Á´« term"
-
-msgid "E531: Use \":gui\" to start the GUI"
-msgstr "E531: ¿é¤J \":gui\" ¨Ó±Ò°Ê¹Ï§Î¬É­±"
-
+#: ../option.c:3885
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' ¸ò 'patchmode' ¬O¤@¼Ëªº"
 
-msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-msgstr "E617: ¦b¹Ï«¬¬É­±¤¤µLªk¤Á´« term"
+#: ../option.c:3964
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr ""
 
+#: ../option.c:3966
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr ""
+
+#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: ¯Ê¤Ö colon"
 
+#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: ¹sªø«×¦r¦ê"
 
+#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: <%s> «á¯Ê¤Ö¼Æ¦r"
 
+#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: ¯Ê¤Ö³r¸¹"
 
+#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: ¥²»Ý«ü©w¤@­Ó ' ­È"
 
+#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: ¤º§tµLªkÅã¥Üªº¦r¤¸"
 
-msgid "E596: Invalid font(s)"
-msgstr "E596: ¤£¥¿½Tªº¦r«¬"
-
-msgid "E597: can't select fontset"
-msgstr "E597: µLªk¨Ï¥Î¦r«¬¶°(Fontset)"
-
-msgid "E598: Invalid fontset"
-msgstr "E598: ¤£¥¿½Tªº¦r«¬¶°(Fontset)"
-
-msgid "E533: can't select wide font"
-msgstr "E533: µLªk¨Ï¥Î³]©wªº¤¤¤å¦r«¬(Widefont)"
-
-msgid "E534: Invalid wide font"
-msgstr "E534: ¤£¥¿½Tªº¦r«¬(Widefont)"
-
+#: ../option.c:4469
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: <%c> «á¦³¤£¥¿½Tªº¦r¤¸"
 
+#: ../option.c:4534
 msgid "E536: comma required"
 msgstr "E536: »Ý­n³r¸¹"
 
+#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' ¥²»Ý¬OªÅ¥Õ©Î¥]§t %s"
 
-msgid "E538: No mouse support"
-msgstr "E538: ¤£¤ä´©·Æ¹«"
-
+#: ../option.c:4928
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: ¨S¦³µ²§ôªº¹Bºâ¦¡: "
 
+#: ../option.c:4932
 msgid "E541: too many items"
 msgstr "E541: ¤Ó¦h¶µ¥Ø"
 
+#: ../option.c:4934
 msgid "E542: unbalanced groups"
 msgstr "E542: ¤£¹ïºÙªº group"
 
+#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: ¹wµøªºµøµ¡¤w¸g¦s¦b¤F"
 
+#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabic »Ý­n UTF-8, ½Ð°õ¦æ ':set encoding=utf-8'"
 
+#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: ¦Ü¤Ö»Ý­n %d ¦æ "
 
+#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: ¦Ü¤Ö»Ý­n %d Äæ"
 
+#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: ¤£¥¿½Tªº¿ï¶µ: %s"
 
+#. There's another character after zeros or the string
+#. * is empty.  In both cases, we are trying to set a
+#. * num option using a string.
+#: ../option.c:6037
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: = «á»Ý­n¦³¼Æ¦r"
+
+#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -3647,6 +4749,7 @@ msgstr ""
 "\n"
 "--- ²×ºÝ¾÷½X ---"
 
+#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -3654,6 +4757,7 @@ msgstr ""
 "\n"
 "--- Global ¿ï¶µ­È ---"
 
+#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -3661,6 +4765,7 @@ msgstr ""
 "\n"
 "--- Local ¿ï¶µ­È ---"
 
+#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -3668,129 +4773,21 @@ msgstr ""
 "\n"
 "--- ¿ï¶µ ---"
 
+#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp ¿ù»~"
 
+#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': §ä¤£¨ì %s ¹ïÀ³ªº¦r¤¸"
 
+#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': ¤À¸¹«á¦³¦h¾lªº¦r¤¸: %s"
 
-msgid "cannot open "
-msgstr "¤£¯à¶}±Ò"
-
-msgid "VIM: Can't open window!\n"
-msgstr "VIM: µLªk¶}±Òµøµ¡!\n"
-
-msgid "Need Amigados version 2.04 or later\n"
-msgstr "»Ý­n Amigados ª©¥» 2.04 ¥H¤W\n"
-
-#, c-format
-msgid "Need %s version %<PRId64>\n"
-msgstr "»Ý­n %s ª©¥» %<PRId64>\n"
-
-msgid "Cannot open NIL:\n"
-msgstr "µLªk¶}±Ò NIL:\n"
-
-msgid "Cannot create "
-msgstr "¤£¯à«Ø¥ß "
-
-#, c-format
-msgid "Vim exiting with %d\n"
-msgstr "Vim µ²§ô¶Ç¦^­È: %d\n"
-
-msgid "cannot change console mode ?!\n"
-msgstr "µLªk¤Á´«¥D±±¥x(console)¼Ò¦¡ !?\n"
-
-msgid "mch_get_shellsize: not a console??\n"
-msgstr "mch_get_shellsize: ¤£¬O¥D±±¥x(console)??\n"
-
-#. if Vim opened a window: Executing a shell may cause crashes
-msgid "E360: Cannot execute shell with -f option"
-msgstr "E360: ¤£¯à¥Î -f ¿ï¶µ°õ¦æ shell"
-
-msgid "Cannot execute "
-msgstr "¤£¯à°õ¦æ "
-
-msgid "shell "
-msgstr "shell "
-
-msgid " returned\n"
-msgstr " ¤wªð¦^\n"
-
-msgid "ANCHOR_BUF_SIZE too small."
-msgstr "ANCHOR_BUF_SIZE ¤Ó¤p"
-
-msgid "I/O ERROR"
-msgstr "I/O ¿ù»~"
-
-msgid "...(truncated)"
-msgstr "...(¤w¤Á±¼)"
-
-msgid "'columns' is not 80, cannot execute external commands"
-msgstr "'columns' ¤£¬O 80, µLªk°õ¦æ¥~³¡©R¥O"
-
-msgid "E237: Printer selection failed"
-msgstr "E237: µLªk¿ï¾Ü¦¹¦Lªí¾÷"
-
-#, c-format
-msgid "to %s on %s"
-msgstr "¨ì %s on %s"
-
-#, c-format
-msgid "E613: Unknown printer font: %s"
-msgstr "E613: ¤£¥¿½Tªº¦Lªí¾÷¦r«¬: %s"
-
-#, c-format
-msgid "E238: Print error: %s"
-msgstr "E238: ¦C¦L¿ù»~: %s"
-
-msgid "Unknown"
-msgstr "¥¼ª¾"
-
-#, c-format
-msgid "Printing '%s'"
-msgstr "¦C¦L¤¤: '%s'"
-
-#, c-format
-msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-msgstr "E244: ¦r¤¸¶° \"%s\" µLªk¹ïÀ³¦r«¬\"%s\""
-
-#, c-format
-msgid "E245: Illegal char '%c' in font name \"%s\""
-msgstr "E245: ¤£¥¿½Tªº¦r¤¸ '%c' ¥X²{¦b¦r«¬¦WºÙ \"%s\" ¤º"
-
-msgid "Vim: Double signal, exiting\n"
-msgstr "Vim: Âù­«signal, Â÷¶}¤¤\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal %s\n"
-msgstr "Vim: CVim: ÄdºI¨ì«H¸¹(signal) %s\n"
-
-#, c-format
-msgid "Vim: Caught deadly signal\n"
-msgstr "Vim: ÄdºI¨ì­P©Rªº«H¸¹(deadly signale)\n"
-
-#, c-format
-msgid "Opening the X display took %<PRId64> msec"
-msgstr "¶}±Ò X Window ¯Ó®É %<PRId64> msec"
-
-msgid ""
-"\n"
-"Vim: Got X error\n"
-msgstr ""
-"\n"
-"Vim: X ¿ù»~\n"
-
-msgid "Testing the X display failed"
-msgstr "´ú¸Õ X Window ¥¢±Ñ"
-
-msgid "Opening the X display timed out"
-msgstr "¶}±Ò X Window ¹O®É"
-
+#: ../os/shell.c:194
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -3798,13 +4795,7 @@ msgstr ""
 "\n"
 "¤£¯à°õ¦æ shell"
 
-msgid ""
-"\n"
-"Cannot execute shell sh\n"
-msgstr ""
-"\n"
-"¤£¯à°õ¦æ shell sh\n"
-
+#: ../os/shell.c:439
 msgid ""
 "\n"
 "shell returned "
@@ -3812,386 +4803,959 @@ msgstr ""
 "\n"
 "Shell ¤wªð¦^"
 
+#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Cannot create pipes\n"
+"Could not get security context for "
 msgstr ""
-"\n"
-"¤£¯à«Ø¥ß pipe ºÞ½u\n"
 
+#: ../os_unix.c:479
 msgid ""
 "\n"
-"Cannot fork\n"
+"Could not set security context for "
 msgstr ""
-"\n"
-"¤£¯à fork\n"
 
-msgid ""
-"\n"
-"Command terminated\n"
-msgstr ""
-"\n"
-"©R¥O¤w²×µ²\n"
-
-msgid "XSMP lost ICE connection"
-msgstr "XSMP ¥¢¥h ICE ³s½u"
-
-msgid "Opening the X display failed"
-msgstr "¶}±Ò X Window ¥¢±Ñ"
-
-msgid "XSMP handling save-yourself request"
-msgstr "XSMP ¥¿¦b³B²z¦Û§ÚÀx¦s­n¨D"
-
-msgid "XSMP opening connection"
-msgstr "¶}±Ò XSMP ³s½u¤¤"
-
-msgid "XSMP ICE connection watch failed"
-msgstr "XSMP ICE ³s½uºÊ¬Ý¥¢±Ñ"
-
+#: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
-msgid "XSMP SmcOpenConnection failed: %s"
-msgstr "XSMP SmcOpenConnection ¥¢±Ñ: %s"
-
-msgid "At line"
-msgstr "¦b¦æ¸¹ "
-
-msgid "Could not allocate memory for command line."
-msgstr "µLªk¬°©R¥O¦C°t¸m°O¾ÐÅé¡C"
-
-msgid "VIM Error"
-msgstr "VIM ¿ù»~"
-
-msgid "Could not load vim32.dll!"
-msgstr "µLªk¸ü¤J vim32.dll¡I"
-
-msgid "Could not fix up function pointers to the DLL!"
-msgstr "¤£¯à­×¥¿¨ç¦¡«ü¼Ð¨ì DLL!"
-
-#, c-format
-msgid "shell returned %d"
-msgstr "Shell ¶Ç¦^­È %d"
-
-#, c-format
-msgid "Vim: Caught %s event\n"
-msgstr "Vim: ÄdºI¨ì %s \n"
-
-msgid "close"
-msgstr "Ãö³¬"
-
-msgid "logoff"
-msgstr "µn¥X"
-
-msgid "shutdown"
-msgstr "Ãö¾÷"
-
-msgid "E371: Command not found"
-msgstr "E371: §ä¤£¨ì©R¥O"
-
-msgid ""
-"VIMRUN.EXE not found in your $PATH.\n"
-"External commands will not pause after completion.\n"
-"See  :help win32-vimrun  for more information."
+msgid "dlerror = \"%s\""
 msgstr ""
-"¦b§Aªº $PATH ¤¤§ä¤£¨ì VIMRUN.EXE.\n"
-"¥~³¡©R¥O°õ¦æ§¹²¦«á±N¤£·|¼È°±.\n"
-"¶i¤@¨B»¡©ú½Ð°õ¦æ :help win32-vimrun "
 
-msgid "Vim Warning"
-msgstr "Vim Äµ§i"
+#: ../path.c:1449
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: ¦b¸ô®|¤¤§ä¤£¨ìÀÉ®× \"%s\""
 
+#: ../quickfix.c:359
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: ®æ¦¡¤Æ¦r¦ê¸Ì¦³¤Ó¦h %%%c "
 
+#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: ®æ¦¡¤Æ¦r¦ê¤£À³¸Ó¥X²{ %%%c "
 
+#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: ®æ¦¡¤Æ¦r¦ê¸Ì¤Ö¤F ]"
 
+#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: ®æ¦¡¤Æ¦r¦ê¸Ì¦³¤£¤ä´©ªº %%%c "
 
+#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: ®æ¦¡¤Æ¦r¦ê¶}ÀY¸Ì¦³¤£¥¿½Tªº %%%c "
 
+#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: ®æ¦¡¤Æ¦r¦ê¸Ì¦³¤£¥¿½Tªº %%%c "
 
+#. nothing found
+#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' ¥¼³]©w"
 
+#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: §ä¤£¨ì¥Ø¿ý¦WºÙ©Î¬OªÅªº¥Ø¿ý¦WºÙ"
 
+#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: ¨S¦³¨ä¥¦¶µ¥Ø"
 
+#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d / %d)%s%s: "
 
+#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (¦æ¤w§R°£)"
 
+#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Quickfix °ïÅ|µ²§À"
 
+#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Quickfix °ïÅ|³»ºÝ"
 
+#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "¿ù»~¦Cªí %d/%d; ¦@¦³ %d ¶µ¿ù»~"
 
+#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: µLªk¼g¤J¡A'buftype' ¿ï¶µ¤w³]©w"
 
+#: ../quickfix.c:2812
+msgid "E683: File name missing or invalid pattern"
+msgstr ""
+
+#: ../quickfix.c:2911
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "µLªk¶}±ÒÀÉ®× %s"
+
+#: ../quickfix.c:3429
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "¤wÄÀ©ñ¤@­Ó½w½Ä°Ï"
+
+#: ../quickfix.c:3487
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E548: À³¸Ó­n¦³¼Æ¦r"
+
+#: ../regexp.c:359
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: ¤£¥¿½Tªº¶µ¥Ø¡G %s%%[]"
 
-msgid "E339: Pattern too long"
-msgstr "E339: ¦W¦r¤Óªø"
+#: ../regexp.c:374
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E69: %s%%[ «á¯Ê¤Ö ]"
 
-msgid "E50: Too many \\z("
-msgstr "E50: ¤Ó¦h \\z("
-
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: ¤Ó¦h %s("
-
-msgid "E52: Unmatched \\z("
-msgstr "E52: µL¹ïÀ³ªº \\z("
-
+#: ../regexp.c:375
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: µL¹ïÀ³ªº %s%%("
 
+#: ../regexp.c:376
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: µL¹ïÀ³ªº %s("
 
+#: ../regexp.c:377
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: µL¹ïÀ³ªº %s)"
 
-#, c-format
-msgid "E56: %s* operand could be empty"
-msgstr "E56: %s* ¹Bºâ¤¸¥i¥H¬OªÅªº"
-
-#, c-format
-msgid "E57: %s+ operand could be empty"
-msgstr "E57: %s+ ¹Bºâ¤¸¥i¥H¬OªÅªº"
-
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: «á­±¦³¤£¥¿½Tªº¦r¤¸: %s@"
-
-#, c-format
-msgid "E58: %s{ operand could be empty"
-msgstr "E58: %s{ ¹Bºâ¤¸¥i¥H¬OªÅªº"
-
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: ¤Ó¦h½ÆÂøªº %s{...}s"
-
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: ±_ª¬ %s*"
-
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: ±_ª¬ %s%c"
-
-msgid "E63: invalid use of \\_"
-msgstr "E63: ¤£¥¿½Tªº¨Ï¥Î \\_"
-
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c ¨S¦³±µªF¦è"
-
-msgid "E65: Illegal back reference"
-msgstr "E65: ¤£¥¿½Tªº¤Ï¦V°Ñ¦Ò"
-
+#: ../regexp.c:378
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( ¤£¯à¦b¦¹¥X²{"
 
+#: ../regexp.c:379
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 et al. ¤£¯à¦b¦¹¥X²{"
 
-msgid "E68: Invalid character after \\z"
-msgstr "E68: «á­±¦³¤£¥¿½Tªº¦r¤¸: \\z"
-
+#: ../regexp.c:380
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: %s%%[ «á¯Ê¤Ö ]"
 
+#: ../regexp.c:381
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: ªÅªº %s%%[]"
 
+#: ../regexp.c:1209 ../regexp.c:1224
+msgid "E339: Pattern too long"
+msgstr "E339: ¦W¦r¤Óªø"
+
+#: ../regexp.c:1371
+msgid "E50: Too many \\z("
+msgstr "E50: ¤Ó¦h \\z("
+
+#: ../regexp.c:1378
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: ¤Ó¦h %s("
+
+#: ../regexp.c:1427
+msgid "E52: Unmatched \\z("
+msgstr "E52: µL¹ïÀ³ªº \\z("
+
+#: ../regexp.c:1637
+#, c-format
+msgid "E59: invalid character after %s@"
+msgstr "E59: «á­±¦³¤£¥¿½Tªº¦r¤¸: %s@"
+
+#: ../regexp.c:1672
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: ¤Ó¦h½ÆÂøªº %s{...}s"
+
+#: ../regexp.c:1687
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: ±_ª¬ %s*"
+
+#: ../regexp.c:1690
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: ±_ª¬ %s%c"
+
+#: ../regexp.c:1800
+msgid "E63: invalid use of \\_"
+msgstr "E63: ¤£¥¿½Tªº¨Ï¥Î \\_"
+
+#: ../regexp.c:1850
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c ¨S¦³±µªF¦è"
+
+#: ../regexp.c:1902
+msgid "E65: Illegal back reference"
+msgstr "E65: ¤£¥¿½Tªº¤Ï¦V°Ñ¦Ò"
+
+#: ../regexp.c:1943
+msgid "E68: Invalid character after \\z"
+msgstr "E68: «á­±¦³¤£¥¿½Tªº¦r¤¸: \\z"
+
+#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E71: «á­±¦³¤£¥¿½Tªº¦r¤¸: %s%%"
+
+#: ../regexp.c:2107
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: «á­±¦³¤£¥¿½Tªº¦r¤¸: %s%%"
 
+#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: »yªk¿ù»~: %s{...}"
 
-msgid "E361: Crash intercepted; regexp too complex?"
-msgstr "E361: µLªk°õ¦æ; regular expression ¤Ó½ÆÂø?"
-
-msgid "E363: pattern caused out-of-stack error"
-msgstr "E363: regular expression ³y¦¨°ïÅ|¥Î¥úªº¿ù»~"
-
+#: ../regexp.c:3805
 msgid "External submatches:\n"
 msgstr "¥~³¡²Å¦X:\n"
 
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "+--¤w fold %3ld ¦æ "
+#: ../regexp.c:7022
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr ""
 
+#: ../regexp_nfa.c:239
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr ""
+
+#: ../regexp_nfa.c:240
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr ""
+
+#: ../regexp_nfa.c:242
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr ""
+
+#: ../regexp_nfa.c:1261
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1387
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1802
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr ""
+
+#: ../regexp_nfa.c:1831
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr ""
+
+#. Can't have a multi follow a multi.
+#: ../regexp_nfa.c:1895
+msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
+msgstr ""
+
+#. Too many `('
+#: ../regexp_nfa.c:2037
+msgid "E872: (NFA regexp) Too many '('"
+msgstr ""
+
+#: ../regexp_nfa.c:2042
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: ¤Ó¦h \\z("
+
+#: ../regexp_nfa.c:2066
+msgid "E873: (NFA regexp) proper termination error"
+msgstr ""
+
+#: ../regexp_nfa.c:2599
+msgid "E874: (NFA) Could not pop the stack !"
+msgstr ""
+
+#: ../regexp_nfa.c:3298
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
+"left on stack"
+msgstr ""
+
+#: ../regexp_nfa.c:3302
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr ""
+
+#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+msgid ""
+"Could not open temporary log file for writing, displaying on stderr ... "
+msgstr ""
+
+#: ../regexp_nfa.c:4840
+#, c-format
+msgid "(NFA) COULD NOT OPEN %s !"
+msgstr ""
+
+#: ../regexp_nfa.c:6049
+#, fuzzy
+msgid "Could not open temporary log file for writing "
+msgstr "E214: §ä¤£¨ì¼g¤J¥Îªº¼È¦sÀÉ"
+
+#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " V-¨ú¥N"
 
+#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " ¨ú¥N"
 
+#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " ¤ÏÂà"
 
+#: ../screen.c:7441
 msgid " INSERT"
 msgstr " ´¡¤J"
 
+#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (´¡¤J)"
 
+#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (¨ú¥N)"
 
+#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (v-¨ú¥N)"
 
+#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Hebrew"
 
+#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Arabic"
 
+#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (»y¨¥)"
 
+#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (¶K¤W)"
 
+#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " ¿ï¨ú"
 
+#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " [¦æ] "
 
+#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " [°Ï¶ô] "
 
+#: ../screen.c:7472
 msgid " SELECT"
 msgstr " ¿ï¨ú"
 
+#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " ¿ï¨ú¦æ "
 
+#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " ¿ï¨ú°Ï¶ô"
 
+#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "°O¿ý¤¤"
 
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "¤w·j´M¨ìÀÉ®×¶}ÀY¡F¦A±qµ²§ÀÄ~Äò·j´M"
-
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "¤w·j´M¨ìÀÉ®×µ²§À¡F¦A±q¶}ÀYÄ~Äò·j´M"
-
+#: ../search.c:487
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: ¿ù»~ªº·j´M¦r¦ê: %s"
 
+#: ../search.c:832
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: ¤w·j´M¨ìÀÉ®×¶}ÀY¤´§ä¤£¨ì %s"
 
+#: ../search.c:835
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: ¤w·j´M¨ìÀÉ®×µ²§À¤´§ä¤£¨ì %s"
 
+#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: ¦b ';' «á­±À³¸Ó¦³ '?' ©Î '/'"
 
+#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (¥]¬A«e¦¸¦C¥X²Å¦X¶µ)"
 
 #. cursor at status line
+#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- ¤Þ¤JÀÉ®× "
 
+#: ../search.c:4106
 msgid "not found "
 msgstr "§ä¤£¨ì "
 
+#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "---\n"
 
+#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr "  (¤w¦C¥X)"
 
+#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr "  §ä¤£¨ì"
 
+#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "·j´M¤Þ¤JÀÉ®×: %s"
 
+#: ../search.c:4216
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "·j´M¤Þ¤JÀÉ®×: %s"
+
+#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: ¥Ø«e©Ò¦b¦æ¤¤¦³¤@¤Ç°t"
 
+#: ../search.c:4517
 msgid "All included files were found"
 msgstr "©Ò¦³¤Þ¤JÀÉ®×³£¤w§ä¨ì"
 
+#: ../search.c:4519
 msgid "No included files"
 msgstr "¨S¦³¤Þ¤JÀÉ®×"
 
+#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: §ä¤£¨ì©w¸q"
 
+#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: §ä¤£¨ì pattern"
 
+#: ../search.c:4668
+#, fuzzy
+msgid "Substitute "
+msgstr "¨ú¥N¤@²Õ "
+
+#: ../search.c:4681
+#, c-format
+msgid ""
+"\n"
+"# Last %sSearch Pattern:\n"
+"~"
+msgstr ""
+
+#: ../spell.c:951
+#, fuzzy
+msgid "E759: Format error in spell file"
+msgstr "E297: ¼È¦sÀÉ¼g¤J¿ù»~"
+
+#: ../spell.c:952
+msgid "E758: Truncated spell file"
+msgstr ""
+
+#: ../spell.c:953
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:954
+#, c-format
+msgid "Affix name too long in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:955
+#, fuzzy
+msgid "E761: Format error in affix file FOL, LOW or UPP"
+msgstr "E431: Tag ÀÉ \"%s\" ®æ¦¡¿ù»~"
+
+#: ../spell.c:957
+msgid "E762: Character in FOL, LOW or UPP is out of range"
+msgstr ""
+
+#: ../spell.c:958
+msgid "Compressing word tree..."
+msgstr ""
+
+#: ../spell.c:1951
+msgid "E756: Spell checking is not enabled"
+msgstr ""
+
+#: ../spell.c:2249
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr ""
+
+#: ../spell.c:2473
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "¨Ï¥Î¼È¦sÀÉ \"%s\""
+
+#: ../spell.c:2496
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s ¬Ý°_¨Ó¤£¹³¬O Vim ¼È¦sÀÉ"
+
+#: ../spell.c:2501
+msgid "E771: Old spell file, needs to be updated"
+msgstr ""
+
+#: ../spell.c:2504
+msgid "E772: Spell file is for newer version of Vim"
+msgstr ""
+
+#: ../spell.c:2602
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: ¼È¦sÀÉ¼g¤J¿ù»~"
+
+#: ../spell.c:3762
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "E519: ¤£¤ä´©¸Ó¿ï¶µ"
+
+#: ../spell.c:4550
+#, fuzzy, c-format
+msgid "Reading affix file %s ..."
+msgstr "·j´M tag ÀÉ®× \"%s\""
+
+#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4630 ../spell.c:6170
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr ""
+
+#: ../spell.c:4642
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4655
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4723
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4731
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+
+#: ../spell.c:4747
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4771
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4777
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4783
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4795
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4847
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4850
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: ¼ÐÅÒ(tag) \"%s\" ¦bÀÉ®× %s ¸Ì­«½Æ¥X²{¦h¦¸"
+
+#: ../spell.c:4871
+#, c-format
+msgid ""
+"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
+"line %d: %s"
+msgstr ""
+
+#: ../spell.c:4893
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:4968
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5091
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5120
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr ""
+
+#: ../spell.c:5132
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr ""
+
+#: ../spell.c:5176
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5197
+#, c-format
+msgid "Missing FOL/LOW/UPP line in %s"
+msgstr ""
+
+#: ../spell.c:5220
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr ""
+
+#: ../spell.c:5236
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "¤Ó¦h½s¿è°Ñ¼Æ"
+
+#: ../spell.c:5238
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "¤Ó¦h½s¿è°Ñ¼Æ"
+
+#: ../spell.c:5240
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr ""
+
+#: ../spell.c:5250
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr ""
+
+#: ../spell.c:5253
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr ""
+
+#: ../spell.c:5331
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5334
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5493 ../spell.c:5501
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr ""
+
+#: ../spell.c:5602
+#, fuzzy, c-format
+msgid "Reading dictionary file %s ..."
+msgstr "±½ºË¦r¨å: %s"
+
+#: ../spell.c:5611
+#, c-format
+msgid "E760: No word count in %s"
+msgstr ""
+
+#: ../spell.c:5669
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr ""
+
+#: ../spell.c:5691
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "¨C¤@¦æ³£§ä¤£¨ì: %s"
+
+#: ../spell.c:5694
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:5746
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr ""
+
+#: ../spell.c:5748
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr ""
+
+#: ../spell.c:6115
+#, fuzzy, c-format
+msgid "Reading word file %s ..."
+msgstr "±q¼Ð·Ç¿é¤JÅª¨ú..."
+
+#: ../spell.c:6155
+#, c-format
+msgid "Duplicate /encoding= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6159
+#, c-format
+msgid "/encoding= line after word ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6180
+#, c-format
+msgid "Duplicate /regions= line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6185
+#, c-format
+msgid "Too many regions in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6198
+#, c-format
+msgid "/ line ignored in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6224
+#, fuzzy, c-format
+msgid "Invalid region nr in %s line %d: %s"
+msgstr "E573: ¤£¥¿½Tªº¦øªA¾¹ id : %s"
+
+#: ../spell.c:6230
+#, c-format
+msgid "Unrecognized flags in %s line %d: %s"
+msgstr ""
+
+#: ../spell.c:6257
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr ""
+
+#: ../spell.c:6656
+#, c-format
+msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgstr ""
+
+#: ../spell.c:7340
+msgid "Reading back spell file..."
+msgstr ""
+
+#. Go through the trie of good words, soundfold each word and add it to
+#. the soundfold trie.
+#: ../spell.c:7357
+msgid "Performing soundfolding..."
+msgstr ""
+
+#: ../spell.c:7368
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr ""
+
+#: ../spell.c:7476
+#, c-format
+msgid "Total number of words: %d"
+msgstr ""
+
+#: ../spell.c:7655
+#, fuzzy, c-format
+msgid "Writing suggestion file %s ..."
+msgstr "¼g¤J viminfo ÀÉ®× \"%s\" ¤¤"
+
+#: ../spell.c:7707 ../spell.c:7927
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr ""
+
+#: ../spell.c:7820
+msgid "E751: Output file name must not have region name"
+msgstr ""
+
+#: ../spell.c:7822
+#, fuzzy
+msgid "E754: Only up to 8 regions supported"
+msgstr "E519: ¤£¤ä´©¸Ó¿ï¶µ"
+
+#: ../spell.c:7846
+#, fuzzy, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E15: ¤£¥¿½Tªº¹Bºâ¦¡: %s"
+
+#: ../spell.c:7907
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr ""
+
+#: ../spell.c:7920
+#, fuzzy, c-format
+msgid "Writing spell file %s ..."
+msgstr "¼g¤J viminfo ÀÉ®× \"%s\" ¤¤"
+
+#: ../spell.c:7925
+msgid "Done!"
+msgstr ""
+
+#: ../spell.c:8034
+#, c-format
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr ""
+
+#: ../spell.c:8074
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr ""
+
+#: ../spell.c:8117
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr ""
+
+#: ../spell.c:8381
+msgid "E763: Word characters differ between spell files"
+msgstr ""
+
+#: ../spell.c:8684
+msgid "Sorry, no suggestions"
+msgstr ""
+
+#: ../spell.c:8687
+#, fuzzy, c-format
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "¡A½d³ò¡G %<PRId64> ¦æ "
+
+#. for when 'cmdheight' > 1
+#. avoid more prompt
+#: ../spell.c:8704
+#, fuzzy, c-format
+msgid "Change \"%.*s\" to:"
+msgstr "±NÅÜ°Ê¦sÀx¦Ü \"%.*s\"?"
+
+#: ../spell.c:8737
+#, c-format
+msgid " < \"%.*s\""
+msgstr ""
+
+#: ../spell.c:8882
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: ¨S¦³«e¤@­Ó·j´M«ü¥O"
+
+#: ../spell.c:8925
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: [¿ï³æ] §ä¤£¨ì %s"
+
+#: ../spell.c:9276
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s ¬Ý°_¨Ó¤£¹³¬O Vim ¼È¦sÀÉ"
+
+#: ../spell.c:9282
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr ""
+
+#: ../spell.c:9286
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr ""
+
+#: ../spell.c:9295
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr ""
+
+#: ../spell.c:9305
+#, fuzzy, c-format
+msgid "E782: error while reading .sug file: %s"
+msgstr "E47: Åª¨ú¿ù»~ÀÉ®×¥¢±Ñ"
+
+#. This should have been checked when generating the .spl
+#. file.
+#: ../spell.c:11575
+msgid "E783: duplicate char in MAP entry"
+msgstr ""
+
+#: ../syntax.c:266
+msgid "No Syntax items defined for this buffer"
+msgstr "³o­Ó½w½Ä°Ï¨S¦³©w¸q¥ô¦ó»yªk"
+
+#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: °Ñ¼Æ¤£¥¿½T: %s"
 
+#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: µL¦¹ syntax cluster: \"%s\""
 
-msgid "No Syntax items defined for this buffer"
-msgstr "³o­Ó½w½Ä°Ï¨S¦³©w¸q¥ô¦ó»yªk"
-
+#: ../syntax.c:3433
 msgid "syncing on C-style comments"
 msgstr "C»y¨¥¦¡µù¸Ñ¦P¨B¤Æ¤¤"
 
+#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "¨S¦³¦P¨B¤Æ"
 
+#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "¦P¨B¤Æ¶}©l"
 
+#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr "¦æ¸¹¶W¥X½d³ò"
 
+#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -4199,6 +5763,7 @@ msgstr ""
 "\n"
 "--- »yªk¦P¨Bª«¥ó (Syntax sync items) ---"
 
+#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -4206,6 +5771,7 @@ msgstr ""
 "\n"
 "¦P¨B¤Æ¤¤:"
 
+#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -4213,200 +5779,274 @@ msgstr ""
 "\n"
 "--- »yªk¶µ¥Ø ---"
 
+#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: µL¦¹ syntax cluster: \"%s\""
 
+#: ../syntax.c:3497
 msgid "minimal "
 msgstr "³Ì¤p"
 
+#: ../syntax.c:3503
 msgid "maximal "
 msgstr "³Ì¤j"
 
+#: ../syntax.c:3513
 msgid "; match "
 msgstr "; ²Å¦X "
 
+#: ../syntax.c:3515
 msgid " line breaks"
 msgstr "Â_¦æ "
 
+#: ../syntax.c:4076
+msgid "E395: contains argument not accepted here"
+msgstr "E395: ¨Ï¥Î¤F¤£¥¿½Tªº°Ñ¼Æ"
+
+#: ../syntax.c:4096
+#, fuzzy
+msgid "E844: invalid cchar value"
+msgstr "E474: ¤£¥¿½Tªº°Ñ¼Æ"
+
+#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: ¨Ï¥Î¤F¤£¥¿½Tªº°Ñ¼Æ"
 
+#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: §ä¤£¨ì %s ªº region item"
 
-msgid "E395: contains argument not accepted here"
-msgstr "E395: ¨Ï¥Î¤F¤£¥¿½Tªº°Ñ¼Æ"
-
-msgid "E396: containedin argument not accepted here"
-msgstr "E396: ¨Ï¥Î¤F¤£¥¿½Tªº°Ñ¼Æ"
-
+#: ../syntax.c:4188
 msgid "E397: Filename required"
 msgstr "E397: »Ý­nÀÉ®×¦WºÙ"
 
+#: ../syntax.c:4221
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: ¤Ó¦hÀÉ¦W"
+
+#: ../syntax.c:4303
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: ¯Ê¤Ö \"=\": %s"
+
+#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: ¯Ê¤Ö \"=\": %s"
 
+#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: syntax region %s ªº¤Þ¼Æ¤Ó¤Ö"
 
+#: ../syntax.c:4870
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: µL¦¹ syntax cluster: \"%s\""
+
+#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: ¨S¦³«ü©wªºÄÝ©Ê"
 
+#. end delimiter not found
+#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: §ä¤£¨ì¤À¹j²Å¸¹: %s"
 
+#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: '%s' «á­±ªºªF¦èµLªk¿ëÃÑ"
 
+#: ../syntax.c:5120
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: »yªk¦P¨B: ³s±µ¦æ²Å¸¹³Q«ü©w¤F¨â¦¸"
 
+#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: °Ñ¼Æ¤£¥¿½T: %s"
 
+#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: ¯Ê¤Ö¬Ûµ¥²Å¸¹: %s"
 
+#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: ªÅ¥Õ°Ñ¼Æ: %s"
 
+#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s ¤£¯à¦b¦¹¥X²{"
 
+#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s ¥²¶·¬O¦Cªí¸Ìªº²Ä¤@­Ó"
 
+#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: ¤£¥¿½Tªº¸s²Õ¦WºÙ: %s"
 
+#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: ¤£¥¿½Tªº :syntax ¤l©R¥O: %s"
 
+#: ../syntax.c:5854
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+
+#: ../syntax.c:6146
+msgid "E679: recursive loop loading syncolor.vim"
+msgstr ""
+
+#: ../syntax.c:6256
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: §ä¤£¨ì highlight group: %s"
 
+#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: °Ñ¼Æ¤Ó¤Ö: \":highlight link %s\""
 
+#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: °Ñ¼Æ¹L¦h: \":highlight link %s\""
 
+#: ../syntax.c:6302
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: ¤w³]©w¸s²Õ, ©¿²¤ highlight link"
 
+#: ../syntax.c:6367
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: ¤£¸Ó¦³ªºµ¥¸¹: %s"
 
+#: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: ¯Ê¤Ö¬Ûµ¥²Å¸¹: %s"
 
+#: ../syntax.c:6418
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: ¯Ê¤Ö°Ñ¼Æ: %s"
 
+#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: ¤£¦Xªkªº­È: %s"
 
+#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: ¿ù»~ªº«e´ºÃC¦â"
 
+#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: ¿ù»~ªº­I´ºÃC¦â"
 
+#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: ¿ù»~ªºÃC¦â¦WºÙ©Î¼Æ­È: %s"
 
+#: ../syntax.c:6714
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: ²×ºÝ¾÷½X¤Óªø: %s"
 
+#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: °Ñ¼Æ¤£¥¿½T: %s"
 
+#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: ¨Ï¥Î¤F¹L¦h¬Û²§ªº°ª«G«×ÄÝ©Ê"
 
+#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: ¸s²Õ¦WºÙ¤¤¦³µLªk¦C¦Lªº¦r¤¸"
 
-#. This is an error, but since there previously was no check only
-#. * give a warning.
+#: ../syntax.c:7434
 msgid "W18: Invalid character in group name"
 msgstr "W18: ¸s²Õ¦WºÙ¤¤¦³¤£¥¿½Tªº¦r¤¸"
 
+#: ../syntax.c:7448
+msgid "E849: Too many highlight and syntax groups"
+msgstr ""
+
+#: ../tag.c:104
 msgid "E555: at bottom of tag stack"
 msgstr "E555: ¼ÐÅÒ(tag)°ïÅ|µ²§À"
 
+#: ../tag.c:105
 msgid "E556: at top of tag stack"
 msgstr "E556: ¼ÐÅÒ(tag)°ïÅ|¶}ÀY"
 
+#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: ¤w¸g¦b³Ì«e­±ªº¼ÐÅÒ(tag)¤F"
 
+#: ../tag.c:504
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: §ä¤£¨ì¼ÐÅÒ(tag): %s"
 
+#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri kind tag"
 
+#: ../tag.c:531
 msgid "file\n"
 msgstr "ÀÉ®×\n"
 
-#.
-#. * Ask to select a tag from the list.
-#. * When using ":silent" assume that <CR> was entered.
-#.
-msgid "Enter nr of choice (<CR> to abort): "
-msgstr "¿é¤J nr ©Î¿ï¾Ü (<CR> Â÷¶}): "
-
+#: ../tag.c:829
 msgid "E427: There is only one matching tag"
 msgstr "E427: ¥u¦³¦¹¶µ²Å¦X"
 
+#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: ¤v¸g¦b³Ì«á¤@­Ó²Å¦Xªº tag ¤F"
 
+#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "ÀÉ®× \"%s\" ¤£¦s¦b"
 
 #. Give an indication of the number of matching tags
+#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "§ä¨ì tag: %d/%d%s"
 
+#: ../tag.c:862
 msgid " or more"
 msgstr " ©Î§ó¦h"
 
+#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr "  ¥H¤£¦P¤j¤p¼g¨Ó¨Ï¥Î tag!"
 
+#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: ÀÉ®× \"%s\" ¤£¦s¦b"
 
 #. Highlight title
+#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -4414,59 +6054,79 @@ msgstr ""
 "\n"
 "  # ¨ì tag         ±q   ¦æ    ¦b ÀÉ®×/¤å¦r"
 
+#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "·j´M tag ÀÉ®× \"%s\""
 
-#, c-format
-msgid "E430: Tag file path truncated for %s\n"
-msgstr "E430: Tag ÀÉ®×¸ô®|³QºIÂ_¬° %s\n"
+#: ../tag.c:1545
+msgid "Ignoring long line in tags file"
+msgstr ""
 
+#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag ÀÉ \"%s\" ®æ¦¡¿ù»~"
 
+#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "¦b %<PRId64> ¦ì¤¸¤§«e"
 
+#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag ÀÉ®×¥¼±Æ§Ç: %s"
 
 #. never opened any tags file
+#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: ¨S¦³ tag ÀÉ"
 
+#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: §ä¤£¨ì tag"
 
+#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: §ä¤£¨ì tag, ¥Î²qªº!"
 
+#: ../tag.c:2797
+#, c-format
+msgid "Duplicate field name: %s"
+msgstr ""
+
+#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' µLªk¸ü¤J¡C¥i¥Îªº¤º«Ø²×ºÝ¾÷§Î¦¡¦³:"
 
+#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "¹w³]: '"
 
+#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: µLªk¶}±Ò termcap ÀÉ®×"
 
+#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: terminfo ¤¤¨S¦³²×ºÝ¾÷¸ê®Æ¶µ"
 
+#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: termcap ¤¤¨S¦³²×ºÝ¾÷¸ê®Æ¶µ"
 
+#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap ¨S¦³ \"%s\" entry"
 
+#: ../term.c:2249
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: ²×ºÝ¾÷»Ý­n \"cm\" ªº¯à¤O"
 
 #. Highlight title
+#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -4474,109 +6134,176 @@ msgstr ""
 "\n"
 "--- ²×ºÝ¾÷«öÁä ---"
 
-msgid "new shell started\n"
-msgstr "°_°Ê·s shell\n"
-
+#: ../ui.c:481
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Åª¨ú¿é¤J¿ù»~¡AÂ÷¶}¤¤...\n"
 
-#. must display the prompt
-msgid "No undo possible; continue anyway"
-msgstr "µLªkÁÙ­ì¡F½ÐÄ~Äò§V¤O"
+#. This happens when the FileChangedRO autocommand changes the
+#. * file in a way it becomes shorter.
+#: ../undo.c:379
+msgid "E881: Line count changed unexpectedly"
+msgstr ""
 
+#: ../undo.c:627
+#, fuzzy, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E212: µLªk¥H¼g¤J¼Ò¦¡¶}±Ò"
+
+#: ../undo.c:717
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr ""
+
+#: ../undo.c:1039
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr ""
+
+#: ../undo.c:1074
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr ""
+
+#: ../undo.c:1092
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr ""
+
+#: ../undo.c:1108
+msgid "Skipping undo file write, nothing to undo"
+msgstr ""
+
+#: ../undo.c:1121
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "¼g¤J viminfo ÀÉ®× \"%s\" ¤¤"
+
+#: ../undo.c:1213
+#, fuzzy, c-format
+msgid "E829: write error in undo file: %s"
+msgstr "E297: ¼È¦sÀÉ¼g¤J¿ù»~"
+
+#: ../undo.c:1280
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr ""
+
+#: ../undo.c:1292
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "Åª¨ú viminfo ÀÉ®× \"%s\"%s%s%s"
+
+#: ../undo.c:1299
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: µLªkÅª¨ú viminfo"
+
+#: ../undo.c:1308
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E484: µLªk¶}±ÒÀÉ®× %s"
+
+#: ../undo.c:1313
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: µLªk¶}±ÒÀÉ®× %s"
+
+#: ../undo.c:1328
+msgid "File contents changed, cannot use undo info"
+msgstr ""
+
+#: ../undo.c:1497
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "µ²§ô°õ¦æ %s"
+
+#: ../undo.c:1586 ../undo.c:1812
+msgid "Already at oldest change"
+msgstr ""
+
+#: ../undo.c:1597 ../undo.c:1814
+msgid "Already at newest change"
+msgstr ""
+
+#: ../undo.c:1806
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: §ä¤£¨ì²Ä %<PRId64> ­Ó½w½Ä°Ï"
+
+#: ../undo.c:1979
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: ¦æ¸¹¿ù»~"
 
-msgid "1 change"
+#: ../undo.c:2183
+#, fuzzy
+msgid "more line"
+msgstr "ÁÙ¦³¤@¦æ "
+
+#: ../undo.c:2185
+#, fuzzy
+msgid "more lines"
+msgstr "ÁÙ¦³¤@¦æ "
+
+#: ../undo.c:2187
+#, fuzzy
+msgid "line less"
+msgstr "¤Ö©ó¤@¦æ "
+
+#: ../undo.c:2189
+#, fuzzy
+msgid "fewer lines"
+msgstr "¥u³Ñ %<PRId64> ¦æ "
+
+#: ../undo.c:2193
+#, fuzzy
+msgid "change"
 msgstr "¤@¶µ§ïÅÜ"
 
-#, c-format
-msgid "%<PRId64> changes"
-msgstr "%<PRId64> ¶µ§ïÅÜ"
+#: ../undo.c:2195
+#, fuzzy
+msgid "changes"
+msgstr "¤@¶µ§ïÅÜ"
 
+#: ../undo.c:2225
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> ¦æ %s ¹L %d ¦¸"
+
+#: ../undo.c:2228
+msgid "before"
+msgstr ""
+
+#: ../undo.c:2228
+msgid "after"
+msgstr ""
+
+#: ../undo.c:2325
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "¨S¦³³o­Ó mapping ¹ïÀ³"
+
+#: ../undo.c:2330
+msgid "number changes  when               saved"
+msgstr ""
+
+#: ../undo.c:2360
+#, fuzzy, c-format
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> Äæ; "
+
+#: ../undo.c:2372
+#, fuzzy
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E407: %s ¤£¯à¦b¦¹¥X²{"
+
+#: ../undo.c:2466
 msgid "E439: undo list corrupt"
 msgstr "E439: ´_­ì¦Cªí·lÃa"
 
+#: ../undo.c:2495
 msgid "E440: undo line missing"
 msgstr "E440: §ä¤£¨ì­n undo ªº¦æ "
 
-#. Only MS VC 4.1 and earlier can do Win32s
-msgid ""
-"\n"
-"MS-Windows 16/32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 16/32 Bit ¹Ï«¬¬É­±ª©¥»"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit GUI version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit ¹Ï«¬¬É­±ª©¥»"
-
-msgid " in Win32s mode"
-msgstr "Win32s ¼Ò¦¡"
-
-msgid " with OLE support"
-msgstr "¤ä´© OLE"
-
-msgid ""
-"\n"
-"MS-Windows 32-bit console version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit console ª©¥»"
-
-msgid ""
-"\n"
-"MS-Windows 16-bit version"
-msgstr ""
-"\n"
-"MS-Windows 32 Bit console ª©¥»"
-
-msgid ""
-"\n"
-"32-bit MS-DOS version"
-msgstr ""
-"\n"
-"32 Bit MS-DOS ª©¥»"
-
-msgid ""
-"\n"
-"16-bit MS-DOS version"
-msgstr ""
-"\n"
-"16 Bit MS-DOS ª©¥»"
-
-msgid ""
-"\n"
-"MacOS X (unix) version"
-msgstr ""
-"\n"
-"MacOS X (unix) ª©¥»"
-
-msgid ""
-"\n"
-"MacOS X version"
-msgstr ""
-"\n"
-"MacOS X ª©¥»"
-
-msgid ""
-"\n"
-"MacOS version"
-msgstr ""
-"\n"
-"MacOS ª©¥»"
-
-msgid ""
-"\n"
-"RISC OS version"
-msgstr ""
-"\n"
-"RISC OS ª©¥»"
-
+#: ../version.c:600
 msgid ""
 "\n"
 "Included patches: "
@@ -4584,9 +6311,18 @@ msgstr ""
 "\n"
 "¤Þ¤J­×¥¿: "
 
+#: ../version.c:627
+#, fuzzy
+msgid ""
+"\n"
+"Extra patches: "
+msgstr "¥~³¡²Å¦X:\n"
+
+#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "­×§ïªÌ¬°"
 
+#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -4594,9 +6330,11 @@ msgstr ""
 "\n"
 "½sÄ¶"
 
+#: ../version.c:649
 msgid "by "
 msgstr "ªÌ:"
 
+#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -4604,567 +6342,1477 @@ msgstr ""
 "\n"
 "¶W±jª©¥» "
 
-msgid ""
-"\n"
-"Big version "
-msgstr ""
-"\n"
-"¤j«¬ª©¥» "
-
-msgid ""
-"\n"
-"Normal version "
-msgstr ""
-"\n"
-"¤@¯ëª©¥» "
-
-msgid ""
-"\n"
-"Small version "
-msgstr ""
-"\n"
-"Â²©öª©¥» "
-
-msgid ""
-"\n"
-"Tiny version "
-msgstr ""
-"\n"
-"ºëÂ²ª©¥» "
-
+#: ../version.c:661
 msgid "without GUI."
 msgstr "¤£¨Ï¥Î¹Ï«¬¬É­±¡C"
 
-msgid "with GTK2-GNOME GUI."
-msgstr "¨Ï¥Î GTK2-GNOME ¹Ï«¬¬É­±¡C"
-
-msgid "with GTK-GNOME GUI."
-msgstr "¨Ï¥Î GTK-GNOME ¹Ï«¬¬É­±¡C"
-
-msgid "with GTK2 GUI."
-msgstr "¨Ï¥Î GTK2 ¹Ï«¬¬É­±¡C"
-
-msgid "with GTK GUI."
-msgstr "¨Ï¥Î GTK ¹Ï«¬¬É­±¡C"
-
-msgid "with X11-Motif GUI."
-msgstr "¨Ï¥Î X11-Motif ¹Ï«¬¬É­±¡C"
-
-msgid "with X11-neXtaw GUI."
-msgstr "¨Ï¥Î X11-neXtaw ¹Ï«¬¬É­±¡C"
-
-msgid "with X11-Athena GUI."
-msgstr "¨Ï¥Î X11-Athena ¹Ï«¬¬É­±¡C"
-
-msgid "with BeOS GUI."
-msgstr "¨Ï¥Î BeOS ¹Ï«¬¬É­±¡C"
-
-msgid "with Photon GUI."
-msgstr "¨Ï¥ÎPhoton¹Ï«¬¬É­±¡C"
-
-msgid "with GUI."
-msgstr "¨Ï¥Î¹Ï«¬¬É­±¡C"
-
-msgid "with Carbon GUI."
-msgstr "¨Ï¥Î Carbon ¹Ï«¬¬É­±¡C"
-
-msgid "with Cocoa GUI."
-msgstr "¨Ï¥Î Cocoa ¹Ï«¬¬É­±¡C"
-
-msgid "with (classic) GUI."
-msgstr "¨Ï¥Î (¶Ç²Î) ¹Ï«¬¬É­±¡C"
-
+#: ../version.c:662
 msgid "  Features included (+) or not (-):\n"
 msgstr " ¥Ø«e¥i¨Ï¥Î(+)»P¤£¥i¨Ï¥Î(-)ªº¼Ò²Õ¦Cªí:\n"
 
+#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "        ¨t²Î vimrc ³]©wÀÉ: \""
 
+#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "  ¨Ï¥ÎªÌ­Ó¤H vimrc ³]©wÀÉ: \""
 
+#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "    ²Ä¤G²Õ­Ó¤H vimrc ÀÉ®×: \""
 
+#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "    ²Ä¤T²Õ­Ó¤H vimrc ÀÉ®×: \""
 
+#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "   ¨Ï¥ÎªÌ­Ó¤H exrc ³]©wÀÉ: \""
 
+#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "   ²Ä¤G²Õ¨Ï¥ÎªÌ exrc ÀÉ®×: \""
 
-msgid "  system gvimrc file: \""
-msgstr "         ¨t²Î gvimrc ÀÉ®×: \""
-
-msgid "    user gvimrc file: \""
-msgstr "     ¨Ï¥ÎªÌ­Ó¤H gvimrc ÀÉ: \""
-
-msgid "2nd user gvimrc file: \""
-msgstr "   ²Ä¤G²Õ­Ó¤H gvimrc ÀÉ®×: \""
-
-msgid "3rd user gvimrc file: \""
-msgstr "   ²Ä¤T²Õ­Ó¤H gvimrc ÀÉ®×: \""
-
-msgid "    system menu file: \""
-msgstr "           ¨t²Î¿ï³æ³]©wÀÉ: \""
-
+#: ../version.c:699
 msgid "  fall-back for $VIM: \""
 msgstr "              $VIM ¹w³]­È: \""
 
+#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "       $VIMRUNTIME ¹w³]­È: \""
 
+#: ../version.c:709
 msgid "Compilation: "
 msgstr "½sÄ¶¤è¦¡: "
 
-msgid "Compiler: "
-msgstr "½sÄ¶¾¹: "
-
+#: ../version.c:712
 msgid "Linking: "
 msgstr "Ãìµ²¤è¦¡: "
 
+#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  °£¿ùª©¥»"
 
+#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM - Vi IMproved"
 
+#: ../version.c:769
 msgid "version "
 msgstr "ª©¥»   "
 
+#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "ºûÅ@ªÌ: Bram Moolenaar et al."
 
+#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim ¬°¥i¦Û¥Ñ´²§Gªº¶}©ñ­ì©l½X³nÅé"
 
+#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "½ÐÀ°§U¯Q¤z¹Fªº¥i¼¦«Äµ£!"
 
+#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "¶i¤@¨B»¡©ú½Ð¿é¤J          :help iccf<Enter>"
 
+#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "­nÂ÷¶}½Ð¿é¤J                  :q<Enter>            "
 
+#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "½u¤W»¡©ú½Ð¿é¤J                :help<Enter>         "
 
+#: ../version.c:781
 msgid "type  :help version7<Enter>   for version info"
 msgstr "·sª©¥»¸ê°T½Ð¿é¤J              :help version7<Enter>"
 
+#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Vi ¬Û®e¼Ò¦¡"
 
+#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "¦pªG­n§¹¥þ¼ÒÀÀ¶Ç²Î Vi ½Ð¿é¤J :set nocp<Enter>"
 
+#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "¦pªG»Ý­n¹ï Vi ¬Û®e¼Ò¦¡ªº¶i¤@¨B»¡©ú½Ð¿é¤J :help cp-default<Enter>"
 
-msgid "menu  Help->Orphans           for information    "
-msgstr "¶i¤@¨B»¡©ú½Ð¿ï¨ú¿ï³æªº »²§U»¡©ú->¬@±Ï©t¨à"
-
-msgid "Running modeless, typed text is inserted"
-msgstr "°õ¦æ Modeless ¼Ò¦¡¡A¿é¤Jªº¤å¦r·|¦Û°Ê´¡¤J"
-
-msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "¿ï¨ú¿ï³æªº¡u½s¿è¡v¡u¥þ°ì³]©w¡v¡u¤Á´«´¡¤J¼Ò¦¡¡v"
-
-msgid "                              for two modes      "
-msgstr "                              ¨âºØ¼Ò¦¡           "
-
-msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-msgstr "¿ï¨ú¿ï³æªº¡u½s¿è¡v¡u¥þ°ì³]©w¡v¡u¤Á´«¶Ç²ÎVi¬Û®e¼Ò¦¡¡v"
-
-msgid "                              for Vim defaults   "
-msgstr "                              ¥H±o Vim ¹w³]­È    "
-
+#: ../version.c:827
 msgid "Sponsor Vim development!"
 msgstr "ÃÙ§U Vim ªº¶}µo»P¦¨ªø¡I"
 
+#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "¦¨¬° Vim ªºµù¥U¨Ï¥ÎªÌ¡I"
 
+#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "¸Ô²Ó»¡©ú½Ð¿é¤J          :help sponsor<Enter>"
 
+#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "¸Ô²Ó»¡©ú½Ð¿é¤J          :help register<Enter> "
 
+#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "¸Ô²Ó»¡©ú½Ð¿ï¨ú¿ï³æªº    »²§U»¡©ú->ÃÙ§U/µù¥U      "
 
-msgid "WARNING: Windows 95/98/ME detected"
-msgstr "ª`·N: °»´ú¨ì Windows 95/98/ME"
-
-msgid "type  :help windows95<Enter>  for info on this"
-msgstr "¦pªG»Ý­n¹ï Windows 95 ¤ä´©ªº§ó¦h¸ê°T½Ð¿é¤J :help windows95<Enter>"
-
-msgid "E441: There is no preview window"
-msgstr "E441: ¨S¦³¹wÄýµøµ¡"
-
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: ¤£¯à¦P®É¤À³Îµøµ¡¬°¥ª¤W©M¥k¤U¨¤"
-
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: ¦³¨ä¥¦¤À³Îµøµ¡®ÉµLªk±ÛÂà"
-
-msgid "E444: Cannot close last window"
-msgstr "E444: ¤£¯àÃö³¬³Ì«á¤@­Óµøµ¡"
-
+#: ../window.c:119
 msgid "Already only one window"
 msgstr "¤w¸g¥u³Ñ¤@­Óµøµ¡¤F"
 
+#: ../window.c:224
+msgid "E441: There is no preview window"
+msgstr "E441: ¨S¦³¹wÄýµøµ¡"
+
+#: ../window.c:559
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: ¤£¯à¦P®É¤À³Îµøµ¡¬°¥ª¤W©M¥k¤U¨¤"
+
+#: ../window.c:1228
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: ¦³¨ä¥¦¤À³Îµøµ¡®ÉµLªk±ÛÂà"
+
+#: ../window.c:1803
+msgid "E444: Cannot close last window"
+msgstr "E444: ¤£¯àÃö³¬³Ì«á¤@­Óµøµ¡"
+
+#: ../window.c:1810
+#, fuzzy
+msgid "E813: Cannot close autocmd window"
+msgstr "E444: ¤£¯àÃö³¬³Ì«á¤@­Óµøµ¡"
+
+#: ../window.c:1814
+#, fuzzy
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E444: ¤£¯àÃö³¬³Ì«á¤@­Óµøµ¡"
+
+#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: ¨ä¥¦µøµ¡¦³§ó°Ê¸ê®Æ"
 
+#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: ´å¼Ð³B¨S¦³ÀÉ¦W"
 
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: ¦b¸ô®|¤¤§ä¤£¨ìÀÉ®× \"%s\""
+#~ msgid "[Error List]"
+#~ msgstr "[¿ù»~¦Cªí]"
 
-#, c-format
-msgid "E370: Could not load library %s"
-msgstr "E370: µLªk­«·s¸ü¤Jµ{¦¡®w %s"
+#~ msgid "[No File]"
+#~ msgstr "[¥¼©R¦W]"
 
-msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "©êºp, ¦¹©R¥OµLªk¨Ï¥Î. ­ì¦]: µLªk¸ü¤J Perl µ{¦¡®w(Library)"
+#~ msgid "Patch file"
+#~ msgstr "Patch ÀÉ®×"
 
-msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-msgstr "E299: ¦b sandbox ¤¤µL Safe ¼Ò²Õ®ÉµLªk°õ¦æ Perl"
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: ¥¼©w¸qªºÅÜ¼Æ: \"%s\""
 
-msgid "Edit with &multiple Vims"
-msgstr "¨Ï¥Î¦h­Ó Vim session ½s¿è(&M)"
+#~ msgid ""
+#~ "&OK\n"
+#~ "&Cancel"
+#~ msgstr ""
+#~ "½T©w(&O)\n"
+#~ "¨ú®ø(&C)"
 
-msgid "Edit with single &Vim"
-msgstr "¥u¨Ï¥Î¦P¤@­Ó Vim session ½s¿è(&V)"
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: ¨S¦³»P Vim Server «Ø¥ß³s½u"
 
-msgid "&Diff with Vim"
-msgstr "¨Ï¥Î Vim ¨Ó¤ñ¸û(&Diff)"
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: µLªkÅª¨ú¦øªA¾¹ªº¦^À³"
 
-msgid "Edit with &Vim"
-msgstr "¨Ï¥Î Vim ½s¿è¦¹ÀÉ(&V)"
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: µLªk¶Ç°e¨ì client"
 
-#. Now concatenate
-msgid "Edit with existing Vim - &"
-msgstr "¨Ï¥Î°õ¦æ¤¤ªº Vim session ½s¿è - &"
+#~ msgid "E241: Unable to send to %s"
+#~ msgstr "E241: µLªk¶Ç°e¨ì %s"
 
-msgid "Edits the selected file(s) with Vim"
-msgstr "¨Ï¥Î Vim ½s¿è¤w¿ï¨úªºÀÉ®×"
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: ¨ç¦¡ %s ©|¥¼©w¸q"
 
-msgid "Error creating process: Check if gvim is in your path!"
-msgstr "µLªk°õ¦æµ{¦¡: ½ÐÀË¬d gvim ¦³¨S¦³¦b§Aªº PATH ÅÜ¼Æ¸Ì!"
+#~ msgid "Save As"
+#~ msgstr "¥t¦s·sÀÉ"
 
-msgid "gvimext.dll error"
-msgstr "gvimext.dll ¿ù»~"
+#~ msgid "Edit File"
+#~ msgstr "½s¿èÀÉ®×"
 
-msgid "Path length too long!"
-msgstr "¸ô®|ªø«×¤Óªø!"
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (§ä¤£¨ì) "
 
-msgid "--No lines in buffer--"
-msgstr "--½w½Ä°ÏµL¸ê®Æ--"
+#~ msgid "Source Vim script"
+#~ msgstr "°õ¦æ Vim script"
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-msgid "E470: Command aborted"
-msgstr "E470: ©R¥O³Q±j¨î¤¤Â_°õ¦æ "
+#~ msgid "Edit File in new window"
+#~ msgstr "¦b·sµøµ¡½s¿èÀÉ®×"
 
-msgid "E471: Argument required"
-msgstr "E471: »Ý­n«ü¥O°Ñ¼Æ"
+#~ msgid "Append File"
+#~ msgstr "ªþ¥[ÀÉ®×"
 
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ «á­±À³¸Ó¦³ / ? ©Î &"
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "µøµ¡¦ì¸m: X %d, Y %d"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: ¤£¯à¦b©R¥O¦Cµøµ¡¤¤¨Ï¥Î¡C<CR>°õ¦æ¡ACTRL-C Â÷¶}"
+#~ msgid "Save Redirection"
+#~ msgstr "Àx¦s Redirection"
 
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: exrc/vimrc ¸Ìªº«ü¥OµLªk°õ¦æ "
+#~ msgid "Save View"
+#~ msgstr "Àx¦s View"
 
-msgid "E171: Missing :endif"
-msgstr "E171: ¯Ê¤Ö :endif"
+#~ msgid "Save Session"
+#~ msgstr "Àx¦s Session"
 
-msgid "E600: Missing :endtry"
-msgstr "E600: ¯Ê¤Ö :endtry"
+#~ msgid "Save Setup"
+#~ msgstr "Àx¦s³]©w"
 
-msgid "E170: Missing :endwhile"
-msgstr "E170: ¯Ê¤Ö :endwhile"
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: ¥»ª©¥»µL½Æ¦X¦r¤¸(digraph)"
 
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile ¯Ê¤Ö¹ïÀ³ªº :while"
+#~ msgid "[NL found]"
+#~ msgstr "[§ä¨ìNL]"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: ÀÉ®×¤w¸g¦s¦b (¥i¥Î ! ±j¨î¨ú¥N)"
+#~ msgid "[crypted]"
+#~ msgstr "[¤w¥[±K]"
 
-msgid "E472: Command failed"
-msgstr "E472: ©R¥O°õ¦æ¥¢±Ñ"
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "Âà´«¿ù»~"
 
-#, c-format
-msgid "E234: Unknown fontset: %s"
-msgstr "E234: ¤£¥¿½Tªº¦r¤¸¶° (Fontset): %s"
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans ¤£¯à¼g¥X¥¼­×§ïªº½w½Ä°Ï"
 
-#, c-format
-msgid "E235: Unknown font: %s"
-msgstr "E235: ¤£¥¿½Tªº¦r«¬¦WºÙ: %s"
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "³¡¥÷¤º®eµLªk¼g¤J Netbeans ½w½Ä°Ï"
 
-#, c-format
-msgid "E236: Font \"%s\" is not fixed-width"
-msgstr "E236: \"%s\" ¤£¬O©T©w¼e«×¦r«¬"
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resource fork ·|®ø¥¢ (½Ð¨Ï¥Î ! ±j¨î°õ¦æ)"
 
-msgid "E473: Internal error"
-msgstr "E473: ¤º³¡¿ù»~"
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: µLªk±Ò°Ê¹Ï«¬¬É­±"
 
-msgid "Interrupted"
-msgstr "¤w¤¤Â_"
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: µLªkÅª¨úÀÉ®× \"%s\""
 
-msgid "E14: Invalid address"
-msgstr "E14: ¤£¥¿½Tªº¦ì§}"
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: µLªk±Ò°Ê¹Ï«¬¬É­±¡A§ä¤£¨ì¥i¥Îªº¦r«¬"
 
-msgid "E474: Invalid argument"
-msgstr "E474: ¤£¥¿½Tªº°Ñ¼Æ"
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: ¤£¥¿½Tªº 'guifontwide'"
 
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: ¤£¥¿½Tªº°Ñ¼Æ: %s"
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' ªº­È¤£¥¿½T"
 
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: ¤£¥¿½Tªº¹Bºâ¦¡: %s"
+#~ msgid "E254: Cannot allocate color %s"
+#~ msgstr "E254: ¤£¯à°t¸mÃC¦â %s"
 
-msgid "E16: Invalid range"
-msgstr "E16: ¤£¥¿½Tªº½d³ò"
+#~ msgid "<cannot open> "
+#~ msgstr "<¤£¯à¶}±Ò>"
 
-msgid "E476: Invalid command"
-msgstr "E476: ¤£¥¿½Tªº©R¥O"
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: ¤£¯à¨Ï¥Î %s ¦r«¬"
 
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" ¬O¥Ø¿ý"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: µLªk¦^¨ì¥Ø«e¥Ø¿ý"
 
-msgid "E18: Unexpected characters before '='"
-msgstr "E18: '=' «e­±¥X²{¤F¿ù»~ªº¦r¤¸"
+#~ msgid "Pathname:"
+#~ msgstr "¸ô®|:"
 
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: ©I¥s¨ç¦¡®w \"%s\"() ¥¢±Ñ"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: µLªk¨ú±o¥Ø«e¥Ø¿ý"
 
-#, c-format
-msgid "E448: Could not load library function %s"
-msgstr "E448: µLªk¸ü¤Jµ{¦¡®wªº¨ç¦¡ %s"
+#~ msgid "OK"
+#~ msgstr "½T©w"
 
-msgid "E19: Mark has invalid line number"
-msgstr "E19: ¼Ð°Oªº¦æ¸¹¿ù»~"
+#~ msgid "Cancel"
+#~ msgstr "¨ú®ø"
 
-msgid "E20: Mark not set"
-msgstr "E20: ¨S¦³³]©w¼Ð°O"
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "±²°Ê¶b: ¤£¯à³]©w thumb pixmap ªº¦ì¸m"
 
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: ¦]¬° 'modifiable' ¿ï¶µ¬OÃö³¬ªº¡A©Ò¥H¤£¯à­×§ï"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim ¹ï¸Ü²°"
 
-msgid "E22: Scripts nested too deep"
-msgstr "E22: ±_ª¬»¼°j©I¥s¤Ó¦h¼h"
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: ¤£¯à¹ï°T®§»P callback «Ø¥ß BallonEval"
 
-msgid "E23: No alternate file"
-msgstr "E23: ¨S¦³´À¥NªºÀÉ®×"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim ¹ï¸Ü²°..."
 
-msgid "E24: No such abbreviation"
-msgstr "E24: ¨S¦³³o­Ó abbreviation ¹ïÀ³"
+#~ msgid "Input _Methods"
+#~ msgstr "¿é¤Jªk"
 
-msgid "E477: No ! allowed"
-msgstr "E477: ¤£¥i¨Ï¥Î '!'"
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - ´M§ä»P¨ú¥N..."
 
-msgid "E25: GUI cannot be used: Not enabled at compile time"
-msgstr "E25: ¦]¬°½sÄ¶®É¨S¦³¥[¤J¹Ï«¬¬É­±ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î¹Ï«¬¬É­±"
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - ´M§ä..."
 
-msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-msgstr "E26: ¦]¬°½sÄ¶®É¨S¦³¥[¤J Hebrew ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î Hebrew\n"
+#~ msgid "Find what:"
+#~ msgstr "·j´M:"
 
-msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-msgstr "E27: ¦]¬°½sÄ¶®É¨S¦³¥[¤J Farsi ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î Farsi\n"
+#~ msgid "Replace with:"
+#~ msgstr "¨ú¥N¬°:"
 
-msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-msgstr "E800: ¦]¬°½sÄ¶®É¨S¦³¥[¤J Arabic ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î\n"
+#~ msgid "Match whole word only"
+#~ msgstr "¥u·j´M§¹¥þ¬Û¦Pªº¦r"
 
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: ¨S¦³¦W¬° '%s' ªº highlight group"
+#~ msgid "Match case"
+#~ msgstr "²Å¦X¤j¤p¼g"
 
-msgid "E29: No inserted text yet"
-msgstr "E29: ÁÙ¨S¦³´¡¤J¤å¦r¹L"
+#~ msgid "Direction"
+#~ msgstr "¤è¦V"
 
-msgid "E30: No previous command line"
-msgstr "E30: ¨S¦³«e¤@¶µ©R¥O"
+#~ msgid "Up"
+#~ msgstr "¦V¤W"
 
-msgid "E31: No such mapping"
-msgstr "E31: ¨S¦³³o­Ó mapping ¹ïÀ³"
+#~ msgid "Down"
+#~ msgstr "¦V¤U"
 
-msgid "E479: No match"
-msgstr "E479: §ä¤£¨ì"
+#~ msgid "Find Next"
+#~ msgstr "§ä¤U¤@­Ó"
 
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: §ä¤£¨ì: %s"
+#~ msgid "Replace"
+#~ msgstr "¨ú¥N"
 
-msgid "E32: No file name"
-msgstr "E32: ¨S¦³ÀÉ¦W"
+#~ msgid "Replace All"
+#~ msgstr "¨ú¥N¥þ³¡"
 
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: ¨S¦³«e¤@­Ó·j´M/¨ú¥Nªº©R¥O"
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: ¥Ñ Session ºÞ²z­û¦¬¨ì \"die\" ­n¨D\n"
 
-msgid "E34: No previous command"
-msgstr "E34: ¨S¦³«e¤@­Ó©R¥O"
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: ¥Dµøµ¡Äê±¼\n"
 
-msgid "E35: No previous regular expression"
-msgstr "E35: ¨S¦³«e¤@­Ó·j´M«ü¥O"
+#~ msgid "Font Selection"
+#~ msgstr "¦r«¬¿ï¾Ü"
 
-msgid "E481: No range allowed"
-msgstr "E481: ¤£¥i¨Ï¥Î½d³ò«ü¥O"
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "¨Ï¥Î CUT_BUFFER0 ¨Ó¨ú¥NªÅ¿ï¾Ü"
 
-msgid "E36: Not enough room"
-msgstr "E36: ¨S¦³¨¬°÷ªºªÅ¶¡"
+#~ msgid "Filter"
+#~ msgstr "¹LÂo¾¹"
 
-#, c-format
-msgid "E247: no registered server named \"%s\""
-msgstr "E247: ¨S¦³µù¥U¬° \"%s\" ªº¦øªA¾¹"
+#~ msgid "Directories"
+#~ msgstr "¥Ø¿ý"
 
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: ¤£¯à«Ø¥ßÀÉ®× %s"
+#~ msgid "Help"
+#~ msgstr "»²§U»¡©ú"
 
-msgid "E483: Can't get temp file name"
-msgstr "E483: µLªk±oª¾¼È¦sÀÉ¦W"
+#~ msgid "Files"
+#~ msgstr "ÀÉ®×"
 
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: µLªk¶}±ÒÀÉ®× %s"
+#~ msgid "Selection"
+#~ msgstr "¿ï¾Ü"
 
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: µLªkÅª¨úÀÉ®× %s"
+#~ msgid "Undo"
+#~ msgstr "´_­ì"
 
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: ¤w§ó§ï¹LÀÉ®×¦ý©|¥¼¦sÀÉ (¥i¥Î ! ±j¨î°õ¦æ)"
+#~ msgid "E671: Cannot find window title \"%s\""
+#~ msgstr "E671: §ä¤£¨ì¼ÐÃD¬° \"%s\" ªºµøµ¡"
 
-msgid "E38: Null argument"
-msgstr "E38: ªÅªº (Null) °Ñ¼Æ"
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: ¤£¤ä´©°Ñ¼Æ \"-%s\"¡C½Ð¥Î OLE ª©¥»¡C"
 
-msgid "E39: Number expected"
-msgstr "E39: À³¸Ó­n¦³¼Æ¦r"
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: µLªk¦b MDI µ{¦¡¤¤¶}±Òµøµ¡"
 
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: µLªk¶}±Ò¿ù»~ÀÉ®× %s"
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "·j´M¦r¦ê (¨Ï¥Î '\\\\' ¨Óªí¥Ü '\\')"
 
-msgid "E233: cannot open display"
-msgstr "E233: <¤£¯à¶}±Ò X Server DISPLAY>"
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "·j´M¤Î¨ú¥N¦r¦ê (¨Ï¥Î '\\\\' ¨Óªí¥Ü '\\')"
 
-msgid "E41: Out of memory!"
-msgstr "E41: °O¾ÐÅé¤£¨¬!"
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: µLªk°t¸m color map ¶µ¥Ø¡A¦³¨ÇÃC¦â¬Ý°_¨Ó·|©Ç©Çªº"
 
-msgid "Pattern not found"
-msgstr "§ä¤£¨ì"
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Fontset %s ¨S¦³³]©w¥¿½Tªº¦r«¬¥H¨ÑÅã¥Ü³o¨Ç¦r¤¸¶°:"
 
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: §ä¤£¨ì %s"
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: ¦r«¬¶°(Fontset)¦WºÙ: %s"
 
-msgid "E487: Argument must be positive"
-msgstr "E487: °Ñ¼ÆÀ³¸Ó¬O¥¿¼Æ"
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "'%s' ¤£¬O©T©w¼e«×¦r«¬"
 
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: µLªk¦^¨ì«e¤@­Ó¥Ø¿ý"
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: ¦r«¬¶°(Fontset)¦WºÙ: %s\n"
 
-msgid "E42: No Errors"
-msgstr "E42: ¨S¦³¿ù»~"
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
-msgid "E43: Damaged match string"
-msgstr "E43: ²Å¦X¦r¦ê¦³°ÝÃD"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-msgid "E44: Corrupted regexp program"
-msgstr "E44: regexp ¦³°ÝÃD"
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "¦r«¬%<PRId64> ¼e«×¤£¬O ¦r«¬0 ªº¨â­¿\n"
 
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: ¦³³]©w 'readonly' ¿ï¶µ(°ßÅª) (¥i¥Î ! ±j¨î°õ¦æ)"
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "¦r«¬0ªº¼e«×¡G%<PRId64>\n"
 
-#, c-format
-msgid "E46: Cannot set read-only variable \"%s\""
-msgstr "E46: µLªk³]©w°ßÅªÅÜ¼Æ \"%s\""
+#~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "¦r«¬1¼e«×: %<PRId64>\n"
+#~ "\n"
 
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Åª¨ú¿ù»~ÀÉ®×¥¢±Ñ"
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata ¿ù»~"
 
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: ¤£¯à¦b sandbox ¸Ì¥X²{"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat ¿ù»~"
 
-msgid "E523: Not allowed here"
-msgstr "E523: ³o¸Ì¤£¥i¨Ï¥Î"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: µLªk¶}±Ò cscope ¸ê®Æ®w %s"
 
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: ¤£¤ä´©³]©w¿Ã¹õ¼Ò¦¡"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: µLªk¨ú±o cscope ¸ê®Æ®w¸ê°T"
 
-msgid "E49: Invalid scroll size"
-msgstr "E49: ¿ù»~ªº±²°Ê¤j¤p"
+#~ msgid "E569: maximum number of cscope connections reached"
+#~ msgstr "E569: ¤w¹F¨ì cscope ³Ì¤j³s½u¼Æ¥Ø"
 
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'E71: ¿ï¶µ 'shell' ¥¼³]©w"
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr "E263: ©êºp¡A³o­Ó©R¥OµLªk¨Ï¥Î¡APython µ{¦¡®w¨S¦³¸ü¤J¡C"
 
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: µLªkÅª¨ú sign data!"
+#~ msgid "E659: Cannot invoke Python recursively"
+#~ msgstr "E659: µLªk»¼°j°õ¦æ Python "
 
-msgid "E72: Close error on swap file"
-msgstr "E72: ¼È¦sÀÉÃö³¬¿ù»~"
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "µLªk§R°£ OutputObject ÄÝ©Ê"
 
-msgid "E73: tag stack empty"
-msgstr "E73: ¼ÐÅÒ°ïÅ|¤wªÅ"
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace ¥²»Ý¬O¾ã¼Æ"
 
-msgid "E74: Command too complex"
-msgstr "E74: ©R¥O¤Ó½ÆÂø"
+#~ msgid "invalid attribute"
+#~ msgstr "¤£¥¿½TªºÄÝ©Ê"
 
-msgid "E75: Name too long"
-msgstr "E75: ¦W¦r¤Óªø"
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() »Ý­n string list ·í°Ñ¼Æ"
 
-msgid "E76: Too many ["
-msgstr "E76: ¤Ó¦h ["
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: µLªkªì©l I/O ª«¥ó"
 
-msgid "E77: Too many file names"
-msgstr "E77: ¤Ó¦hÀÉ¦W"
+#~ msgid "invalid expression"
+#~ msgstr "¤£¥¿½Tªº¹Bºâ¦¡"
 
-msgid "E488: Trailing characters"
-msgstr "E488: §A¿é¤J¤F¦h¾lªº¦r¤¸"
+#~ msgid "expressions disabled at compile time"
+#~ msgstr "¦]¬°½sÄ¶®É¨S¦³¥[¤J¹Bºâ¦¡(expression)ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î¹Bºâ¦¡"
 
-msgid "E78: Unknown mark"
-msgstr "E78: µLªk¿ìÃÑªº¼Ð°O"
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "¸Õ¹Ï¨Ï¥Î¤w³Q§R°£ªº buffer"
 
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: µLªk®i¶}¸U¥Î¦r¤¸"
+#~ msgid "line number out of range"
+#~ msgstr "¦æ¸¹¶W¥X½d³ò"
 
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' ¤£¯à¤ñ 'winminheight' §ó¤Ö"
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffer ª«¥ó (¤w§R°£): %8lX>"
 
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' ¤£¯à¤ñ 'winminwidth' §ó¤Ö"
+#~ msgid "invalid mark name"
+#~ msgstr "¼Ð°O¦WºÙ¤£¥¿½T"
 
-msgid "E80: Error while writing"
-msgstr "E80: ¼g¤J¿ù»~"
+#~ msgid "no such buffer"
+#~ msgstr "µL¦¹ buffer"
 
-msgid "Zero count"
-msgstr "¼Æ¨ì¹s (?)"
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "¸Õ¹Ï¨Ï¥Î¤w³Q§R°£ªºµøµ¡"
 
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> ¤£¯à¦b script ¥»¤å¥~¨Ï¥Î."
+#~ msgid "readonly attribute"
+#~ msgstr "°ßÅªÄÝ©Ê"
 
-msgid "E449: Invalid expression received"
-msgstr "E449: ¦¬¨ì¤£¥¿½Tªº¹Bºâ¦¡"
+#~ msgid "cursor position outside buffer"
+#~ msgstr "´å¼Ð©w¦ì¦b½w½Ä°Ï¤§¥~"
 
-msgid "E463: Region is guarded, cannot modify"
-msgstr "E463: °Ï°ì³Q«OÅ@¡AµLªk­×§ï"
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<µøµ¡ª«¥ó(¤w§R°£): %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<µøµ¡ª«¥ó(¥¼ª¾): %.8lX>"
+
+#~ msgid "<window %d>"
+#~ msgstr "<µøµ¡ %d>"
+
+#~ msgid "no such window"
+#~ msgstr "µL¦¹µøµ¡"
+
+#~ msgid "cannot save undo information"
+#~ msgstr "µLªkÀx¦s´_­ì¸ê°T"
+
+#~ msgid "cannot delete line"
+#~ msgstr "¤£¯à§R°£¦¹¦æ "
+
+#~ msgid "cannot replace line"
+#~ msgstr "¤£¯à´À¥N¦¹¦æ "
+
+#~ msgid "cannot insert line"
+#~ msgstr "¤£¯à´À¥N´¡¤J¦¹¦æ "
+
+#~ msgid "string cannot contain newlines"
+#~ msgstr "¦r¦êµLªk¥]§t·s¦æ "
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: ¦¹©R¥OµLªk¨Ï¥Î¡AµLªk¸ü¤J Ruby µ{¦¡®w(Library)"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: ¥¼ª¾ªº longjmp status %d"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "¤Á´«¹ê§@/©w¸q"
+
+#~ msgid "Show base class of"
+#~ msgstr "Åã¥Ü base class of:"
+
+#~ msgid "Show overridden member function"
+#~ msgstr "Åã¥Ü³Q override ªº member function"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "Åª¨ú: ±qÀÉ®×"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "Åª¨ú: ±qª«¥ó"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "Åª¨ú: ±q©Ò¦³ project"
+
+#~ msgid "Retrieve"
+#~ msgstr "Åª¨ú"
+
+#~ msgid "Show source of"
+#~ msgstr "Åã¥Ü­ì©l½X: "
+
+#~ msgid "Find symbol"
+#~ msgstr "·j´M symbol"
+
+#~ msgid "Browse class"
+#~ msgstr "ÂsÄý class"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "Åã¥Ü¶¥¼h¦¡ªº class"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "Åã¥Ü restricted ¶¥¼h¦¡ªº class"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref °Ñ¦Ò¨ì"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref ³Q½Ö°Ñ¦Ò:"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref ¦³"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref ³Q½Ö¨Ï¥Î:"
+
+#~ msgid "Show docu of"
+#~ msgstr "Åã¥Ü¤å¥ó: "
+
+#~ msgid "Generate docu for"
+#~ msgstr "²£¥Í¤å¥ó: "
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "µLªk³s½u¨ì SNiFF+¡C½ÐÀË¬dÀô¹ÒÅÜ¼Æ ($PATH ¸Ì¥²»Ý¥i¥H§ä¨ì sniffemacs)\n"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: Åª¨ú¿ù»~. ¨ú®ø³s½u"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ ¥Ø«e"
+
+#~ msgid "not "
+#~ msgstr "¥¼"
+
+#~ msgid "connected"
+#~ msgstr "³s½u¤¤"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: ¤£¥¿½Tªº SNiff+ ©I¥s: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: ³s½u¨ì SNiFF+ ¥¢±Ñ"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: ¥¼³s½u¨ì SNiFF+"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: ¼g¤J¿ù»~¡Cµ²§ô³s½u"
+
+#~ msgid "not implemented yet"
+#~ msgstr "©|¥¼¹ê§@"
+
+#~ msgid "unknown option"
+#~ msgstr "¤£¥¿½Tªº¿ï¶µ"
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "¤£¯à³]©w¦æ "
+
+#~ msgid "mark not set"
+#~ msgstr "¨S¦³³]©w¼Ð°O"
+
+#~ msgid "row %d column %d"
+#~ msgstr "¦C %d ¦æ %d"
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "¤£¯à´¡¤J©Îªþ¥[¦¹¦æ "
+
+#~ msgid "unknown flag: "
+#~ msgstr "¿ù»~ªººX¼Ð: "
+
+#~ msgid "unknown vimOption"
+#~ msgstr "¤£¥¿½Tªº VIM ¿ï¶µ"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "Áä½L¤¤Â_"
+
+#~ msgid "vim error"
+#~ msgstr "vim ¿ù»~"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "µLªk«Ø¥ß½w½Ä°Ï/µøµ¡©R¥O: ª«¥ó±N·|³Q§R°£"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "µLªkµù¥U callback ©R¥O: ½w½Ä°Ï/µøµ¡¤w¸g³Q§R°£¤F"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E280: TCL ÄY­«¿ù»~: reflist Äê±¼¤F!? ½Ð³ø§iµ¹ to vim-dev@vim.org"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "µLªkµù¥U callback ©R¥O: §ä¤£¨ì½w½Ä°Ï/µøµ¡"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: ¦¹©R¥OµLªk¨Ï¥Î, ¦]¬°µLªk¸ü¤J Tcl µ{¦¡®w(Library)"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
+#~ "org"
+#~ msgstr "E281: TCL ¿ù»~: µ²§ô½X¤£¬O¾ã¼Æ!? ½Ð³ø§iµ¹ to vim-dev@vim.org"
+
+#~ msgid "cannot get line"
+#~ msgstr "¤£¯à¨ú±o¦¹¦æ "
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "µLªkµù¥U©R¥O¦øªA¾¹¦WºÙ"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: µLªk°e¥X©R¥O¨ì¥Øªº¦aµ{¦¡"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM ªº registry ³]©w¶µ¦³»~¡C¤w§R°£¡C"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "±zªº Vim ½sÄ¶®É¨S¦³¥[¤J diff ªº¯à¤O"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\tµù¥U gvim ¨ì OLE"
+
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\t¨ú®ø OLE ¤¤ªº gvim µù¥U"
+
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\t¨Ï¥Î¹Ï§Î¬É­± (¦P \"gvim\")"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  ©Î  --nofork\t«e´º: °_©l¹Ï§Î¬É­±®É¤£ fork"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose µ¥¯Å"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t¤£¨Ï¥Î newcli ¨Ó¶}±Òµøµ¡"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\t¨Ï¥Î <device> °µ¿é¥X¤J"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t¨Ï¥Î <gvimrc> ¨ú¥N¥ô¦ó .gvimrc"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t½s¿è½s½X¹LªºÀÉ®×"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t±N vim »P«ü©wªº X-server ³s½u"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\t¤£­n³s½u¨ì X Server"
+
+#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+#~ msgstr "--remote <files>\t½s¿è Vim ¦øªA¾¹¤Wªº <files> «áÂ÷¶}"
+
+#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-silent <files>  ¬Û¦P¡A¦ý¨S¦³¦øªA¾¹®É¤£Äµ§i"
+
+#~ msgid ""
+#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
+#~ msgstr "--remote-wait <files>  ¦P --remote, ¦ý·|µ¥­ÔÀÉ®×§¹¦¨½s¿è"
+
+#~ msgid ""
+#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
+#~ msgstr "--remote-wait-silent <files>  ¬Û¦P¡A¦ý¨S¦øªA¾¹®É¤£Äµ§i"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t°e¥X <keys> ¨ì Vim ¦øªA¾¹¨ÃÂ÷¶}"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t¦b¦øªA¾¹¤W°õ¦æ <expr> ¨Ã¦L¥Xµ²ªG"
+
+#~ msgid "--serverlist\t\tList available Vim server names and exit"
+#~ msgstr "--serverlist\t\t¦C¥X¥i¥Îªº Vim ¦øªA¾¹¦WºÙ¨ÃÂ÷¶}"
+
+#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
+#~ msgstr "--servername <name>\t°e¦Ü/¦¨¬° Vim ¦øªA¾¹ <name>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim »{±oªº°Ñ¼Æ (Motif ª©):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim »{±oªº°Ñ¼Æ (neXtaw ª©):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim »{±oªº°Ñ¼Æ (Athena ª©):\n"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t¦bµøµ¡ <display> °õ¦æ vim"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t±Ò°Ê«á¹Ï¥Ü¤Æ(iconified)"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\tÅª¨ú Resource ®É§â vim ªº¦WºÙµø¬° <name>"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (©|¥¼¹ê§@)\n"
+
+#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
+#~ msgstr "-background <color>\t³]©w <color> ¬°­I´º¦â (¤]¥i¥Î -bg)"
+
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t³]©w <color> ¬°¤@¯ë¤å¦rÃC¦â (¤]¥i¥Î -fg)"
+
+#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+#~ msgstr "-font <font>\t¨Ï¥Î <font> ¬°¤@¯ë¦r«¬ (¤]¥i¥Î -fn)"
+
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t¨Ï¥Î <font> ¬°²ÊÅé¦r«¬"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t¨Ï¥Î <font> ¬°±×Åé¦r«¬"
+
+#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+#~ msgstr "-geometry <geom>\t¨Ï¥Î<geom>¬°°_©l¦ì¸m (¤]¥i¥Î -geom)"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t¨Ï¥Î¼e«×¬° <width> ªºÃä®Ø (¤]¥i¥Î -bw)"
+
+#~ msgid ""
+#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+#~ msgstr "-scrollbarwidth <width>  ³]©w±²°Ê¶b¼e«×¬° <width> (¤]¥i¥Î -sw)"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t³]©w¿ï³æ¦Cªº°ª«×¬° <height> (¤]¥i¥Î -mh)"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t¨Ï¥Î¤Ï¬ÛÅã¥Ü (¤]¥i¥Î -rv)"
+
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t¤£¨Ï¥Î¤Ï¬ÛÅã¥Ü (¤]¥i¥Î +rv)"
+
+#~ msgid "-xrm <resource>\tSet the specified resource"
+#~ msgstr "-xrm <resource>\t³]©w«ü©wªº resource"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim »{±oªº°Ñ¼Æ (RISC OS ª©):\n"
+
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <number>\tµøµ¡ªì©l¤Æ¼e«×"
+
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <number>\tµøµ¡ªì©l¤Æ°ª«×"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim »{±oªº°Ñ¼Æ (GTK+ ª©):\n"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t¦b <display> °õ¦æ vim (¤]¥i¥Î --display)"
+
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t³]©w¿W¯Sªº¨¤¦â(role)¥H°Ï¤À¥Dµøµ¡"
+
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t¦b¥t¤@­Ó GTK widget ¤º¶}±Ò Vim"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\t¦b¤÷µ{¦¡¤¤¶}±Ò Vim"
+
+#~ msgid "No display"
+#~ msgstr "µLÅã¥Ü"
+
+#~ msgid ": Send failed.\n"
+#~ msgstr ": ¶Ç°e¥¢±Ñ¡C\n"
+
+#~ msgid ": Send failed. Trying to execute locally\n"
+#~ msgstr ": °e¥X¥¢±Ñ¡C¸Õ¹Ï¦b¥»¦a°õ¦æ\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "¤w½s¿è %d/%d ­ÓÀÉ®×"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "µL Display: µLªk¶Ç°e¹Bºâ¦¡¡C\n"
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": µLªk¶Ç°e¹Bºâ¦¡¡C\n"
+
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: ¤£¥¿½Tªº codepage"
+
+#~ msgid "E285: Failed to create input context"
+#~ msgstr "E285: µLªk«Ø¥ß input context"
+
+#~ msgid "E286: Failed to open input method"
+#~ msgstr "E286: µLªk¶}±Ò¿é¤Jªk"
+
+#~ msgid "E287: Warning: Could not set destroy callback to IM"
+#~ msgstr "E287: Äµ§i: µLªk²¾°£ IM ªº callback"
+
+#~ msgid "E288: input method doesn't support any style"
+#~ msgstr "E288: ¿é¤Jªk¤£¤ä´©¥ô¦ó style"
+
+#~ msgid "E289: input method doesn't support my preedit type"
+#~ msgstr "E289: ¿é¤Jªk¤£¤ä´©¥ô¦ó style"
+
+#~ msgid "E290: over-the-spot style requires fontset"
+#~ msgstr "E290: over-the-spot »Ý­n¦r«¬¶°(Fontset)"
+
+#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+#~ msgstr "E291: §Aªº GTK+ ¤ñ 1.2.3 ÁÙÂÂ¡CµLªk¨Ï¥Îª¬ºA°Ï¡C"
+
+#~ msgid "E292: Input Method Server is not running"
+#~ msgstr "E292: ¨S¦³°õ¦æ¤¤ªº¿é¤JªkºÞ²zµ{¦¡(Input Method Server)"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [µLªk¦b¥»ª©¥»ªº Vim ¤W¨Ï¥Î]"
+
+#~ msgid ""
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
+#~ msgstr ""
+#~ "¥H°ßÅª¤è¦¡¶}±Ò(&O)\n"
+#~ "ª½±µ½s¿è(&E)\n"
+#~ "­×´_(&R)\n"
+#~ "Â÷¶}(&Q)\n"
+#~ "¸õ¥X(&A)\n"
+#~ "§R°£¼È¦sÀÉ(&D)"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "¤Á¤U¦¹¿ï³æ"
+
+#~ msgid "[string too long]"
+#~ msgstr "[¦¹¦æ¹Lªø]"
+
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "½Ð«ö ENTER Ä~Äò"
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: ¦V¤U/¦V¤W¤@¦æ, ªÅ¥ÕÁä/b: ¤@­¶, d/u: ¥b­¶, q: Â÷¶})"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: ¦V¤U¤@¦æ, ªÅ¥ÕÁä: ¤@­¶, d: ¥b­¶, q: Â÷¶})"
+
+#~ msgid "Save File dialog"
+#~ msgstr "¦sÀÉ"
+
+#~ msgid "Open File dialog"
+#~ msgstr "¶}ÀÉ"
+
+#~ msgid "E338: Sorry, no file browser in console mode"
+#~ msgstr "E338: ¥D±±¥x(Console)¼Ò¦¡®É¨S¦³ÀÉ®×ÂsÄý¾¹(file browser)"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: «O¯dÀÉ®×¤¤...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: µ²§ô.\n"
+
+#~ msgid "ERROR: "
+#~ msgstr "¿ù»~: "
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] ¥þ³¡ alloc-freed %<PRIu64>-%<PRIu64>, ¨Ï¥Î¤¤ %<PRIu64>, peak ¨Ï¥Î "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[©I¥s] ¥þ³¡ re/malloc(): %<PRIu64>, ¥þ³¡ free()': %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "E340: Line is becoming too long"
+#~ msgstr "E340: ¦¹¦æ¹Lªø"
+
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
+#~ msgstr "E341: ¤º³¡¿ù»~: lalloc(%<PRId64>, )"
+
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: ¤£¥¿½Tªº·Æ¹«§Îª¬"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "¿é¤J±K½X: "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "½Ð¦A¿é¤J¤@¦¸: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "¨â¦¸¿é¤J±K½X¤£¬Û¦P!"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "µLªk³s±µ¨ì Netbeans #2"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "µLªk³s±µ¨ì Netbeans"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans ³s½u¸ê°TÀÉ®×: \"%s\" ¦s¨ú¼Ò¦¡¤£¥¿½T"
+
+#~ msgid "read from Netbeans socket"
+#~ msgstr "¥Ñ Netbeans socket Åª¨ú"
+
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: ½w½Ä°Ï %<PRId64> »P NetBeans ªº³s½u¤w¤¤Â_"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "ÄÀ©ñ %<PRId64> ¦æ¤¤ "
+
+#~ msgid "E530: Cannot change term in GUI"
+#~ msgstr "E530: ¦b¹Ï«¬¬É­±¤¤µLªk¤Á´« term"
+
+#~ msgid "E531: Use \":gui\" to start the GUI"
+#~ msgstr "E531: ¿é¤J \":gui\" ¨Ó±Ò°Ê¹Ï§Î¬É­±"
+
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: ¦b¹Ï«¬¬É­±¤¤µLªk¤Á´« term"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: µLªk¨Ï¥Î¦r«¬¶°(Fontset)"
+
+#~ msgid "E598: Invalid fontset"
+#~ msgstr "E598: ¤£¥¿½Tªº¦r«¬¶°(Fontset)"
+
+#~ msgid "E533: can't select wide font"
+#~ msgstr "E533: µLªk¨Ï¥Î³]©wªº¤¤¤å¦r«¬(Widefont)"
+
+#~ msgid "E534: Invalid wide font"
+#~ msgstr "E534: ¤£¥¿½Tªº¦r«¬(Widefont)"
+
+#~ msgid "E538: No mouse support"
+#~ msgstr "E538: ¤£¤ä´©·Æ¹«"
+
+#~ msgid "cannot open "
+#~ msgstr "¤£¯à¶}±Ò"
+
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: µLªk¶}±Òµøµ¡!\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "»Ý­n Amigados ª©¥» 2.04 ¥H¤W\n"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "»Ý­n %s ª©¥» %<PRId64>\n"
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "µLªk¶}±Ò NIL:\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "¤£¯à«Ø¥ß "
+
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim µ²§ô¶Ç¦^­È: %d\n"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "µLªk¤Á´«¥D±±¥x(console)¼Ò¦¡ !?\n"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: ¤£¬O¥D±±¥x(console)??\n"
+
+#~ msgid "Cannot execute "
+#~ msgstr "¤£¯à°õ¦æ "
+
+#~ msgid "shell "
+#~ msgstr "shell "
+
+#~ msgid " returned\n"
+#~ msgstr " ¤wªð¦^\n"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE ¤Ó¤p"
+
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O ¿ù»~"
+
+#~ msgid "...(truncated)"
+#~ msgstr "...(¤w¤Á±¼)"
+
+#~ msgid "'columns' is not 80, cannot execute external commands"
+#~ msgstr "'columns' ¤£¬O 80, µLªk°õ¦æ¥~³¡©R¥O"
+
+#~ msgid "to %s on %s"
+#~ msgstr "¨ì %s on %s"
+
+#~ msgid "E613: Unknown printer font: %s"
+#~ msgstr "E613: ¤£¥¿½Tªº¦Lªí¾÷¦r«¬: %s"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: ¦C¦L¿ù»~: %s"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "¦C¦L¤¤: '%s'"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: ¦r¤¸¶° \"%s\" µLªk¹ïÀ³¦r«¬\"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: ¤£¥¿½Tªº¦r¤¸ '%c' ¥X²{¦b¦r«¬¦WºÙ \"%s\" ¤º"
+
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: Âù­«signal, Â÷¶}¤¤\n"
+
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: CVim: ÄdºI¨ì«H¸¹(signal) %s\n"
+
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: ÄdºI¨ì­P©Rªº«H¸¹(deadly signale)\n"
+
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "¶}±Ò X Window ¯Ó®É %<PRId64> msec"
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X ¿ù»~\n"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "´ú¸Õ X Window ¥¢±Ñ"
+
+#~ msgid "Opening the X display timed out"
+#~ msgstr "¶}±Ò X Window ¹O®É"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "¤£¯à°õ¦æ shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "¤£¯à«Ø¥ß pipe ºÞ½u\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "¤£¯à fork\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "©R¥O¤w²×µ²\n"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP ¥¢¥h ICE ³s½u"
+
+#~ msgid "Opening the X display failed"
+#~ msgstr "¶}±Ò X Window ¥¢±Ñ"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP ¥¿¦b³B²z¦Û§ÚÀx¦s­n¨D"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "¶}±Ò XSMP ³s½u¤¤"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE ³s½uºÊ¬Ý¥¢±Ñ"
+
+#~ msgid "XSMP SmcOpenConnection failed: %s"
+#~ msgstr "XSMP SmcOpenConnection ¥¢±Ñ: %s"
+
+#~ msgid "At line"
+#~ msgstr "¦b¦æ¸¹ "
+
+#~ msgid "Could not allocate memory for command line."
+#~ msgstr "µLªk¬°©R¥O¦C°t¸m°O¾ÐÅé¡C"
+
+#~ msgid "VIM Error"
+#~ msgstr "VIM ¿ù»~"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "µLªk¸ü¤J vim32.dll¡I"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "¤£¯à­×¥¿¨ç¦¡«ü¼Ð¨ì DLL!"
+
+#~ msgid "shell returned %d"
+#~ msgstr "Shell ¶Ç¦^­È %d"
+
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: ÄdºI¨ì %s \n"
+
+#~ msgid "close"
+#~ msgstr "Ãö³¬"
+
+#~ msgid "logoff"
+#~ msgstr "µn¥X"
+
+#~ msgid "shutdown"
+#~ msgstr "Ãö¾÷"
+
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: §ä¤£¨ì©R¥O"
+
+#~ msgid ""
+#~ "VIMRUN.EXE not found in your $PATH.\n"
+#~ "External commands will not pause after completion.\n"
+#~ "See  :help win32-vimrun  for more information."
+#~ msgstr ""
+#~ "¦b§Aªº $PATH ¤¤§ä¤£¨ì VIMRUN.EXE.\n"
+#~ "¥~³¡©R¥O°õ¦æ§¹²¦«á±N¤£·|¼È°±.\n"
+#~ "¶i¤@¨B»¡©ú½Ð°õ¦æ :help win32-vimrun "
+
+#~ msgid "Vim Warning"
+#~ msgstr "Vim Äµ§i"
+
+#~ msgid "E56: %s* operand could be empty"
+#~ msgstr "E56: %s* ¹Bºâ¤¸¥i¥H¬OªÅªº"
+
+#~ msgid "E57: %s+ operand could be empty"
+#~ msgstr "E57: %s+ ¹Bºâ¤¸¥i¥H¬OªÅªº"
+
+#~ msgid "E58: %s{ operand could be empty"
+#~ msgstr "E58: %s{ ¹Bºâ¤¸¥i¥H¬OªÅªº"
+
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr "E361: µLªk°õ¦æ; regular expression ¤Ó½ÆÂø?"
+
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: regular expression ³y¦¨°ïÅ|¥Î¥úªº¿ù»~"
+
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: ¨Ï¥Î¤F¤£¥¿½Tªº°Ñ¼Æ"
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "¿é¤J nr ©Î¿ï¾Ü (<CR> Â÷¶}): "
+
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag ÀÉ®×¸ô®|³QºIÂ_¬° %s\n"
+
+#~ msgid "new shell started\n"
+#~ msgstr "°_°Ê·s shell\n"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "µLªkÁÙ­ì¡F½ÐÄ~Äò§V¤O"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 Bit ¹Ï«¬¬É­±ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit ¹Ï«¬¬É­±ª©¥»"
+
+#~ msgid " in Win32s mode"
+#~ msgstr "Win32s ¼Ò¦¡"
+
+#~ msgid " with OLE support"
+#~ msgstr "¤ä´© OLE"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit console ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit console ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 Bit MS-DOS ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 Bit MS-DOS ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS ª©¥»"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "¤j«¬ª©¥» "
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "¤@¯ëª©¥» "
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "Â²©öª©¥» "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "ºëÂ²ª©¥» "
+
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "¨Ï¥Î GTK2-GNOME ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "¨Ï¥Î GTK-GNOME ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with GTK2 GUI."
+#~ msgstr "¨Ï¥Î GTK2 ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with GTK GUI."
+#~ msgstr "¨Ï¥Î GTK ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "¨Ï¥Î X11-Motif ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "¨Ï¥Î X11-neXtaw ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "¨Ï¥Î X11-Athena ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with BeOS GUI."
+#~ msgstr "¨Ï¥Î BeOS ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with Photon GUI."
+#~ msgstr "¨Ï¥ÎPhoton¹Ï«¬¬É­±¡C"
+
+#~ msgid "with GUI."
+#~ msgstr "¨Ï¥Î¹Ï«¬¬É­±¡C"
+
+#~ msgid "with Carbon GUI."
+#~ msgstr "¨Ï¥Î Carbon ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with Cocoa GUI."
+#~ msgstr "¨Ï¥Î Cocoa ¹Ï«¬¬É­±¡C"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "¨Ï¥Î (¶Ç²Î) ¹Ï«¬¬É­±¡C"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "         ¨t²Î gvimrc ÀÉ®×: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "     ¨Ï¥ÎªÌ­Ó¤H gvimrc ÀÉ: \""
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "   ²Ä¤G²Õ­Ó¤H gvimrc ÀÉ®×: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "   ²Ä¤T²Õ­Ó¤H gvimrc ÀÉ®×: \""
+
+#~ msgid "    system menu file: \""
+#~ msgstr "           ¨t²Î¿ï³æ³]©wÀÉ: \""
+
+#~ msgid "Compiler: "
+#~ msgstr "½sÄ¶¾¹: "
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "¶i¤@¨B»¡©ú½Ð¿ï¨ú¿ï³æªº »²§U»¡©ú->¬@±Ï©t¨à"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "°õ¦æ Modeless ¼Ò¦¡¡A¿é¤Jªº¤å¦r·|¦Û°Ê´¡¤J"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "¿ï¨ú¿ï³æªº¡u½s¿è¡v¡u¥þ°ì³]©w¡v¡u¤Á´«´¡¤J¼Ò¦¡¡v"
+
+#~ msgid "                              for two modes      "
+#~ msgstr "                              ¨âºØ¼Ò¦¡           "
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "¿ï¨ú¿ï³æªº¡u½s¿è¡v¡u¥þ°ì³]©w¡v¡u¤Á´«¶Ç²ÎVi¬Û®e¼Ò¦¡¡v"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              ¥H±o Vim ¹w³]­È    "
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "ª`·N: °»´ú¨ì Windows 95/98/ME"
+
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "¦pªG»Ý­n¹ï Windows 95 ¤ä´©ªº§ó¦h¸ê°T½Ð¿é¤J :help windows95<Enter>"
+
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: µLªk­«·s¸ü¤Jµ{¦¡®w %s"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "©êºp, ¦¹©R¥OµLªk¨Ï¥Î. ­ì¦]: µLªk¸ü¤J Perl µ{¦¡®w(Library)"
+
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: ¦b sandbox ¤¤µL Safe ¼Ò²Õ®ÉµLªk°õ¦æ Perl"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "¨Ï¥Î¦h­Ó Vim session ½s¿è(&M)"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "¥u¨Ï¥Î¦P¤@­Ó Vim session ½s¿è(&V)"
+
+#~ msgid "&Diff with Vim"
+#~ msgstr "¨Ï¥Î Vim ¨Ó¤ñ¸û(&Diff)"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "¨Ï¥Î Vim ½s¿è¦¹ÀÉ(&V)"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "¨Ï¥Î°õ¦æ¤¤ªº Vim session ½s¿è - &"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "¨Ï¥Î Vim ½s¿è¤w¿ï¨úªºÀÉ®×"
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "µLªk°õ¦æµ{¦¡: ½ÐÀË¬d gvim ¦³¨S¦³¦b§Aªº PATH ÅÜ¼Æ¸Ì!"
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll ¿ù»~"
+
+#~ msgid "Path length too long!"
+#~ msgstr "¸ô®|ªø«×¤Óªø!"
+
+#~ msgid "E234: Unknown fontset: %s"
+#~ msgstr "E234: ¤£¥¿½Tªº¦r¤¸¶° (Fontset): %s"
+
+#~ msgid "E235: Unknown font: %s"
+#~ msgstr "E235: ¤£¥¿½Tªº¦r«¬¦WºÙ: %s"
+
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: µLªk¸ü¤Jµ{¦¡®wªº¨ç¦¡ %s"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: ¦]¬°½sÄ¶®É¨S¦³¥[¤J Hebrew ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î Hebrew\n"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: ¦]¬°½sÄ¶®É¨S¦³¥[¤J Farsi ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î Farsi\n"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: ¦]¬°½sÄ¶®É¨S¦³¥[¤J Arabic ªºµ{¦¡½X¡A©Ò¥HµLªk¨Ï¥Î\n"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: ¨S¦³µù¥U¬° \"%s\" ªº¦øªA¾¹"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: <¤£¯à¶}±Ò X Server DISPLAY>"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: °Ï°ì³Q«OÅ@¡AµLªk­×§ï"
 
 #~ msgid "E565: error reading cscope connection %d"
 #~ msgstr "E565: Åª¨ú cscope ³s½u %d ¿ù»~"
@@ -5205,26 +7853,14 @@ msgstr "E463: °Ï°ì³Q«OÅ@¡AµLªk­×§ï"
 #~ msgid "Run Macro"
 #~ msgstr "°õ¦æ¥¨¶°"
 
-#~ msgid "E221: 'commentstring' is empty"
-#~ msgstr "E221: ¿ï¶µ 'commentstring' ¥¼³]©w"
-
 #~ msgid "E242: Color name not recognized: %s"
 #~ msgstr "E242: %s ¬°µLªkÃÑ§OªºÃC¦â¦WºÙ"
-
-#~ msgid "E242: Missing color: %s"
-#~ msgstr "E242: §ä¤£¨ìÃC¦â: %s"
 
 #~ msgid "error reading cscope connection %d"
 #~ msgstr "Åª¨ú cscope ³s½u %d ®É¿ù»~"
 
 #~ msgid "E249: couldn't read VIM instance registry property"
 #~ msgstr "E249: µLªkÅª¨ú VIM ªº registry ³]©w¶µ"
-
-#~ msgid "Can't open file %s"
-#~ msgstr "µLªk¶}±ÒÀÉ®× %s"
-
-#~ msgid "Unable to send reply"
-#~ msgstr "µLªk¶Ç°e¦^À³°T®§"
 
 #~ msgid "E241: Unable to send to Vim server"
 #~ msgstr "E241: µLªk¶Ç°e¨ì Vim ¦øªA¾¹"


### PR DESCRIPTION
The existing build process to deal with localization files was broken.

This fixes found errors, and once build is running again, updates po files to sync them to current code (3a68a4861adcc950cdbde709d4841f8ea0c52b12).

I was also going to remove all unused messages (in #~ lines at the end of po files), cause a lot of code has been removed and that woud certainly produce a good number of deleted lines.
But then I learnt that gettext uses all known message/translation pairs (even unused ones) to give a tentative translation for new messages until proper translation is done.
For many languages, it can be a long time until a native-speaker gives a proper translation, and something is better than nothing, so I decided to keep existing unused messages, as they certainly add value to the project, and reducing lines in non-source-code files is much less valuable than the extra translation precision.
