### PR TITLE
[RDY] vim-patch:7.4.288

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3900,6 +3900,7 @@ char_u *did_set_spelllang(win_T *wp)
 theend:
   free(spl_copy);
   recursive = FALSE;
+  redraw_win_later(wp, NOT_VALID);
   return ret_msg;
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -201,6 +201,20 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  288,
+  //287,
+  //286,
+  //285,
+  //284,
+  //283,
+  //282,
+  //281,
+  //280,
+  //279,
+  //278,
+  //277,
+  //276,
+  //275,
   274,
   //273,
   272,


### PR DESCRIPTION
Merging vim-patch:7.4.288

Problem:    When 'spellfile' is set the screen is not redrawn.
Solution:   Redraw when updating the spelling info. (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=7965cb6a435ae1ea331c7c2f8740d3d4c3625f3b
