### PR TITLE
[RDY] vim-patch:7.4.284

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1019,7 +1019,7 @@ static struct vimoption
 #  endif
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"langmap",     "lmap", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"langmap",     "lmap", P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_langmap, PV_NONE,
    {(char_u *)"",                               /* unmatched } */
     (char_u *)0L} SCRIPTID_INIT},

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,16 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  284,
+  //283,
+  //282,
+  //281,
+  //280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.284

Problem:    Setting 'langmap' in the modeline can cause trouble.  E.g. mapping
            ":" breaks many commands. (Jens-Wolfhard Schicke-Uffmann)
Solution:   Disallow setting 'langmap' from the modeline.

https://code.google.com/p/vim/source/detail?r=3c35ca9666e88a8024af6dab585b8e79ab295f83
