### PR TITLE
[RFC] coverity: add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ env:
     # via the "travis encrypt" command using the project repo's public key
     - secure: "QEz92NyItkzQu52kCFD928jEwUYnA2OIgSyeNrp+Y3gm5rOmSZerY8hGiXyNZxocap9+qIPCapRRYU3ZYKWZPeucWMLN3aIjxAFdhugKbnmNYE1jFugb6b8N3SxiX/3206NHXlYaz0OZhh6OBAFmPUXamJC8OrWVgPNPo7wv4UQ="
   matrix:
-    - TRAVIS_BUILD_TYPE=clang/asan
-    - TRAVIS_BUILD_TYPE=gcc/ia32
-    - TRAVIS_BUILD_TYPE=gcc/unittest
-    - TRAVIS_BUILD_TYPE=clint
-    - TRAVIS_BUILD_TYPE=api/python
+    # - TRAVIS_BUILD_TYPE=clang/asan
+    # - TRAVIS_BUILD_TYPE=gcc/ia32
+    # - TRAVIS_BUILD_TYPE=gcc/unittest
+    # - TRAVIS_BUILD_TYPE=clint
+    # - TRAVIS_BUILD_TYPE=api/python
     - TRAVIS_BUILD_TYPE=coverity
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - TRAVIS_BUILD_TYPE=gcc/unittest
     - TRAVIS_BUILD_TYPE=clint
     - TRAVIS_BUILD_TYPE=api/python
+    - TRAVIS_BUILD_TYPE=coverity
 addons:
   coverity_scan:
     project:
@@ -20,7 +21,7 @@ addons:
 
     # Commands to prepare for build_command
     # ** likely specific to your build **
-    build_command_prepend: make build/.ran-cmake
+    build_command_prepend: make cmake
 
     # The command that will be added as an argument to "cov-build" to compile your project for analysis,
     # ** likely specific to your build **

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,34 @@
 language: c
 env:
-  - TRAVIS_BUILD_TYPE=clang/asan
-  - TRAVIS_BUILD_TYPE=gcc/ia32
-  - TRAVIS_BUILD_TYPE=gcc/unittest
-  - TRAVIS_BUILD_TYPE=clint
-  - TRAVIS_BUILD_TYPE=api/python
+  global:
+    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+    # via the "travis encrypt" command using the project repo's public key
+    - secure: "QEz92NyItkzQu52kCFD928jEwUYnA2OIgSyeNrp+Y3gm5rOmSZerY8hGiXyNZxocap9+qIPCapRRYU3ZYKWZPeucWMLN3aIjxAFdhugKbnmNYE1jFugb6b8N3SxiX/3206NHXlYaz0OZhh6OBAFmPUXamJC8OrWVgPNPo7wv4UQ="
+  matrix:
+    - TRAVIS_BUILD_TYPE=clang/asan
+    - TRAVIS_BUILD_TYPE=gcc/ia32
+    - TRAVIS_BUILD_TYPE=gcc/unittest
+    - TRAVIS_BUILD_TYPE=clint
+    - TRAVIS_BUILD_TYPE=api/python
+addons:
+  coverity_scan:
+    project:
+      name: neovim/neovim
+      version: 1.0
+      description: The main Neovim project
+    notification_email: coverity@aktau.be
+
+    # Commands to prepare for build_command
+    # ** likely specific to your build **
+    build_command_prepend: make build/.ran-cmake
+
+    # The command that will be added as an argument to "cov-build" to compile your project for analysis,
+    # ** likely specific to your build **
+    build_command: make nvim
+
+    # Pattern to match selecting branches that will run analysis. We recommend leaving this set to 'coverity_scan'.
+    # Take care in resource usage, and consider the build frequency allowances per
+    #   https://scan.coverity.com/faq#frequency
+    branch_pattern: .*
 script:
   - ./scripts/travis.sh

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Build Status](https://travis-ci.org/neovim/neovim.svg?branch=master)](https://travis-ci.org/neovim/neovim)
 [![Stories in Ready](https://badge.waffle.io/neovim/neovim.png?label=ready)](https://waffle.io/neovim/neovim)
 [![Coverage Status](https://coveralls.io/repos/neovim/neovim/badge.png)](https://coveralls.io/r/neovim/neovim)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/2227/badge.svg)](https://scan.coverity.com/projects/2227)
 
 Neovim is a project that seeks to aggressively refactor Vim in order to:
 
@@ -38,7 +39,7 @@ For lots more details, see
 - Reworked out-of-memory handling resulting in greatly simplified control flow
 - Merged 50+ upstream patches (nearly caught up with upstream)
 - [Removed](https://github.com/neovim/neovim/pull/635) 8.3 filename support
-- [Changed](https://github.com/neovim/neovim/pull/574) to portable format 
+- [Changed](https://github.com/neovim/neovim/pull/574) to portable format
   specifiers (first step towards building on Windows)
 
 [unifdef]: http://freecode.com/projects/unifdef

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+set -e
+
+# Environment check
+echo -e "\033[33;1mNote: PROJECT_NAME and COVERITY_SCAN_TOKEN are available on Project Settings page on scan.coverity.com\033[0m"
+[ -z "$COVERITY_SCAN_PROJECT_NAME" ] && echo "ERROR: COVERITY_SCAN_PROJECT_NAME must be set" && exit 1
+#[ -z "$COVERITY_SCAN_NOTIFICATION_EMAIL" ] && echo "ERROR: COVERITY_SCAN_NOTIFICATION_EMAIL must be set" && exit 1
+[ -z "$COVERITY_SCAN_BRANCH_PATTERN" ] && echo "ERROR: COVERITY_SCAN_BRANCH_PATTERN must be set" && exit 1
+[ -z "$COVERITY_SCAN_BUILD_COMMAND" ] && echo "ERROR: COVERITY_SCAN_BUILD_COMMAND must be set" && exit 1
+[ -z "$COVERITY_SCAN_TOKEN" ] && echo "ERROR: COVERITY_SCAN_TOKEN must be set" && exit 1
+
+PLATFORM=`uname`
+TOOL_ARCHIVE=/tmp/cov-analysis-${PLATFORM}.tgz
+TOOL_URL=https://scan.coverity.com/download/${PLATFORM}
+TOOL_BASE=/tmp/coverity-scan-analysis
+UPLOAD_URL="https://scan.coverity.com/builds"
+SCAN_URL="https://scan.coverity.com"
+
+# Do not run on pull requests
+if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then
+  echo -e "\033[33;1mINFO: Skipping Coverity Analysis: branch is a pull request.\033[0m"
+  exit 0
+fi
+
+# Verify this branch should run
+IS_COVERITY_SCAN_BRANCH=`ruby -e "puts '${TRAVIS_BRANCH}' =~ /\\A$COVERITY_SCAN_BRANCH_PATTERN\\z/ ? 1 : 0"`
+if [ "$IS_COVERITY_SCAN_BRANCH" = "1" ]; then
+  echo -e "\033[33;1mCoverity Scan configured to run on branch ${TRAVIS_BRANCH}\033[0m"
+else
+  echo -e "\033[33;1mCoverity Scan NOT configured to run on branch ${TRAVIS_BRANCH}\033[0m"
+  exit 1
+fi
+
+# Verify upload is permitted
+AUTH_RES=`curl -s --form project="$COVERITY_SCAN_PROJECT_NAME" --form token="$COVERITY_SCAN_TOKEN" $SCAN_URL/api/upload_permitted`
+if [ "$AUTH_RES" = "Access denied" ]; then
+  echo -e "\033[33;1mCoverity Scan API access denied. Check COVERITY_SCAN_PROJECT_NAME and COVERITY_SCAN_TOKEN.\033[0m"
+  exit 1
+else
+  AUTH=`echo $AUTH_RES | ruby -e "require 'rubygems'; require 'json'; puts JSON[STDIN.read]['upload_permitted']"`
+  if [ "$AUTH" = "true" ]; then
+    echo -e "\033[33;1mCoverity Scan analysis authorized per quota.\033[0m"
+  else
+    WHEN=`echo $AUTH_RES | ruby -e "require 'rubygems'; require 'json'; puts JSON[STDIN.read]['next_upload_permitted_at']"`
+    echo -e "\033[33;1mCoverity Scan analysis NOT authorized until $WHEN.\033[0m"
+    exit 1
+  fi
+fi
+
+if [ ! -d $TOOL_BASE ]; then
+  # Download Coverity Scan Analysis Tool
+  if [ ! -e $TOOL_ARCHIVE ]; then
+    echo -e "\033[33;1mDownloading Coverity Scan Analysis Tool...\033[0m"
+    wget -nv -O $TOOL_ARCHIVE $TOOL_URL --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN"
+  fi
+
+  # Extract Coverity Scan Analysis Tool
+  echo -e "\033[33;1mExtracting Coverity Scan Analysis Tool...\033[0m"
+  mkdir -p $TOOL_BASE
+  pushd $TOOL_BASE
+  tar xzf $TOOL_ARCHIVE
+  popd
+fi
+
+TOOL_DIR=`find $TOOL_BASE -type d -name 'cov-analysis*'`
+export PATH=$TOOL_DIR/bin:$PATH
+
+# Build
+echo -e "\033[33;1mRunning Coverity Scan Analysis Tool...\033[0m"
+COV_BUILD_OPTIONS=""
+#COV_BUILD_OPTIONS="--return-emit-failures 8 --parse-error-threshold 85"
+RESULTS_DIR="cov-int"
+eval "${COVERITY_SCAN_BUILD_COMMAND_PREPEND}"
+COVERITY_UNSUPPORTED=1 cov-build --dir $RESULTS_DIR $COV_BUILD_OPTIONS $COVERITY_SCAN_BUILD_COMMAND
+cov-import-scm --dir $RESULTS_DIR --scm git --log $RESULTS_DIR/scm_log.txt 2>&1
+
+# Upload results
+echo -e "\033[33;1mTarring Coverity Scan Analysis results...\033[0m"
+RESULTS_ARCHIVE=analysis-results.tgz
+tar czf $RESULTS_ARCHIVE $RESULTS_DIR
+SHA=`git rev-parse --short HEAD`
+
+echo -e "\033[33;1mUploading Coverity Scan Analysis results...\033[0m"
+curl \
+  --progress-bar \
+  --form project=$COVERITY_SCAN_PROJECT_NAME \
+  --form token=$COVERITY_SCAN_TOKEN \
+  --form email=$COVERITY_SCAN_NOTIFICATION_EMAIL \
+  --form file=@$RESULTS_ARCHIVE \
+  --form version=$SHA \
+  --form description="Travis CI build" \
+  $UPLOAD_URL
+

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# printout environment
+printenv
+
 # Environment check
 echo -e "\033[33;1mNote: PROJECT_NAME and COVERITY_SCAN_TOKEN are available on Project Settings page on scan.coverity.com\033[0m"
 [ -z "$COVERITY_SCAN_PROJECT_NAME" ] && echo "ERROR: COVERITY_SCAN_PROJECT_NAME must be set" && exit 1

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -18,10 +18,10 @@ UPLOAD_URL="https://scan.coverity.com/builds"
 SCAN_URL="https://scan.coverity.com"
 
 # Do not run on pull requests
-if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then
-  echo -e "\033[33;1mINFO: Skipping Coverity Analysis: branch is a pull request.\033[0m"
-  exit 0
-fi
+# if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then
+#   echo -e "\033[33;1mINFO: Skipping Coverity Analysis: branch is a pull request.\033[0m"
+#   exit 0
+# fi
 
 # Verify this branch should run
 IS_COVERITY_SCAN_BRANCH=`ruby -e "puts '${TRAVIS_BRANCH}' =~ /\\A$COVERITY_SCAN_BRANCH_PATTERN\\z/ ? 1 : 0"`

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -8,7 +8,7 @@ printenv
 # Environment check
 echo -e "\033[33;1mNote: PROJECT_NAME and COVERITY_SCAN_TOKEN are available on Project Settings page on scan.coverity.com\033[0m"
 [ -z "$COVERITY_SCAN_PROJECT_NAME" ] && echo "ERROR: COVERITY_SCAN_PROJECT_NAME must be set" && exit 1
-#[ -z "$COVERITY_SCAN_NOTIFICATION_EMAIL" ] && echo "ERROR: COVERITY_SCAN_NOTIFICATION_EMAIL must be set" && exit 1
+[ -z "$COVERITY_SCAN_NOTIFICATION_EMAIL" ] && echo "ERROR: COVERITY_SCAN_NOTIFICATION_EMAIL must be set" && exit 1
 [ -z "$COVERITY_SCAN_BRANCH_PATTERN" ] && echo "ERROR: COVERITY_SCAN_BRANCH_PATTERN must be set" && exit 1
 [ -z "$COVERITY_SCAN_BUILD_COMMAND" ] && echo "ERROR: COVERITY_SCAN_BUILD_COMMAND must be set" && exit 1
 [ -z "$COVERITY_SCAN_TOKEN" ] && echo "ERROR: COVERITY_SCAN_TOKEN must be set" && exit 1

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -78,6 +78,11 @@ fi
 MAKE_CMD="make -j2"
 
 if [ "$TRAVIS_BUILD_TYPE" = "coverity" ]; then
+    export COVERITY_SCAN_PROJECT_NAME="neovim/neovim"
+    export COVERITY_SCAN_BRANCH_PATTERN='.*'
+    export COVERITY_SCAN_BUILD_COMMAND_PREPEND='make cmake'
+    export COVERITY_SCAN_BUILD_COMMAND='make nvim'
+    export COVERITY_SCAN_TOKEN='haNQZKw9AL6c0b5F7x3fww'
     ./scripts/coverity.sh
     exit $?
 elif [ "$TRAVIS_BUILD_TYPE" = "clang/asan" ]; then

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -80,7 +80,7 @@ MAKE_CMD="make -j2"
 if [ "$TRAVIS_BUILD_TYPE" = "coverity" ]; then
     export COVERITY_SCAN_PROJECT_NAME="neovim/neovim"
     export COVERITY_SCAN_BRANCH_PATTERN='.*'
-    export COVERITY_SCAN_BUILD_COMMAND_PREPEND='make cmake'
+    export COVERITY_SCAN_BUILD_COMMAND_PREPEND='make deps'
     export COVERITY_SCAN_BUILD_COMMAND='make nvim'
     export COVERITY_SCAN_TOKEN='haNQZKw9AL6c0b5F7x3fww'
     ./scripts/coverity.sh

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -79,6 +79,7 @@ MAKE_CMD="make -j2"
 
 if [ "$TRAVIS_BUILD_TYPE" = "coverity" ]; then
     export COVERITY_SCAN_PROJECT_NAME="neovim/neovim"
+    export COVERITY_SCAN_NOTIFICATION_EMAIL="coverity@aktau.be"
     export COVERITY_SCAN_BRANCH_PATTERN='.*'
     export COVERITY_SCAN_BUILD_COMMAND_PREPEND='make deps'
     export COVERITY_SCAN_BUILD_COMMAND='make nvim'

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -77,7 +77,10 @@ fi
 # for more information.
 MAKE_CMD="make -j2"
 
-if [ "$TRAVIS_BUILD_TYPE" = "clang/asan" ]; then
+if [ "$TRAVIS_BUILD_TYPE" = "coverity" ]; then
+    ./scripts/coverity.sh
+    exit $?
+elif [ "$TRAVIS_BUILD_TYPE" = "clang/asan" ]; then
 	if [ ! -d /usr/local/clang-3.4 ]; then
 		echo "Downloading clang 3.4..."
 		sudo sh <<- "EOF"


### PR DESCRIPTION
Install the coverity addon in Travis-CI. To save resources (coverity scan has an allowance), the static analysis will only be run when pushing to a specific repository.

This is the recommended approach by Coverity itself, but it is not ideal in my opinion. It would be better to just run it once every X days (or once every week) if there has been a new PR. An idea would be to run the coverity addon when pushing to the **master** branch but to let it exit early when it's not "monday" for example. I'm most likely going to need some help with this @jszakmeister and @tarruda. (pinging you guys because you seem to have most experience interacting with travis).

Please do not merge this to master, when this is ready/works, I'll do it myself depending on the route we take with respect to different branches or on master directly.

Also ping @justinmk.
- Documentation: https://scan.coverity.com/travis_ci
- An example project using travis/coverity integration: https://github.com/daksheshvyas/MyHelloWorld
- The script that the coverity addon apparantly executes on travis: https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh
