### PR TITLE
[RFC] vim-patch:7.4.282

### DIFF
--- a/src/nvim/testdir/test97.in
+++ b/src/nvim/testdir/test97.in
@@ -3,7 +3,10 @@ characters.
 
 STARTTEST
 :so small.vim
+:" make sure glob() doesn't use the shell
 :set shell=doesnotexist
+:" consistent sorting of file names
+:set nofileignorecase
 :e test.out
 :put =glob('Xxx\{')
 :put =glob('Xxx\$')

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,14 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  282,
+  //281,
+  //280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.282

Problem:    Test 97 fails on Mac.
Solution:   Do not ignore case in file names. (Jun Takimoto)

https://code.google.com/p/vim/source/detail?r=6d0a1132dd71c7f55f7ed53fe99e97c79bfd05a4
