### PR TITLE
[RDY] Don't allow undefined references under Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ else()
   set(DEBUG 0)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-undefined")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
+endif()
+
 option(USE_GCOV "Enable gcov support" OFF)
 
 if(USE_GCOV)


### PR DESCRIPTION
Many other systems expect this already, but on Linux the default is to
allow them.  Let's turn that off.
