### PR TITLE
[RDY] Add --api-msgpack-metadata command line option

### DIFF
--- a/scripts/msgpack-gen.lua
+++ b/scripts/msgpack-gen.lua
@@ -100,7 +100,7 @@ end
 output:write([[
 
 
-static const uint8_t msgpack_metadata[] = {
+const uint8_t msgpack_metadata[] = {
 
 ]])
 -- serialize the API metadata using msgpack and embed into the resulting
@@ -116,6 +116,7 @@ end
 -- usually it is the first function called by clients.
 output:write([[
 };
+const unsigned int msgpack_metadata_size = sizeof(msgpack_metadata);
 
 void msgpack_rpc_dispatch(uint64_t channel_id, msgpack_object *req, msgpack_packer *res)
 {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1049,7 +1049,7 @@ static void command_line_scan(mparm_T *parmp)
             msg_putchar('\n');
             msg_didout = FALSE;
             mch_exit(0);
-	  } else if (STRICMP(argv[0] + argv_idx, "api-metadata") == 0) {
+	  } else if (STRICMP(argv[0] + argv_idx, "api-msgpack-metadata") == 0) {
             for (unsigned int i = 0; i<msgpack_metadata_size; i++) {
               putchar(msgpack_metadata[i]);
             }
@@ -2247,7 +2247,7 @@ static void usage(void)
   main_msg(_("--startuptime <file>\tWrite startup timing messages to <file>"));
 #endif
   main_msg(_("-i <viminfo>\t\tUse <viminfo> instead of .viminfo"));
-  main_msg(_("--api-metadata\tDump API metadata information and exit"));
+  main_msg(_("--api-msgpack-metadata\tDump API metadata information and exit"));
   main_msg(_("-h  or  --help\tPrint Help (this message) and exit"));
   main_msg(_("--version\t\tPrint version information and exit"));
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -135,6 +135,8 @@ static void check_swap_exists_action(void);
 # endif
 #endif /* NO_VIM_MAIN */
 
+extern const uint8_t msgpack_metadata[];
+extern const unsigned int msgpack_metadata_size;
 
 /*
  * Different types of error messages.
@@ -1046,6 +1048,11 @@ static void command_line_scan(mparm_T *parmp)
             list_version();
             msg_putchar('\n');
             msg_didout = FALSE;
+            mch_exit(0);
+	  } else if (STRICMP(argv[0] + argv_idx, "api-metadata") == 0) {
+            for (unsigned int i = 0; i<msgpack_metadata_size; i++) {
+              putchar(msgpack_metadata[i]);
+            }
             mch_exit(0);
           } else if (STRNICMP(argv[0] + argv_idx, "literal", 7) == 0) {
 #if !defined(UNIX)
@@ -2240,6 +2247,7 @@ static void usage(void)
   main_msg(_("--startuptime <file>\tWrite startup timing messages to <file>"));
 #endif
   main_msg(_("-i <viminfo>\t\tUse <viminfo> instead of .viminfo"));
+  main_msg(_("--api-metadata\tDump API metadata information and exit"));
   main_msg(_("-h  or  --help\tPrint Help (this message) and exit"));
   main_msg(_("--version\t\tPrint version information and exit"));
 


### PR DESCRIPTION
This commit adds a new command line option that prints the list of API functions and exits. I've marked this as WIP since I have not yet decided what would be the best format for this information (or if I am missing anything).

The rationale for this comes from this googlegroups [post](https://groups.google.com/forum/#!topic/neovim/tXiZdX4pRDk). The idea is to make it easier to get the API metadata, e.g. for building Neovim bindings in statically typed languages you need this information at compile time.

Right now it prints all function signatures as a space separated table (can_fail, return_type, name, argument types).

e.g.
    $ nvim --api-metadata
    true WindowArray tabpage_get_windows Tabpage 
    true Object tabpage_get_var Tabpage String 
    true Object tabpage_set_var Tabpage String Object 
    true Window tabpage_get_window Tabpage 
    false Boolean tabpage_is_valid Tabpage 
    (...)

but json would probably be a better choice, specially if we want to include more information besides the function signatures. I'm open to suggestions on this.
