### PR TITLE
[RFC] vim-patch:7.4.285

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2203,6 +2203,11 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra
       * changed.  Esp. when the buffer was changed in another window. */
       if (hasAnyFolding(wp))
         set_topline(wp, wp->w_topline);
+
+      // relative numbering may require updating more
+      if (wp->w_p_rnu) {
+        redraw_win_later(wp, SOME_VALID);
+      }
     }
   }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,17 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  285,
+  //284,
+  //283,
+  //282,
+  //281,
+  //280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.285

Problem:    When 'relativenumber' is set and deleting lines or undoing that,
            line numbers are not always updated. (Robert Arkwright)
Solution:   (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=5cb1828fd0056de3c166e71fbafc67a74c57d7b1
