### PR TITLE
[RDY] fix a few strncpy calls by using xstrlcpy

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -67,7 +67,7 @@ bool try_end(Error *err)
                                              ET_ERROR,
                                              NULL,
                                              &should_free);
-    strncpy(err->msg, msg, sizeof(err->msg));
+    xstrlcpy(err->msg, msg, sizeof(err->msg));
     err->set = true;
     free_global_msglist();
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -5,10 +5,11 @@
 
 #include "nvim/api/private/defs.h"
 #include "nvim/vim.h"
+#include "nvim/memory.h"
 
 #define set_api_error(message, err)                \
   do {                                             \
-    strncpy(err->msg, message, sizeof(err->msg));  \
+    xstrlcpy(err->msg, message, sizeof(err->msg)); \
     err->set = true;                               \
   } while (0)
 

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -183,6 +183,19 @@ char *xstpncpy(char *restrict dst, const char *restrict src, size_t maxlen)
     }
 }
 
+size_t xstrlcpy(char *restrict dst, const char *restrict src, size_t size)
+{
+    size_t ret = strlen(src);
+
+    if (size) {
+        size_t len = (ret >= size) ? size - 1 : ret;
+        memcpy(dst, src, len);
+        dst[len] = '\0';
+    }
+
+    return ret;
+}
+
 char *xstrdup(const char *str)
 {
   char *ret = strdup(str);

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -125,6 +125,19 @@ char *xstpcpy(char *restrict dst, const char *restrict src);
 /// @param maxlen
 char *xstpncpy(char *restrict dst, const char *restrict src, size_t maxlen);
 
+/// xstrlcpy - Copy a %NUL terminated string into a sized buffer
+///
+/// Compatible with *BSD strlcpy: the result is always a valid
+/// NUL-terminated string that fits in the buffer (unless,
+/// of course, the buffer size is zero). It does not pad
+/// out the result like strncpy() does.
+///
+/// @param dst Where to copy the string to
+/// @param src Where to copy the string from
+/// @param size Size of destination buffer
+/// @return Length of the source string (i.e.: strlen(src))
+size_t xstrlcpy(char *restrict dst, const char *restrict src, size_t size);
+
 /// Duplicates a chunk of memory using xmalloc
 ///
 /// @see {xmalloc}


### PR DESCRIPTION
NOTE: the PR where we really try to get rid of strncpy is #743, this is just a smaller version to test how appeasing coverity works.

Fix some coverity warnings (see #760). Since this is mostly new code, I'd like for @tarruda to give it a small look as well.

@dougschneider If this is merged before your PR (which is likely, this is much smaller), you can just remove your commit that adds `xstrlcpy` and rebase :). Otherwise, I'll do the same.
