### PR TITLE
[RDY] vim-patch:7.4.286

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3898,10 +3898,11 @@ static int eval4(char_u **arg, typval_T *rettv, int evaluate)
             n1 = !n1;
         } else if (rettv->v_type != var2.v_type
                    || (type != TYPE_EQUAL && type != TYPE_NEQUAL)) {
-          if (rettv->v_type != var2.v_type)
+          if (rettv->v_type != var2.v_type) {
             EMSG(_("E691: Can only compare List with List"));
-          else
-            EMSG(_("E692: Invalid operation for Lists"));
+          } else {
+            EMSG(_("E692: Invalid operation for List"));
+          }
           clear_tv(rettv);
           clear_tv(&var2);
           return FAIL;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,18 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  286,
+  //285,
+  //284,
+  //283,
+  //282,
+  //281,
+  //280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.286

Problem:    Error messages are inconsistant. (ZyX)
Solution:   Change "Lists" to "list".

https://code.google.com/p/vim/source/detail?r=be19015ef43cc17825929206790696c2e716035d
