### PR TITLE
[RFC] vim-patch:7.4.277

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4374,6 +4374,8 @@ void buf_addsign(
     return;
 }
 
+// For an existing, placed sign "markId" change the type to "typenr".
+// Returns the line number of the sign, or zero if the sign is not found.
 linenr_T buf_change_sign_type(
     buf_T *buf,         /* buffer to store sign in */
     int markId,         /* sign ID */
@@ -4494,6 +4496,15 @@ void buf_delete_signs(buf_T *buf)
 {
     signlist_T *next;
 
+    // When deleting the last sign need to redraw the windows to remove the
+    // sign column.
+    if (buf->b_signlist != NULL) {
+      redraw_buf_later(buf, NOT_VALID);
+      // TODO(oni-link): Is this call necessary if curwin is not a viewport
+      // for buf?
+      changed_cline_bef_curs();
+    }
+
     while (buf->b_signlist != NULL) {
         next = buf->b_signlist->next;
         free(buf->b_signlist);
@@ -4509,11 +4520,9 @@ void buf_delete_all_signs()
     buf_T *buf;     /* buffer we are checking for signs */
 
     for (buf = firstbuf; buf != NULL; buf = buf->b_next) {
-        if (buf->b_signlist != NULL) {
-            /* Need to redraw the windows to remove the sign column. */
-            redraw_buf_later(buf, NOT_VALID);
-            buf_delete_signs(buf);
-        }
+      if (buf->b_signlist != NULL) {
+        buf_delete_signs(buf);
+      }
     }
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,9 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.277

Problem:    Using ":sign unplace *" may leave the cursor in the wrong position
            (Christian Brabandt)
Solution:   Update the cursor position when removing all signs.

https://code.google.com/p/vim/source/detail?r=373204662d82e894b27ee76bc3319bc62c91f6ae
