### PR TITLE
[RDY] api/helpers: implement C string to String helper

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -2307,7 +2307,8 @@ def CheckBraces(filename, clean_lines, linenum, error):
                'TEST', 'TEST_F', 'MATCHER', 'MATCHER_P', 'TYPED_TEST',
                'EXCLUSIVE_LOCKS_REQUIRED', 'SHARED_LOCKS_REQUIRED',
                'LOCKS_EXCLUDED', 'INTERFACE_DEF')) or
-          Search(r'\s+=\s*$', line_prefix)):
+          Search(r'\s+=\s*$', line_prefix) or
+          Search(r'^\s*return\s*$', line_prefix)):
         match = None
 
   else:

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -108,8 +108,8 @@ StringArray buffer_get_slice(Buffer buffer,
       goto end;
     }
 
-    rv.items[i].data = xstrdup((char *)ml_get_buf(buf, (linenr_T)lnum, false));
-    rv.items[i].size = strlen(rv.items[i].data);
+    const char *bufstr = (char *) ml_get_buf(buf, (linenr_T) lnum, false);
+    rv.items[i] = cstr_to_string(bufstr);
   }
 
 end:
@@ -307,9 +307,7 @@ String buffer_get_name(Buffer buffer, Error *err)
     return rv;
   }
 
-  rv.data = xstrdup((char *)buf->b_ffname);
-  rv.size = strlen(rv.data);
-  return rv;
+  return cstr_to_string((char *)buf->b_ffname);
 }
 
 void buffer_set_name(Buffer buffer, String name, Error *err)

--- a/src/nvim/api/helpers.c
+++ b/src/nvim/api/helpers.c
@@ -339,6 +339,18 @@ tabpage_T * find_tab(Tabpage tabpage, Error *err)
   return rv;
 }
 
+String cstr_to_string(const char *str) {
+    if (str == NULL) {
+        return (String) { .data = NULL, .size = 0 };
+    }
+
+    size_t len = strlen(str);
+    return (String) {
+        .data = xmemdup(str, len),
+        .size = len
+    };
+}
+
 static bool object_to_vim(Object obj, typval_T *tv, Error *err)
 {
   tv->v_type = VAR_UNKNOWN;

--- a/src/nvim/api/helpers.h
+++ b/src/nvim/api/helpers.h
@@ -86,5 +86,12 @@ win_T * find_window(Window window, Error *err);
 /// @return the tabpage pointer
 tabpage_T * find_tab(Tabpage tabpage, Error *err);
 
+/// Copies a C string into a String (binary safe string, characters + length)
+///
+/// @param str the C string to copy
+/// @return the resulting String, if the input string was NULL, then an
+///         empty String is returned
+String cstr_to_string(const char *str);
+
 #endif  // NVIM_API_HELPERS_H
 


### PR DESCRIPTION
@tarruda as suggested by @oni-link we could use `xmemdup` there, which is faster since it avoids an extra `strlen`, and saves a whopping byte of memory ;). To save on lines I abstracted it out into a separate function.

The obvious parameter commenting is a bit annoying though, let's hope something useful flows out of it.

Reference: https://github.com/neovim/neovim/pull/727#discussion_r12768748

**UPDATE**: It appears clint is flagging a false positive here:

``` c
// clint: `src/nvim/api/helpers.c:344:  You don't need a ; after a }  [readability/braces] [4]`
return (String) { .data = NULL, .size = 0 };
```

Who knows enough of clint to make it disregard that?

And why the does it not error in the same way after https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L56? Because of the return? Because of the cast?

``` c
// why is this ok?
String rv = {.size = 0};
```
