### PR TITLE
[RFC] Map improvements

### DIFF
--- a/clint-files.txt
+++ b/clint-files.txt
@@ -2,6 +2,9 @@ src/nvim/indent.c
 src/nvim/indent.h
 src/nvim/log.c
 src/nvim/log.h
+src/nvim/map.c
+src/nvim/map.h
+src/nvim/map_defs.h
 src/nvim/os/env.c
 src/nvim/os/event.c
 src/nvim/os/event_defs.h

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CONV_SRCS
   arabic.c
   garray.c
   memory.c
+  map.c
   os/env.c
   os/event.c
   os/job.c

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -15,6 +15,15 @@
 #define uint32_t_hash kh_int_hash_func
 #define uint32_t_eq kh_int_hash_equal
 
+#if defined(ARCH_64)
+#define ptr_t_hash(key) uint64_t_hash((uint64_t)key)
+#define ptr_t_eq(a, b) uint64_t_eq((uint64_t)a, (uint64_t)b)
+#elif defined(ARCH_32)
+#define ptr_t_hash(key) uint32_t_hash((uint32_t)key)
+#define ptr_t_eq(a, b) uint32_t_eq((uint32_t)a, (uint32_t)b)
+#endif
+
+
 #define MAP_IMPL(T)                                                          \
   __KHASH_IMPL(T##_map,, T, void *, 1, T##_hash, T##_eq)                     \
                                                                              \
@@ -27,7 +36,6 @@
                                                                              \
   void map_##T##_free(Map(T) *map)                                           \
   {                                                                          \
-    kh_clear(T##_map, map->table);                                           \
     kh_destroy(T##_map, map->table);                                         \
     free(map);                                                               \
   }                                                                          \
@@ -56,11 +64,9 @@
                                                                              \
     if (!ret) {                                                              \
       rv = kh_val(map->table, k);                                            \
-      kh_del(T##_map, map->table, k);                                        \
     }                                                                        \
                                                                              \
     kh_val(map->table, k) = value;                                           \
-                                                                             \
     return rv;                                                               \
   }                                                                          \
                                                                              \
@@ -78,3 +84,4 @@
   }
 
 MAP_IMPL(cstr_t)
+MAP_IMPL(ptr_t)

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -8,15 +8,7 @@
 
 #include "nvim/lib/khash.h"
 
-typedef struct {
-  void *ptr;
-} Value;
-
-KHASH_MAP_INIT_STR(Map, Value)
-
-struct map {
-  khash_t(Map) *table;
-};
+__KHASH_IMPL(Map,, kh_cstr_t, void *, 1, kh_str_hash_func, kh_str_hash_equal)
 
 Map *map_new()
 {
@@ -40,7 +32,7 @@ void *map_get(Map *map, const char *key)
     return NULL;
   }
 
-  return kh_val(map->table, k).ptr;
+  return kh_val(map->table, k);
 }
 
 bool map_has(Map *map, const char *key)
@@ -53,15 +45,14 @@ void *map_put(Map *map, const char *key, void *value)
   int ret;
   void *rv = NULL;
   khiter_t k = kh_put(Map, map->table, key, &ret);
-  Value val = {.ptr = value};
 
   if (!ret) {
     // key present, return the current value
-    rv = kh_val(map->table, k).ptr;
+    rv = kh_val(map->table, k);
     kh_del(Map, map->table, k);
   }
 
-  kh_val(map->table, k) = val;
+  kh_val(map->table, k) = value;
 
   return rv;
 }
@@ -72,20 +63,10 @@ void *map_del(Map *map, const char *key)
   khiter_t k;
 
   if ((k = kh_get(Map, map->table, key)) != kh_end(map->table)) {
-    rv = kh_val(map->table, k).ptr;
+    rv = kh_val(map->table, k);
     kh_del(Map, map->table, k);
   }
 
   return rv;
-}
-
-void map_foreach(Map *map, key_value_cb cb)
-{
-  const char *key;
-  Value value;
-
-  kh_foreach(map->table, key, value, {
-    cb(map, (const char *)key, value.ptr);
-  });
 }
 

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -45,7 +45,7 @@ void *map_get(Map *map, const char *key)
 
 bool map_has(Map *map, const char *key)
 {
-  return map_get(map, key) != NULL;
+  return kh_get(Map, map->table, key) != kh_end(map->table);
 }
 
 void *map_put(Map *map, const char *key, void *value)

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -16,10 +16,11 @@
   void map_##T##_free(Map(T) *map);                                           \
   void *map_##T##_get(Map(T) *map, T key);                                    \
   bool map_##T##_has(Map(T) *map, T key);                                     \
-  void *map_##T##_put(Map(T) *map, T key, void *value);                       \
-  void *map_##T##_del(Map(T) *map, T key);
+  void* map_##T##_put(Map(T) *map, T key, void *value);                       \
+  void* map_##T##_del(Map(T) *map, T key);
 
 MAP_DECLS(cstr_t)
+MAP_DECLS(ptr_t)
 
 #define map_new(T) map_##T##_new
 #define map_free(T) map_##T##_free

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -53,5 +53,5 @@ void *map_del(Map *map, const char *key);
 /// @param cb A function that will be called for each key/value
 void map_foreach(Map *map, key_value_cb cb);
 
-#endif /* NVIM_MAP_H */
+#endif  // NVIM_MAP_H
 

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -47,11 +47,11 @@ void *map_put(Map *map, const char *key, void *value);
 /// @return The current value if exists or NULL otherwise
 void *map_del(Map *map, const char *key);
 
-/// Iterates through each key/value pair in the map
-///
-/// @param map The `Map` instance
-/// @param cb A function that will be called for each key/value
-void map_foreach(Map *map, key_value_cb cb);
+#define map_foreach(map, key, value, block) \
+  kh_foreach(map->table, key, value, block)
+
+#define map_foreach_value(map, value, block) \
+  kh_foreach_value(map->table, value, block)
 
 #endif  // NVIM_MAP_H
 

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -1,4 +1,3 @@
-// General-purpose string->pointer associative array with a simple API
 #ifndef NVIM_MAP_H
 #define NVIM_MAP_H
 
@@ -6,46 +5,28 @@
 
 #include "nvim/map_defs.h"
 
-/// Creates a new `Map` instance
-///
-/// @return a pointer to the new instance
-Map *map_new(void);
+#define MAP_DECLS(T)                                                          \
+  KHASH_DECLARE(T##_map, T, void *)                                           \
+                                                                              \
+  typedef struct {                                                            \
+    khash_t(T##_map) *table;                                                  \
+  } Map(T);                                                                   \
+                                                                              \
+  Map(T) *map_##T##_new(void);                                                \
+  void map_##T##_free(Map(T) *map);                                           \
+  void *map_##T##_get(Map(T) *map, T key);                                    \
+  bool map_##T##_has(Map(T) *map, T key);                                     \
+  void *map_##T##_put(Map(T) *map, T key, void *value);                       \
+  void *map_##T##_del(Map(T) *map, T key);
 
-/// Frees memory for a `Map` instance
-///
-/// @param map The `Map` instance
-void map_free(Map *map);
+MAP_DECLS(cstr_t)
 
-/// Gets the value corresponding to a key in a `Map` instance
-///
-/// @param map The `Map` instance
-/// @param key A key string
-/// @return The value if the key exists in the map, or NULL if it doesn't
-void *map_get(Map *map, const char *key);
-
-/// Checks if a key exists in the map
-///
-/// @param map The `Map` instance
-/// @param key A key string
-/// @return true if the key exists, false otherwise
-bool map_has(Map *map, const char *key);
-
-/// Set the value corresponding to a key in a `Map` instance and returns
-/// the old value.
-///
-/// @param map The `Map` instance
-/// @param key A key string
-/// @param value A value
-/// @return The current value if exists or NULL otherwise
-void *map_put(Map *map, const char *key, void *value);
-
-/// Deletes the value corresponding to a key in a `Map` instance and returns
-/// the old value.
-///
-/// @param map The `Map` instance
-/// @param key A key string
-/// @return The current value if exists or NULL otherwise
-void *map_del(Map *map, const char *key);
+#define map_new(T) map_##T##_new
+#define map_free(T) map_##T##_free
+#define map_get(T) map_##T##_get
+#define map_has(T) map_##T##_has
+#define map_put(T) map_##T##_put
+#define map_del(T) map_##T##_del
 
 #define map_foreach(map, key, value, block) \
   kh_foreach(map->table, key, value, block)

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -10,5 +10,5 @@ typedef struct map Map;
 /// @param value A value
 typedef void (*key_value_cb)(Map *map, const char *key, void *value);
 
-#endif /* NVIM_MAP_DEFS_H */
+#endif  // NVIM_MAP_DEFS_H
 

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -5,6 +5,7 @@
 #include "nvim/lib/khash.h"
 
 typedef const char * cstr_t;
+typedef void * ptr_t;
 
 #define Map(T) Map_##T
 

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -1,21 +1,13 @@
 #ifndef NVIM_MAP_DEFS_H
 #define NVIM_MAP_DEFS_H
 
+
 #include "nvim/lib/khash.h"
 
-KHASH_DECLARE(Map, kh_cstr_t, void *)
+typedef const char * cstr_t;
 
-typedef struct {
-  khash_t(Map) *table;
-} Map;
+#define Map(T) Map_##T
 
-
-/// Callback for iterating through each key/value pair in a map
-///
-/// @param map The `Map` instance
-/// @param key A key string
-/// @param value A value
-typedef void (*key_value_cb)(Map *map, const char *key, void *value);
 
 #endif  // NVIM_MAP_DEFS_H
 

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -1,7 +1,14 @@
 #ifndef NVIM_MAP_DEFS_H
 #define NVIM_MAP_DEFS_H
 
-typedef struct map Map;
+#include "nvim/lib/khash.h"
+
+KHASH_DECLARE(Map, kh_cstr_t, void *)
+
+typedef struct {
+  khash_t(Map) *table;
+} Map;
+
 
 /// Callback for iterating through each key/value pair in a map
 ///

--- a/src/nvim/os/server.c
+++ b/src/nvim/os/server.c
@@ -43,7 +43,7 @@ typedef struct {
   } socket;
 } Server;
 
-static Map *servers = NULL;
+static Map(cstr_t) *servers = NULL;
 
 static void connection_cb(uv_stream_t *server, int status);
 static void free_client(uv_handle_t *handle);
@@ -51,7 +51,7 @@ static void free_server(uv_handle_t *handle);
 
 void server_init()
 {
-  servers = map_new();
+  servers = map_new(cstr_t)();
 
   if (!os_getenv("NEOVIM_LISTEN_ADDRESS")) {
     char *listen_address = (char *)vim_tempname('s');
@@ -88,7 +88,7 @@ void server_start(char *endpoint, ChannelProtocol prot)
   strncpy(addr, endpoint, sizeof(addr));
 
   // Check if the server already exists
-  if (map_has(servers, addr)) {
+  if (map_has(cstr_t)(servers, addr)) {
     EMSG2("Already listening on %s", addr);
     return;
   }
@@ -174,7 +174,7 @@ void server_start(char *endpoint, ChannelProtocol prot)
   server->type = server_type;
 
   // Add the server to the hash table
-  map_put(servers, addr, server);
+  map_put(cstr_t)(servers, addr, server);
 }
 
 void server_stop(char *endpoint)
@@ -185,7 +185,7 @@ void server_stop(char *endpoint)
   // Trim to `ADDRESS_MAX_SIZE`
   strncpy(addr, endpoint, sizeof(addr));
 
-  if ((server = map_get(servers, addr)) == NULL) {
+  if ((server = map_get(cstr_t)(servers, addr)) == NULL) {
     EMSG2("Not listening on %s", addr);
     return;
   }
@@ -196,7 +196,7 @@ void server_stop(char *endpoint)
     uv_close((uv_handle_t *)&server->socket.pipe.handle, free_server);
   }
 
-  map_del(servers, addr);
+  map_del(cstr_t)(servers, addr);
 }
 
 static void connection_cb(uv_stream_t *server, int status)


### PR DESCRIPTION
I will need khash in other modules soon, but I find it's API displeasing to write and read(bucket iterators are exposed, for example). This PR is to refactor the map module into a generic macro with the key type as parameter. This will also replace the 'khash set' used in api/helpers.c with a uintptr->ptr macro
