### PR TITLE
[RDY] vim-patch:7.4.280

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,12 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4506,8 +4506,8 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
  */
 static void set_fraction(win_T *wp)
 {
-  wp->w_fraction = ((long)wp->w_wrow * FRACTION_MULT
-                    + FRACTION_MULT / 2) / (long)wp->w_height;
+  wp->w_fraction = ((long)wp->w_wrow * FRACTION_MULT + wp->w_height / 2)
+                   / (long)wp->w_height;
 }
 
 /*
@@ -4519,6 +4519,7 @@ void win_new_height(win_T *wp, int height)
 {
   linenr_T lnum;
   int sline, line_size;
+  int prev_height = wp->w_height;
 
   /* Don't want a negative height.  Happens when splitting a tiny window.
    * Will equalize heights soon to fix it. */
@@ -4527,8 +4528,14 @@ void win_new_height(win_T *wp, int height)
   if (wp->w_height == height)
     return;         /* nothing to do */
 
-  if (wp->w_wrow != wp->w_prev_fraction_row && wp->w_height > 0)
-    set_fraction(wp);
+  if (wp->w_height > 0) {
+    if (wp == curwin) {
+      validate_cursor();  // w_wrow needs to be valid
+    }
+    if (wp->w_wrow != wp->w_prev_fraction_row) {
+      set_fraction(wp);
+    }
+  }
 
   wp->w_height = height;
   wp->w_skipcol = 0;
@@ -4545,7 +4552,8 @@ void win_new_height(win_T *wp, int height)
     lnum = wp->w_cursor.lnum;
     if (lnum < 1)               /* can happen when starting up */
       lnum = 1;
-    wp->w_wrow = ((long)wp->w_fraction * (long)height - 1L) / FRACTION_MULT;
+    wp->w_wrow = ((long)wp->w_fraction * (long)height - 1L + FRACTION_MULT / 2)
+                 / FRACTION_MULT;
     line_size = plines_win_col(wp, lnum, (long)(wp->w_cursor.col)) - 1;
     sline = wp->w_wrow - line_size;
 
@@ -4616,7 +4624,9 @@ void win_new_height(win_T *wp, int height)
       update_topline();
     curs_columns(FALSE);        /* validate w_wrow */
   }
-  wp->w_prev_fraction_row = wp->w_wrow;
+  if (prev_height > 0) {
+    wp->w_prev_fraction_row = wp->w_wrow;
+  }
 
   win_comp_scroll(wp);
   redraw_win_later(wp, SOME_VALID);


### PR DESCRIPTION
Merging vim-patch:7.4.280

Problem:    When using a session file the relative position of the cursor is
            not restored if there is another tab. (Nobuhiro Takasaki)
Solution:   Update w_wrow before calculating the fraction.

https://code.google.com/p/vim/source/detail?r=daf7e98675cf395e1ef96f8040567affb2782a11
