### PR TITLE
[RFC] Add ${API_SOURCES} to `nvim-test` cmake target.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ if(NOT DEFINED ENV{SKIP_EXEC})
 endif()
 
 if(NOT DEFINED ENV{SKIP_UNITTEST})
-  add_library(nvim-test MODULE EXCLUDE_FROM_ALL ${NEOVIM_SOURCES} ${OS_SOURCES})
+  add_library(nvim-test MODULE EXCLUDE_FROM_ALL ${NEOVIM_SOURCES}
+    ${OS_SOURCES} ${API_SOURCES})
   target_link_libraries(nvim-test ${NVIM_LINK_LIBRARIES})
 endif()


### PR DESCRIPTION
This should fix the build on OS X as reported in #720. I wonder why travis didn't caught this error(I can't reproduce on ubuntu 12.04). @elmart can you try this branch?
