### PR TITLE
[RFC] Tell cmake to use `-isystem` third-party includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,17 @@ include_directories("${PROJECT_SOURCE_DIR}/src")
 include(CheckLibraryExists)
 
 find_package(LibUV REQUIRED)
-include_directories(${LIBUV_INCLUDE_DIRS})
+include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 
 find_package(Msgpack REQUIRED)
-include_directories(${MSGPACK_INCLUDE_DIRS})
+include_directories(SYSTEM ${MSGPACK_INCLUDE_DIRS})
 
 find_package(LuaJit REQUIRED)
-include_directories(${LUAJIT_INCLUDE_DIRS})
+include_directories(SYSTEM ${LUAJIT_INCLUDE_DIRS})
 
 find_package(LibIntl)
 if(LibIntl_FOUND)
-  include_directories(${LibIntl_INCLUDE_DIR})
+  include_directories(SYSTEM ${LibIntl_INCLUDE_DIR})
 endif()
 
 # Determine platform's threading library. Set CMAKE_THREAD_PREFER_PTHREAD


### PR DESCRIPTION
This adds the `SYSTEM` parameter to `include_directories`, which will tell cmake to use `-isystem` instead of `-I` for specifying include directories. One advantage is that GCC/clang won't emit warnings for included files that belong to dependencies(I got errors from `<msgpack.h>` when fixing msgpack_rpc.c).

@jszakmeister do you know if the `-isystem` is part of C99? If not(and we are supporting C99) then it might not  be possible to use this flag.
