### PR TITLE
[RDY] vim-patch:7.4.281

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8147,6 +8147,17 @@ makeopens (
       return FAIL;
   }
 
+  int restore_stal = FALSE;
+  // When there are two or more tabpages and 'showtabline' is 1 the tabline
+  // will be displayed when creating the next tab.  That resizes the windows
+  // in the first tab, which may cause problems.  Set 'showtabline' to 2
+  // temporarily to avoid that.
+  if (p_stal == 1 && first_tabpage->tp_next != NULL) {
+    if (put_line(fd, "set stal=2") == FAIL) {
+      return FAIL;
+    }
+    restore_stal = TRUE;
+  }
 
   /*
    * May repeat putting Windows for each tab, when "tabpages" is in
@@ -8285,6 +8296,9 @@ makeopens (
     if (fprintf(fd, "tabnext %d", tabpage_index(curtab)) < 0
         || put_eol(fd) == FAIL)
       return FAIL;
+  }
+  if (restore_stal && put_line(fd, "set stal=1") == FAIL) {
+    return FAIL;
   }
 
   /*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,13 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  281,
+  //280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.281

Problem:    When a session file has more than one tabpage and 'showtabline' is
            one the positions may be slightly off.
Solution:   Set 'showtabline' to two while positioning windows.

https://code.google.com/p/vim/source/detail?r=24c90f1fec859b54cf2b854b98c4c9e614c46061
