### PR TITLE
[RDY] vim-patch:7.4.275

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -6059,7 +6059,10 @@ void ex_sign(exarg_T *eap)
 	    else
 		/* ":sign place {id} file={fname}": change sign type */
 		lnum = buf_change_sign_type(buf, id, sp->sn_typenr);
-	    update_debug_sign(buf, lnum);
+            if (lnum > 0)
+                update_debug_sign(buf, lnum);
+            else
+                EMSG2(_("E885: Not possible to change sign %s"), sign_name);
 	}
 	else
 	    EMSG(_(e_invarg));

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -202,6 +202,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  275,
   274,
   //273,
   272,


### PR DESCRIPTION
Problem:  When changing the type of a sign that hasn't been
          placed ther is no error message.
Solution: Add an error message. (Christian Brabandt)

Author: Bram Moolenaar

https://code.google.com/p/vim/source/detail?r=8a3117a4887c1e12a1165c9719491f96753
