### PR TITLE
[RDY] Implement `FileID` struct

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -88,6 +88,9 @@ typedef struct memfile memfile_T;
 // for signlist_T
 #include "nvim/sign_defs.h"
 
+// for FileID
+#include "nvim/os/fs_defs.h"
+
 /*
  * The taggy struct is used to store the information about a :tag command.
  */
@@ -471,9 +474,8 @@ struct file_buffer {
   char_u      *b_sfname;        /* short file name */
   char_u      *b_fname;         /* current file name */
 
-  int b_dev_valid;              /* TRUE when b_dev has a valid number */
-  uint64_t b_dev;                  /* device number */
-  uint64_t b_ino;                  /* inode number */
+  bool file_id_valid;
+  FileID file_id;
 
   int b_fnum;                   /* buffer number for this file. */
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3433,10 +3433,11 @@ restore_backup:
         (void)os_setperm(wfname, perm);
     }
 # endif
-    buf_setino(buf);
-  } else if (!buf->b_dev_valid)
-    /* Set the inode when creating a new file. */
-    buf_setino(buf);
+    buf_set_file_id(buf);
+  } else if (!buf->file_id_valid) {
+    // Set the file_id when creating a new file.
+    buf_set_file_id(buf);
+  }
 #endif
 
   if (close(fd) != 0) {

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1139,14 +1139,7 @@ static void clear_csinfo(int i)
   csinfo[i].fname  = NULL;
   csinfo[i].ppath  = NULL;
   csinfo[i].flags  = NULL;
-#if defined(UNIX)
-  csinfo[i].st_dev = (dev_t)0;
-  csinfo[i].st_ino = (ino_t)0;
-#else
-  csinfo[i].nVolume = 0;
-  csinfo[i].nIndexHigh = 0;
-  csinfo[i].nIndexLow = 0;
-#endif
+  csinfo[i].file_id = FILE_ID_EMPTY;
   csinfo[i].pid    = 0;
   csinfo[i].fr_fp  = NULL;
   csinfo[i].to_fp  = NULL;
@@ -1181,8 +1174,7 @@ static int cs_insert_filelist(char *fname, char *ppath, char *flags,
   i = -1;   /* can be set to the index of an empty item in csinfo */
   for (j = 0; j < csinfo_size; j++) {
     if (csinfo[j].fname != NULL
-        && csinfo[j].st_dev == file_info->stat.st_dev
-        && csinfo[j].st_ino == file_info->stat.st_ino) {
+        && os_file_id_equal_file_info(&(csinfo[j].file_id), file_info)) {
       if (p_csverbose)
         (void)EMSG(_("E568: duplicate cscope database not added"));
       return -1;
@@ -1225,8 +1217,7 @@ static int cs_insert_filelist(char *fname, char *ppath, char *flags,
   } else
     csinfo[i].flags = NULL;
 
-  csinfo[i].st_dev = file_info->stat.st_dev;
-  csinfo[i].st_ino = file_info->stat.st_ino;
+  os_file_info_get_id(file_info, &(csinfo[i].file_id));
   return i;
 } /* cs_insert_filelist */
 

--- a/src/nvim/if_cscope_defs.h
+++ b/src/nvim/if_cscope_defs.h
@@ -14,9 +14,9 @@
 
 #if defined(UNIX)
 # include <sys/types.h>         /* pid_t */
-# include <sys/stat.h>          /* dev_t, ino_t */
-#else
 #endif
+
+#include "nvim/os/fs_defs.h"
 
 #define CSCOPE_SUCCESS          0
 #define CSCOPE_FAILURE          -1
@@ -52,8 +52,7 @@ typedef struct csi {
 #if defined(UNIX)
   pid_t pid;                    /* PID of the connected cscope process. */
 #endif
-  uint64_t st_dev;                 /* ID of dev containing cscope db */
-  uint64_t st_ino;                 /* inode number of cscope db */
+  FileID file_id;
 
   FILE *          fr_fp;        /* from cscope: FILE. */
   FILE *          to_fp;        /* to cscope: FILE. */

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -686,16 +686,12 @@ static void set_b0_fname(ZERO_BL *b0p, buf_T *buf)
     FileInfo file_info;
     if (os_get_file_info((char *)buf->b_ffname, &file_info)) {
       long_to_char((long)file_info.stat.st_mtim.tv_sec, b0p->b0_mtime);
-#ifdef CHECK_INODE
       long_to_char((long)os_file_info_get_inode(&file_info), b0p->b0_ino);
-#endif
       buf_store_file_info(buf, &file_info);
       buf->b_mtime_read = buf->b_mtime;
     } else {
       long_to_char(0L, b0p->b0_mtime);
-#ifdef CHECK_INODE
       long_to_char(0L, b0p->b0_ino);
-#endif
       buf->b_mtime = 0;
       buf->b_mtime_read = 0;
       buf->b_orig_size = 0;
@@ -3339,17 +3335,16 @@ findswapname (
              */
             if (b0.b0_flags & B0_SAME_DIR) {
               if (fnamecmp(path_tail(buf->b_ffname),
-                      path_tail(b0.b0_fname)) != 0
+                           path_tail(b0.b0_fname)) != 0
                   || !same_directory(fname, buf->b_ffname)) {
-#ifdef CHECK_INODE
                 /* Symlinks may point to the same file even
                  * when the name differs, need to check the
                  * inode too. */
                 expand_env(b0.b0_fname, NameBuff, MAXPATHL);
                 if (fnamecmp_ino(buf->b_ffname, NameBuff,
-                        char_to_long(b0.b0_ino)))
-#endif
-                differ = TRUE;
+                    char_to_long(b0.b0_ino))) {
+                  differ = TRUE;
+                }
               }
             } else {
               /*
@@ -3357,14 +3352,10 @@ findswapname (
                * "~user/path/file".  Expand it first.
                */
               expand_env(b0.b0_fname, NameBuff, MAXPATHL);
-#ifdef CHECK_INODE
               if (fnamecmp_ino(buf->b_ffname, NameBuff,
-                      char_to_long(b0.b0_ino)))
+                  char_to_long(b0.b0_ino))) {
                 differ = TRUE;
-#else
-              if (fnamecmp(NameBuff, buf->b_ffname) != 0)
-                differ = TRUE;
-#endif
+              }
             }
           }
           close(fd);
@@ -3504,7 +3495,6 @@ static int b0_magic_wrong(ZERO_BL *b0p)
          || b0p->b0_magic_char != B0_MAGIC_CHAR;
 }
 
-#ifdef CHECK_INODE
 /*
  * Compare current file name with file name from swap file.
  * Try to use inode numbers when possible.
@@ -3603,7 +3593,6 @@ fnamecmp_ino (
     return FALSE;
   return TRUE;
 }
-#endif /* CHECK_INODE */
 
 /*
  * Move a long integer into a four byte character array.

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -687,7 +687,7 @@ static void set_b0_fname(ZERO_BL *b0p, buf_T *buf)
     if (os_get_file_info((char *)buf->b_ffname, &file_info)) {
       long_to_char((long)file_info.stat.st_mtim.tv_sec, b0p->b0_mtime);
 #ifdef CHECK_INODE
-      long_to_char((long)file_info.stat.st_ino, b0p->b0_ino);
+      long_to_char((long)os_file_info_get_inode(&file_info), b0p->b0_ino);
 #endif
       buf_store_file_info(buf, &file_info);
       buf->b_mtime_read = buf->b_mtime;
@@ -3549,20 +3549,19 @@ static int b0_magic_wrong(ZERO_BL *b0p)
  * available -> probably same file
  *		== 0   == 0    FAIL	FAIL	FALSE
  *
- * Note that when the ino_t is 64 bits, only the last 32 will be used.  This
- * can't be changed without making the block 0 incompatible with 32 bit
- * versions.
+ * Only the last 32 bits of the inode will be used. This can't be changed
+ * without making the block 0 incompatible with 32 bit versions.
  */
 
-static int 
+static int
 fnamecmp_ino (
     char_u *fname_c,               /* current file name */
     char_u *fname_s,               /* file name from swap file */
     long ino_block0
 )
 {
-  ino_t ino_c = 0;                  /* ino of current file */
-  ino_t ino_s;                      /* ino of file from swap file */
+  uint64_t ino_c = 0;               /* ino of current file */
+  uint64_t ino_s;                   /* ino of file from swap file */
   char_u buf_c[MAXPATHL];           /* full path of fname_c */
   char_u buf_s[MAXPATHL];           /* full path of fname_s */
   int retval_c;                     /* flag: buf_c valid */
@@ -3570,7 +3569,7 @@ fnamecmp_ino (
 
   FileInfo file_info;
   if (os_get_file_info((char *)fname_c, &file_info)) {
-    ino_c = (ino_t)file_info.stat.st_ino;
+    ino_c = os_file_info_get_inode(&file_info);
   }
 
   /*
@@ -3579,9 +3578,9 @@ fnamecmp_ino (
    * valid on this machine), use the inode from block 0.
    */
   if (os_get_file_info((char *)fname_s, &file_info)) {
-    ino_s = (ino_t)file_info.stat.st_ino;
+    ino_s = os_file_info_get_inode(&file_info);
   } else {
-    ino_s = (ino_t)ino_block0;
+    ino_s = (uint64_t)ino_block0;
   }
 
   if (ino_c && ino_s)

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -345,8 +345,69 @@ bool os_get_file_info_fd(int file_descriptor, FileInfo *file_info)
 /// Compare the inodes of two FileInfos
 ///
 /// @return `true` if the two FileInfos represent the same file.
-bool os_file_info_id_equal(FileInfo *file_info_1, FileInfo *file_info_2)
+bool os_file_info_id_equal(const FileInfo *file_info_1,
+                           const FileInfo *file_info_2)
 {
   return file_info_1->stat.st_ino == file_info_2->stat.st_ino
          && file_info_1->stat.st_dev == file_info_2->stat.st_dev;
 }
+
+/// Get the `FileID` of a `FileInfo`
+///
+/// @param file_info Pointer to the `FileInfo`
+/// @param[out] file_id Pointer to a `FileID`
+void os_file_info_get_id(const FileInfo *file_info, FileID *file_id)
+{
+  file_id->inode = file_info->stat.st_ino;
+  file_id->device_id = file_info->stat.st_dev;
+}
+
+/// Get the inode of a `FileInfo`
+///
+/// @deprecated Use `FileID` instead, this function is only needed in memline.c
+/// @param file_info Pointer to the `FileInfo`
+/// @return the inode number
+uint64_t os_file_info_get_inode(const FileInfo *file_info)
+{
+  return file_info->stat.st_ino;
+}
+
+/// Get the `FileID` for a given path
+///
+/// @param path Path to the file.
+/// @param[out] file_info Pointer to a `FileID` to fill in.
+/// @return `true` on sucess, `false` for failure.
+bool os_get_file_id(const char *path, FileID *file_id)
+{
+  uv_stat_t statbuf;
+  if (os_stat((char_u *)path, &statbuf) == OK) {
+    file_id->inode = statbuf.st_ino;
+    file_id->device_id = statbuf.st_dev;
+    return true;
+  }
+  return false;
+}
+
+/// Check if two `FileID`s are equal
+///
+/// @param file_id_1 Pointer to first `FileID`
+/// @param file_id_2 Pointer to second `FileID`
+/// @return `true` if the two `FileID`s represent te same file.
+bool os_file_id_equal(const FileID *file_id_1, const FileID *file_id_2)
+{
+  return file_id_1->inode == file_id_2->inode
+         && file_id_1->device_id == file_id_2->device_id;
+}
+
+/// Check if a `FileID` is equal to a `FileInfo`
+///
+/// @param file_id Pointer to a `FileID`
+/// @param file_info Pointer to a `FileInfo`
+/// @return `true` if the `FileID` and the `FileInfo` represent te same file.
+bool os_file_id_equal_file_info(const FileID *file_id,
+                                const FileInfo *file_info)
+{
+  return file_id->inode == file_info->stat.st_ino
+         && file_id->device_id == file_info->stat.st_dev;
+}
+

--- a/src/nvim/os/fs_defs.h
+++ b/src/nvim/os/fs_defs.h
@@ -1,0 +1,19 @@
+#ifndef NVIM_OS_FS_DEFS_H
+#define NVIM_OS_FS_DEFS_H
+
+#include <uv.h>
+
+/// Struct which encapsulates stat information.
+typedef struct {
+  uv_stat_t stat;  ///< @private
+} FileInfo;
+
+/// Struct which encapsulates inode/dev_id information.
+typedef struct {
+  uint64_t inode;      ///< @private The inode of the file
+  uint64_t device_id;  ///< @private The id of the device containing the file
+} FileID;
+
+#define FILE_ID_EMPTY (FileID){.inode = 0, .device_id = 0}
+
+#endif  // NVIM_OS_FS_DEFS_H

--- a/src/nvim/os/os.h
+++ b/src/nvim/os/os.h
@@ -2,13 +2,8 @@
 #define NVIM_OS_OS_H
 #include <uv.h>
 
+#include "nvim/os/fs_defs.h"
 #include "nvim/vim.h"
-
-/// Struct which encapsulates stat information.
-typedef struct {
-  // TODO(stefan991): make stat private
-  uv_stat_t stat;
-} FileInfo;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/fs.h.generated.h"

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -381,12 +381,12 @@ char_u      *name,
 int len               /* buffer size, only used when name gets longer */
 )
 {
-  struct stat st;
   char_u      *slash, *tail;
   DIR         *dirp;
   struct dirent *dp;
 
-  if (lstat((char *)name, &st) >= 0) {
+  FileInfo file_info;
+  if (os_get_file_info_link((char *)name, &file_info)) {
     /* Open the directory where the file is located. */
     slash = vim_strrchr(name, '/');
     if (slash == NULL) {
@@ -406,15 +406,14 @@ int len               /* buffer size, only used when name gets longer */
         if (STRICMP(tail, dp->d_name) == 0
             && STRLEN(tail) == STRLEN(dp->d_name)) {
           char_u newname[MAXPATHL + 1];
-          struct stat st2;
 
           /* Verify the inode is equal. */
           STRLCPY(newname, name, MAXPATHL + 1);
           STRLCPY(newname + (tail - name), dp->d_name,
               MAXPATHL - (tail - name) + 1);
-          if (lstat((char *)newname, &st2) >= 0
-              && st.st_ino == st2.st_ino
-              && st.st_dev == st2.st_dev) {
+          FileInfo file_info_new;
+          if (os_get_file_info_link((char *)newname, &file_info_new)
+              && os_file_info_id_equal(&file_info, &file_info_new)) {
             STRCPY(tail, dp->d_name);
             break;
           }

--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -229,9 +229,6 @@
 # define MAXPATHL       1024
 #endif
 
-// TODO(stefan991): remove macro
-#define CHECK_INODE             /* used when checking if a swap file already
-                                    exists for a file */
 # ifndef DFLT_MAXMEM
 #  define DFLT_MAXMEM   (5*1024)         /* use up to 5 Mbyte for a buffer */
 # endif

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -52,13 +52,13 @@ FileComparison path_full_compare(char_u *s1, char_u *s2, int checkname)
   char_u exp1[MAXPATHL];
   char_u full1[MAXPATHL];
   char_u full2[MAXPATHL];
-  uv_stat_t st1, st2;
+  FileID file_id_1, file_id_2;
 
   expand_env(s1, exp1, MAXPATHL);
-  int r1 = os_stat(exp1, &st1);
-  int r2 = os_stat(s2, &st2);
-  if (r1 != OK && r2 != OK) {
-    // If os_stat() doesn't work, may compare the names.
+  bool id_ok_1 = os_get_file_id((char *)exp1, &file_id_1);
+  bool id_ok_2 = os_get_file_id((char *)s2, &file_id_2);
+  if (!id_ok_1 && !id_ok_2) {
+    // If os_get_file_id() doesn't work, may compare the names.
     if (checkname) {
       vim_FullName(exp1, full1, MAXPATHL, FALSE);
       vim_FullName(s2, full2, MAXPATHL, FALSE);
@@ -68,10 +68,10 @@ FileComparison path_full_compare(char_u *s1, char_u *s2, int checkname)
     }
     return kBothFilesMissing;
   }
-  if (r1 != OK || r2 != OK) {
+  if (!id_ok_1 || !id_ok_2) {
     return kOneFileMissing;
   }
-  if (st1.st_dev == st2.st_dev && st1.st_ino == st2.st_ino) {
+  if (os_file_id_equal(&file_id_1, &file_id_2)) {
     return kEqualFiles;
   }
   return kDifferentFiles;


### PR DESCRIPTION
`FileID` encapsulates `st_dev` and `st_ino`. It is a new abstraction used to check if two files are the same. `FileID`s are embedded inside other struts like `buf_t` or `ff_visited_T`, where a full `FileInfo` would be to big.

All uses of `stat.st_dev` and `stat.st_ino` outside of `src/os/` are replaced with `FileInfo`/`FileID`.
The only exception is `memline.c`, which needs the inode for the block0 used in swapfiles.

This continues #619.
