### PR TITLE
[RDY] Update German translation.

### DIFF
--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -20,13 +20,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8-bit\n"
 
 #: ../api/private/helpers.c:197
-#, fuzzy
 msgid "Unable to get option value"
-msgstr "Schrott nach dem Optionsargument"
+msgstr "Kann Optionswert nicht ermitteln"
 
 #: ../api/private/helpers.c:200
 msgid "internal error: unknown option type"
-msgstr ""
+msgstr "interner Fehler: unbekannter Optionstyp"
 
 #: ../cursor_shape.c:68
 msgid "E545: Missing colon"
@@ -66,11 +65,11 @@ msgstr "[Positionsliste]"
 
 #: ../buffer.c:89
 msgid "[Quickfix List]"
-msgstr "[QuickFix-Liste]"
+msgstr "[Quickfix-Liste]"
 
 #: ../buffer.c:90
 msgid "E855: Autocommands caused command to abort"
-msgstr ""
+msgstr "E855: Befehl durch Autokommandos abgebrochen"
 
 #: ../buffer.c:131
 msgid "E82: Cannot allocate any buffer, exiting..."
@@ -150,8 +149,8 @@ msgstr "E88: Kann nicht vor den ersten Puffer gehen"
 msgid ""
 "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Puffer %<PRId64> nicht gesichert seit der letzten Änderung (erzwinge "
-"mit !)"
+"E89: Puffer %<PRId64> seit der letzten Änderung nicht gesichert (mit ! "
+"erzwingen)"
 
 #. wrap around (may cause duplicates)
 #: ../buffer.c:1414
@@ -188,7 +187,7 @@ msgstr " [Verändert]"
 
 #: ../buffer.c:2491
 msgid "[Not edited]"
-msgstr "[Nicht editiert]"
+msgstr "[Nicht bearbeitet]"
 
 #: ../buffer.c:2494
 msgid "[New file]"
@@ -260,7 +259,7 @@ msgstr ""
 
 #: ../buffer.c:4272
 msgid "[Scratch]"
-msgstr ""
+msgstr "[Notizen]"
 
 #: ../buffer.c:4521
 msgid ""
@@ -286,18 +285,16 @@ msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Keine Differenz für mehr als %<PRId64> Puffer"
 
 #: ../diff.c:737
-#, fuzzy
 msgid "E810: Cannot read or write temp files"
-msgstr "E557: Termcap-Datei kann nicht geöffnet werden"
+msgstr "E810: Kann temporäre Dateien nicht lesen oder schreiben"
 
 #: ../diff.c:739
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kann keine Differenz erstellen"
 
 #: ../diff.c:950
-#, fuzzy
 msgid "E816: Cannot read patch output"
-msgstr "E98: Differenz-Ausgabe kann nicht gelesen werden"
+msgstr "E816: Patch-Ausgabe kann nicht gelesen werden"
 
 #: ../diff.c:1204
 msgid "E98: Cannot read diff output"
@@ -308,9 +305,8 @@ msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktueller Puffer ist nicht im Differenz-Modus"
 
 #: ../diff.c:2084
-#, fuzzy
 msgid "E793: No other buffer in diff mode is modifiable"
-msgstr "E100: Kein weiterer Puffer ist im Differenz-Modus"
+msgstr "E793: Es gibt keine weiteren änderbaren Puffer im Differenz-Modus"
 
 #: ../diff.c:2086
 msgid "E100: No other buffer in diff mode"
@@ -332,7 +328,7 @@ msgstr "E103: Puffer \"%s\" ist nicht im Differenz-Modus"
 
 #: ../diff.c:2177
 msgid "E787: Buffer changed unexpectedly"
-msgstr ""
+msgstr "E787: Puffer unerwartet verändert"
 
 #: ../digraph.c:1597
 msgid "E104: Escape not allowed in digraph"
@@ -348,7 +344,7 @@ msgstr "E105: :loadkeymap außerhalb einer eingelesenen Datei"
 
 #: ../digraph.c:1818
 msgid "E791: Empty keymap entry"
-msgstr ""
+msgstr "E791: Leerer Tastaturbelegungs-Eintrag"
 
 #: ../edit.c:83
 msgid " Keyword completion (^N^P)"
@@ -357,7 +353,7 @@ msgstr " Stichwort-Ergänzung (^N^P)"
 #. ctrl_x_mode == 0, ^P/^N compl.
 #: ../edit.c:84
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
-msgstr " ^X Modus (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
+msgstr " ^X-Modus (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
 #: ../edit.c:86
 msgid " Whole line completion (^L^N^P)"
@@ -413,11 +409,11 @@ msgstr "Absatzende erreicht"
 
 #: ../edit.c:102
 msgid "E839: Completion function changed window"
-msgstr ""
+msgstr "E839: Ergänzungs-Funktion veränderte Fenster"
 
 #: ../edit.c:103
 msgid "E840: Completion function deleted text"
-msgstr ""
+msgstr "E840: Ergänzungs-Funktion löschte Text"
 
 #: ../edit.c:1748
 msgid "'dictionary' option is empty"
@@ -504,7 +500,7 @@ msgstr "E134: Verschiebe Zeilen in sich selbst"
 
 #: ../ex_cmds.c:742
 msgid "1 line moved"
-msgstr "1 Zeile verschoben"
+msgstr "eine Zeile verschoben"
 
 #: ../ex_cmds.c:744
 #, c-format
@@ -531,7 +527,7 @@ msgstr "%sviminfo: %s in Zeile: "
 
 #: ../ex_cmds.c:1425
 msgid "E136: viminfo: Too many errors, skipping rest of file"
-msgstr "E136: viminfo: Zu viele Fehler; überspringe Rest der Datei"
+msgstr "E136: Viminfo: Zu viele Fehler; überspringe Rest der Datei"
 
 #: ../ex_cmds.c:1452
 #, c-format
@@ -544,12 +540,11 @@ msgstr " Information"
 
 #: ../ex_cmds.c:1455
 msgid " marks"
-msgstr " Markierungen"
+msgstr " Marken"
 
 #: ../ex_cmds.c:1456
-#, fuzzy
 msgid " oldfiles"
-msgstr "Keine inkludierten Dateien"
+msgstr " oldfiles"
 
 #: ../ex_cmds.c:1457
 msgid " FAILED"
@@ -569,7 +564,7 @@ msgstr "E138: Schreiben der viminfo-Datei %s ist nicht möglich!"
 #: ../ex_cmds.c:1629
 #, c-format
 msgid "Writing viminfo file \"%s\""
-msgstr "Schreiben der viminfo-Datei \"%s\""
+msgstr "Schreibe viminfo-Datei \"%s\""
 
 #. Write the info:
 #: ../ex_cmds.c:1714
@@ -582,7 +577,7 @@ msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
 msgstr ""
-"# Sie können sie verändern, wenn Sie vorsichtig vorgehen!\n"
+"# Sie können sie bearbeiten, wenn Sie vorsichtig vorgehen!\n"
 "\n"
 
 #: ../ex_cmds.c:1717
@@ -599,7 +594,7 @@ msgstr "Partielle Datei schreiben?"
 
 #: ../ex_cmds.c:2160
 msgid "E140: Use ! to write partial buffer"
-msgstr "E140: Zum Schreiben von partiellen Puffern ! verwenden"
+msgstr "E140: Zum Schreiben von Teil-Puffern ! verwenden"
 
 #: ../ex_cmds.c:2275
 #, c-format
@@ -643,11 +638,14 @@ msgid ""
 "It may still be possible to write it.\n"
 "Do you wish to try?"
 msgstr ""
+"Datei \"%s\" ist schreibgeschützt.\n"
+"Es könnte trotzdem möglich sein, sie zu schreiben.\n"
+"Wollen Sie es versuchen?"
 
 #: ../ex_cmds.c:2445
-#, fuzzy, c-format
+#, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
-msgstr "ist Schreibgeschützt (erzwinge mit !)"
+msgstr "E505: \"%s\" ist schreibgeschützt (mit ! erzwingen)"
 
 #: ../ex_cmds.c:3114
 #, c-format
@@ -716,9 +714,9 @@ msgid "Pattern found in every line: %s"
 msgstr "Muster in jeder Zeile gefunden: %s"
 
 #: ../ex_cmds.c:4504
-#, fuzzy, c-format
+#, c-format
 msgid "Pattern not found: %s"
-msgstr "Muster nicht gefunden"
+msgstr "Muster nicht gefunden: %s"
 
 #: ../ex_cmds.c:4581
 msgid ""
@@ -737,7 +735,7 @@ msgstr "E478: Nur keine Panik!"
 #: ../ex_cmds.c:4711
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
-msgstr "E661: Schade, keine '%s' Hilfe für %s"
+msgstr "E661: Kein '%s'-Hilfeeintrag für %s"
 
 #: ../ex_cmds.c:4713
 #, c-format
@@ -768,7 +766,8 @@ msgstr "E153: %s kann nicht zum Lesen geöffnet werden"
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr ""
-"E670: Mischung von Kodierungen einer Hilfedatei innerhalb einer Sprache: %s"
+"E670: Mischung von Zeichenkodierungen einer Hilfedatei innerhalb einer "
+"Sprache: %s"
 
 #: ../ex_cmds.c:5556
 #, c-format
@@ -805,7 +804,7 @@ msgstr "E159: Fehlende Zeichennummer"
 #: ../ex_cmds.c:5954
 #, c-format
 msgid "E158: Invalid buffer name: %s"
-msgstr "E158: ungültige Puffernummer: %s"
+msgstr "E158: Ungültige Puffernummer: %s"
 
 #: ../ex_cmds.c:5991
 #, c-format
@@ -815,7 +814,7 @@ msgstr "E157: Ungültige Zeichen-ID: %<PRId64>"
 #: ../ex_cmds.c:6031
 #, c-format
 msgid "E885: Not possible to change sign %s"
-msgstr ""
+msgstr "E885: Zeichen %s kann nicht verändert werden"
 
 #: ../ex_cmds.c:6049
 msgid " (not supported)"
@@ -859,9 +858,8 @@ msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  Zeile %<PRId64>"
 
 #: ../ex_cmds2.c:940
-#, fuzzy
 msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: Erste Verwendung von :profile startet <fname>"
+msgstr "E750: Zuerst \":profile start {fname}\" ausführen"
 
 #: ../ex_cmds2.c:1265
 #, c-format
@@ -880,12 +878,12 @@ msgstr "E162: Puffer \"%s\" wurde seit der letzten Änderung nicht geschrieben"
 #: ../ex_cmds2.c:1475
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
-"Achtung: Unerwarteter Eintritt in einen andren Puffer (überprüfen Sie die "
+"Achtung: Unerwarteter Eintritt in einen anderen Puffer (überprüfen Sie die "
 "Autokommandos)"
 
 #: ../ex_cmds2.c:1813
 msgid "E163: There is only one file to edit"
-msgstr "E163: Es gibt nur eine Datei zum Editieren"
+msgstr "E163: Es gibt nur eine Datei zu bearbeiten"
 
 #: ../ex_cmds2.c:1815
 msgid "E164: Cannot go before first file"
@@ -923,27 +921,27 @@ msgstr "Kann kein Verzeichnis einlesen: \"%s\""
 #: ../ex_cmds2.c:2473
 #, c-format
 msgid "could not source \"%s\""
-msgstr "\"%s\" konnte nicht gelesen werden"
+msgstr "\"%s\" konnte nicht ausgeführt werden"
 
 #: ../ex_cmds2.c:2475
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
-msgstr "Zeile %<PRId64>: \"%s\" konnte nicht gelesen werden"
+msgstr "Zeile %<PRId64>: \"%s\" konnte nicht ausgeführt werden"
 
 #: ../ex_cmds2.c:2490
 #, c-format
 msgid "sourcing \"%s\""
-msgstr "lese \"%s\""
+msgstr "führe \"%s\" aus"
 
 #: ../ex_cmds2.c:2492
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "Zeile %<PRId64>: lese \"%s\""
+msgstr "Zeile %<PRId64>: führe \"%s\" aus"
 
 #: ../ex_cmds2.c:2639
 #, c-format
 msgid "finished sourcing %s"
-msgstr "Lesen von %s beendet"
+msgstr "Ausführen von %s beendet"
 
 #: ../ex_cmds2.c:2641 ../eval.c:18115
 #, c-format
@@ -952,7 +950,7 @@ msgstr "weiter in %s"
 
 #: ../ex_cmds2.c:2709
 msgid "modeline"
-msgstr "modeline"
+msgstr "Modeline"
 
 #: ../ex_cmds2.c:2711
 msgid "--cmd argument"
@@ -968,7 +966,7 @@ msgstr "Umgebungsvariable"
 
 #: ../ex_cmds2.c:2717
 msgid "error handler"
-msgstr "Error-Handler"
+msgstr "Fehler-Routine"
 
 #: ../ex_cmds2.c:2890
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
@@ -985,7 +983,7 @@ msgstr "E168: :finish außerhalb einer eingelesenen Datei"
 #: ../ex_cmds2.c:3251
 #, c-format
 msgid "Current %slanguage: \"%s\""
-msgstr "Momentane %sSprache: \"%s\""
+msgstr "Aktuelle %sSprache: \"%s\""
 
 #: ../ex_cmds2.c:3266
 #, c-format
@@ -996,8 +994,7 @@ msgstr "E197: Sprache kann nicht auf \"%s\" gesetzt werden"
 #. don't wait for return
 #: ../ex_docmd.c:257
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
-msgstr ""
-"Ex-Modus. Geben Sie \"visual\" ein, um zum Normal-Modus zurückzukehren."
+msgstr "Ex-Modus. Geben Sie \"visual\" ein, um zum Normalmodus zurückzukehren."
 
 #: ../ex_docmd.c:298
 msgid "E501: At end-of-file"
@@ -1014,7 +1011,7 @@ msgstr "E605: Ausnahme nicht aufgefangen: %s"
 
 #: ../ex_docmd.c:953
 msgid "End of sourced file"
-msgstr "Ende der eingelesenen Datei"
+msgstr "Ende der ausgeführten Datei"
 
 #: ../ex_docmd.c:954
 msgid "End of function"
@@ -1030,11 +1027,11 @@ msgstr "E492: Kein Editorbefehl"
 
 #: ../ex_docmd.c:1594
 msgid "E493: Backwards range given"
-msgstr "E493: Bereichsgrenzen rückwärts"
+msgstr "E493: Bereich rückwärts definiert"
 
 #: ../ex_docmd.c:1598
 msgid "Backwards range given, OK to swap"
-msgstr "Bereichsgrenzen rückwärts; vertauschen"
+msgstr "Bereich rückwärts definiert; vertauschen?"
 
 #. append
 #. typed wrong
@@ -1052,21 +1049,21 @@ msgstr "E172: Nur ein Dateiname erlaubt"
 
 #: ../ex_docmd.c:4094
 msgid "1 more file to edit.  Quit anyway?"
-msgstr "Eine weitere Datei zum Editieren. Trotzdem beenden?"
+msgstr "Eine weitere Datei zu bearbeiten. Trotzdem beenden?"
 
 #: ../ex_docmd.c:4098
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
-msgstr "%d weitere Dateien zum Editieren. Trotzdem beenden?"
+msgstr "%d weitere Dateien zu bearbeiten. Trotzdem beenden?"
 
 #: ../ex_docmd.c:4104
 msgid "E173: 1 more file to edit"
-msgstr "E173: Eine weitere Datei zum Editieren"
+msgstr "E173: Eine weitere Datei zu bearbeiten"
 
 #: ../ex_docmd.c:4106
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
-msgstr "E173: %<PRId64> weitere Dateien zum Editieren"
+msgstr "E173: %<PRId64> weitere Dateien zu bearbeiten"
 
 #: ../ex_docmd.c:4164
 msgid "E174: Command already exists: add ! to replace it"
@@ -1118,9 +1115,10 @@ msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Benutzerdefinierte Befehle müssen mit Großbuchstaben beginnen"
 
 #: ../ex_docmd.c:4540
-#, fuzzy
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr "E464: Mehrdeutige Verwendung eines benutzerdefinierten Befehls"
+msgstr ""
+"E841: Reservierter Name, kann nicht für benutzerdefinierten Befehl verwendet "
+"werden"
 
 #: ../ex_docmd.c:4594
 #, c-format
@@ -1142,13 +1140,13 @@ msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Eigene Vervollständigung benötigt eine Funktion als Argument"
 
 #: ../ex_docmd.c:5100
-#, fuzzy, c-format
+#, c-format
 msgid "E185: Cannot find color scheme '%s'"
-msgstr "E185: Kann Farbschema %s nicht finden"
+msgstr "E185: Kann Farbschema '%s' nicht finden"
 
 #: ../ex_docmd.c:5106
 msgid "Greetings, Vim user!"
-msgstr "Herzliche Grüße, Vim Benutzer!"
+msgstr "Herzliche Grüße, Vim-Benutzer!"
 
 #: ../ex_docmd.c:5274
 msgid "E784: Cannot close last tab page"
@@ -1165,14 +1163,13 @@ msgstr "Tab %d"
 
 #: ../ex_docmd.c:6138
 msgid "No swap file"
-msgstr "Keine Auslagerungsdatei"
+msgstr "Keine Auslagerungsdatei (.swp)"
 
 #: ../ex_docmd.c:6321
-#, fuzzy
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
-"E747: Kann das Verzeichnis nicht wechseln, da der Puffer verändert wurde "
-"(erzwinge mit !)"
+"E747: Kann Verzeichnis nicht wechseln, Puffer wurde verändert (mit ! "
+"erzwingen)"
 
 #: ../ex_docmd.c:6328
 msgid "E186: No previous directory"
@@ -1203,7 +1200,7 @@ msgstr "E739: Kann Verzeichnis nicht erstellen: %s"
 #: ../ex_docmd.c:7110
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
-msgstr "E189: \"%s\" existiert (erzwinge mit !)"
+msgstr "E189: \"%s\" existiert (mit ! erzwingen)"
 
 #: ../ex_docmd.c:7115
 #, c-format
@@ -1219,7 +1216,7 @@ msgstr ""
 
 #: ../ex_docmd.c:7175
 msgid "E192: Recursive use of :normal too deep"
-msgstr "E192: Rekursive Verwendung von :normal zu tief"
+msgstr "E192: Rekursive Verwendung von :normal zu tief verschachtelt"
 
 #: ../ex_docmd.c:7649
 msgid "E194: No alternate file name to substitute for '#'"
@@ -1240,12 +1237,11 @@ msgstr ""
 
 #: ../ex_docmd.c:7712
 msgid "E498: no :source file name to substitute for \"<sfile>\""
-msgstr "E498: kein :source Dateiname zur Ersetzung mit \"<sfile>\""
+msgstr "E498: Kein :source-Dateiname zur Ersetzung mit \"<sfile>\""
 
 #: ../ex_docmd.c:7718
-#, fuzzy
 msgid "E842: no line number to use for \"<slnum>\""
-msgstr "E498: kein :source Dateiname zur Ersetzung mit \"<sfile>\""
+msgstr "E842: Keine Zeilennummer für \"<slnum>\""
 
 #: ../ex_docmd.c:7745
 #, c-format
@@ -1258,11 +1254,11 @@ msgstr "E500: Ergibt eine leere Zeichenkette"
 
 #: ../ex_docmd.c:8675
 msgid "E195: Cannot open viminfo file for reading"
-msgstr "E195: viminfo kann nicht zum Lesen geöffnet werden"
+msgstr "E195: Viminfo kann nicht zum Lesen geöffnet werden"
 
 #: ../ex_eval.c:460
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
-msgstr "E608: Kann nicht :throw Exceptions mit 'Vim' Präfix"
+msgstr "E608: :throw kann keine Ausnahmen mit 'Vim'-Präfix werfen"
 
 #. always scroll up, don't overwrite
 #: ../ex_eval.c:492
@@ -1294,7 +1290,7 @@ msgstr "Ausnahme gefangen: %s"
 #: ../ex_eval.c:672
 #, c-format
 msgid "%s made pending"
-msgstr "%s schwebend gemacht"
+msgstr "%s als ausstehend gekennzeichnet"
 
 #: ../ex_eval.c:675
 #, c-format
@@ -1400,12 +1396,12 @@ msgstr "E193: :endfunction außerhalb einer Funktion"
 
 #: ../ex_getln.c:1614
 msgid "E788: Not allowed to edit another buffer now"
-msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
+msgstr ""
+"E788: Einen weiteren Puffer zu bearbeiten, ist im Moment nicht zulässig"
 
 #: ../ex_getln.c:1627
-#, fuzzy
 msgid "E811: Not allowed to change buffer information now"
-msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
+msgstr "E811: Puffer-Informationen zu ändern, ist im Moment nicht zulässig"
 
 #: ../ex_getln.c:3138
 msgid "tagname"
@@ -1442,7 +1438,7 @@ msgstr "Ausdruck"
 
 #: ../ex_getln.c:5002
 msgid "Input Line"
-msgstr "Eingabe-Zeile"
+msgstr "Eingabezeile"
 
 #: ../ex_getln.c:5069
 msgid "E198: cmd_pchar beyond the command length"
@@ -1454,7 +1450,7 @@ msgstr "E199: Aktives Fenster oder Puffer gelöscht"
 
 #: ../file_search.c:193
 msgid "E854: path too long for completion"
-msgstr ""
+msgstr "E854: Pfad zu lang für Vervollständigung"
 
 #: ../file_search.c:436
 #, c-format
@@ -1486,9 +1482,8 @@ msgid "E347: No more file \"%s\" found in path"
 msgstr "E347: Keine weitere Datei \"%s\" im Pfad gefunden"
 
 #: ../fileio.c:185
-#, fuzzy
 msgid "E812: Autocommands changed buffer or buffer name"
-msgstr "E135: *Filter*-Autokommandos dürfen den aktuellen Puffer nicht ändern"
+msgstr "E812: Puffer oder Puffername durch Autokommandos verändert"
 
 #: ../fileio.c:416
 msgid "Illegal file name"
@@ -1520,12 +1515,12 @@ msgstr "[Keine Erlaubnis]"
 
 #: ../fileio.c:701
 msgid "E200: *ReadPre autocommands made the file unreadable"
-msgstr "E200: *ReadPre Autokommandos haben die Datei unlesbar gemacht"
+msgstr "E200: *ReadPre-Autokommandos haben die Datei unlesbar gemacht"
 
 #: ../fileio.c:703
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr ""
-"E201: *ReadPre Autokommandos dürfen nicht den aktuellen Puffer wechseln"
+"E201: *ReadPre-Autokommandos dürfen den aktuellen Puffer nicht wechseln"
 
 #: ../fileio.c:720
 msgid "Vim: Reading from stdin...\n"
@@ -1553,9 +1548,8 @@ msgstr "[socket]"
 
 #. or character special
 #: ../fileio.c:1849
-#, fuzzy
 msgid "[character special]"
-msgstr "ein Zeichen"
+msgstr "[character special]"
 
 #: ../fileio.c:1863
 msgid "[CR missing]"
@@ -1601,7 +1595,7 @@ msgstr "Ausgabe von 'charconvert' kann nicht gelesen werden"
 
 #: ../fileio.c:2482
 msgid "E676: No matching autocommands for acwrite buffer"
-msgstr "E676: Keine übereinstimmenden Autokommandos für acwrite Puffer"
+msgstr "E676: Keine übereinstimmenden Autokommandos für acwrite-Puffer"
 
 #: ../fileio.c:2511
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
@@ -1616,31 +1610,31 @@ msgstr ""
 
 #: ../fileio.c:2593 ../fileio.c:2610
 msgid "is not a file or writable device"
-msgstr "ist keine Datei oder beschreibbares Device"
+msgstr "ist keine Datei oder beschreibbares Gerät"
 
 #: ../fileio.c:2646
 msgid "is read-only (add ! to override)"
-msgstr "ist Schreibgeschützt (erzwinge mit !)"
+msgstr "ist schreibgeschützt (mit ! erzwingen)"
 
 #: ../fileio.c:2931
 msgid "E506: Can't write to backup file (add ! to override)"
-msgstr "E506: Sicherungsdatei kann nicht geschrieben werden (erzwinge mit !)"
+msgstr "E506: Sicherungsdatei kann nicht geschrieben werden (mit ! erzwingen)"
 
 #: ../fileio.c:2943
 msgid "E507: Close error for backup file (add ! to override)"
-msgstr "E507: Fehler beim Schließen der Sicherungsdatei (erzwinge mit !)"
+msgstr "E507: Fehler beim Schließen der Sicherungsdatei (mit ! erzwingen)"
 
 #: ../fileio.c:2946
 msgid "E508: Can't read file for backup (add ! to override)"
-msgstr "E508: Sicherungsdatei kann nicht gelesen werden (erzwinge mit !)"
+msgstr "E508: Sicherungsdatei kann nicht gelesen werden (mit ! erzwingen)"
 
 #: ../fileio.c:2968
 msgid "E509: Cannot create backup file (add ! to override)"
-msgstr "E509: Sicherungsdatei kann nicht angelegt werden (erzwinge mit !)"
+msgstr "E509: Sicherungsdatei kann nicht angelegt werden (mit ! erzwingen)"
 
 #: ../fileio.c:3053
 msgid "E510: Can't make backup file (add ! to override)"
-msgstr "E510: Sicherungsdatei kann nicht erstellt werden (erzwinge mit !)"
+msgstr "E510: Sicherungsdatei kann nicht erstellt werden (mit ! erzwingen)"
 
 #. Can't write without a tempfile!
 #: ../fileio.c:3166
@@ -1653,7 +1647,7 @@ msgstr "E213: Fehler bei der Umwandlung (schreibe ohne Umwandlung mit !)"
 
 #: ../fileio.c:3214
 msgid "E166: Can't open linked file for writing"
-msgstr "E166: Gelinkte Datei kann nicht zum Schreiben geöffnet werden"
+msgstr "E166: Verlinkte Datei kann nicht zum Schreiben geöffnet werden"
 
 #: ../fileio.c:3218
 msgid "E212: Can't open file for writing"
@@ -1670,17 +1664,17 @@ msgstr "E512: Fehler beim Schließen"
 #: ../fileio.c:3481
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
-"E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu "
-"erzwingen)"
+"E513: Schreibfehler, Umwandlung fehlgeschlagen (leere 'fenc', um trotzdem zu "
+"schreiben)"
 
 #: ../fileio.c:3486
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu "
-"erzwingen)"
+"E513: Schreibfehler, Umwandlung fehlgeschlagen in Zeile %<PRId64> (leere "
+"'fenc', um trotzdem zu schreiben)"
 
 #: ../fileio.c:3493
 msgid "E514: write error (file system full?)"
@@ -1688,12 +1682,12 @@ msgstr "E514: Schreibfehler (Dateisystem voll?)"
 
 #: ../fileio.c:3551
 msgid " CONVERSION ERROR"
-msgstr "KONVERTIERUNGSFEHLER"
+msgstr "UMWANDLUNGSFEHLER"
 
 #: ../fileio.c:3554
-#, fuzzy, c-format
+#, c-format
 msgid " in line %<PRId64>;"
-msgstr "Zeile %<PRId64>"
+msgstr " in Zeile %<PRId64>;"
 
 #: ../fileio.c:3564
 msgid "[Device]"
@@ -1729,7 +1723,7 @@ msgstr "E206: patchmode: leere Original-Datei kann nicht verändert werden"
 
 #: ../fileio.c:3661
 msgid "E207: Can't delete backup file"
-msgstr "E207: Backup-Datei kann nicht gelöscht werden"
+msgstr "E207: Sicherungsdatei kann nicht gelöscht werden"
 
 #: ../fileio.c:3717
 msgid ""
@@ -1737,11 +1731,11 @@ msgid ""
 "WARNING: Original file may be lost or damaged\n"
 msgstr ""
 "\n"
-"ACHTUNG: Original-Datei kann verloren oder zerstört sein\n"
+"ACHTUNG: Original-Datei kann verloren oder beschädigt sein\n"
 
 #: ../fileio.c:3720
 msgid "don't quit the editor until the file is successfully written!"
-msgstr "beende nicht den Editor bis die Datei erfolgreich geschrieben wurde!"
+msgstr "Vim nicht beenden, bis die Datei erfolgreich geschrieben wurde!"
 
 #: ../fileio.c:3840
 msgid "[dos]"
@@ -1757,7 +1751,7 @@ msgstr "[mac]"
 
 #: ../fileio.c:3845
 msgid "[mac format]"
-msgstr "[mac Format]"
+msgstr "[mac-Format]"
 
 #: ../fileio.c:3850
 msgid "[unix]"
@@ -1765,7 +1759,7 @@ msgstr "[unix]"
 
 #: ../fileio.c:3850
 msgid "[unix format]"
-msgstr "[unix Format]"
+msgstr "[unix-Format]"
 
 #: ../fileio.c:3874
 msgid "1 line, "
@@ -1845,7 +1839,7 @@ msgstr "Siehe \":help W12\" für mehr Information"
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
-"W11: Achtung: Datei \"%s\" wurde verändert, seit mit dem Editieren "
+"W11: Achtung: Datei \"%s\" wurde verändert, seit mit dem Bearbeiten "
 "angefangen wurde"
 
 #: ../fileio.c:4909
@@ -1856,7 +1850,7 @@ msgstr "Siehe \":help W11\" für mehr Information"
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
-"W16: Achtung: Mode der Datei \"%s\" wurde verändert seit mit dem Editieren "
+"W16: Achtung: Mode der Datei \"%s\" wurde verändert seit mit dem Bearbeiten "
 "angefangen wurde"
 
 #: ../fileio.c:4913
@@ -1867,7 +1861,7 @@ msgstr "Siehe \":help W16\" für mehr Information"
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
-"W13: Achtung: Datei \"%s\" wurde erstellt, nachdem mit dem Editieren "
+"W13: Achtung: Datei \"%s\" wurde erstellt, nachdem mit dem Bearbeiten "
 "begonnen wurde"
 
 #: ../fileio.c:4945
@@ -1899,7 +1893,7 @@ msgstr "--gelöscht--"
 #: ../fileio.c:5641
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
-msgstr ""
+msgstr "Automatische Entfernung von Autokommando: %s <buffer=%d>"
 
 #. the group doesn't exist
 #: ../fileio.c:5679
@@ -1946,7 +1940,7 @@ msgstr "Keine passenden Autokommandos"
 
 #: ../fileio.c:6730
 msgid "E218: autocommand nesting too deep"
-msgstr "E218: Autokommando-Schachtelung zu tief"
+msgstr "E218: Autokommandos zu tief verschachtelt"
 
 #: ../fileio.c:7042
 #, c-format
@@ -2061,8 +2055,8 @@ msgstr "E11: Ungültig im Kommandozeilenfenster; <CR> führt aus, CTRL-C beendet"
 #: ../globals.h:1001
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E12: Befehl nicht zulässig vom exrc/vimrc in der momentanen Verzeichnis- "
-"oder Tag-Suche"
+"E12: exrc/vimrc-Befehl in der aktuellen Verzeichnis- oder Tag-Suche nicht "
+"zulässig"
 
 #: ../globals.h:1002
 msgid "E171: Missing :endif"
@@ -2090,7 +2084,7 @@ msgstr "E588: :endfor ohne :for"
 
 #: ../globals.h:1008
 msgid "E13: File exists (add ! to override)"
-msgstr "E13: Datei existiert bereits (erzwinge mit !)"
+msgstr "E13: Datei existiert bereits (mit ! erzwingen)"
 
 #: ../globals.h:1009
 msgid "E472: Command failed"
@@ -2136,23 +2130,22 @@ msgid "E17: \"%s\" is a directory"
 msgstr "E17: \"%s\" ist ein Verzeichnis"
 
 #: ../globals.h:1019
-#, fuzzy
 msgid "E900: Invalid job id"
-msgstr "E49: Ungültige Scroll-Größe"
+msgstr "E900: Ungültige Job-ID"
 
 #: ../globals.h:1020
 msgid "E901: Job table is full"
-msgstr ""
+msgstr "E901: Job-Tabelle ist voll"
 
 #: ../globals.h:1021
 #, c-format
 msgid "E902: \"%s\" is not an executable"
-msgstr ""
+msgstr "E902: \"%s\" ist nicht ausführbar"
 
 #: ../globals.h:1023
 #, c-format
 msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Bibliotheksaufruf für \"%s()\" schlug fehl"
+msgstr "E364: Bibliotheksaufruf für \"%s()\" fehlgeschlagen"
 
 #: ../globals.h:1025
 msgid "E19: Mark has invalid line number"
@@ -2259,12 +2252,11 @@ msgstr "E485: Kann Datei %s nicht lesen"
 
 #: ../globals.h:1053
 msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Kein Schreibvorgang seit der letzten Änderung (erzwinge mit !)"
+msgstr "E37: Kein Schreibvorgang seit der letzten Änderung (mit ! erzwingen)"
 
 #: ../globals.h:1054
-#, fuzzy
 msgid "E37: No write since last change"
-msgstr "[Kein Schreiben seit der letzten Änderung]\n"
+msgstr "E37: Kein Schreiben seit der letzten Änderung"
 
 #: ../globals.h:1055
 msgid "E38: Null argument"
@@ -2314,11 +2306,11 @@ msgstr "E43: Beschädigter Suchausdruck"
 
 #: ../globals.h:1068
 msgid "E44: Corrupted regexp program"
-msgstr "E44: schadhaftes regexp Programm"
+msgstr "E44: Schadhaftes regexp-Programm"
 
 #: ../globals.h:1070
 msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Die Option 'readonly' ist gesetzt (erzwinge mit !)"
+msgstr "E45: Die Option 'readonly' ist gesetzt (mit ! erzwingen)"
 
 #: ../globals.h:1072
 #, c-format
@@ -2326,9 +2318,9 @@ msgid "E46: Cannot change read-only variable \"%s\""
 msgstr "E46: Variable \"%s\" kann nur gelesen werden"
 
 #: ../globals.h:1074
-#, fuzzy, c-format
+#, c-format
 msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: Variable \"%s\" kann in der Sandbox nur gelesen werden"
+msgstr "E794: Variable \"%s\" kann in der Sandbox nicht gesetzt werden"
 
 #: ../globals.h:1075
 msgid "E47: Error while reading errorfile"
@@ -2356,15 +2348,15 @@ msgstr "E91: Die Option 'shell' ist leer"
 
 #: ../globals.h:1084
 msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Fehler -- Daten für Debuggersymbol konnten nicht gelesen werden"
+msgstr "E255: Daten für Debuggersymbol konnten nicht gelesen werden"
 
 #: ../globals.h:1085
 msgid "E72: Close error on swap file"
-msgstr "E72: Fehler beim Schließen der Auslagerungsdatei"
+msgstr "E72: Fehler beim Schließen der Auslagerungsdatei (.swp)"
 
 #: ../globals.h:1086
 msgid "E73: tag stack empty"
-msgstr "E73: tag Stapel leer."
+msgstr "E73: Tag-Stapel leer."
 
 #: ../globals.h:1087
 msgid "E74: Command too complex"
@@ -2441,9 +2433,8 @@ msgid "E764: Option '%s' is not set"
 msgstr "E764: Option '%s' ist nicht gesetzt"
 
 #: ../globals.h:1110
-#, fuzzy
 msgid "E850: Invalid register name"
-msgstr "E354: Ungültiger Register Name: '%s'"
+msgstr "E850: Ungültiger Registername"
 
 #: ../globals.h:1113
 msgid "search hit TOP, continuing at BOTTOM"
@@ -2491,7 +2482,7 @@ msgstr "Gedruckt: %s"
 
 #: ../hardcopy.c:796
 msgid "Printing aborted"
-msgstr "Ausdruck abgebrochen"
+msgstr "Druck abgebrochen"
 
 #: ../hardcopy.c:1307
 msgid "E455: Error writing to PostScript output file"
@@ -2505,17 +2496,17 @@ msgstr "E624: Datei \"%s\" kann nicht geöffnet werden"
 #: ../hardcopy.c:1688 ../hardcopy.c:2401
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
-msgstr "E457: PostScript Ressource-Datei \"%s\" kann nicht gelesen werden"
+msgstr "E457: PostScript-Ressourcendatei \"%s\" kann nicht gelesen werden"
 
 #: ../hardcopy.c:1704
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
-msgstr "E618: Datei \"%s\" ist keine PostScript Ressource-Datei"
+msgstr "E618: Datei \"%s\" ist keine PostScript-Ressourcendatei"
 
 #: ../hardcopy.c:1720 ../hardcopy.c:1737 ../hardcopy.c:1776
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
-msgstr "E619: Datei \"%s\" ist keine unterstützte PostScript Ressource-Datei"
+msgstr "E619: Datei \"%s\" ist keine unterstützte PostScript-Ressourcendatei"
 
 #: ../hardcopy.c:1788
 #, c-format
@@ -2524,19 +2515,19 @@ msgstr "E621: \"%s\" Ressource-Datei hat die falsche Version"
 
 #: ../hardcopy.c:2157
 msgid "E673: Incompatible multi-byte encoding and character set."
-msgstr "E673: Unzulässiger Multi-Byte Zeichensatz"
+msgstr "E673: Unzulässiger Multibyte-Zeichensatz"
 
 #: ../hardcopy.c:2169
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
-msgstr "E674: printmbcharset darf nicht leer sein mit Multi-Byte Zeichensatz."
+msgstr "E674: Bei Multibyte-Zeichensatz darf 'printmbcharset' nicht leer sein."
 
 #: ../hardcopy.c:2185
 msgid "E675: No default font specified for multi-byte printing."
-msgstr "E675: Keine Standardschriftart angegeben für Multi-Byte Ausdruck."
+msgstr "E675: Keine Standardschriftart für Multibyte-Druck angegeben."
 
 #: ../hardcopy.c:2357
 msgid "E324: Can't open PostScript output file"
-msgstr "E324: PostScript Ausgabe-Datei kann nicht geöffnet werden"
+msgstr "E324: PostScript-Ausgabedatei kann nicht geöffnet werden"
 
 #: ../hardcopy.c:2389
 #, c-format
@@ -2545,22 +2536,21 @@ msgstr "E456: Datei \"%s\" kann nicht geöffnet werden"
 
 #: ../hardcopy.c:2514
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
-msgstr "E456: PostScript Ressource-Datei \"prolog.ps\" nicht gefunden"
+msgstr "E456: PostScript-Ressourcendatei \"prolog.ps\" nicht gefunden"
 
 #: ../hardcopy.c:2524
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
-msgstr "E456: PostScript Ressource-Datei \"cidfont.ps\" nicht gefunden"
+msgstr "E456: PostScript-Ressourcendatei \"cidfont.ps\" nicht gefunden"
 
 #: ../hardcopy.c:2553 ../hardcopy.c:2570 ../hardcopy.c:2596
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: PostScript Ressource-Datei \"%s\" nicht gefunden"
+msgstr "E456: PostScript-Ressourcendatei \"%s\" nicht gefunden"
 
 #: ../hardcopy.c:2585
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
-msgstr ""
-"E620: Umwandlung nach dem Zeichensatz für den Ausdruck \"%s\" fehlgeschlagen"
+msgstr "E620: Umwandlung zu Drucker-Zeichensatz \"%s\" fehlgeschlagen"
 
 #: ../hardcopy.c:2808
 msgid "Sending to printer..."
@@ -2568,7 +2558,7 @@ msgstr "Schicke zum Drucker..."
 
 #: ../hardcopy.c:2812
 msgid "E365: Failed to print PostScript file"
-msgstr "E365: Druck der PostScript-Datei schlug fehl"
+msgstr "E365: Druck der PostScript-Datei fehlgeschlagen"
 
 #: ../hardcopy.c:2814
 msgid "Print job sent."
@@ -2584,11 +2574,11 @@ msgstr "Muster suchen"
 
 #: ../if_cscope.c:53
 msgid "Show this message"
-msgstr "diese Nachricht anzeigen"
+msgstr "Diese Nachricht anzeigen"
 
 #: ../if_cscope.c:55
 msgid "Kill a connection"
-msgstr "Verbindung abbrechen"
+msgstr "Verbindung trennen"
 
 #: ../if_cscope.c:57
 msgid "Reinit all connections"
@@ -2623,17 +2613,17 @@ msgstr "E563: stat(%s) Fehler: %d"
 #: ../if_cscope.c:515
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
-msgstr "E564: %s ist kein Verzeichnis oder eine gültige cscope Datenbank"
+msgstr "E564: %s ist weder ein Verzeichnis noch eine gültige cscope-Datenbank"
 
 #: ../if_cscope.c:530
 #, c-format
 msgid "Added cscope database %s"
-msgstr "csope Datenbank %s hinzugefügt"
+msgstr "csope-Datenbank %s hinzugefügt"
 
 #: ../if_cscope.c:580
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
-msgstr "E262: Fehler beim Lesen aus der cscope Verbindung %<PRId64>"
+msgstr "E262: Fehler beim Lesen der cscope-Verbindung %<PRId64>"
 
 #: ../if_cscope.c:675
 msgid "E561: unknown cscope search type"
@@ -2648,48 +2638,47 @@ msgid "E622: Could not fork for cscope"
 msgstr "E622: Konnte nicht für cscope verzweigen"
 
 #: ../if_cscope.c:813
-#, fuzzy
 msgid "cs_create_connection setpgid failed"
-msgstr "cs_create_connection exec misslang"
+msgstr "cs_create_connection setpgid fehlgeschlagen"
 
 #: ../if_cscope.c:817 ../if_cscope.c:853
 msgid "cs_create_connection exec failed"
-msgstr "cs_create_connection exec misslang"
+msgstr "cs_create_connection exec fehlgeschlagen"
 
 #: ../if_cscope.c:827 ../if_cscope.c:866
 msgid "cs_create_connection: fdopen for to_fp failed"
-msgstr "cs_create_connection: fdopen von to_fp misslang"
+msgstr "cs_create_connection: fdopen von to_fp fehlgeschlagen"
 
 #: ../if_cscope.c:829 ../if_cscope.c:870
 msgid "cs_create_connection: fdopen for fr_fp failed"
-msgstr "cs_create_connection: fdopen von fr_fp misslang"
+msgstr "cs_create_connection: fdopen von fr_fp fehlgeschlagen"
 
 #: ../if_cscope.c:854
 msgid "E623: Could not spawn cscope process"
-msgstr "E623: Konnte cscope Prozess nicht hervorbringen"
+msgstr "E623: Konnte cscope-Prozess nicht starten"
 
 #: ../if_cscope.c:896
 msgid "E567: no cscope connections"
-msgstr "E567: Keine cscope Verbindungen"
+msgstr "E567: Keine cscope-Verbindungen"
 
 #: ../if_cscope.c:973
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
-msgstr "E469: Unzulässiges cscopequickfix Flag %c für %c"
+msgstr "E469: Unzulässiges cscopequickfix-Flag %c für %c"
 
 #: ../if_cscope.c:1022
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: keine Übereinstimmungen gefunden für cscope Abfrage %s aus %s"
+msgstr "E259: keine Übereinstimmungen gefunden für cscope-Abfrage %s aus %s"
 
 #: ../if_cscope.c:1106
 msgid "cscope commands:\n"
-msgstr "cscope Befehle:\n"
+msgstr "cscope-Befehle:\n"
 
 #: ../if_cscope.c:1114
-#, fuzzy, c-format
+#, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
-msgstr "%-5s: %-30s (Verwendung: %s)"
+msgstr "%-5s: %s%*s (Verwendung: %s)"
 
 #: ../if_cscope.c:1119
 msgid ""
@@ -2703,20 +2692,29 @@ msgid ""
 "       s: Find this C symbol\n"
 "       t: Find this text string\n"
 msgstr ""
+"\n"
+"       c: Finde Funktionen, die diese Funktion aufrufen\n"
+"       d: Finde Funktionen, die von dieser Funktion aufgerufen werden\n"
+"       e: Finde dieses egrep-Muster\n"
+"       f: Finde diese Datei\n"
+"       g: Finde diese Definition\n"
+"       i: Finde Dateien, die diese Datei mit #include einbinden\n"
+"       s: Finde dieses C-Symbol\n"
+"       t: Finde diesen Text\n"
 
 #: ../if_cscope.c:1187
 msgid "E568: duplicate cscope database not added"
-msgstr "E568: cscope Datenbank nicht doppelt hinzugefügt"
+msgstr "E568: cscope-Datenbank nicht hinzugefügt, da bereits vorhanden"
 
 #: ../if_cscope.c:1295
 #, c-format
 msgid "E261: cscope connection %s not found"
-msgstr "E261: cscope Verbindung %s nicht gefunden"
+msgstr "E261: cscope-Verbindung %s nicht gefunden"
 
 #: ../if_cscope.c:1324
 #, c-format
 msgid "cscope connection %s closed"
-msgstr "cscope Verbindung %s geschlossen"
+msgstr "cscope-Verbindung %s geschlossen"
 
 #. should not reach here
 #: ../if_cscope.c:1446
@@ -2726,7 +2724,7 @@ msgstr "E570: Fataler Fehler in cs_manage_matches"
 #: ../if_cscope.c:1653
 #, c-format
 msgid "Cscope tag: %s"
-msgstr "Cscope Tag: %s"
+msgstr "Cscope-Tag: %s"
 
 #: ../if_cscope.c:1671
 msgid ""
@@ -2743,11 +2741,11 @@ msgstr "Dateiname / Kontext / Zeile\n"
 #: ../if_cscope.c:1769
 #, c-format
 msgid "E609: Cscope error: %s"
-msgstr "E609: Cscope Fehler: %s"
+msgstr "E609: Cscope-Fehler: %s"
 
 #: ../if_cscope.c:2013
 msgid "All cscope databases reset"
-msgstr "alle cscope Datenbanken zurückgesetzt"
+msgstr "Alle cscope-Datenbanken zurückgesetzt"
 
 #: ../if_cscope.c:2083
 msgid "no cscope connections\n"
@@ -2755,7 +2753,7 @@ msgstr "keine cscope-Verbindungen\n"
 
 #: ../if_cscope.c:2086
 msgid " # pid    database name                       prepend path\n"
-msgstr " # pid   Datenbank Name\t                    führender Pfad\n"
+msgstr " # pid   Datenbankname                        führender Pfad\n"
 
 #: ../main.c:120
 msgid "Unknown option argument"
@@ -2784,7 +2782,7 @@ msgstr "Ungültiges Argument für"
 #: ../main.c:270
 #, c-format
 msgid "%d files to edit\n"
-msgstr "%d Dateien zum Editieren\n"
+msgstr "%d Dateien zu bearbeiten\n"
 
 #: ../main.c:1320
 msgid "Attempt to open script file again: \""
@@ -2792,11 +2790,11 @@ msgstr "Versuche, die Skript-Datei erneut zu öffnen: \""
 
 #: ../main.c:1328
 msgid "Cannot open for reading: \""
-msgstr "kann nicht zum Lesen geöffnet werden: \""
+msgstr "Kann nicht zum Lesen geöffnet werden: \""
 
 #: ../main.c:1371
 msgid "Cannot open for script output: \""
-msgstr "kann nicht zur Skript-Ausgabe geöffnet werden: \""
+msgstr "Kann nicht zur Skript-Ausgabe geöffnet werden: \""
 
 #: ../main.c:1600
 msgid "Vim: Warning: Output is not to a terminal\n"
@@ -2826,7 +2824,7 @@ msgstr ""
 
 #: ../main.c:2156
 msgid "[file ..]       edit specified file(s)"
-msgstr "[Datei ..]      editiere die angegebenen Datei(-en)"
+msgstr "[Datei ..]      bearbeite die angegebenen Datei(en)"
 
 #: ../main.c:2157
 msgid "-               read text from stdin"
@@ -2882,15 +2880,15 @@ msgstr "--literal\t\tPlatzhalter werden nicht ausgewertet"
 
 #: ../main.c:2179
 msgid "-v\t\t\tVi mode (like \"vi\")"
-msgstr "-v\t\t\tVi Modus (wie \"vi\")"
+msgstr "-v\t\t\tVi-Modus (wie \"vi\")"
 
 #: ../main.c:2180
 msgid "-e\t\t\tEx mode (like \"ex\")"
-msgstr "-e\t\t\tEx Modus (wie \"ex\")"
+msgstr "-e\t\t\tEx-Modus (wie \"ex\")"
 
 #: ../main.c:2181
 msgid "-E\t\t\tImproved Ex mode"
-msgstr ""
+msgstr "-E\t\t\tVerbesserter Ex-Modus"
 
 #: ../main.c:2182
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
@@ -2898,7 +2896,7 @@ msgstr "-s\t\t\tLeiser (batch) Modus (nur für \"ex\")"
 
 #: ../main.c:2183
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
-msgstr "-d\t\t\tDiff Modus (wie \"vimdiff\")"
+msgstr "-d\t\t\tDiff-Modus (wie \"vimdiff\")"
 
 #: ../main.c:2184
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
@@ -2914,11 +2912,11 @@ msgstr "-Z\t\t\tEingeschränkter Modus (wie \"rvim\")"
 
 #: ../main.c:2187
 msgid "-m\t\t\tModifications (writing files) not allowed"
-msgstr "-m\t\t\tModifikationen (beim Schreiben von Dateien) sind nicht erlaubt"
+msgstr "-m\t\t\tÄnderungen (beim Schreiben von Dateien) sind nicht erlaubt"
 
 #: ../main.c:2188
 msgid "-M\t\t\tModifications in text not allowed"
-msgstr "-M\t\t\tModifikationen im Text nicht erlaubt"
+msgstr "-M\t\t\tÄnderungen im Text nicht erlaubt"
 
 #: ../main.c:2189
 msgid "-b\t\t\tBinary mode"
@@ -2926,7 +2924,7 @@ msgstr "-b\t\t\tBinärmodus"
 
 #: ../main.c:2190
 msgid "-l\t\t\tLisp mode"
-msgstr "-l\t\t\tLisp Modus"
+msgstr "-l\t\t\tLisp-Modus"
 
 #: ../main.c:2191
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
@@ -2939,6 +2937,8 @@ msgstr "-N\t\t\tNicht ganz kompatibel zu Vi: 'nocompatible'"
 #: ../main.c:2193
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
+"-V[N][fname]\t\tAusführliche Ausgabe [Level N] [Log-Nachrichten nach fname "
+"schreiben]"
 
 #: ../main.c:2194
 msgid "-D\t\t\tDebugging mode"
@@ -2946,11 +2946,11 @@ msgstr "-D\t\t\tDebug-Modus"
 
 #: ../main.c:2195
 msgid "-n\t\t\tNo swap file, use memory only"
-msgstr "-n\t\t\tKeine Auslagerungsdatei, verwende nur Speicher"
+msgstr "-n\t\t\tKeine Auslagerungsdatei (.swp), verwende nur Arbeitsspeicher"
 
 #: ../main.c:2196
 msgid "-r\t\t\tList swap files and exit"
-msgstr "-r\t\t\tListe nur Auslagerungsdateien auf"
+msgstr "-r\t\t\tAuslagerungsdateien (.swp) auflisten und beenden"
 
 #: ../main.c:2197
 msgid "-r (with file name)\tRecover crashed session"
@@ -3014,12 +3014,13 @@ msgstr "-c <Befehl>\t\tFühre <Befehl> nach dem Laden der ersten Datei aus"
 
 #: ../main.c:2213
 msgid "-S <session>\t\tSource file <session> after loading the first file"
-msgstr "-S <session>\t\tLese Datei <session> nach dem Laden der ersten Datei"
+msgstr ""
+"-S <session>\t\tFühre Datei <session> nach dem Laden der ersten Datei aus"
 
 #: ../main.c:2214
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr ""
-"-s <scriptin>\tLese Normal-Modus Befehle aus der Skript-Datei <scriptin>"
+"-s <scriptin>\tLese Normalmodus-Befehle aus der Skript-Datei <scriptin>"
 
 #: ../main.c:2215
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
@@ -3031,7 +3032,7 @@ msgstr "-W <scriptout>\tSchreibe Befehle in die Skript-Datei <scriptout>"
 
 #: ../main.c:2218
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
-msgstr ""
+msgstr "--startuptime <Datei>\tSchreibe Startzeit-Messungen nach <Datei>"
 
 #: ../main.c:2220
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
@@ -3039,11 +3040,11 @@ msgstr "-i <viminfo>\t\tBenutze <viminfo> statt .viminfo"
 
 #: ../main.c:2221
 msgid "--api-msgpack-metadata\tDump API metadata information and exit"
-msgstr ""
+msgstr "--api-msgpack-metadata\tAPI-Metainformationen ausgeben und beenden"
 
 #: ../main.c:2222
 msgid "-h  or  --help\tPrint Help (this message) and exit"
-msgstr "-h  or  --help\tAnzeigen der Hilfe (diesen Text) und beenden"
+msgstr "-h  or  --help\tAnzeigen der Hilfe (dieser Text) und beenden"
 
 #: ../main.c:2223
 msgid "--version\t\tPrint version information and exit"
@@ -3051,12 +3052,12 @@ msgstr "--version\t\tVersionsinformation anzeigen und beenden"
 
 #: ../mark.c:673
 msgid "No marks set"
-msgstr "Keine Markierungen gesetzt"
+msgstr "Keine Marken gesetzt"
 
 #: ../mark.c:675
 #, c-format
 msgid "E283: No marks matching \"%s\""
-msgstr "E283: Keine Markierungen passen zu \"%s\""
+msgstr "E283: Keine passenden Marken zu \"%s\""
 
 #. Highlight title
 #: ../mark.c:684
@@ -3065,7 +3066,7 @@ msgid ""
 "mark line  col file/text"
 msgstr ""
 "\n"
-"Mark Zeile Sp  Datei/Text"
+"Marke Zeile Sp  Datei/Text"
 
 #. Highlight title
 #: ../mark.c:786
@@ -3074,7 +3075,7 @@ msgid ""
 " jump line  col file/text"
 msgstr ""
 "\n"
-" Sprung Zeile Sp Datei/Text"
+" Sprung Zeile Sp  Datei/Text"
 
 #. Highlight title
 #: ../mark.c:828
@@ -3100,7 +3101,7 @@ msgid ""
 "# Jumplist (newest first):\n"
 msgstr ""
 "\n"
-"# Geschichte (neueste zuerst):\n"
+"# Sprungliste (neueste zuerst):\n"
 
 #: ../mark.c:1348
 msgid ""
@@ -3108,7 +3109,7 @@ msgid ""
 "# History of marks within files (newest to oldest):\n"
 msgstr ""
 "\n"
-"# Geschichte der Markierungen innerhalb von Dateien (neueste zuerst):\n"
+"# Marken-Abfolge innerhalb von Dateien (neueste zuerst):\n"
 
 #: ../mark.c:1426
 msgid "Missing '>'"
@@ -3120,23 +3121,25 @@ msgstr "E293: Block war nicht gesperrt"
 
 #: ../memfile.c:779
 msgid "E294: Seek error in swap file read"
-msgstr "E294: Positionierungsfehler beim Lesen der Auslagerungsdatei"
+msgstr "E294: Positionierungsfehler beim Lesen der Auslagerungsdatei (.swp)"
 
 #: ../memfile.c:783
 msgid "E295: Read error in swap file"
-msgstr "E295: Lesefehler in der Auslagerungsdatei"
+msgstr "E295: Lesefehler in der Auslagerungsdatei (.swp)"
 
 #: ../memfile.c:829
 msgid "E296: Seek error in swap file write"
-msgstr "E296: Positionierungsfehler beim Schreiben in die Auslagerungsdatei"
+msgstr ""
+"E296: Positionierungsfehler beim Schreiben in die Auslagerungsdatei (.swp)"
 
 #: ../memfile.c:845
 msgid "E297: Write error in swap file"
-msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei"
+msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei (.swp)"
 
 #: ../memfile.c:1016
 msgid "E300: Swap file already exists (symlink attack?)"
-msgstr "E300: Auslagerungsdatei ist bereits vorhanden (symlink Attacke?)"
+msgstr ""
+"E300: Auslagerungsdatei (.swp) ist bereits vorhanden (symlink-Angriff?)"
 
 #: ../memline.c:296
 msgid "E298: Didn't get block nr 0?"
@@ -3153,17 +3156,17 @@ msgstr "E298: Block Nr. 2 nicht erhalten?"
 #. could not (re)open the swap file, what can we do????
 #: ../memline.c:442
 msgid "E301: Oops, lost the swap file!!!"
-msgstr "E301: Ups, Verlust der Auslagerungsdatei!!!"
+msgstr "E301: Ups, Verlust der Auslagerungsdatei (.swp)!!!"
 
 #: ../memline.c:454
 msgid "E302: Could not rename swap file"
-msgstr "E302: Auslagerungsdatei konnte nicht umbenannt werden"
+msgstr "E302: Auslagerungsdatei (.swp) konnte nicht umbenannt werden"
 
 #: ../memline.c:531
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
-"E303: Auslagerungsdatei für \"%s\" konnte nicht geöffnet werden, "
+"E303: Auslagerungsdatei (.swp) für \"%s\" konnte nicht geöffnet werden, "
 "Wiederherstellung unmöglich"
 
 #: ../memline.c:643
@@ -3174,12 +3177,12 @@ msgstr "E304: ml_upd_block0(): Block Nr. 0 nicht erhalten?"
 #: ../memline.c:806
 #, c-format
 msgid "E305: No swap file found for %s"
-msgstr "E305: Keine Auslagerungsdatei für %s gefunden"
+msgstr "E305: Keine Auslagerungsdatei (.swp) für %s gefunden"
 
 #: ../memline.c:815
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
-"Geben Sie die Nummer der Auslagerungsdatei ein die verwendet werden soll (0 "
+"Geben Sie die Nummer der Auslagerungsdatei ein, die verwendet werden soll (0 "
 "um abzubrechen): "
 
 #: ../memline.c:855
@@ -3198,20 +3201,20 @@ msgid ""
 msgstr ""
 "\n"
 "Vielleicht wurden keine Änderungen vorgenommen oder Vim hatte die "
-"Auslagerungsdatei nicht aktualisiert."
+"Auslagerungsdatei (.swp) nicht aktualisiert."
 
 #: ../memline.c:885
 msgid " cannot be used with this version of Vim.\n"
-msgstr " kann nicht zusammen mit dieser Vim Version verwendet werden.\n"
+msgstr " kann nicht zusammen mit dieser Vim-Version verwendet werden.\n"
 
 #: ../memline.c:887
 msgid "Use Vim version 3.0.\n"
-msgstr "Benutze Vim Version 3.0.\n"
+msgstr "Vim-Version 3.0 benötigt.\n"
 
 #: ../memline.c:892
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
-msgstr "E307: %s sieht nicht wie eine Vim Auslagerungsdatei aus"
+msgstr "E307: %s sieht nicht wie eine Vim-Auslagerungsdatei (.swp) aus"
 
 #: ../memline.c:898
 msgid " cannot be used on this computer.\n"
@@ -3219,7 +3222,7 @@ msgstr " kann auf diesem Rechner nicht verwendet werden.\n"
 
 #: ../memline.c:900
 msgid "The file was created on "
-msgstr "Die Datei wurde erstellt um "
+msgstr "Datei erstellt: "
 
 #: ../memline.c:904
 msgid ""
@@ -3227,11 +3230,11 @@ msgid ""
 "or the file has been damaged."
 msgstr ""
 ",\n"
-"oder die Datei wurde zerstört."
+"oder die Datei wurde beschädigt."
 
 #: ../memline.c:921
 msgid " has been damaged (page size is smaller than minimum value).\n"
-msgstr ""
+msgstr " wurde beschädigt (Seitengröße ist kleiner als minimaler Wert).\n"
 
 #: ../memline.c:950
 #, c-format
@@ -3258,7 +3261,7 @@ msgstr "???VIELE ZEILEN FEHLEN"
 
 #: ../memline.c:1052
 msgid "???LINE COUNT WRONG"
-msgstr "???ZEILEN ZÄHLER FALSCH"
+msgstr "???ZEILENANZAHL FALSCH"
 
 #: ../memline.c:1058
 msgid "???EMPTY BLOCK"
@@ -3271,7 +3274,7 @@ msgstr "???ZEILEN FEHLEN"
 #: ../memline.c:1104
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
-msgstr "E310: Block 1 ID falsch (ist %s keine .swp-Datei?)"
+msgstr "E310: Block 1 ID falsch, ist %s keine Auslagerungsdatei (.swp)?"
 
 #: ../memline.c:1109
 msgid "???BLOCK MISSING"
@@ -3306,7 +3309,7 @@ msgstr "Lesen Sie \":help E312\" für weitere Informationen."
 
 #: ../memline.c:1225
 msgid "Recovery completed. You should check if everything is OK."
-msgstr "Wiederherstellung beendet. Prüfen Sie, ob alles alles OK ist."
+msgstr "Wiederherstellung beendet. Prüfen Sie, ob alles in Ordnung ist."
 
 #: ../memline.c:1227
 msgid ""
@@ -3314,25 +3317,27 @@ msgid ""
 "(You might want to write out this file under another name\n"
 msgstr ""
 "\n"
-"(Wollen Sie vielleicht diese Datei unter einem neuen Namen speichern\n"
+"(Sie könnten diese Datei unter einem neuen Namen speichern\n"
 
 #: ../memline.c:1228
-#, fuzzy
 msgid "and run diff with the original file to check for changes)"
-msgstr "und \"diff\" zur Original-Datei machen, um Änderungen zu prüfen)\n"
+msgstr ""
+"und \"diff\" mit der Original-Datei ausführen, um Änderungen zu finden)"
 
 #: ../memline.c:1230
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr ""
+"Wiederherstellung abgeschlossen. Inhalt des Puffers entspricht dem "
+"Dateiinhalt."
 
 #: ../memline.c:1231
-#, fuzzy
 msgid ""
 "\n"
 "You may want to delete the .swp file now.\n"
 "\n"
 msgstr ""
-"Löschen Sie die .swp-Datei danach.\n"
+"\n"
+"Sie können die Auslagerungsdatei (.swp) nun löschen.\n"
 "\n"
 
 #. use msg() to start the scrolling properly
@@ -3342,7 +3347,7 @@ msgstr "Auslagerungsdateien gefunden:"
 
 #: ../memline.c:1422
 msgid "   In current directory:\n"
-msgstr "   Im laufenden Verzeichnis:\n"
+msgstr "   Im aktuellen Verzeichnis:\n"
 
 #: ../memline.c:1424
 msgid "   Using specified name:\n"
@@ -3374,7 +3379,7 @@ msgstr "         [von Vim Version 3.0]"
 
 #: ../memline.c:1526
 msgid "         [does not look like a Vim swap file]"
-msgstr "         [sieht nicht wie eine Vim Auslagerungsdatei aus]"
+msgstr "         [sieht nicht wie eine Auslagerungsdatei (.swp) aus]"
 
 #: ../memline.c:1528
 msgid "         file name: "
@@ -3422,7 +3427,7 @@ msgid ""
 "        process ID: "
 msgstr ""
 "\n"
-"        Process-ID: "
+"        Prozess-ID: "
 
 #: ../memline.c:1555
 msgid " (still running)"
@@ -3446,15 +3451,15 @@ msgstr "         [kann nicht geöffnet werden]"
 
 #: ../memline.c:1674
 msgid "E313: Cannot preserve, there is no swap file"
-msgstr "E313: Kann nicht absichern, es gibt keine Auslagerungsdatei"
+msgstr "E313: Kann nicht erhalten, es gibt keine Auslagerungsdatei (.swp)"
 
 #: ../memline.c:1723
 msgid "File preserved"
-msgstr "Datei gesichert"
+msgstr "Datei erhalten"
 
 #: ../memline.c:1725
 msgid "E314: Preserve failed"
-msgstr "E314: Absicherung fehlgeschlagen"
+msgstr "E314: Erhalten fehlgeschlagen"
 
 #: ../memline.c:1778
 #, c-format
@@ -3468,7 +3473,7 @@ msgstr "E316: ml_get: kann Zeile %<PRId64> nicht finden"
 
 #: ../memline.c:2195
 msgid "E317: pointer block id wrong 3"
-msgstr "E317: Zeiger Block id falsch 3"
+msgstr "E317: Zeiger-Block-ID falsch 3"
 
 #: ../memline.c:2270
 msgid "stack_idx should be 0"
@@ -3480,7 +3485,7 @@ msgstr "E318: Zu viele Blocks aktualisiert?"
 
 #: ../memline.c:2469
 msgid "E317: pointer block id wrong 4"
-msgstr "E317: Zeiger Block id falsch 4"
+msgstr "E317: Zeiger-Block-ID falsch 4"
 
 #: ../memline.c:2494
 msgid "deleted block 1?"
@@ -3493,7 +3498,7 @@ msgstr "E320: Kann Zeile %<PRId64> nicht finden"
 
 #: ../memline.c:2874
 msgid "E317: pointer block id wrong"
-msgstr "E317: Zeiger Block id ist falsch"
+msgstr "E317: Zeiger-Block-ID ist falsch"
 
 #: ../memline.c:2888
 msgid "pe_line_count is zero"
@@ -3508,20 +3513,20 @@ msgstr ""
 #: ../memline.c:2917
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
-msgstr "E323: Zeilen Zähler falsch in Block %<PRId64>"
+msgstr "E323: Zeilenanzahl in Block %<PRId64> falsch"
 
 #: ../memline.c:2957
 msgid "Stack size increases"
-msgstr "Stapel Größe wächst"
+msgstr "Stapel vergrößert"
 
 #: ../memline.c:2996
 msgid "E317: pointer block id wrong 2"
-msgstr "E317: Zeiger Block id falsch 2"
+msgstr "E317: Zeiger-Block-ID falsch 2"
 
 #: ../memline.c:3028
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
-msgstr "E773: Symlink Schleife für \"%s\""
+msgstr "E773: Rekursiver Symlink für \"%s\""
 
 #: ../memline.c:3178
 msgid "E325: ATTENTION"
@@ -3541,10 +3546,9 @@ msgstr "Beim Öffnen der Datei \""
 
 #: ../memline.c:3196
 msgid "      NEWER than swap file!\n"
-msgstr "      neuer als Auslagerungsdatei!\n"
+msgstr "      neuer als Auslagerungsdatei (.swp)!\n"
 
 #: ../memline.c:3201
-#, fuzzy
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
@@ -3552,21 +3556,18 @@ msgid ""
 "    file when making changes."
 msgstr ""
 "\n"
-"(1) Ein anderes Programm editiert möglicherweise diese Datei.\n"
-"    Wenn dies der Fall ist, sollten Sie vorsichtig sein, damit\n"
-"    es nicht zu Überschneidungen kommt.\n"
+"(1) Möglicherweise bearbeitet ein anderes Programm gerade diese Datei.\n"
+"    Falls dem so ist, sollten Sie darauf achten, dass nicht zwei\n"
+"    verschiedene Versionen derselben Datei entstehen, wenn Sie\n"
+"    Änderungen durchführen."
 
 #: ../memline.c:3202
-#, fuzzy
 msgid "  Quit, or continue with caution.\n"
-msgstr "    Ende, oder Fortsetzung mit Vorsicht.\n"
+msgstr "  Beenden Sie Vim oder fahren Sie vorsichtig fort.\n"
 
 #: ../memline.c:3203
-#, fuzzy
 msgid "(2) An edit session for this file crashed.\n"
-msgstr ""
-"\n"
-"(2) Eine Editiersitzung für diese Datei ist abgestürzt.\n"
+msgstr "(2) Eine Sitzung für diese Datei ist abgestürzt.\n"
 
 #: ../memline.c:3204
 msgid "    If this is the case, use \":recover\" or \"vim -r "
@@ -3591,7 +3592,7 @@ msgid ""
 "\"\n"
 "    to avoid this message.\n"
 msgstr ""
-"\"\n"
+"\",\n"
 "    um diese Nachricht zu vermeiden.\n"
 
 #: ../memline.c:3406 ../memline.c:3408
@@ -3608,7 +3609,7 @@ msgstr "VIM - ACHTUNG"
 
 #: ../memline.c:3415
 msgid "Swap file already exists!"
-msgstr "Auslagerungsdatei ist bereits vorhanden!"
+msgstr "Auslagerungsdatei (.swp) ist bereits vorhanden!"
 
 #: ../memline.c:3420
 msgid ""
@@ -3619,7 +3620,7 @@ msgid ""
 "&Abort"
 msgstr ""
 "Nur zum &Lesen öffnen\n"
-"Trotzdem &editieren\n"
+"Trotzdem b&earbeiten\n"
 "&Wiederherstellen\n"
 "&Beenden\n"
 "&Abbrechen"
@@ -3634,9 +3635,9 @@ msgid ""
 "&Abort"
 msgstr ""
 "Nur zum &Lesen öffnen\n"
-"Trotzdem &editieren\n"
+"Trotzdem b&earbeiten\n"
 "&Wiederherstellen\n"
-"&Datei Löschen\n"
+"&Datei löschen\n"
 "&Beenden\n"
 "&Abbrechen"
 
@@ -3650,7 +3651,7 @@ msgstr ""
 #. ".saa": tried enough, give up
 #: ../memline.c:3484
 msgid "E326: Too many swap files found"
-msgstr "E326: Zu viele Auslagerungsdateien gefunden"
+msgstr "E326: Zu viele Auslagerungsdateien (.swp) gefunden"
 
 #: ../memory.c:363
 #, c-format
@@ -3663,7 +3664,7 @@ msgstr "E327: Teil des Menüpunkt-Pfades muss zum Untermenü führen"
 
 #: ../menu.c:48
 msgid "E328: Menu only exists in another mode"
-msgstr "E328: Menü existiert nur in anderen Modus"
+msgstr "E328: Menü existiert nur in einem anderen Modus"
 
 #: ../menu.c:49
 #, c-format
@@ -3672,9 +3673,8 @@ msgstr "E329: Kein Menü \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
 #: ../menu.c:306
-#, fuzzy
 msgid "E792: Empty menu name"
-msgstr "E749: Leerer Puffer"
+msgstr "E792: Leerer Menüname"
 
 #: ../menu.c:317
 msgid "E330: Menu path must not lead to a sub-menu"
@@ -3718,7 +3718,7 @@ msgstr "E336: Menü-Pfad muss zum Untermenü führen"
 
 #: ../menu.c:1420
 msgid "E337: Menu not found - check menu names"
-msgstr "E337: Menü nicht gefunden - überprüfe Menü-Namen"
+msgstr "E337: Menü nicht gefunden - Menünamen überprüfen"
 
 #: ../message.c:383
 #, c-format
@@ -3733,7 +3733,7 @@ msgstr "Zeile %4ld:"
 #: ../message.c:577
 #, c-format
 msgid "E354: Invalid register name: '%s'"
-msgstr "E354: Ungültiger Register Name: '%s'"
+msgstr "E354: Ungültiger Registername: '%s'"
 
 #: ../message.c:705
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
@@ -3798,8 +3798,8 @@ msgid ""
 msgstr ""
 "&Ja\n"
 "&Nein\n"
-"Alle &Speichern\n"
-"Alle &Verwerfen\n"
+"Alle &speichern\n"
+"Alle &verwerfen\n"
 "&Abbrechen"
 
 #: ../message.c:3017
@@ -3807,9 +3807,8 @@ msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Zu wenige Argumente für printf()"
 
 #: ../message.c:3074
-#, fuzzy
 msgid "E807: Expected Float argument for printf()"
-msgstr "E766: Zu wenige Argumente für printf()"
+msgstr "E807: Float-Argument für printf() erwartet"
 
 #: ../message.c:3827
 msgid "E767: Too many arguments to printf()"
@@ -3820,15 +3819,14 @@ msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Warnung: Ändern einer schreibgeschützten Datei"
 
 #: ../misc1.c:2516
-#, fuzzy
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
-"Bitte Nummer eingeben oder mit der Maus auswählen (abbrechen mit <Enter>)"
+"Nummer eingeben und <Enter> oder mit der Maus klicken (nichts eingeben, um "
+"abzubrechen):"
 
 #: ../misc1.c:2518
-#, fuzzy
 msgid "Type number and <Enter> (empty cancels): "
-msgstr "Gewünschte Nummer (abbrechen mit <Enter>)"
+msgstr "Nummer eingeben und <Enter> (nichts eingeben, um abzubrechen):"
 
 #: ../misc1.c:2564
 msgid "1 more line"
@@ -3861,7 +3859,6 @@ msgstr "Beep!"
 msgid "Calling shell to execute: \"%s\""
 msgstr "Rufe Shell auf, um \"%s\" auszuführen"
 
-# Identifizierungszeichen/merkmal, Bezeichner
 #.
 #. * nv_*(): functions called to handle Normal and Visual mode commands.
 #. * n_*(): functions called to handle Normal mode commands.
@@ -3869,7 +3866,7 @@ msgstr "Rufe Shell auf, um \"%s\" auszuführen"
 #.
 #: ../normal.c:80
 msgid "E349: No identifier under cursor"
-msgstr "E349: Kein Merkmal unter dem Cursor"
+msgstr "E349: Kein Bezeichner unter dem Cursor"
 
 #: ../normal.c:1763
 msgid "E774: 'operatorfunc' is empty"
@@ -3886,8 +3883,8 @@ msgstr "E348: Keine Zeichenkette unter dem Cursor"
 #: ../normal.c:3834
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr ""
-"E352: Faltung kann mit der eingestellten Faltungsmethode nicht gelöscht "
-"werden"
+"E352: Faltung kann mit der eingestellten Faltungsmethode ('foldmethod') "
+"nicht gelöscht werden"
 
 #: ../normal.c:5794
 msgid "E664: changelist is empty"
@@ -3928,7 +3925,7 @@ msgstr "%<PRId64> Zeilen %s %d Mal"
 #: ../ops.c:571
 #, c-format
 msgid "%<PRId64> lines to indent... "
-msgstr "%<PRId64> Zeilen zum Einrücken... "
+msgstr "%<PRId64> Zeilen einzurücken... "
 
 #: ../ops.c:613
 msgid "1 line indented "
@@ -3991,7 +3988,7 @@ msgstr ""
 
 #: ../ops.c:4435
 msgid "Illegal register name"
-msgstr "Unzulässiger Register Name"
+msgstr "Unzulässiger Registername"
 
 #: ../ops.c:4513
 msgid ""
@@ -4004,7 +4001,7 @@ msgstr ""
 #: ../ops.c:4555
 #, c-format
 msgid "E574: Unknown register type %d"
-msgstr "E574: Unbekannter Register Typ %d"
+msgstr "E574: Unbekannter Registertyp %d"
 
 #: ../ops.c:5095
 #, c-format
@@ -4075,7 +4072,7 @@ msgstr "E520: Nicht erlaubt in einer Modeline"
 
 #: ../option.c:2761
 msgid "E846: Key code not set"
-msgstr ""
+msgstr "E846: Tastencode nicht gesetzt"
 
 #: ../option.c:2870
 msgid "E521: Number required after ="
@@ -4100,11 +4097,11 @@ msgstr "E589: 'backupext' und 'patchmode' sind gleich"
 
 #: ../option.c:3909
 msgid "E834: Conflicts with value of 'listchars'"
-msgstr ""
+msgstr "E834: Konflikt mit dem Wert von 'listchars'"
 
 #: ../option.c:3911
 msgid "E835: Conflicts with value of 'fillchars'"
-msgstr ""
+msgstr "E835: Konflikt mit dem Wert von 'fillchars'"
 
 #: ../option.c:4096
 msgid "E524: Missing colon"
@@ -4159,7 +4156,7 @@ msgstr "E542: Unausgewogene Gruppen"
 
 #: ../option.c:5081
 msgid "E590: A preview window already exists"
-msgstr "E590: Ein Voransichtsfenster existiert bereits"
+msgstr "E590: Ein Vorschaufenster existiert bereits"
 
 #: ../option.c:5244
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
@@ -4184,9 +4181,9 @@ msgstr "E355: Unbekannte Option: %s"
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
 #: ../option.c:5970
-#, fuzzy, c-format
+#, c-format
 msgid "E521: Number required: &%s = '%s'"
-msgstr "E521: Zahl benötigt nach ="
+msgstr "E521: Zahl benötigt: &%s = '%s'"
 
 #: ../option.c:6082
 msgid ""
@@ -4194,7 +4191,7 @@ msgid ""
 "--- Terminal codes ---"
 msgstr ""
 "\n"
-"--- Terminal Codes ---"
+"--- Terminal-Codes ---"
 
 #: ../option.c:6084
 msgid ""
@@ -4239,12 +4236,16 @@ msgid ""
 "\n"
 "Could not get security context for "
 msgstr ""
+"\n"
+"Sicherheitskontext konnte nicht gelesen werden: "
 
 #: ../os_unix.c:476
 msgid ""
 "\n"
 "Could not set security context for "
 msgstr ""
+"\n"
+"Sicherheitskontext konnte nicht gesetzt werden: "
 
 #: ../os_unix.c:1540 ../os_unix.c:1629
 #, c-format
@@ -4309,11 +4310,11 @@ msgstr " (Zeile gelöscht)"
 
 #: ../quickfix.c:1831
 msgid "E380: At bottom of quickfix stack"
-msgstr "E380: Am Anfang der quickfix Liste"
+msgstr "E380: Am Anfang der Quickfix-Liste"
 
 #: ../quickfix.c:1837
 msgid "E381: At top of quickfix stack"
-msgstr "E381: An Ende der quickfix Liste"
+msgstr "E381: An Ende der Quickfix-Liste"
 
 #: ../quickfix.c:1848
 #, c-format
@@ -4322,7 +4323,7 @@ msgstr "Fehlerliste %d aus %d; %d Fehler"
 
 #: ../quickfix.c:2395
 msgid "E382: Cannot write, 'buftype' option is set"
-msgstr "E382: Kann nicht schreiben, 'buftype'-Option ist gesetzt"
+msgstr "E382: Schreiben nicht möglich, 'buftype'-Option ist gesetzt"
 
 #: ../quickfix.c:2780
 msgid "E683: File name missing or invalid pattern"
@@ -4335,7 +4336,7 @@ msgstr "Kann Datei \"%s\" nicht öffnen"
 
 #: ../quickfix.c:3396
 msgid "E681: Buffer is not loaded"
-msgstr "E681: Buffer ist nicht geladen"
+msgstr "E681: Puffer ist nicht geladen"
 
 #: ../quickfix.c:3454
 msgid "E777: String or List expected"
@@ -4432,7 +4433,7 @@ msgstr "E64: %s%c nach Nichts"
 
 #: ../regexp.c:1952
 msgid "E65: Illegal back reference"
-msgstr "E65: Ungültige Rückreferenz"
+msgstr "E65: Ungültige 'back reference'"
 
 #: ../regexp.c:1993
 msgid "E68: Invalid character after \\z"
@@ -4462,87 +4463,91 @@ msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
 msgstr ""
+"E864: Auf \\%#= dürfen nur 0, 1 oder 2 folgen. Die automatische Engine wird "
+"verwendet "
 
 #: ../regexp_nfa.c:239
 msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr ""
+msgstr "E865: (NFA) Regexp-Ende zu früh erreicht"
 
 #: ../regexp_nfa.c:240
 #, c-format
 msgid "E866: (NFA regexp) Misplaced %c"
-msgstr ""
+msgstr "E866: (NFA-Regexp) Falsch platziertes %c"
 
 #: ../regexp_nfa.c:242
 #, c-format
 msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
-msgstr ""
+msgstr "E877: (NFA-Regexp) Ungültige Zeichenklasse: %<PRId64>"
 
 #: ../regexp_nfa.c:1288
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
-msgstr ""
+msgstr "E867: (NFA) Unbekannter Operator '\\z%c'"
 
 #: ../regexp_nfa.c:1414
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
-msgstr ""
+msgstr "E867: (NFA) Unbekannter Operator '\\%%%c'"
 
 #: ../regexp_nfa.c:1829
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
-msgstr ""
+msgstr "E869: (NFA) Unbekannter Operator '\\@%c'"
 
 #: ../regexp_nfa.c:1858
 msgid "E870: (NFA regexp) Error reading repetition limits"
-msgstr ""
+msgstr "E870: (NFA-Regexp) Fehler beim Lesen von Wiederholungslimits"
 
 #. Can't have a multi follow a multi.
 #: ../regexp_nfa.c:1922
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
-msgstr ""
+msgstr "E871: (NFA-Regexp) Multi darf nicht auf Multi folgen!"
 
 #. Too many `('
 #: ../regexp_nfa.c:2064
 msgid "E872: (NFA regexp) Too many '('"
-msgstr ""
+msgstr "E872: (NFA-Regexp) Zu viele '('"
 
 #: ../regexp_nfa.c:2069
-#, fuzzy
 msgid "E879: (NFA regexp) Too many \\z("
-msgstr "E50: Zu viele \\z("
+msgstr "E879: (NFA-Regexp) Zu viele \\z("
 
 #: ../regexp_nfa.c:2093
 msgid "E873: (NFA regexp) proper termination error"
-msgstr ""
+msgstr "E873: (NFA-Regexp) ungültiges Ende"
 
 #: ../regexp_nfa.c:2605
 msgid "E874: (NFA) Could not pop the stack !"
-msgstr ""
+msgstr "E874: (NFA) Konnte kein Element vom Stack holen!"
 
 #: ../regexp_nfa.c:3304
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
 msgstr ""
+"E875: (NFA-Regexp) (Bei Konvertierung von Postfix zu NFA), zu viele Zustände "
+"auf dem Stack"
 
 #: ../regexp_nfa.c:3308
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
-msgstr ""
+msgstr "E876: (NFA-Regexp) Nicht genügend Speicher für den gesamten NFA "
 
 #: ../regexp_nfa.c:4532 ../regexp_nfa.c:4827
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
+"Temporäre Log-Datei konnte nicht zum Schreiben geöffnet werden, gebe auf "
+"stderr aus ... "
 
 #: ../regexp_nfa.c:4798
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
-msgstr ""
+msgstr "(NFA) KONNTE %s NICHT ÖFFNEN!"
 
 #: ../regexp_nfa.c:6007
-#, fuzzy
 msgid "Could not open temporary log file for writing "
-msgstr "E214: Temporäre Datei kann nicht zum Schreiben geöffnet werden"
+msgstr "Temporäre Log-Datei konnte nicht zum Schreiben geöffnet werden"
 
 #: ../screen.c:7365
 msgid " VREPLACE"
@@ -4672,7 +4677,7 @@ msgstr "Suche inkludierte Datei %s"
 
 #: ../search.c:4382
 msgid "E387: Match is on current line"
-msgstr "E387: Treffer ist auf der momentanen Zeile"
+msgstr "E387: Treffer ist in der aktuellen Zeile"
 
 #: ../search.c:4494
 msgid "All included files were found"
@@ -4691,9 +4696,8 @@ msgid "E389: Couldn't find pattern"
 msgstr "E389: Konnte Muster nicht finden"
 
 #: ../search.c:4645
-#, fuzzy
 msgid "Substitute "
-msgstr "eine Ersetzung"
+msgstr "Ersetze "
 
 #: ../search.c:4658
 #, c-format
@@ -4722,7 +4726,7 @@ msgstr "Angehängter Text in %s Zeile %d: %s"
 #: ../spell.c:1038
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
-msgstr "Affix Name zu lang in %s Zeile %d: %s"
+msgstr "Affix-Name zu lang in %s Zeile %d: %s"
 
 #: ../spell.c:1039
 msgid "E761: Format error in affix file FOL, LOW or UPP"
@@ -4803,7 +4807,7 @@ msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
 "%d"
 msgstr ""
-"Die Definition von COMPOUNDFORBIDFLAG nach dem PFX Element kann falsches "
+"Die Definition von COMPOUNDFORBIDFLAG nach dem PFX-Element kann ein falsches "
 "Ergebnis in Zeile %s ergeben %d"
 
 #: ../spell.c:4545
@@ -4812,13 +4816,13 @@ msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
 "%d"
 msgstr ""
-"Die Definition von COMPOUNDPERMITFLAG nach dem PFX Element kann falsches "
+"Die Definition von COMPOUNDPERMITFLAG nach dem PFX-Element kann ein falsches "
 "Ergebnis in Zeile %s ergeben %d"
 
 #: ../spell.c:4561
-#, fuzzy, c-format
+#, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
-msgstr "Falscher COMPOUNDMIN-Wert in %s Zeile %d: %s"
+msgstr "Falscher COMPOUNDRULES-Wert in %s Zeile %d: %s"
 
 #: ../spell.c:4585
 #, c-format
@@ -4936,7 +4940,7 @@ msgstr "Unerlaubtes Flag in %s Zeile %d: %s"
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr ""
-"%s Wert unterscheidet sich von dem, was in einer anderen .aff Datei "
+"Wert von %s unterscheidet sich von dem, was in einer anderen .aff Datei "
 "verwendet wird"
 
 #: ../spell.c:5416
@@ -4972,7 +4976,7 @@ msgstr "%d doppelte(s) Wort(e) in %s"
 #: ../spell.c:5562
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
-msgstr "%d Wort(e) mit nicht-ASCII Zeichen ignoriert in %s"
+msgstr "%d Wort(e) mit Nicht-ASCII-Zeichen ignoriert in %s"
 
 #: ../spell.c:5929
 #, c-format
@@ -5017,7 +5021,7 @@ msgstr "Nicht erkanntes Flag in %s Zeile %d: %s"
 #: ../spell.c:6071
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
-msgstr "%d Wörter mit nicht-ASCII Zeichen ignoriert"
+msgstr "%d Wörter mit Nicht-ASCII-Zeichen ignoriert"
 
 #: ../spell.c:6470
 #, c-format
@@ -5052,7 +5056,7 @@ msgstr "Schreibe Datei %s für Vorschläge ..."
 #: ../spell.c:7520 ../spell.c:7740
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
-msgstr "Geschätzter Speicher zur Laufzeit: %d Bytes"
+msgstr "Geschätzter Arbeitsspeicherbedarf zur Laufzeit: %d Bytes"
 
 #: ../spell.c:7633
 msgid "E751: Output file name must not have region name"
@@ -5083,17 +5087,17 @@ msgstr "Fertig!"
 #: ../spell.c:7847
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
-msgstr "E765: 'spellfile' hat nicht %<PRId64> Einträge"
+msgstr "E765: 'spellfile' hat keine %<PRId64> Einträge"
 
 #: ../spell.c:7887
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' removed from %s"
-msgstr "Wort entfernt von %s"
+msgstr "Wort '%.*s' aus %s entfernt"
 
 #: ../spell.c:7930
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' added to %s"
-msgstr "Wort zu %s hinzugefügt"
+msgstr "Wort '%.*s' zu %s hinzugefügt"
 
 #: ../spell.c:8194
 msgid "E763: Word characters differ between spell files"
@@ -5133,33 +5137,33 @@ msgstr "E753: Nicht gefunden: %s"
 #: ../spell.c:9084
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
-msgstr "E778: Das sieht nicht nach einer .sug Datei aus: %s"
+msgstr "E778: Das sieht nicht nach einer .sug-Datei aus: %s"
 
 #: ../spell.c:9090
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
-msgstr "E779: Veraltete .sug Datei; Aktualisierung erforderlich: %s"
+msgstr "E779: Veraltete .sug-Datei; Aktualisierung erforderlich: %s"
 
 #: ../spell.c:9094
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
-msgstr "E780: .sug Datei ist für eine neuere Version von Vim: %s"
+msgstr "E780: .sug-Datei ist für eine neuere Version von Vim: %s"
 
 #: ../spell.c:9103
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
-msgstr "E781: .sug Datei passt nicht zur .spl Datei: %s"
+msgstr "E781: .sug-Datei passt nicht zur .spl-Datei: %s"
 
 #: ../spell.c:9113
 #, c-format
 msgid "E782: error while reading .sug file: %s"
-msgstr "E782: Fehler beim Lesen der .sug Datei: %s"
+msgstr "E782: Fehler beim Lesen der .sug-Datei: %s"
 
 #. This should have been checked when generating the .spl
 #. file.
 #: ../spell.c:11370
 msgid "E783: duplicate char in MAP entry"
-msgstr "E783: Doppeltes Zeichen im MAP Eintrag"
+msgstr "E783: Doppeltes Zeichen im MAP-Eintrag"
 
 #: ../syntax.c:317
 msgid "No Syntax items defined for this buffer"
@@ -5168,12 +5172,12 @@ msgstr "Keine Syntax-Elemente für diesen Puffer definiert"
 #: ../syntax.c:2985 ../syntax.c:3006 ../syntax.c:3029
 #, c-format
 msgid "E390: Illegal argument: %s"
-msgstr "E390: Unerlaubtes Argument: %s"
+msgstr "E390: Unzulässiges Argument: %s"
 
 #: ../syntax.c:3201
 #, c-format
 msgid "E391: No such syntax cluster: %s"
-msgstr "E391: Kein solcher Syntax Cluster: %s"
+msgstr "E391: Kein solcher Syntax-Cluster: %s"
 
 #: ../syntax.c:3333
 msgid "syncing on C-style comments"
@@ -5197,7 +5201,7 @@ msgid ""
 "--- Syntax sync items ---"
 msgstr ""
 "\n"
-"--- Syntax Synchronisations-Elemente ---"
+"--- Syntax-Synchronisations-Elemente ---"
 
 #: ../syntax.c:3352
 msgid ""
@@ -5241,9 +5245,8 @@ msgid "E395: contains argument not accepted here"
 msgstr "E395: \"contains\"-Argument ist an dieser Stelle ungültig"
 
 #: ../syntax.c:3989
-#, fuzzy
 msgid "E844: invalid cchar value"
-msgstr "E474: Ungültiges Argument"
+msgstr "E844: Ungültiger cchar-Wert"
 
 #: ../syntax.c:4000
 msgid "E393: group[t]here not accepted here"
@@ -5259,9 +5262,8 @@ msgid "E397: Filename required"
 msgstr "E397: Dateiname wird benötigt"
 
 #: ../syntax.c:4115
-#, fuzzy
 msgid "E847: Too many syntax includes"
-msgstr "E77: Zu viele Dateinamen"
+msgstr "E847: Zu viele Syntax-Includes"
 
 #: ../syntax.c:4197
 #, c-format
@@ -5271,7 +5273,7 @@ msgstr "E789: Fehlende ']': %s"
 #: ../syntax.c:4419
 #, c-format
 msgid "E398: Missing '=': %s"
-msgstr "E398: Fehlendes '=': %s"
+msgstr "E398: Fehlendes '=' fehlt: %s"
 
 #: ../syntax.c:4554
 #, c-format
@@ -5279,9 +5281,8 @@ msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Nicht ausreichend viele Argumente: syntax region %s"
 
 #: ../syntax.c:4754
-#, fuzzy
 msgid "E848: Too many syntax clusters"
-msgstr "E391: Kein solcher Syntax Cluster: %s"
+msgstr "E848: Zu viele Syntax-Cluster"
 
 #: ../syntax.c:4838
 msgid "E400: No cluster specified"
@@ -5300,7 +5301,8 @@ msgstr "E402: Schrott nach Muster: %s"
 
 #: ../syntax.c:5004
 msgid "E403: syntax sync: line continuations pattern specified twice"
-msgstr "E403: Syntax sync: Zeilen-Fortsetzungsmuster zweifach angegeben"
+msgstr ""
+"E403: Syntax-Synchronisation: Zeilen-Fortsetzungsmuster doppelt angegeben"
 
 #: ../syntax.c:5053
 #, c-format
@@ -5336,12 +5338,14 @@ msgstr "E409: Unbekannter Gruppenname: %s"
 #: ../syntax.c:5395
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
-msgstr "E410: Ungültiger :syntax Befehl: %s"
+msgstr "E410: Ungültiger :syntax-Befehl: %s"
 
 #: ../syntax.c:5726
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
+"  GESAMT     ANZAHL  GEFUNDEN  LANGSAMSTE  DURCHSCHNITT  NAME               "
+"MUSTER"
 
 #: ../syntax.c:6018
 msgid "E679: recursive loop loading syncolor.vim"
@@ -5374,7 +5378,7 @@ msgstr "E415: Unerwartetes Gleichheitszeichen: %s"
 #: ../syntax.c:6268
 #, c-format
 msgid "E416: missing equal sign: %s"
-msgstr "E416: fehlendes Gleichheitszeichen: %s"
+msgstr "E416: Fehlendes Gleichheitszeichen: %s"
 
 #: ../syntax.c:6291
 #, c-format
@@ -5388,11 +5392,11 @@ msgstr "E418: Unzulässiger Wert: %s"
 
 #: ../syntax.c:6369
 msgid "E419: FG color unknown"
-msgstr "E419: FG Farbe unbekannt"
+msgstr "E419: Vordergrundfarbe (fg) unbekannt"
 
 #: ../syntax.c:6377
 msgid "E420: BG color unknown"
-msgstr "E420: BG Farbe unbekannt"
+msgstr "E420: Hintergrundfarbe (bg) unbekannt"
 
 #: ../syntax.c:6437
 #, c-format
@@ -5423,7 +5427,7 @@ msgstr "W18: Ungültiges Zeichen im Namen der Gruppe"
 
 #: ../syntax.c:7318
 msgid "E849: Too many highlight and syntax groups"
-msgstr ""
+msgstr "E849: Zu viele Hervorhebungs- und Syntaxgruppen"
 
 #: ../tag.c:109
 msgid "E555: at bottom of tag stack"
@@ -5475,7 +5479,7 @@ msgstr " oder mehr"
 
 #: ../tag.c:867
 msgid "  Using tag with different case!"
-msgstr "  Verwendung eines Tags mit abgewandelter Groß-/Klein-Schreibung"
+msgstr "  Verwendung eines Tags mit unterschiedlicher Groß-/Kleinschreibung!"
 
 #: ../tag.c:912
 #, c-format
@@ -5494,21 +5498,21 @@ msgstr ""
 #: ../tag.c:1286
 #, c-format
 msgid "Searching tags file %s"
-msgstr "tags file %s wird durchsucht"
+msgstr "Tag-Datei %s wird durchsucht"
 
 #: ../tag.c:1528
 msgid "Ignoring long line in tags file"
-msgstr ""
+msgstr "Ignoriere lange Zeile in Tag-Datei"
 
 #: ../tag.c:1898
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
-msgstr "E431: Format Fehler in Tag-Datei \"%s\""
+msgstr "E431: Falsches Format in Tag-Datei \"%s\""
 
 #: ../tag.c:1900
 #, c-format
 msgid "Before byte %<PRId64>"
-msgstr "Vor byte %<PRId64>"
+msgstr "Vor Byte %<PRId64>"
 
 #: ../tag.c:1912
 #, c-format
@@ -5526,12 +5530,12 @@ msgstr "E434: Kann Tag-Muster nicht finden"
 
 #: ../tag.c:2526
 msgid "E435: Couldn't find tag, just guessing!"
-msgstr "E435: Konnte Tag möglicherweise nicht finden!"
+msgstr "E435: Nur geraten: konnte Tag nicht finden!"
 
 #: ../tag.c:2777
-#, fuzzy, c-format
+#, c-format
 msgid "Duplicate field name: %s"
-msgstr "Doppeltes Affix in %s Zeile %d: %s"
+msgstr "Doppelter Feldname: %s"
 
 #: ../term.c:1431
 msgid "' not known. Available builtin terminals are:"
@@ -5540,7 +5544,7 @@ msgstr ""
 
 #: ../term.c:1452
 msgid "defaulting to '"
-msgstr "Voreinstellung '"
+msgstr "Falle zurück auf '"
 
 #: ../term.c:1720
 msgid "E557: Cannot open termcap file"
@@ -5570,7 +5574,7 @@ msgid ""
 "--- Terminal keys ---"
 msgstr ""
 "\n"
-"--- Terminal Tasten ---"
+"--- Terminal-Tasten ---"
 
 #: ../ui.c:477
 msgid "Vim: Error reading input, exiting...\n"
@@ -5580,79 +5584,86 @@ msgstr "Vim: Fehler beim Lesen der Eingabe, Abbruch...\n"
 #. * file in a way it becomes shorter.
 #: ../undo.c:355
 msgid "E881: Line count changed unexpectedly"
-msgstr ""
+msgstr "E881: Zeilenanzahl unerwartet verändert"
 
 #: ../undo.c:603
-#, fuzzy, c-format
+#, c-format
 msgid "E828: Cannot open undo file for writing: %s"
-msgstr "E212: Datei kann nicht zum Schreiben geöffnet werden"
+msgstr ""
+"E828: Rückgängig-Schrittedatei kann nicht zum Schreiben geöffnet werden: %s"
 
 #: ../undo.c:693
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
-msgstr ""
+msgstr "E825: Beschädigte Rückgängig-Schrittedatei (%s): %s"
 
 #: ../undo.c:1015
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr ""
+"Kann Rückgängig-Schrittedatei in keinem Verzeichnis in 'undodir' schreiben"
 
 #: ../undo.c:1050
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr ""
+"Wird nicht mit Rückgängig-Schrittedatei überschrieben, konnte nicht gelesen "
+"werden: %s"
 
 #: ../undo.c:1068
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
-msgstr ""
+msgstr "Wird nicht überschrieben, keine Rückgängig-Schrittedatei: %s"
 
 #: ../undo.c:1084
 msgid "Skipping undo file write, nothing to undo"
 msgstr ""
+"Überspringe Schreiben der Rückgängig-Schrittedatei, nichts rückgängig zu "
+"machen"
 
 #: ../undo.c:1097
-#, fuzzy, c-format
+#, c-format
 msgid "Writing undo file: %s"
-msgstr "Schreiben der viminfo-Datei \"%s\""
+msgstr "Schreibe Rückgängig-Schrittedatei: %s"
 
 #: ../undo.c:1189
-#, fuzzy, c-format
+#, c-format
 msgid "E829: write error in undo file: %s"
-msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei"
+msgstr "E829: Fehler beim Schreiben in Rückgängig-Schrittedatei: %s"
 
 #: ../undo.c:1256
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
-msgstr ""
+msgstr "Überspringe Lesen von Rückgängig-Schrittedatei, anderer Besitzer: %s"
 
 #: ../undo.c:1268
-#, fuzzy, c-format
+#, c-format
 msgid "Reading undo file: %s"
-msgstr "Lese Wort-Datei %s ..."
+msgstr "Lese Rückgängig-Schrittedatei: %s"
 
 #: ../undo.c:1275
-#, fuzzy, c-format
+#, c-format
 msgid "E822: Cannot open undo file for reading: %s"
-msgstr "E195: viminfo kann nicht zum Lesen geöffnet werden"
+msgstr ""
+"E822: Rückgängig-Schrittedatei kann nicht zum Lesen geöffnet werden: %s"
 
 #: ../undo.c:1284
-#, fuzzy, c-format
+#, c-format
 msgid "E823: Not an undo file: %s"
-msgstr "E753: Nicht gefunden: %s"
+msgstr "E823: Keine Rückgängig-Schrittedatei: %s"
 
 #: ../undo.c:1289
-#, fuzzy, c-format
+#, c-format
 msgid "E824: Incompatible undo file: %s"
-msgstr "E484: Kann die Datei %s nicht öffnen"
+msgstr "E824: Inkompatible Rückgängig-Schrittedatei: %s"
 
 #: ../undo.c:1304
 msgid "File contents changed, cannot use undo info"
-msgstr ""
+msgstr "Dateiinhalt geändert, kann Rückgängig-Schritte nicht verwenden"
 
 #: ../undo.c:1473
-#, fuzzy, c-format
+#, c-format
 msgid "Finished reading undo file %s"
-msgstr "Lesen von %s beendet"
+msgstr "Lesen von Rückgängig-Schrittedatei %s beendet"
 
 #: ../undo.c:1562 ../undo.c:1788
 msgid "Already at oldest change"
@@ -5663,13 +5674,13 @@ msgid "Already at newest change"
 msgstr "Bereits bei der jüngsten Änderung"
 
 #: ../undo.c:1782
-#, fuzzy, c-format
+#, c-format
 msgid "E830: Undo number %<PRId64> not found"
-msgstr "Nummer %<PRId64> zur Wiederherstellung nicht gefunden"
+msgstr "E830: Rückgängig-Schritt %<PRId64> nicht gefunden"
 
 #: ../undo.c:1955
 msgid "E438: u_undo: line numbers wrong"
-msgstr "E438: u_undo: Zeilennummer falsch"
+msgstr "E438: u_undo: Zeilennummern falsch"
 
 #: ../undo.c:2159
 msgid "more line"
@@ -5710,11 +5721,11 @@ msgstr "nach"
 
 #: ../undo.c:2300
 msgid "Nothing to undo"
-msgstr "Nichts wiederherzustellen"
+msgstr "Nichts rückgängig zu machen"
 
 #: ../undo.c:2305
 msgid "number changes  when               saved"
-msgstr ""
+msgstr "Nummer  Änder.  wann         gespeichert"
 
 #: ../undo.c:2335
 #, c-format
@@ -5727,11 +5738,11 @@ msgstr "E790: 'undojoin' ist nicht erlaubt nach 'undo'"
 
 #: ../undo.c:2441
 msgid "E439: undo list corrupt"
-msgstr "E439: Liste der Wiederherstellungen fehlerhaft"
+msgstr "E439: Liste der Rückgängig-Schritte fehlerhaft"
 
 #: ../undo.c:2470
 msgid "E440: undo line missing"
-msgstr "E440: Wiederherstellungszeile fehlt"
+msgstr "E440: Rückgängig-Schrittezeile fehlt"
 
 #: ../version.c:643
 msgid ""
@@ -5739,14 +5750,15 @@ msgid ""
 "Included patches: "
 msgstr ""
 "\n"
-"Inklusive der Korrekturen: "
+"Enthaltene Patches: "
 
 #: ../version.c:670
-#, fuzzy
 msgid ""
 "\n"
 "Extra patches: "
-msgstr "Externe 'submatches':\n"
+msgstr ""
+"\n"
+"Zusätzliche Patches: "
 
 #: ../version.c:682 ../version.c:906
 msgid "Modified by "
@@ -5854,7 +5866,7 @@ msgstr "Tippe  :q<Enter>                zum Beenden               "
 
 #: ../version.c:822
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
-msgstr "Tippe  :help<Enter>  oder <F1>  für Online Hilfe          "
+msgstr "Tippe  :help<Enter>  oder <F1>  für die Online-Hilfe          "
 
 #: ../version.c:823
 msgid "type  :help version7<Enter>   for version info"
@@ -5862,7 +5874,7 @@ msgstr "Tippe  :help version7<Enter>    für Versions-Informationen"
 
 #: ../version.c:826
 msgid "Running in Vi compatible mode"
-msgstr "Vi kompatible Einstellung"
+msgstr "Vi-kompatible Einstellung"
 
 #: ../version.c:827
 msgid "type  :set nocp<Enter>        for Vim defaults"
@@ -5874,7 +5886,7 @@ msgstr "Tippe  :help cp-default<Enter>  für Informationen darüber "
 
 #: ../version.c:869
 msgid "Sponsor Vim development!"
-msgstr "Unterstützen Sie die Entwicklung von Vim"
+msgstr "Unterstützen Sie die Entwicklung von Vim!"
 
 #: ../version.c:870
 msgid "Become a registered Vim user!"
@@ -5898,7 +5910,7 @@ msgstr "Bereits nur ein Fenster"
 
 #: ../window.c:170
 msgid "E441: There is no preview window"
-msgstr "E441: Es gibt kein Fenster zur Voransicht"
+msgstr "E441: Es gibt kein Vorschaufenster"
 
 # should read: topleft / botright
 #: ../window.c:505
@@ -5907,21 +5919,21 @@ msgstr "E442: topleft und botright können nicht gleichzeitig verwendet werden"
 
 #: ../window.c:1174
 msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: Rotieren nicht möglich wenn ein anderes Fenster geteilt ist"
+msgstr "E443: Rotieren nicht möglich, wenn ein anderes Fenster geteilt ist"
 
 #: ../window.c:1749
 msgid "E444: Cannot close last window"
 msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
 
 #: ../window.c:1756
-#, fuzzy
 msgid "E813: Cannot close autocmd window"
-msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
+msgstr "E813: autocmd-Fenster kann nicht geschlossen werden"
 
 #: ../window.c:1760
-#, fuzzy
 msgid "E814: Cannot close window, only autocmd window would remain"
-msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
+msgstr ""
+"E814: Fenster kann nicht geschlossen werden, nur autocmd-Fenster würde "
+"übrigbleiben"
 
 #: ../window.c:2663
 msgid "E445: Other window contains changes"
@@ -5939,12 +5951,12 @@ msgstr "E18: Unerwartete Zeichen in :let"
 #: ../eval.c:139
 #, c-format
 msgid "E684: list index out of range: %<PRId64>"
-msgstr "E684: Index der Liste außerhalb des zulässigen Bereichs: %<PRId64>"
+msgstr "E684: List-Index außerhalb des zulässigen Bereichs: %<PRId64>"
 
 #: ../eval.c:140
 #, c-format
 msgid "E121: Undefined variable: %s"
-msgstr "E121: Undefinierte Variable: %s"
+msgstr "E121: Nicht definierte Variable: %s"
 
 #: ../eval.c:141
 msgid "E111: Missing ']'"
@@ -5953,24 +5965,24 @@ msgstr "E111: Fehlende ']'"
 #: ../eval.c:142
 #, c-format
 msgid "E686: Argument of %s must be a List"
-msgstr "E686: Argument von %s muss eine Liste sein"
+msgstr "E686: Argument von %s muss vom Typ List sein"
 
 #: ../eval.c:144
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
-msgstr "E712: Argument von %s muss eine Liste oder ein Wörterbuch"
+msgstr "E712: Argument von %s muss vom Typ List oder Dictionary sein"
 
 #: ../eval.c:145
 msgid "E713: Cannot use empty key for Dictionary"
-msgstr "E713: Der Schlüssel für das Wörterbuch darf nicht leer sein"
+msgstr "E713: Schlüssel für Dictionary darf nicht leer sein"
 
 #: ../eval.c:146
 msgid "E714: List required"
-msgstr "E714: Liste benötigt"
+msgstr "E714: List benötigt"
 
 #: ../eval.c:147
 msgid "E715: Dictionary required"
-msgstr "E715: Wörterbuch benötigt"
+msgstr "E715: Dictionary benötigt"
 
 #: ../eval.c:148
 #, c-format
@@ -5980,7 +5992,7 @@ msgstr "E118: Zu viele Argumente für Funktion: %s"
 #: ../eval.c:149
 #, c-format
 msgid "E716: Key not present in Dictionary: %s"
-msgstr "E716: Schlüssel nicht vorhanden im Wörterbuch: %s"
+msgstr "E716: Schlüssel nicht in Dictionary enthalten: %s"
 
 #: ../eval.c:151
 #, c-format
@@ -5989,7 +6001,7 @@ msgstr "E122: Funktion %s existiert bereits; zum Ersetzen ! hinzufügen"
 
 #: ../eval.c:152
 msgid "E717: Dictionary entry already exists"
-msgstr "E717: Wörterbuch-Eintrag existiert bereits"
+msgstr "E717: Dictionary-Eintrag existiert bereits"
 
 #: ../eval.c:153
 msgid "E718: Funcref required"
@@ -5997,7 +6009,7 @@ msgstr "E718: Funktionsreferenz benötigt"
 
 #: ../eval.c:154
 msgid "E719: Cannot use [:] with a Dictionary"
-msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
+msgstr "E719: Kann [:] nicht mit Dictionary verwenden"
 
 #: ../eval.c:155
 #, c-format
@@ -6015,17 +6027,16 @@ msgid "E461: Illegal variable name: %s"
 msgstr "E461: Unzulässiger Name der Variable: %s"
 
 #: ../eval.c:158
-#, fuzzy
 msgid "E806: using Float as a String"
-msgstr "E730: Liste als String verwendet"
+msgstr "E806: Float als String verwendet"
 
 #: ../eval.c:1381
 msgid "E687: Less targets than List items"
-msgstr "E687: Weniger Ziele als Einträge der Liste"
+msgstr "E687: Weniger Ziele als List-Einträge"
 
 #: ../eval.c:1385
 msgid "E688: More targets than List items"
-msgstr "E688: Mehr Ziele als Einträge der Liste"
+msgstr "E688: Mehr Ziele als List-Einträge"
 
 #: ../eval.c:1455
 msgid "Double ; in list of variables"
@@ -6038,7 +6049,7 @@ msgstr "E738: Kann Variablen nicht auflisten: %s"
 
 #: ../eval.c:1940
 msgid "E689: Can only index a List or Dictionary"
-msgstr "E689: Kann nur Listen und Wörterbücher indizieren"
+msgstr "E689: Kann nur List oder Dictionary indizieren"
 
 #: ../eval.c:1945
 msgid "E708: [:] must come last"
@@ -6046,15 +6057,15 @@ msgstr "E708: [:] muss am Schluss kommen"
 
 #: ../eval.c:1988
 msgid "E709: [:] requires a List value"
-msgstr "E709: [:] benötigt eine Liste als Wert"
+msgstr "E709: [:] benötigt List"
 
 #: ../eval.c:2223
 msgid "E710: List value has more items than target"
-msgstr "E710: Listenwert hat mehr Einträge als das Ziel"
+msgstr "E710: List-Wert hat mehr Einträge als das Ziel"
 
 #: ../eval.c:2227
 msgid "E711: List value has not enough items"
-msgstr "E711: Listenwert hat nicht genügend Einträge"
+msgstr "E711: List-Wert hat nicht genügend Einträge"
 
 #: ../eval.c:2414
 msgid "E690: Missing \"in\" after :for"
@@ -6080,34 +6091,31 @@ msgstr "E109: Fehlender ':' nach '?'"
 
 #: ../eval.c:3435
 msgid "E691: Can only compare List with List"
-msgstr "E691: Kann nur eine Liste mit einer Liste vergleichen"
+msgstr "E691: Kann List nur mit List vergleichen"
 
 #: ../eval.c:3437
-#, fuzzy
 msgid "E692: Invalid operation for List"
-msgstr "E692: Unzulässige Operation für Listen"
+msgstr "E692: Unzulässige Operation für List"
 
 #: ../eval.c:3458
 msgid "E735: Can only compare Dictionary with Dictionary"
-msgstr "E735: Kann nur ein Wörterbuch mit einem Wörterbuch vergleichen"
+msgstr "E735: Kann Dictionary nur mit Dictionary vergleichen"
 
 #: ../eval.c:3460
 msgid "E736: Invalid operation for Dictionary"
-msgstr "E736: Unzulässige Operation für ein Wörterbuch"
+msgstr "E736: Unzulässige Operation für Dictionary"
 
 #: ../eval.c:3475
 msgid "E693: Can only compare Funcref with Funcref"
-msgstr ""
-"E693: Kann nur eine Funktionsreferenz mit einer Funktionsreferenz vergleichen"
+msgstr "E693: Kann Funcref nur mit Funcref vergleichen"
 
 #: ../eval.c:3477
 msgid "E694: Invalid operation for Funcrefs"
-msgstr "E694: Unzulässige Operation für Funktionsreferenzen"
+msgstr "E694: Unzulässige Operation für Funcref"
 
 #: ../eval.c:3820
-#, fuzzy
 msgid "E804: Cannot use '%' with Float"
-msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
+msgstr "E804: '%' kann nicht mit Float verwendet werden"
 
 #: ../eval.c:4021
 msgid "E110: Missing ')'"
@@ -6115,7 +6123,7 @@ msgstr "E110: Fehlende ')'"
 
 #: ../eval.c:4152
 msgid "E695: Cannot index a Funcref"
-msgstr "E695: Kann keine Funktionsreferenz indizieren"
+msgstr "E695: Kann Funcref nicht indizieren"
 
 #: ../eval.c:4380
 #, c-format
@@ -6140,41 +6148,41 @@ msgstr "E115: Fehlendes Anführungszeichen: %s"
 #: ../eval.c:4620
 #, c-format
 msgid "E696: Missing comma in List: %s"
-msgstr "E696: Fehlendes Komma in der Liste: %s"
+msgstr "E696: Fehlendes Komma in List: %s"
 
 #: ../eval.c:4627
 #, c-format
 msgid "E697: Missing end of List ']': %s"
-msgstr "E697: Fehlendes Ende der Liste ']': %s"
+msgstr "E697: Fehlendes List-Ende ']': %s"
 
 #: ../eval.c:5979
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
-msgstr "E720: Fehlender Doppelpunkt im Wörterbuch: %s"
+msgstr "E720: Fehlender Doppelpunkt in Dictionary: %s"
 
 #: ../eval.c:6003
 #, c-format
 msgid "E721: Duplicate key in Dictionary: \"%s\""
-msgstr "E721: Doppelter Schlüssel im Wörterbuch: \"%s\""
+msgstr "E721: Doppelter Schlüssel in Dictionary: \"%s\""
 
 #: ../eval.c:6020
 #, c-format
 msgid "E722: Missing comma in Dictionary: %s"
-msgstr "E722: Fehlendes Komma im Wörterbuch: %s"
+msgstr "E722: Fehlendes Komma in Dictionary: %s"
 
 #: ../eval.c:6027
 #, c-format
 msgid "E723: Missing end of Dictionary '}': %s"
-msgstr "E723: Fehlendes Ende des Wörterbuchs '}': %s"
+msgstr "E723: Fehlendes Dictionary-Ende '}': %s"
 
 #: ../eval.c:6058
 msgid "E724: variable nested too deep for displaying"
 msgstr "E724: Variable ist zu tief verschachtelt für die Anzeige"
 
 #: ../eval.c:6686
-#, fuzzy, c-format
+#, c-format
 msgid "E740: Too many arguments for function %s"
-msgstr "E118: Zu viele Argumente für Funktion: %s"
+msgstr "E740: Zu viele Argumente für Funktion %s"
 
 #: ../eval.c:6688
 #, c-format
@@ -6199,17 +6207,15 @@ msgstr "E120: <SID> wurde nicht in einer Skript-Umgebung benutzt: %s"
 #: ../eval.c:6889
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
-msgstr "E725: Aufruf der 'dict' Funktion ohne Wörterbuch: %s"
+msgstr "E725: Aufruf der 'dict' Funktion ohne Dictionary: %s"
 
 #: ../eval.c:6950
-#, fuzzy
 msgid "E808: Number or Float required"
-msgstr "E521: Zahl benötigt nach ="
+msgstr "E808: Number oder Float benötigt"
 
 #: ../eval.c:7000
-#, fuzzy
 msgid "add() argument"
-msgstr "-c Argument"
+msgstr "add()-Argument"
 
 #: ../eval.c:7402
 msgid "E699: Too many arguments"
@@ -6229,19 +6235,16 @@ msgid "E737: Key already exists: %s"
 msgstr "E737: Schlüssel existiert bereits: %s"
 
 #: ../eval.c:8187
-#, fuzzy
 msgid "extend() argument"
-msgstr "--cmd Argument"
+msgstr "extend()-Argument"
 
 #: ../eval.c:8404
-#, fuzzy
 msgid "map() argument"
-msgstr "-c Argument"
+msgstr "map()-Argument"
 
 #: ../eval.c:8405
-#, fuzzy
 msgid "filter() argument"
-msgstr "-c Argument"
+msgstr "filter()-Argument"
 
 #: ../eval.c:8717
 #, c-format
@@ -6258,9 +6261,8 @@ msgid "called inputrestore() more often than inputsave()"
 msgstr "inputrestore() wurde öfter als inputsave() aufgerufen"
 
 #: ../eval.c:10254
-#, fuzzy
 msgid "insert() argument"
-msgstr "-c Argument"
+msgstr "insert()-Argument"
 
 #: ../eval.c:10324
 msgid "E786: Range not allowed"
@@ -6276,48 +6278,43 @@ msgstr "E726: Stride ist Null"
 
 #: ../eval.c:11461
 msgid "E727: Start past end"
-msgstr "E727: Start hinter dem Ende"
+msgstr "E727: Startpunkt liegt hinter dem Endpunkt"
 
 #: ../eval.c:11502 ../eval.c:14739
 msgid "<empty>"
 msgstr "<leer>"
 
 #: ../eval.c:11709
-#, fuzzy
 msgid "remove() argument"
-msgstr "--cmd Argument"
+msgstr "remove()-Argument"
 
 #: ../eval.c:11890
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Zu viele symbolische Links (zirkulär?)"
 
 #: ../eval.c:12010
-#, fuzzy
 msgid "reverse() argument"
-msgstr "-c Argument"
+msgstr "reverse()-Argument"
 
 #: ../eval.c:12565
 msgid "Error converting the call result"
-msgstr ""
+msgstr "Fehler beim Konvertieren des Aufruf-Ergebnisses"
 
 #: ../eval.c:13186
-#, fuzzy
 msgid "sort() argument"
-msgstr "-c Argument"
+msgstr "sort()-Argument"
 
 #: ../eval.c:13186
-#, fuzzy
 msgid "uniq() argument"
-msgstr "-c Argument"
+msgstr "uniq()-Argument"
 
 #: ../eval.c:13241
 msgid "E702: Sort compare function failed"
-msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
+msgstr "E702: Fehler in sort()-Vergleichsfunktion"
 
 #: ../eval.c:13271
-#, fuzzy
 msgid "E882: Uniq compare function failed"
-msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
+msgstr "E882: Fehler in uniq()-Vergleichsfunktion"
 
 #: ../eval.c:13545
 msgid "(Invalid)"
@@ -6328,33 +6325,32 @@ msgid "E677: Error writing temp file"
 msgstr "E677: Fehler beim Schreiben einer temporären Datei"
 
 #: ../eval.c:15601
-#, fuzzy
 msgid "E805: Using a Float as a Number"
-msgstr "E745: Liste als Zahl verwendet"
+msgstr "E805: Float als Number verwendet"
 
 #: ../eval.c:15604
 msgid "E703: Using a Funcref as a Number"
-msgstr "E703: Funktionsreferenz als Zahl verwendet"
+msgstr "E703: Funcref als Number verwendet"
 
 #: ../eval.c:15612
 msgid "E745: Using a List as a Number"
-msgstr "E745: Liste als Zahl verwendet"
+msgstr "E745: List als Number verwendet"
 
 #: ../eval.c:15615
 msgid "E728: Using a Dictionary as a Number"
-msgstr "E728: Wörterbuch als Zahl verwendet"
+msgstr "E728: Dictionary als Number verwendet"
 
 #: ../eval.c:15701
 msgid "E729: using Funcref as a String"
-msgstr "E729: Funktionsreferenz als String verwendet"
+msgstr "E729: Funcref als String verwendet"
 
 #: ../eval.c:15704
 msgid "E730: using List as a String"
-msgstr "E730: Liste als String verwendet"
+msgstr "E730: List als String verwendet"
 
 #: ../eval.c:15707
 msgid "E731: using Dictionary as a String"
-msgstr "E731: Wörterbuch als String verwendet"
+msgstr "E731: Dictionary als String verwendet"
 
 #: ../eval.c:16060
 #, c-format
@@ -6362,20 +6358,19 @@ msgid "E706: Variable type mismatch for: %s"
 msgstr "E706: Typ der Variable falsch zugeordnet: %s"
 
 #: ../eval.c:16146
-#, fuzzy, c-format
+#, c-format
 msgid "E795: Cannot delete variable %s"
-msgstr "E738: Kann Variablen nicht auflisten: %s"
+msgstr "E795: Kann Variable %s nicht löschen"
 
 #: ../eval.c:16166
 #, c-format
 msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr ""
-"E704: Funktionsreferenz-Variable muss mit einem Großbuchstaben beginnen: %s"
+msgstr "E704: Funcref-Variablenname muss mit einem Großbuchstaben beginnen: %s"
 
 #: ../eval.c:16173
 #, c-format
 msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Konflikt eines Variablennamens mit bestehender Funktion: %s"
+msgstr "E705: Variablenname kollidiert mit bestehender Funktion: %s"
 
 #: ../eval.c:16204
 #, c-format
@@ -6392,9 +6387,9 @@ msgid "E698: variable nested too deep for making a copy"
 msgstr "E698: Variable ist zu tief verschachtelt für eine Kopie"
 
 #: ../eval.c:16688
-#, fuzzy, c-format
+#, c-format
 msgid "E123: Undefined function: %s"
-msgstr "E130: Unbekannte Funktion: %s"
+msgstr "E123: Nicht definierte Funktion: %s"
 
 #: ../eval.c:16699
 #, c-format
@@ -6402,9 +6397,8 @@ msgid "E124: Missing '(': %s"
 msgstr "E124: Fehlendes '(': %s"
 
 #: ../eval.c:16729
-#, fuzzy
 msgid "E862: Cannot use g: here"
-msgstr "E284: Kann die IC Werte nicht setzen"
+msgstr "E862: g: kann hier nicht verwendet werden"
 
 #: ../eval.c:16748
 #, c-format
@@ -6412,24 +6406,24 @@ msgid "E125: Illegal argument: %s"
 msgstr "E125: Unzulässiges Argument: %s"
 
 #: ../eval.c:16759
-#, fuzzy, c-format
+#, c-format
 msgid "E853: Duplicate argument name: %s"
-msgstr "E154: Doppelter Tag \"%s\" in der Datei %s"
+msgstr "E853: Doppelter Argumentname: %s"
 
 #: ../eval.c:16852
 msgid "E126: Missing :endfunction"
 msgstr "E126: Fehlendes :endfunction"
 
 #: ../eval.c:16973
-#, fuzzy, c-format
+#, c-format
 msgid "E707: Function name conflicts with variable: %s"
-msgstr ""
-"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
+msgstr "E707: Funktionsname kollidiert mit Variable: %s"
 
 #: ../eval.c:16985
-#, fuzzy, c-format
+#, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
-msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
+msgstr ""
+"E127: Funktion %s kann nicht neu definiert werden: sie ist in Verwendung"
 
 #: ../eval.c:17038
 #, c-format
@@ -6442,18 +6436,15 @@ msgid "E129: Function name required"
 msgstr "E129: Funktionsname wird verlangt"
 
 #: ../eval.c:17254
-#, fuzzy, c-format
+#, c-format
 msgid "E128: Function name must start with a capital or \"s:\": %s"
 msgstr ""
-"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
-"Doppelpunkt enthalten: %s"
+"E128: Funktionsname muss mit einem Großbuchstaben oder \"s:\" beginnen: %s"
 
 #: ../eval.c:17263
-#, fuzzy, c-format
+#, c-format
 msgid "E884: Function name cannot contain a colon: %s"
-msgstr ""
-"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
-"Doppelpunkt enthalten: %s"
+msgstr "E884: Funktionsname darf keinen Doppelpunkt enthalten: %s"
 
 #: ../eval.c:17761
 #, c-format
@@ -6505,9 +6496,8 @@ msgstr ""
 "\tZuletzt gesetzt von "
 
 #: ../eval.c:18682
-#, fuzzy
 msgid "No old files"
-msgstr "Keine inkludierten Dateien"
+msgstr "Keine alten Dateien"
 
 #~ msgid "Patch file"
 #~ msgstr "Patch-Datei"
@@ -6598,10 +6588,10 @@ msgstr "Keine inkludierten Dateien"
 #~ msgstr "Partielles Schreiben für NetBeans Puffer verweigert"
 
 #~ msgid "E460: The resource fork would be lost (add ! to override)"
-#~ msgstr "E460: Der Ressourcefork geht verloren (erzwinge mit !)"
+#~ msgstr "E460: Der Ressourcefork geht verloren (mit ! erzwingen)"
 
 #~ msgid "E513: write error, conversion failed"
-#~ msgstr "E513: Schreibfehler, Umwandlung schlug fehl"
+#~ msgstr "E513: Schreibfehler, Umwandlung fehlgeschlagen"
 
 #~ msgid "E211: Warning: File \"%s\" no longer available"
 #~ msgstr "E211: Achtung: Datei \"%s\" ist nicht länger vorhanden"
@@ -7166,7 +7156,7 @@ msgstr "Keine inkludierten Dateien"
 #~ msgstr "Befehls-Server Name kann nicht registriert werden"
 
 #~ msgid "E248: Failed to send command to the destination program"
-#~ msgstr "E248: Schicken des Befehls zum Ziel-Programm schlug fehl"
+#~ msgstr "E248: Schicken des Befehls zum Ziel-Programm fehlgeschlagen"
 
 #~ msgid "E573: Invalid server id used: %s"
 #~ msgstr "E573: Ungültige Server ID verwendet: %s"
@@ -7629,7 +7619,7 @@ msgstr "Keine inkludierten Dateien"
 #~ "Vim: ein X11 Fehler trat auf\n"
 
 #~ msgid "Testing the X display failed"
-#~ msgstr "Test des X-Displays schlug fehl"
+#~ msgstr "Test des X-Displays fehlgeschlagen"
 
 #~ msgid "Opening the X display timed out"
 #~ msgstr "Zeitüberschreitung während des Öffnens des X-Displays"
@@ -7653,7 +7643,7 @@ msgstr "Keine inkludierten Dateien"
 #~ "Cannot fork\n"
 #~ msgstr ""
 #~ "\n"
-#~ "'fork' schlug fehl\n"
+#~ "'fork' fehlgeschlagen\n"
 
 #~ msgid ""
 #~ "\n"
@@ -7666,7 +7656,7 @@ msgstr "Keine inkludierten Dateien"
 #~ msgstr "XSMP verlor ICE Verbindung"
 
 #~ msgid "Opening the X display failed"
-#~ msgstr "Öffnen des X-Displays schlug fehl"
+#~ msgstr "Öffnen des X-Displays fehlgeschlagen"
 
 #~ msgid "XSMP handling save-yourself request"
 #~ msgstr "XSMP verarbeitet 'save-yourself request'"

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(deutsch)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-26 14:21+0200\n"
+"POT-Creation-Date: 2014-06-26 15:13+0200\n"
 "PO-Revision-Date: 2008-05-24 17:26+0200\n"
 "Last-Translator: Georg Dahn <georg.dahn@gmail.com>\n"
 "Language-Team: German <de@li.org>\n"
@@ -19,234 +19,14 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO_8859-1\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
-#: ../api/private/helpers.c:201
+#: ../api/private/helpers.c:197
 #, fuzzy
 msgid "Unable to get option value"
 msgstr "Schrott nach dem Optionsargument"
 
-#: ../api/private/helpers.c:204
+#: ../api/private/helpers.c:200
 msgid "internal error: unknown option type"
 msgstr ""
-
-#: ../buffer.c:92
-msgid "[Location List]"
-msgstr "[Positionsliste]"
-
-#: ../buffer.c:93
-msgid "[Quickfix List]"
-msgstr "[QuickFix-Liste]"
-
-#: ../buffer.c:94
-msgid "E855: Autocommands caused command to abort"
-msgstr ""
-
-#: ../buffer.c:135
-msgid "E82: Cannot allocate any buffer, exiting..."
-msgstr "E82: Kann keinen Puffer zuweisen; beenden..."
-
-#: ../buffer.c:138
-msgid "E83: Cannot allocate buffer, using other one..."
-msgstr "E83: Kann den Puffer nicht zuweisen; benutze einen anderen..."
-
-#: ../buffer.c:763
-msgid "E515: No buffers were unloaded"
-msgstr "E515: Keine Puffer wurden entladen"
-
-#: ../buffer.c:765
-msgid "E516: No buffers were deleted"
-msgstr "E516: Keine Puffer wurden vollständig gelöscht"
-
-#: ../buffer.c:767
-msgid "E517: No buffers were wiped out"
-msgstr "E517: Keine Puffer wurden vollständig gelöscht"
-
-#: ../buffer.c:772
-msgid "1 buffer unloaded"
-msgstr "ein Puffer entladen"
-
-#: ../buffer.c:774
-#, c-format
-msgid "%d buffers unloaded"
-msgstr "%d Puffer entladen"
-
-#: ../buffer.c:777
-msgid "1 buffer deleted"
-msgstr "ein Puffer gelöscht"
-
-#: ../buffer.c:779
-#, c-format
-msgid "%d buffers deleted"
-msgstr "%d Puffer gelöscht"
-
-#: ../buffer.c:782
-msgid "1 buffer wiped out"
-msgstr "ein Puffer vollständig gelöscht"
-
-#: ../buffer.c:784
-#, c-format
-msgid "%d buffers wiped out"
-msgstr "%d Puffer vollständig gelöscht"
-
-#: ../buffer.c:806
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Kann letzten Puffer nicht ausladen"
-
-#: ../buffer.c:874
-msgid "E84: No modified buffer found"
-msgstr "E84: Kein veränderter Puffer gefunden"
-
-#. back where we started, didn't find anything.
-#: ../buffer.c:903
-msgid "E85: There is no listed buffer"
-msgstr "E85: Es gibt keine angezeigten Puffer"
-
-#: ../buffer.c:913
-#, c-format
-msgid "E86: Buffer %<PRId64> does not exist"
-msgstr "E86: Puffer %<PRId64> existiert nicht"
-
-#: ../buffer.c:915
-msgid "E87: Cannot go beyond last buffer"
-msgstr "E87: Kann nicht über den letzten Puffer hinaus gehen"
-
-#: ../buffer.c:917
-msgid "E88: Cannot go before first buffer"
-msgstr "E88: Kann nicht vor den ersten Puffer gehen"
-
-#: ../buffer.c:945
-#, c-format
-msgid ""
-"E89: No write since last change for buffer %<PRId64> (add ! to override)"
-msgstr ""
-"E89: Puffer %<PRId64> nicht gesichert seit der letzten Änderung (erzwinge "
-"mit !)"
-
-#. wrap around (may cause duplicates)
-#: ../buffer.c:1423
-msgid "W14: Warning: List of file names overflow"
-msgstr "W14: Achtung: Überlauf der Liste der Dateinamen"
-
-#: ../buffer.c:1555 ../quickfix.c:3361
-#, c-format
-msgid "E92: Buffer %<PRId64> not found"
-msgstr "E92: Kein Puffer %<PRId64> gefunden"
-
-#: ../buffer.c:1798
-#, c-format
-msgid "E93: More than one match for %s"
-msgstr "E93: Mehr als ein Treffer für %s"
-
-#: ../buffer.c:1800
-#, c-format
-msgid "E94: No matching buffer for %s"
-msgstr "E94: Kein übereinstimmender Puffer für %s"
-
-#: ../buffer.c:2161
-#, c-format
-msgid "line %<PRId64>"
-msgstr "Zeile %<PRId64>"
-
-#: ../buffer.c:2233
-msgid "E95: Buffer with this name already exists"
-msgstr "E95: Ein Puffer mit diesem Namen existiert bereits"
-
-#: ../buffer.c:2498
-msgid " [Modified]"
-msgstr " [Verändert]"
-
-#: ../buffer.c:2501
-msgid "[Not edited]"
-msgstr "[Nicht editiert]"
-
-#: ../buffer.c:2504
-msgid "[New file]"
-msgstr "[Neue Datei]"
-
-#: ../buffer.c:2505
-msgid "[Read errors]"
-msgstr "[Lesefehler]"
-
-#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
-msgid "[RO]"
-msgstr "[RO]"
-
-#: ../buffer.c:2507 ../fileio.c:1807
-msgid "[readonly]"
-msgstr "[Nur Lesen]"
-
-#: ../buffer.c:2524
-#, c-format
-msgid "1 line --%d%%--"
-msgstr "1 Zeile --%d%%--"
-
-#: ../buffer.c:2526
-#, c-format
-msgid "%<PRId64> lines --%d%%--"
-msgstr "%<PRId64> Zeilen --%d%%--"
-
-#: ../buffer.c:2530
-#, c-format
-msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
-msgstr "Zeile %<PRId64> von %<PRId64> --%d%%-- Spalte "
-
-#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
-msgid "[No Name]"
-msgstr "[Unbenannt]"
-
-#. must be a help buffer
-#: ../buffer.c:2667
-msgid "help"
-msgstr "Hilfe"
-
-#: ../buffer.c:3225 ../screen.c:4883
-msgid "[Help]"
-msgstr "[Hilfe]"
-
-#: ../buffer.c:3254 ../screen.c:4887
-msgid "[Preview]"
-msgstr "[Vorschau]"
-
-#: ../buffer.c:3528
-msgid "All"
-msgstr "Alles"
-
-#: ../buffer.c:3528
-msgid "Bot"
-msgstr "Ende"
-
-#: ../buffer.c:3531
-msgid "Top"
-msgstr "Anfang"
-
-#: ../buffer.c:4244
-msgid ""
-"\n"
-"# Buffer list:\n"
-msgstr ""
-"\n"
-"# Liste der Puffer:\n"
-
-#: ../buffer.c:4289
-msgid "[Scratch]"
-msgstr ""
-
-#: ../buffer.c:4529
-msgid ""
-"\n"
-"--- Signs ---"
-msgstr ""
-"\n"
-"--- Zeichen ---"
-
-#: ../buffer.c:4538
-#, c-format
-msgid "Signs for %s:"
-msgstr "Zeichen für %s:"
-
-#: ../buffer.c:4543
-#, c-format
-msgid "    line=%<PRId64>  id=%d  name=%s"
-msgstr "    Zeile=%<PRId64>  id=%d  Name=%s"
 
 #: ../cursor_shape.c:68
 msgid "E545: Missing colon"
@@ -264,176 +44,412 @@ msgstr "E548: Ziffer erwartet"
 msgid "E549: Illegal percentage"
 msgstr "E549: Unzulässige Prozentangabe"
 
-#: ../diff.c:146
+#: ../os/shell.c:184
+msgid ""
+"\n"
+"Cannot execute shell "
+msgstr ""
+"\n"
+"Shell kann nicht ausführt werden "
+
+#: ../os/shell.c:450
+msgid ""
+"\n"
+"shell returned "
+msgstr ""
+"\n"
+"Shell beendet "
+
+#: ../buffer.c:88
+msgid "[Location List]"
+msgstr "[Positionsliste]"
+
+#: ../buffer.c:89
+msgid "[Quickfix List]"
+msgstr "[QuickFix-Liste]"
+
+#: ../buffer.c:90
+msgid "E855: Autocommands caused command to abort"
+msgstr ""
+
+#: ../buffer.c:131
+msgid "E82: Cannot allocate any buffer, exiting..."
+msgstr "E82: Kann keinen Puffer zuweisen; beenden..."
+
+#: ../buffer.c:134
+msgid "E83: Cannot allocate buffer, using other one..."
+msgstr "E83: Kann den Puffer nicht zuweisen; benutze einen anderen..."
+
+#: ../buffer.c:758
+msgid "E515: No buffers were unloaded"
+msgstr "E515: Keine Puffer wurden entladen"
+
+#: ../buffer.c:760
+msgid "E516: No buffers were deleted"
+msgstr "E516: Keine Puffer wurden vollständig gelöscht"
+
+#: ../buffer.c:762
+msgid "E517: No buffers were wiped out"
+msgstr "E517: Keine Puffer wurden vollständig gelöscht"
+
+#: ../buffer.c:767
+msgid "1 buffer unloaded"
+msgstr "ein Puffer entladen"
+
+#: ../buffer.c:769
+#, c-format
+msgid "%d buffers unloaded"
+msgstr "%d Puffer entladen"
+
+#: ../buffer.c:772
+msgid "1 buffer deleted"
+msgstr "ein Puffer gelöscht"
+
+#: ../buffer.c:774
+#, c-format
+msgid "%d buffers deleted"
+msgstr "%d Puffer gelöscht"
+
+#: ../buffer.c:777
+msgid "1 buffer wiped out"
+msgstr "ein Puffer vollständig gelöscht"
+
+#: ../buffer.c:779
+#, c-format
+msgid "%d buffers wiped out"
+msgstr "%d Puffer vollständig gelöscht"
+
+#: ../buffer.c:800
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Kann letzten Puffer nicht ausladen"
+
+#: ../buffer.c:868
+msgid "E84: No modified buffer found"
+msgstr "E84: Kein veränderter Puffer gefunden"
+
+#. back where we started, didn't find anything.
+#: ../buffer.c:897
+msgid "E85: There is no listed buffer"
+msgstr "E85: Es gibt keine angezeigten Puffer"
+
+#: ../buffer.c:907
+#, c-format
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Puffer %<PRId64> existiert nicht"
+
+#: ../buffer.c:909
+msgid "E87: Cannot go beyond last buffer"
+msgstr "E87: Kann nicht über den letzten Puffer hinaus gehen"
+
+#: ../buffer.c:911
+msgid "E88: Cannot go before first buffer"
+msgstr "E88: Kann nicht vor den ersten Puffer gehen"
+
+#: ../buffer.c:939
+#, c-format
+msgid ""
+"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr ""
+"E89: Puffer %<PRId64> nicht gesichert seit der letzten Änderung (erzwinge "
+"mit !)"
+
+#. wrap around (may cause duplicates)
+#: ../buffer.c:1414
+msgid "W14: Warning: List of file names overflow"
+msgstr "W14: Achtung: Überlauf der Liste der Dateinamen"
+
+#: ../buffer.c:1546 ../quickfix.c:3328
+#, c-format
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Kein Puffer %<PRId64> gefunden"
+
+#: ../buffer.c:1789
+#, c-format
+msgid "E93: More than one match for %s"
+msgstr "E93: Mehr als ein Treffer für %s"
+
+#: ../buffer.c:1791
+#, c-format
+msgid "E94: No matching buffer for %s"
+msgstr "E94: Kein übereinstimmender Puffer für %s"
+
+#: ../buffer.c:2151
+#, c-format
+msgid "line %<PRId64>"
+msgstr "Zeile %<PRId64>"
+
+#: ../buffer.c:2223
+msgid "E95: Buffer with this name already exists"
+msgstr "E95: Ein Puffer mit diesem Namen existiert bereits"
+
+#: ../buffer.c:2488
+msgid " [Modified]"
+msgstr " [Verändert]"
+
+#: ../buffer.c:2491
+msgid "[Not edited]"
+msgstr "[Nicht editiert]"
+
+#: ../buffer.c:2494
+msgid "[New file]"
+msgstr "[Neue Datei]"
+
+#: ../buffer.c:2495
+msgid "[Read errors]"
+msgstr "[Lesefehler]"
+
+#: ../buffer.c:2496 ../buffer.c:3205 ../fileio.c:1855 ../screen.c:4822
+msgid "[RO]"
+msgstr "[RO]"
+
+#: ../buffer.c:2497 ../fileio.c:1855
+msgid "[readonly]"
+msgstr "[Nur Lesen]"
+
+#: ../buffer.c:2514
+#, c-format
+msgid "1 line --%d%%--"
+msgstr "1 Zeile --%d%%--"
+
+#: ../buffer.c:2516
+#, c-format
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> Zeilen --%d%%--"
+
+#: ../buffer.c:2520
+#, c-format
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "Zeile %<PRId64> von %<PRId64> --%d%%-- Spalte "
+
+#: ../buffer.c:2622 ../buffer.c:4275 ../memline.c:1530
+msgid "[No Name]"
+msgstr "[Unbenannt]"
+
+#. must be a help buffer
+#: ../buffer.c:2657
+msgid "help"
+msgstr "Hilfe"
+
+#: ../buffer.c:3213 ../screen.c:4810
+msgid "[Help]"
+msgstr "[Hilfe]"
+
+#: ../buffer.c:3242 ../screen.c:4814
+msgid "[Preview]"
+msgstr "[Vorschau]"
+
+#: ../buffer.c:3514
+msgid "All"
+msgstr "Alles"
+
+#: ../buffer.c:3514
+msgid "Bot"
+msgstr "Ende"
+
+#: ../buffer.c:3516
+msgid "Top"
+msgstr "Anfang"
+
+#: ../buffer.c:4227
+msgid ""
+"\n"
+"# Buffer list:\n"
+msgstr ""
+"\n"
+"# Liste der Puffer:\n"
+
+#: ../buffer.c:4272
+msgid "[Scratch]"
+msgstr ""
+
+#: ../buffer.c:4521
+msgid ""
+"\n"
+"--- Signs ---"
+msgstr ""
+"\n"
+"--- Zeichen ---"
+
+#: ../buffer.c:4530
+#, c-format
+msgid "Signs for %s:"
+msgstr "Zeichen für %s:"
+
+#: ../buffer.c:4535
+#, c-format
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    Zeile=%<PRId64>  id=%d  Name=%s"
+
+#: ../diff.c:130
 #, c-format
 msgid "E96: Can not diff more than %<PRId64> buffers"
 msgstr "E96: Keine Differenz für mehr als %<PRId64> Puffer"
 
-#: ../diff.c:753
+#: ../diff.c:737
 #, fuzzy
 msgid "E810: Cannot read or write temp files"
 msgstr "E557: Termcap-Datei kann nicht geöffnet werden"
 
-#: ../diff.c:755
+#: ../diff.c:739
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kann keine Differenz erstellen"
 
-#: ../diff.c:966
+#: ../diff.c:950
 #, fuzzy
 msgid "E816: Cannot read patch output"
 msgstr "E98: Differenz-Ausgabe kann nicht gelesen werden"
 
-#: ../diff.c:1220
+#: ../diff.c:1204
 msgid "E98: Cannot read diff output"
 msgstr "E98: Differenz-Ausgabe kann nicht gelesen werden"
 
-#: ../diff.c:2081
+#: ../diff.c:2065
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Aktueller Puffer ist nicht im Differenz-Modus"
 
-#: ../diff.c:2100
+#: ../diff.c:2084
 #, fuzzy
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E100: Kein weiterer Puffer ist im Differenz-Modus"
 
-#: ../diff.c:2102
+#: ../diff.c:2086
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Kein weiterer Puffer ist im Differenz-Modus"
 
-#: ../diff.c:2112
+#: ../diff.c:2096
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: Mehrdeutigkeit: Mehr als zwei Puffer im Differenz-Modus"
 
-#: ../diff.c:2141
+#: ../diff.c:2125
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Kann Puffer \"%s\" nicht finden"
 
-#: ../diff.c:2152
+#: ../diff.c:2136
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Puffer \"%s\" ist nicht im Differenz-Modus"
 
-#: ../diff.c:2193
+#: ../diff.c:2177
 msgid "E787: Buffer changed unexpectedly"
 msgstr ""
 
-#: ../digraph.c:1598
+#: ../digraph.c:1597
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: 'Escape' ist in einem Digraphen nicht erlaubt"
 
-#: ../digraph.c:1760
+#: ../digraph.c:1758
 msgid "E544: Keymap file not found"
 msgstr "E544: Datei für die Tastaturbelegung nicht gefunden"
 
-#: ../digraph.c:1785
+#: ../digraph.c:1782
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: :loadkeymap außerhalb einer eingelesenen Datei"
 
-#: ../digraph.c:1821
+#: ../digraph.c:1818
 msgid "E791: Empty keymap entry"
 msgstr ""
 
-#: ../edit.c:82
+#: ../edit.c:83
 msgid " Keyword completion (^N^P)"
 msgstr " Stichwort-Ergänzung (^N^P)"
 
 #. ctrl_x_mode == 0, ^P/^N compl.
-#: ../edit.c:83
+#: ../edit.c:84
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " ^X Modus (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 
-#: ../edit.c:85
+#: ../edit.c:86
 msgid " Whole line completion (^L^N^P)"
 msgstr " Zeilen-Ergänzung (^L^N^P)"
 
-#: ../edit.c:86
+#: ../edit.c:87
 msgid " File name completion (^F^N^P)"
 msgstr " Dateinamen-Ergänzung (^F^N^P)"
 
-#: ../edit.c:87
+#: ../edit.c:88
 msgid " Tag completion (^]^N^P)"
 msgstr " Tag-Ergänzung  (^]^N^P)"
 
-#: ../edit.c:88
+#: ../edit.c:89
 msgid " Path pattern completion (^N^P)"
 msgstr " Pfadmuster-Ergänzung (^N^P)"
 
-#: ../edit.c:89
+#: ../edit.c:90
 msgid " Definition completion (^D^N^P)"
 msgstr " Definitions-Ergänzung (^D^N^P)"
 
-#: ../edit.c:91
+#: ../edit.c:92
 msgid " Dictionary completion (^K^N^P)"
 msgstr " Wörterbuch-Ergänzung (^K^N^P) "
 
-#: ../edit.c:92
+#: ../edit.c:93
 msgid " Thesaurus completion (^T^N^P)"
 msgstr " Thesaurus-Ergänzung (^T^N^P)"
 
-#: ../edit.c:93
+#: ../edit.c:94
 msgid " Command-line completion (^V^N^P)"
 msgstr " Kommandozeilen-Ergänzung (^V^N^P)"
 
-#: ../edit.c:94
+#: ../edit.c:95
 msgid " User defined completion (^U^N^P)"
 msgstr " Benutzerdefinierte Ergänzung (^U^N^P)"
 
-#: ../edit.c:95
+#: ../edit.c:96
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-Ergänzung (^O^N^P)"
 
-#: ../edit.c:96
+#: ../edit.c:97
 msgid " Spelling suggestion (s^N^P)"
 msgstr " Vorschlag der Rechtschreibprüfung (s^N^P)"
 
-#: ../edit.c:97
+#: ../edit.c:98
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokale Schlüsselwort-Ergänzung(^N^P)"
 
-#: ../edit.c:100
+#: ../edit.c:101
 msgid "Hit end of paragraph"
 msgstr "Absatzende erreicht"
 
-#: ../edit.c:101
+#: ../edit.c:102
 msgid "E839: Completion function changed window"
 msgstr ""
 
-#: ../edit.c:102
+#: ../edit.c:103
 msgid "E840: Completion function deleted text"
 msgstr ""
 
-#: ../edit.c:1847
+#: ../edit.c:1748
 msgid "'dictionary' option is empty"
 msgstr "Die Option 'dictionary' ist leer"
 
-#: ../edit.c:1848
+#: ../edit.c:1749
 msgid "'thesaurus' option is empty"
 msgstr "Die Option 'thesaurus' ist leer"
 
-#: ../edit.c:2655
+#: ../edit.c:2555
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Durchsuchen des Wörterbuchs: %s"
 
-#: ../edit.c:3079
+#: ../edit.c:2979
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (Einfügen) Scrollen (^E/^Y)"
 
-#: ../edit.c:3081
+#: ../edit.c:2981
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (Ersetzen) Scrollen (^E/^Y)"
 
-#: ../edit.c:3587
+#: ../edit.c:3486
 #, c-format
 msgid "Scanning: %s"
 msgstr "Durchsuche: %s"
 
-#: ../edit.c:3614
+#: ../edit.c:3513
 msgid "Scanning tags."
 msgstr "Durchsuchen von Tags."
 
-#: ../edit.c:4519
+#: ../edit.c:4418
 msgid " Adding"
 msgstr " Füge hinzu"
 
@@ -441,708 +457,127 @@ msgstr " Füge hinzu"
 #. * be called before line = ml_get(), or when this address is no
 #. * longer needed.  -- Acevedo.
 #.
-#: ../edit.c:4562
+#: ../edit.c:4461
 msgid "-- Searching..."
 msgstr "-- Suche..."
 
-#: ../edit.c:4618
+#: ../edit.c:4517
 msgid "Back at original"
 msgstr "Zurück am Ursprung"
 
-#: ../edit.c:4621
+#: ../edit.c:4520
 msgid "Word from other line"
 msgstr "Wort aus anderer Zeile"
 
-#: ../edit.c:4624
+#: ../edit.c:4523
 msgid "The only match"
 msgstr "Einziger Treffer"
 
-#: ../edit.c:4680
+#: ../edit.c:4579
 #, c-format
 msgid "match %d of %d"
 msgstr "Treffer %d von %d"
 
-#: ../edit.c:4684
+#: ../edit.c:4583
 #, c-format
 msgid "match %d"
 msgstr "Treffer %d"
 
-#: ../eval.c:137
-msgid "E18: Unexpected characters in :let"
-msgstr "E18: Unerwartete Zeichen in :let"
-
-#: ../eval.c:138
-#, c-format
-msgid "E684: list index out of range: %<PRId64>"
-msgstr "E684: Index der Liste außerhalb des zulässigen Bereichs: %<PRId64>"
-
-#: ../eval.c:139
-#, c-format
-msgid "E121: Undefined variable: %s"
-msgstr "E121: Undefinierte Variable: %s"
-
-#: ../eval.c:140
-msgid "E111: Missing ']'"
-msgstr "E111: Fehlende ']'"
-
-#: ../eval.c:141
-#, c-format
-msgid "E686: Argument of %s must be a List"
-msgstr "E686: Argument von %s muss eine Liste sein"
-
-#: ../eval.c:143
-#, c-format
-msgid "E712: Argument of %s must be a List or Dictionary"
-msgstr "E712: Argument von %s muss eine Liste oder ein Wörterbuch"
-
-#: ../eval.c:144
-msgid "E713: Cannot use empty key for Dictionary"
-msgstr "E713: Der Schlüssel für das Wörterbuch darf nicht leer sein"
-
-#: ../eval.c:145
-msgid "E714: List required"
-msgstr "E714: Liste benötigt"
-
-#: ../eval.c:146
-msgid "E715: Dictionary required"
-msgstr "E715: Wörterbuch benötigt"
-
-#: ../eval.c:147
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: Zu viele Argumente für Funktion: %s"
-
-#: ../eval.c:148
-#, c-format
-msgid "E716: Key not present in Dictionary: %s"
-msgstr "E716: Schlüssel nicht vorhanden im Wörterbuch: %s"
-
-#: ../eval.c:150
-#, c-format
-msgid "E122: Function %s already exists, add ! to replace it"
-msgstr "E122: Funktion %s existiert bereits; zum Ersetzen ! hinzufügen"
-
-#: ../eval.c:151
-msgid "E717: Dictionary entry already exists"
-msgstr "E717: Wörterbuch-Eintrag existiert bereits"
-
-#: ../eval.c:152
-msgid "E718: Funcref required"
-msgstr "E718: Funktionsreferenz benötigt"
-
-#: ../eval.c:153
-msgid "E719: Cannot use [:] with a Dictionary"
-msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
-
-#: ../eval.c:154
-#, c-format
-msgid "E734: Wrong variable type for %s="
-msgstr "E734: Falscher Typ der Variable für %s="
-
-#: ../eval.c:155
-#, c-format
-msgid "E130: Unknown function: %s"
-msgstr "E130: Unbekannte Funktion: %s"
-
-#: ../eval.c:156
-#, c-format
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: Unzulässiger Name der Variable: %s"
-
-#: ../eval.c:157
-#, fuzzy
-msgid "E806: using Float as a String"
-msgstr "E730: Liste als String verwendet"
-
-#: ../eval.c:1830
-msgid "E687: Less targets than List items"
-msgstr "E687: Weniger Ziele als Einträge der Liste"
-
-#: ../eval.c:1834
-msgid "E688: More targets than List items"
-msgstr "E688: Mehr Ziele als Einträge der Liste"
-
-#: ../eval.c:1906
-msgid "Double ; in list of variables"
-msgstr "Doppeltes ; in der Liste von Variablen"
-
-#: ../eval.c:2078
-#, c-format
-msgid "E738: Can't list variables for %s"
-msgstr "E738: Kann Variablen nicht auflisten: %s"
-
-#: ../eval.c:2391
-msgid "E689: Can only index a List or Dictionary"
-msgstr "E689: Kann nur Listen und Wörterbücher indizieren"
-
-#: ../eval.c:2396
-msgid "E708: [:] must come last"
-msgstr "E708: [:] muss am Schluss kommen"
-
-#: ../eval.c:2439
-msgid "E709: [:] requires a List value"
-msgstr "E709: [:] benötigt eine Liste als Wert"
-
-#: ../eval.c:2674
-msgid "E710: List value has more items than target"
-msgstr "E710: Listenwert hat mehr Einträge als das Ziel"
-
-#: ../eval.c:2678
-msgid "E711: List value has not enough items"
-msgstr "E711: Listenwert hat nicht genügend Einträge"
-
-#: ../eval.c:2867
-msgid "E690: Missing \"in\" after :for"
-msgstr "E690: Fehlendes \"in\" nach :for"
-
-#: ../eval.c:3063
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: Fehlende Klammern: %s"
-
-#: ../eval.c:3263
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: Keine solche Variable: \"%s\""
-
-#: ../eval.c:3333
-msgid "E743: variable nested too deep for (un)lock"
-msgstr "E743: Variable ist zu tief verschachtelt für (un)lock"
-
-#: ../eval.c:3630
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: Fehlender ':' nach '?'"
-
-#: ../eval.c:3893
-msgid "E691: Can only compare List with List"
-msgstr "E691: Kann nur eine Liste mit einer Liste vergleichen"
-
-#: ../eval.c:3895
-msgid "E692: Invalid operation for Lists"
-msgstr "E692: Unzulässige Operation für Listen"
-
-#: ../eval.c:3915
-msgid "E735: Can only compare Dictionary with Dictionary"
-msgstr "E735: Kann nur ein Wörterbuch mit einem Wörterbuch vergleichen"
-
-#: ../eval.c:3917
-msgid "E736: Invalid operation for Dictionary"
-msgstr "E736: Unzulässige Operation für ein Wörterbuch"
-
-#: ../eval.c:3932
-msgid "E693: Can only compare Funcref with Funcref"
-msgstr ""
-"E693: Kann nur eine Funktionsreferenz mit einer Funktionsreferenz vergleichen"
-
-#: ../eval.c:3934
-msgid "E694: Invalid operation for Funcrefs"
-msgstr "E694: Unzulässige Operation für Funktionsreferenzen"
-
-#: ../eval.c:4277
-#, fuzzy
-msgid "E804: Cannot use '%' with Float"
-msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
-
-#: ../eval.c:4478
-msgid "E110: Missing ')'"
-msgstr "E110: Fehlende ')'"
-
-#: ../eval.c:4609
-msgid "E695: Cannot index a Funcref"
-msgstr "E695: Kann keine Funktionsreferenz indizieren"
-
-#: ../eval.c:4839
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: Bezeichnung der Option fehlt: %s"
-
-#: ../eval.c:4855
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: Unbekannte Option: %s"
-
-#: ../eval.c:4904
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: Fehlendes Anführungszeichen: %s"
-
-#: ../eval.c:5020
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: Fehlendes Anführungszeichen: %s"
-
-#: ../eval.c:5084
-#, c-format
-msgid "E696: Missing comma in List: %s"
-msgstr "E696: Fehlendes Komma in der Liste: %s"
-
-#: ../eval.c:5091
-#, c-format
-msgid "E697: Missing end of List ']': %s"
-msgstr "E697: Fehlendes Ende der Liste ']': %s"
-
-#: ../eval.c:6475
-#, c-format
-msgid "E720: Missing colon in Dictionary: %s"
-msgstr "E720: Fehlender Doppelpunkt im Wörterbuch: %s"
-
-#: ../eval.c:6499
-#, c-format
-msgid "E721: Duplicate key in Dictionary: \"%s\""
-msgstr "E721: Doppelter Schlüssel im Wörterbuch: \"%s\""
-
-#: ../eval.c:6517
-#, c-format
-msgid "E722: Missing comma in Dictionary: %s"
-msgstr "E722: Fehlendes Komma im Wörterbuch: %s"
-
-#: ../eval.c:6524
-#, c-format
-msgid "E723: Missing end of Dictionary '}': %s"
-msgstr "E723: Fehlendes Ende des Wörterbuchs '}': %s"
-
-#: ../eval.c:6555
-msgid "E724: variable nested too deep for displaying"
-msgstr "E724: Variable ist zu tief verschachtelt für die Anzeige"
-
-#: ../eval.c:7188
-#, fuzzy, c-format
-msgid "E740: Too many arguments for function %s"
-msgstr "E118: Zu viele Argumente für Funktion: %s"
-
-#: ../eval.c:7190
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: Ungültige Argumente für die Funktion %s"
-
-#: ../eval.c:7377
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: Unbekannte Funktion: %s"
-
-#: ../eval.c:7383
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Zu wenige Argumente für Funktion: %s"
-
-#: ../eval.c:7387
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: <SID> wurde nicht in einer Skript-Umgebung benutzt: %s"
-
-#: ../eval.c:7391
-#, c-format
-msgid "E725: Calling dict function without Dictionary: %s"
-msgstr "E725: Aufruf der 'dict' Funktion ohne Wörterbuch: %s"
-
-#: ../eval.c:7453
-#, fuzzy
-msgid "E808: Number or Float required"
-msgstr "E521: Zahl benötigt nach ="
-
-#: ../eval.c:7503
-#, fuzzy
-msgid "add() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:7907
-msgid "E699: Too many arguments"
-msgstr "E699: Zu viele Argumente"
-
-#: ../eval.c:8073
-msgid "E785: complete() can only be used in Insert mode"
-msgstr "E785: complete() kann nur im Einfüge-Modus verwendet werden"
-
-#: ../eval.c:8156
-msgid "&Ok"
-msgstr "&Ok"
-
-#: ../eval.c:8676
-#, c-format
-msgid "E737: Key already exists: %s"
-msgstr "E737: Schlüssel existiert bereits: %s"
-
-#: ../eval.c:8692
-#, fuzzy
-msgid "extend() argument"
-msgstr "--cmd Argument"
-
-#: ../eval.c:8915
-#, fuzzy
-msgid "map() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:8916
-#, fuzzy
-msgid "filter() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:9229
-#, c-format
-msgid "+-%s%3ld lines: "
-msgstr "+-%s%3ld Zeilen: "
-
-#: ../eval.c:9291
-#, c-format
-msgid "E700: Unknown function: %s"
-msgstr "E700: Unbekannte Funktion: %s"
-
-#: ../eval.c:10729
-msgid "called inputrestore() more often than inputsave()"
-msgstr "inputrestore() wurde öfter als inputsave() aufgerufen"
-
-#: ../eval.c:10771
-#, fuzzy
-msgid "insert() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:10841
-msgid "E786: Range not allowed"
-msgstr "E786: Bereich nicht erlaubt"
-
-#: ../eval.c:11140
-msgid "E701: Invalid type for len()"
-msgstr "E701: Unzulässiger Typ für len()"
-
-#: ../eval.c:11980
-msgid "E726: Stride is zero"
-msgstr "E726: Stride ist Null"
-
-#: ../eval.c:11982
-msgid "E727: Start past end"
-msgstr "E727: Start hinter dem Ende"
-
-#: ../eval.c:12024 ../eval.c:15297
-msgid "<empty>"
-msgstr "<leer>"
-
-#: ../eval.c:12282
-#, fuzzy
-msgid "remove() argument"
-msgstr "--cmd Argument"
-
-#: ../eval.c:12466
-msgid "E655: Too many symbolic links (cycle?)"
-msgstr "E655: Zu viele symbolische Links (zirkulär?)"
-
-#: ../eval.c:12593
-#, fuzzy
-msgid "reverse() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:13721
-#, fuzzy
-msgid "sort() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:13721
-#, fuzzy
-msgid "uniq() argument"
-msgstr "-c Argument"
-
-#: ../eval.c:13776
-msgid "E702: Sort compare function failed"
-msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
-
-#: ../eval.c:13806
-#, fuzzy
-msgid "E882: Uniq compare function failed"
-msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
-
-#: ../eval.c:14085
-msgid "(Invalid)"
-msgstr "(Ungültig)"
-
-#: ../eval.c:14590
-msgid "E677: Error writing temp file"
-msgstr "E677: Fehler beim Schreiben einer temporären Datei"
-
-#: ../eval.c:16159
-#, fuzzy
-msgid "E805: Using a Float as a Number"
-msgstr "E745: Liste als Zahl verwendet"
-
-#: ../eval.c:16162
-msgid "E703: Using a Funcref as a Number"
-msgstr "E703: Funktionsreferenz als Zahl verwendet"
-
-#: ../eval.c:16170
-msgid "E745: Using a List as a Number"
-msgstr "E745: Liste als Zahl verwendet"
-
-#: ../eval.c:16173
-msgid "E728: Using a Dictionary as a Number"
-msgstr "E728: Wörterbuch als Zahl verwendet"
-
-#: ../eval.c:16259
-msgid "E729: using Funcref as a String"
-msgstr "E729: Funktionsreferenz als String verwendet"
-
-#: ../eval.c:16262
-msgid "E730: using List as a String"
-msgstr "E730: Liste als String verwendet"
-
-#: ../eval.c:16265
-msgid "E731: using Dictionary as a String"
-msgstr "E731: Wörterbuch als String verwendet"
-
-#: ../eval.c:16619
-#, c-format
-msgid "E706: Variable type mismatch for: %s"
-msgstr "E706: Typ der Variable falsch zugeordnet: %s"
-
-#: ../eval.c:16705
-#, fuzzy, c-format
-msgid "E795: Cannot delete variable %s"
-msgstr "E738: Kann Variablen nicht auflisten: %s"
-
-#: ../eval.c:16724
-#, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr ""
-"E704: Funktionsreferenz-Variable muss mit einem Großbuchstaben beginnen: %s"
-
-#: ../eval.c:16732
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: Konflikt eines Variablennamens mit bestehender Funktion: %s"
-
-#: ../eval.c:16763
-#, c-format
-msgid "E741: Value is locked: %s"
-msgstr "E741: Wert ist gesperrt: %s"
-
-#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: ../eval.c:16768
-#, c-format
-msgid "E742: Cannot change value of %s"
-msgstr "E742: Kann Wert nicht ändern: %s"
-
-#: ../eval.c:16838
-msgid "E698: variable nested too deep for making a copy"
-msgstr "E698: Variable ist zu tief verschachtelt für eine Kopie"
-
-#: ../eval.c:17249
-#, fuzzy, c-format
-msgid "E123: Undefined function: %s"
-msgstr "E130: Unbekannte Funktion: %s"
-
-#: ../eval.c:17260
-#, c-format
-msgid "E124: Missing '(': %s"
-msgstr "E124: Fehlendes '(': %s"
-
-#: ../eval.c:17293
-#, fuzzy
-msgid "E862: Cannot use g: here"
-msgstr "E284: Kann die IC Werte nicht setzen"
-
-#: ../eval.c:17312
-#, c-format
-msgid "E125: Illegal argument: %s"
-msgstr "E125: Unzulässiges Argument: %s"
-
-#: ../eval.c:17323
-#, fuzzy, c-format
-msgid "E853: Duplicate argument name: %s"
-msgstr "E154: Doppelter Tag \"%s\" in der Datei %s"
-
-#: ../eval.c:17416
-msgid "E126: Missing :endfunction"
-msgstr "E126: Fehlendes :endfunction"
-
-#: ../eval.c:17537
-#, fuzzy, c-format
-msgid "E707: Function name conflicts with variable: %s"
-msgstr ""
-"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
-
-#: ../eval.c:17549
-#, fuzzy, c-format
-msgid "E127: Cannot redefine function %s: It is in use"
-msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
-
-#: ../eval.c:17604
-#, c-format
-msgid "E746: Function name does not match script file name: %s"
-msgstr ""
-"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
-
-#: ../eval.c:17716
-msgid "E129: Function name required"
-msgstr "E129: Funktionsname wird verlangt"
-
-#: ../eval.c:17824
-#, fuzzy, c-format
-msgid "E128: Function name must start with a capital or \"s:\": %s"
-msgstr ""
-"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
-"Doppelpunkt enthalten: %s"
-
-#: ../eval.c:17833
-#, fuzzy, c-format
-msgid "E884: Function name cannot contain a colon: %s"
-msgstr ""
-"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
-"Doppelpunkt enthalten: %s"
-
-#: ../eval.c:18336
-#, c-format
-msgid "E131: Cannot delete function %s: It is in use"
-msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
-
-#: ../eval.c:18441
-msgid "E132: Function call depth is higher than 'maxfuncdepth'"
-msgstr "E132: Funktionsaufrufstiefe überschreitet 'maxfuncdepth'"
-
-#: ../eval.c:18568
-#, c-format
-msgid "calling %s"
-msgstr "rufe %s auf"
-
-#: ../eval.c:18651
-#, c-format
-msgid "%s aborted"
-msgstr "%s abgebrochen"
-
-#: ../eval.c:18653
-#, c-format
-msgid "%s returning #%<PRId64>"
-msgstr "%s lieferte #%<PRId64> zurück"
-
-#: ../eval.c:18670
-#, c-format
-msgid "%s returning %s"
-msgstr "%s lieferte \"%s\" zurück"
-
-#: ../eval.c:18691 ../ex_cmds2.c:2695
-#, c-format
-msgid "continuing in %s"
-msgstr "weiter in %s"
-
-#: ../eval.c:18795
-msgid "E133: :return not inside a function"
-msgstr "E133: :return außerhalb einer Funktion"
-
-#: ../eval.c:19159
-msgid ""
-"\n"
-"# global variables:\n"
-msgstr ""
-"\n"
-"# globale Variablen:\n"
-
-#: ../eval.c:19254
-msgid ""
-"\n"
-"\tLast set from "
-msgstr ""
-"\n"
-"\tZuletzt gesetzt von "
-
-#: ../eval.c:19272
-#, fuzzy
-msgid "No old files"
-msgstr "Keine inkludierten Dateien"
-
-#: ../ex_cmds.c:122
+#: ../ex_cmds.c:119
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Oktal %03o"
 
-#: ../ex_cmds.c:145
+#: ../ex_cmds.c:142
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Oktal %o"
 
-#: ../ex_cmds.c:146
+#: ../ex_cmds.c:143
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Oktal %o"
 
-#: ../ex_cmds.c:684
+#: ../ex_cmds.c:679
 msgid "E134: Move lines into themselves"
 msgstr "E134: Verschiebe Zeilen in sich selbst"
 
-#: ../ex_cmds.c:747
+#: ../ex_cmds.c:742
 msgid "1 line moved"
 msgstr "1 Zeile verschoben"
 
-#: ../ex_cmds.c:749
+#: ../ex_cmds.c:744
 #, c-format
 msgid "%<PRId64> lines moved"
 msgstr "%<PRId64> Zeilen verschoben"
 
-#: ../ex_cmds.c:1175
+#: ../ex_cmds.c:1170
 #, c-format
 msgid "%<PRId64> lines filtered"
 msgstr "%<PRId64> Zeilen gefiltert"
 
-#: ../ex_cmds.c:1194
+#: ../ex_cmds.c:1189
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-Autokommandos dürfen den aktuellen Puffer nicht ändern"
 
-#: ../ex_cmds.c:1244
+#: ../ex_cmds.c:1239
 msgid "[No write since last change]\n"
 msgstr "[Kein Schreiben seit der letzten Änderung]\n"
 
-#: ../ex_cmds.c:1424
+#: ../ex_cmds.c:1418
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s in Zeile: "
 
-#: ../ex_cmds.c:1431
+#: ../ex_cmds.c:1425
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Zu viele Fehler; überspringe Rest der Datei"
 
-#: ../ex_cmds.c:1458
+#: ../ex_cmds.c:1452
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Lesen der viminfo-Datei \"%s\"%s%s%s"
 
-#: ../ex_cmds.c:1460
+#: ../ex_cmds.c:1454
 msgid " info"
 msgstr " Information"
 
-#: ../ex_cmds.c:1461
+#: ../ex_cmds.c:1455
 msgid " marks"
 msgstr " Markierungen"
 
-#: ../ex_cmds.c:1462
+#: ../ex_cmds.c:1456
 #, fuzzy
 msgid " oldfiles"
 msgstr "Keine inkludierten Dateien"
 
-#: ../ex_cmds.c:1463
+#: ../ex_cmds.c:1457
 msgid " FAILED"
 msgstr " FEHLGESCHLAGEN"
 
 #. avoid a wait_return for this message, it's annoying
-#: ../ex_cmds.c:1541
+#: ../ex_cmds.c:1535
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Viminfo-Datei ist nicht schreibbar: %s"
 
-#: ../ex_cmds.c:1626
+#: ../ex_cmds.c:1620
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Schreiben der viminfo-Datei %s ist nicht möglich!"
 
-#: ../ex_cmds.c:1635
+#: ../ex_cmds.c:1629
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Schreiben der viminfo-Datei \"%s\""
 
 #. Write the info:
-#: ../ex_cmds.c:1720
+#: ../ex_cmds.c:1714
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Diese viminfo-Datei wurde von Vim %s generiert.\n"
 
-#: ../ex_cmds.c:1722
+#: ../ex_cmds.c:1716
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1150,49 +585,49 @@ msgstr ""
 "# Sie können sie verändern, wenn Sie vorsichtig vorgehen!\n"
 "\n"
 
-#: ../ex_cmds.c:1723
+#: ../ex_cmds.c:1717
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Wert von 'encoding', als diese Datei geschrieben wurde\n"
 
-#: ../ex_cmds.c:1800
+#: ../ex_cmds.c:1794
 msgid "Illegal starting char"
 msgstr "Unzulässiges Zeichen am Anfang"
 
-#: ../ex_cmds.c:2162
+#: ../ex_cmds.c:2156
 msgid "Write partial file?"
 msgstr "Partielle Datei schreiben?"
 
-#: ../ex_cmds.c:2166
+#: ../ex_cmds.c:2160
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Zum Schreiben von partiellen Puffern ! verwenden"
 
-#: ../ex_cmds.c:2281
+#: ../ex_cmds.c:2275
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
 msgstr "Überschreibe existierende Datei \"%s\"?"
 
-#: ../ex_cmds.c:2317
+#: ../ex_cmds.c:2311
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
 msgstr "Auslagerungsdatei \"%s\" existiert bereits. Überschreiben?"
 
-#: ../ex_cmds.c:2326
+#: ../ex_cmds.c:2320
 #, c-format
 msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Auslagerungsdatei existiert bereits: %s (mit :silent! erzwingen)"
 
-#: ../ex_cmds.c:2381
+#: ../ex_cmds.c:2375
 #, c-format
 msgid "E141: No file name for buffer %<PRId64>"
 msgstr "E141: Kein Dateiname für Puffer %<PRId64>"
 
-#: ../ex_cmds.c:2412
+#: ../ex_cmds.c:2406
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr ""
 "E142: Datei wurde nicht geschrieben: Schreiben ist durch die Option 'write' "
 "ausgeschaltet"
 
-#: ../ex_cmds.c:2434
+#: ../ex_cmds.c:2428
 #, c-format
 msgid ""
 "'readonly' option is set for \"%s\".\n"
@@ -1201,7 +636,7 @@ msgstr ""
 "'readonly'-Option ist für \"%s\" gesetzt.\n"
 "Möchten Sie trotzdem schreiben?"
 
-#: ../ex_cmds.c:2439
+#: ../ex_cmds.c:2433
 #, c-format
 msgid ""
 "File permissions of \"%s\" are read-only.\n"
@@ -1209,83 +644,83 @@ msgid ""
 "Do you wish to try?"
 msgstr ""
 
-#: ../ex_cmds.c:2451
+#: ../ex_cmds.c:2445
 #, fuzzy, c-format
 msgid "E505: \"%s\" is read-only (add ! to override)"
 msgstr "ist Schreibgeschützt (erzwinge mit !)"
 
-#: ../ex_cmds.c:3120
+#: ../ex_cmds.c:3114
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autokommandos löschten unerwartet neuen Puffer %s"
 
-#: ../ex_cmds.c:3313
+#: ../ex_cmds.c:3307
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Nicht-numerisches Argument für :z"
 
-#: ../ex_cmds.c:3404
+#: ../ex_cmds.c:3398
 msgid "E145: Shell commands not allowed in rvim"
 msgstr "E145: Shell-Befehle sind in rvim nicht erlaubt"
 
-#: ../ex_cmds.c:3498
+#: ../ex_cmds.c:3492
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Reguläre Ausdrücke können nicht durch Buchstaben begrenzt werden"
 
-#: ../ex_cmds.c:3964
+#: ../ex_cmds.c:3958
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "ersetze durch %s (y/n/a/q/l/^E/^Y)?"
 
-#: ../ex_cmds.c:4379
+#: ../ex_cmds.c:4373
 msgid "(Interrupted) "
 msgstr "(Unterbrochen) "
 
-#: ../ex_cmds.c:4384
+#: ../ex_cmds.c:4378
 msgid "1 match"
 msgstr "ein Treffer"
 
-#: ../ex_cmds.c:4384
+#: ../ex_cmds.c:4378
 msgid "1 substitution"
 msgstr "eine Ersetzung"
 
-#: ../ex_cmds.c:4387
+#: ../ex_cmds.c:4381
 #, c-format
 msgid "%<PRId64> matches"
 msgstr "%<PRId64> Treffer"
 
-#: ../ex_cmds.c:4388
+#: ../ex_cmds.c:4382
 #, c-format
 msgid "%<PRId64> substitutions"
 msgstr "%<PRId64> Ersetzungen"
 
-#: ../ex_cmds.c:4392
+#: ../ex_cmds.c:4386
 msgid " on 1 line"
 msgstr " auf einer Zeile"
 
-#: ../ex_cmds.c:4395
+#: ../ex_cmds.c:4389
 #, c-format
 msgid " on %<PRId64> lines"
 msgstr " auf %<PRId64> Zeilen"
 
-#: ../ex_cmds.c:4438
+#: ../ex_cmds.c:4432
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kann :global nicht rekursiv ausführen"
 
-#: ../ex_cmds.c:4467
+#: ../ex_cmds.c:4461
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Regulärer Ausdruck fehlt in global"
 
-#: ../ex_cmds.c:4508
+#: ../ex_cmds.c:4502
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Muster in jeder Zeile gefunden: %s"
 
-#: ../ex_cmds.c:4510
+#: ../ex_cmds.c:4504
 #, fuzzy, c-format
 msgid "Pattern not found: %s"
 msgstr "Muster nicht gefunden"
 
-#: ../ex_cmds.c:4587
+#: ../ex_cmds.c:4581
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1295,339 +730,349 @@ msgstr ""
 "# Letzte ersetzte Zeichenkette:\n"
 "$"
 
-#: ../ex_cmds.c:4679
+#: ../ex_cmds.c:4673
 msgid "E478: Don't panic!"
 msgstr "E478: Nur keine Panik!"
 
-#: ../ex_cmds.c:4717
+#: ../ex_cmds.c:4711
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Schade, keine '%s' Hilfe für %s"
 
-#: ../ex_cmds.c:4719
+#: ../ex_cmds.c:4713
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Schade, keine Hilfe für %s"
 
-#: ../ex_cmds.c:4751
+#: ../ex_cmds.c:4745
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Hilfe-Datei \"%s\" nicht gefunden"
 
-#: ../ex_cmds.c:5323
+#: ../ex_cmds.c:5314
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: Kein Verzeichnis: %s"
 
-#: ../ex_cmds.c:5446
+#: ../ex_cmds.c:5437
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: %s kann nicht zum Schreiben geöffnet werden"
 
-#: ../ex_cmds.c:5471
+#: ../ex_cmds.c:5462
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: %s kann nicht zum Lesen geöffnet werden"
 
-#: ../ex_cmds.c:5500
+#: ../ex_cmds.c:5491
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr ""
 "E670: Mischung von Kodierungen einer Hilfedatei innerhalb einer Sprache: %s"
 
-#: ../ex_cmds.c:5565
+#: ../ex_cmds.c:5556
 #, c-format
 msgid "E154: Duplicate tag \"%s\" in file %s/%s"
 msgstr "E154: Doppelter Tag \"%s\" in der Datei %s/%s"
 
-#: ../ex_cmds.c:5687
+#: ../ex_cmds.c:5670
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Unbekannter \"sign\"-Befehl: %s"
 
-#: ../ex_cmds.c:5704
+#: ../ex_cmds.c:5687
 msgid "E156: Missing sign name"
 msgstr "E156: Name des Zeichens fehlt"
 
-#: ../ex_cmds.c:5746
+#: ../ex_cmds.c:5729
 msgid "E612: Too many signs defined"
 msgstr "E612: Zu viele Zeichen definiert"
 
-#: ../ex_cmds.c:5813
+#: ../ex_cmds.c:5796
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Ungültiger Text für ein Zeichen: %s"
 
-#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
+#: ../ex_cmds.c:5827 ../ex_cmds.c:6018
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Unbekanntes Zeichen: %s"
 
-#: ../ex_cmds.c:5877
+#: ../ex_cmds.c:5860
 msgid "E159: Missing sign number"
 msgstr "E159: Fehlende Zeichennummer"
 
-#: ../ex_cmds.c:5971
+#: ../ex_cmds.c:5954
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: ungültige Puffernummer: %s"
 
-#: ../ex_cmds.c:6008
+#: ../ex_cmds.c:5991
 #, c-format
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: Ungültige Zeichen-ID: %<PRId64>"
 
-#: ../ex_cmds.c:6066
+#: ../ex_cmds.c:6031
+#, c-format
+msgid "E885: Not possible to change sign %s"
+msgstr ""
+
+#: ../ex_cmds.c:6049
 msgid " (not supported)"
 msgstr " (nicht unterstützt)"
 
-#: ../ex_cmds.c:6169
+#: ../ex_cmds.c:6135
 msgid "[Deleted]"
 msgstr "[Gelöscht]"
 
-#: ../ex_cmds2.c:139
+#: ../ex_cmds2.c:163
 msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Debug-Modus. Geben Sie \"cont\" zum Fortsetzen ein."
 
-#: ../ex_cmds2.c:143 ../ex_docmd.c:759
+#: ../ex_cmds2.c:167 ../ex_docmd.c:627
 #, c-format
 msgid "line %<PRId64>: %s"
 msgstr "Zeile %<PRId64>: %s"
 
-#: ../ex_cmds2.c:145
+#: ../ex_cmds2.c:169
 #, c-format
 msgid "cmd: %s"
 msgstr "Befehl: %s"
 
-#: ../ex_cmds2.c:322
+#: ../ex_cmds2.c:346
 #, c-format
 msgid "Breakpoint in \"%s%s\" line %<PRId64>"
 msgstr "Haltepunkt in \"%s%s\" Zeile %<PRId64>"
 
-#: ../ex_cmds2.c:581
+#: ../ex_cmds2.c:600
 #, c-format
 msgid "E161: Breakpoint not found: %s"
 msgstr "E161: Haltepunkt nicht gefunden: %s"
 
-#: ../ex_cmds2.c:611
+#: ../ex_cmds2.c:629
 msgid "No breakpoints defined"
 msgstr "Keine Haltepunkte definiert"
 
-#: ../ex_cmds2.c:617
+#: ../ex_cmds2.c:635
 #, c-format
 msgid "%3d  %s %s  line %<PRId64>"
 msgstr "%3d  %s %s  Zeile %<PRId64>"
 
-#: ../ex_cmds2.c:942
+#: ../ex_cmds2.c:940
 #, fuzzy
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Erste Verwendung von :profile startet <fname>"
 
-#: ../ex_cmds2.c:1269
+#: ../ex_cmds2.c:1265
 #, c-format
 msgid "Save changes to \"%s\"?"
 msgstr "Änderungen in \"%s\" speichern?"
 
-#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
+#: ../ex_cmds2.c:1267 ../ex_docmd.c:8688
 msgid "Untitled"
 msgstr "Unbenannt"
 
-#: ../ex_cmds2.c:1421
+#: ../ex_cmds2.c:1416
 #, c-format
 msgid "E162: No write since last change for buffer \"%s\""
 msgstr "E162: Puffer \"%s\" wurde seit der letzten Änderung nicht geschrieben"
 
-#: ../ex_cmds2.c:1480
+#: ../ex_cmds2.c:1475
 msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
 "Achtung: Unerwarteter Eintritt in einen andren Puffer (überprüfen Sie die "
 "Autokommandos)"
 
-#: ../ex_cmds2.c:1826
+#: ../ex_cmds2.c:1813
 msgid "E163: There is only one file to edit"
 msgstr "E163: Es gibt nur eine Datei zum Editieren"
 
-#: ../ex_cmds2.c:1828
+#: ../ex_cmds2.c:1815
 msgid "E164: Cannot go before first file"
 msgstr "E164: Kann nicht über die erste Datei hinausgehen"
 
-#: ../ex_cmds2.c:1830
+#: ../ex_cmds2.c:1817
 msgid "E165: Cannot go beyond last file"
 msgstr "E165: Kann nicht über die letzte Datei hinausgehen"
 
-#: ../ex_cmds2.c:2175
+#: ../ex_cmds2.c:2157
 #, c-format
 msgid "E666: compiler not supported: %s"
 msgstr "E666: Compiler nicht unterstützt: %s"
 
-#: ../ex_cmds2.c:2257
+#: ../ex_cmds2.c:2235
 #, c-format
 msgid "Searching for \"%s\" in \"%s\""
 msgstr "Suche nach \"%s\" in \"%s\""
 
-#: ../ex_cmds2.c:2284
+#: ../ex_cmds2.c:2262
 #, c-format
 msgid "Searching for \"%s\""
 msgstr "Suche nach \"%s\""
 
-#: ../ex_cmds2.c:2307
+#: ../ex_cmds2.c:2285
 #, c-format
 msgid "not found in 'runtimepath': \"%s\""
 msgstr "im 'runtimepath' nicht gefunden: \"%s\""
 
-#: ../ex_cmds2.c:2472
+#: ../ex_cmds2.c:2427
 #, c-format
 msgid "Cannot source a directory: \"%s\""
 msgstr "Kann kein Verzeichnis einlesen: \"%s\""
 
-#: ../ex_cmds2.c:2518
+#: ../ex_cmds2.c:2473
 #, c-format
 msgid "could not source \"%s\""
 msgstr "\"%s\" konnte nicht gelesen werden"
 
-#: ../ex_cmds2.c:2520
+#: ../ex_cmds2.c:2475
 #, c-format
 msgid "line %<PRId64>: could not source \"%s\""
 msgstr "Zeile %<PRId64>: \"%s\" konnte nicht gelesen werden"
 
-#: ../ex_cmds2.c:2535
+#: ../ex_cmds2.c:2490
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "lese \"%s\""
 
-#: ../ex_cmds2.c:2537
+#: ../ex_cmds2.c:2492
 #, c-format
 msgid "line %<PRId64>: sourcing \"%s\""
 msgstr "Zeile %<PRId64>: lese \"%s\""
 
-#: ../ex_cmds2.c:2693
+#: ../ex_cmds2.c:2639
 #, c-format
 msgid "finished sourcing %s"
 msgstr "Lesen von %s beendet"
 
-#: ../ex_cmds2.c:2765
+#: ../ex_cmds2.c:2641 ../eval.c:18115
+#, c-format
+msgid "continuing in %s"
+msgstr "weiter in %s"
+
+#: ../ex_cmds2.c:2709
 msgid "modeline"
 msgstr "modeline"
 
-#: ../ex_cmds2.c:2767
+#: ../ex_cmds2.c:2711
 msgid "--cmd argument"
 msgstr "--cmd Argument"
 
-#: ../ex_cmds2.c:2769
+#: ../ex_cmds2.c:2713
 msgid "-c argument"
 msgstr "-c Argument"
 
-#: ../ex_cmds2.c:2771
+#: ../ex_cmds2.c:2715
 msgid "environment variable"
 msgstr "Umgebungsvariable"
 
-#: ../ex_cmds2.c:2773
+#: ../ex_cmds2.c:2717
 msgid "error handler"
 msgstr "Error-Handler"
 
-#: ../ex_cmds2.c:3020
+#: ../ex_cmds2.c:2890
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Achtung: Falscher Zeilentrenner, vielleicht fehlt ein ^M"
 
-#: ../ex_cmds2.c:3139
+#: ../ex_cmds2.c:3009
 msgid "E167: :scriptencoding used outside of a sourced file"
 msgstr "E167: :scriptencoding außerhalb einer eingelesenen Datei"
 
-#: ../ex_cmds2.c:3166
+#: ../ex_cmds2.c:3034
 msgid "E168: :finish used outside of a sourced file"
 msgstr "E168: :finish außerhalb einer eingelesenen Datei"
 
-#: ../ex_cmds2.c:3389
+#: ../ex_cmds2.c:3251
 #, c-format
 msgid "Current %slanguage: \"%s\""
 msgstr "Momentane %sSprache: \"%s\""
 
-#: ../ex_cmds2.c:3404
+#: ../ex_cmds2.c:3266
 #, c-format
 msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: Sprache kann nicht auf \"%s\" gesetzt werden"
 
 #. don't redisplay the window
 #. don't wait for return
-#: ../ex_docmd.c:387
+#: ../ex_docmd.c:257
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr ""
 "Ex-Modus. Geben Sie \"visual\" ein, um zum Normal-Modus zurückzukehren."
 
-#: ../ex_docmd.c:428
+#: ../ex_docmd.c:298
 msgid "E501: At end-of-file"
 msgstr "E501: Am Dateiende"
 
-#: ../ex_docmd.c:513
+#: ../ex_docmd.c:381
 msgid "E169: Command too recursive"
 msgstr "E169: Befehl zu rekursiv"
 
-#: ../ex_docmd.c:1006
+#: ../ex_docmd.c:874
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Ausnahme nicht aufgefangen: %s"
 
-#: ../ex_docmd.c:1085
+#: ../ex_docmd.c:953
 msgid "End of sourced file"
 msgstr "Ende der eingelesenen Datei"
 
-#: ../ex_docmd.c:1086
+#: ../ex_docmd.c:954
 msgid "End of function"
 msgstr "Ende der Funktion"
 
-#: ../ex_docmd.c:1628
+#: ../ex_docmd.c:1493
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Mehrdeutige Verwendung eines benutzerdefinierten Befehls"
 
-#: ../ex_docmd.c:1638
+#: ../ex_docmd.c:1503
 msgid "E492: Not an editor command"
 msgstr "E492: Kein Editorbefehl"
 
-#: ../ex_docmd.c:1729
+#: ../ex_docmd.c:1594
 msgid "E493: Backwards range given"
 msgstr "E493: Bereichsgrenzen rückwärts"
 
-#: ../ex_docmd.c:1733
+#: ../ex_docmd.c:1598
 msgid "Backwards range given, OK to swap"
 msgstr "Bereichsgrenzen rückwärts; vertauschen"
 
 #. append
 #. typed wrong
-#: ../ex_docmd.c:1787
+#: ../ex_docmd.c:1652
 msgid "E494: Use w or w>>"
 msgstr "E494: Verwenden Sie w oder w>>"
 
-#: ../ex_docmd.c:3454
+#: ../ex_docmd.c:3319
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Der Befehl ist in dieser Version nicht implementiert"
 
-#: ../ex_docmd.c:3752
+#: ../ex_docmd.c:3612
 msgid "E172: Only one file name allowed"
 msgstr "E172: Nur ein Dateiname erlaubt"
 
-#: ../ex_docmd.c:4238
+#: ../ex_docmd.c:4094
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Eine weitere Datei zum Editieren. Trotzdem beenden?"
 
-#: ../ex_docmd.c:4242
+#: ../ex_docmd.c:4098
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "%d weitere Dateien zum Editieren. Trotzdem beenden?"
 
-#: ../ex_docmd.c:4248
+#: ../ex_docmd.c:4104
 msgid "E173: 1 more file to edit"
 msgstr "E173: Eine weitere Datei zum Editieren"
 
-#: ../ex_docmd.c:4250
+#: ../ex_docmd.c:4106
 #, c-format
 msgid "E173: %<PRId64> more files to edit"
 msgstr "E173: %<PRId64> weitere Dateien zum Editieren"
 
-#: ../ex_docmd.c:4320
+#: ../ex_docmd.c:4164
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Befehl existiert bereits: ! zum Ersetzen hinzufügen"
 
-#: ../ex_docmd.c:4432
+#: ../ex_docmd.c:4276
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1635,346 +1080,346 @@ msgstr ""
 "\n"
 "   Name        Args Bereich Fertig  Definition"
 
-#: ../ex_docmd.c:4516
+#: ../ex_docmd.c:4360
 msgid "No user-defined commands found"
 msgstr "Keine vom Benutzer definierten Befehle gefunden"
 
-#: ../ex_docmd.c:4538
+#: ../ex_docmd.c:4382
 msgid "E175: No attribute specified"
 msgstr "E175: Kein Attribut angegeben"
 
-#: ../ex_docmd.c:4583
+#: ../ex_docmd.c:4427
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Falsche Anzahl von Argumenten"
 
-#: ../ex_docmd.c:4594
+#: ../ex_docmd.c:4438
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Zähler kann nicht zweimal angegeben werden"
 
-#: ../ex_docmd.c:4603
+#: ../ex_docmd.c:4447
 msgid "E178: Invalid default value for count"
 msgstr "E178: Ungültige Voreinstellung für den Zähler"
 
-#: ../ex_docmd.c:4625
+#: ../ex_docmd.c:4469
 msgid "E179: argument required for -complete"
 msgstr "E179: Argument benötigt für -complete"
 
-#: ../ex_docmd.c:4635
+#: ../ex_docmd.c:4479
 #, c-format
 msgid "E181: Invalid attribute: %s"
 msgstr "E181: Ungültiges Attribut: %s"
 
-#: ../ex_docmd.c:4678
+#: ../ex_docmd.c:4522
 msgid "E182: Invalid command name"
 msgstr "E182: Ungültiger Befehls-Name"
 
-#: ../ex_docmd.c:4691
+#: ../ex_docmd.c:4535
 msgid "E183: User defined commands must start with an uppercase letter"
 msgstr "E183: Benutzerdefinierte Befehle müssen mit Großbuchstaben beginnen"
 
-#: ../ex_docmd.c:4696
+#: ../ex_docmd.c:4540
 #, fuzzy
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E464: Mehrdeutige Verwendung eines benutzerdefinierten Befehls"
 
-#: ../ex_docmd.c:4751
+#: ../ex_docmd.c:4594
 #, c-format
 msgid "E184: No such user-defined command: %s"
 msgstr "E184: Unbekannter benutzerdefinierter Befehl: %s"
 
-#: ../ex_docmd.c:5219
+#: ../ex_docmd.c:5062
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Ungültiger Wert der Vervollständigung: %s"
 
-#: ../ex_docmd.c:5225
+#: ../ex_docmd.c:5068
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Argument für Vervollständigung nur für eigene Vervollständigung erlaubt"
 
-#: ../ex_docmd.c:5231
+#: ../ex_docmd.c:5074
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Eigene Vervollständigung benötigt eine Funktion als Argument"
 
-#: ../ex_docmd.c:5257
+#: ../ex_docmd.c:5100
 #, fuzzy, c-format
 msgid "E185: Cannot find color scheme '%s'"
 msgstr "E185: Kann Farbschema %s nicht finden"
 
-#: ../ex_docmd.c:5263
+#: ../ex_docmd.c:5106
 msgid "Greetings, Vim user!"
 msgstr "Herzliche Grüße, Vim Benutzer!"
 
-#: ../ex_docmd.c:5431
+#: ../ex_docmd.c:5274
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Kann letztes Tab nicht schließen"
 
-#: ../ex_docmd.c:5462
+#: ../ex_docmd.c:5305
 msgid "Already only one tab page"
 msgstr "Es existiert bereits nur ein Tab"
 
-#: ../ex_docmd.c:6004
+#: ../ex_docmd.c:5847
 #, c-format
 msgid "Tab page %d"
 msgstr "Tab %d"
 
-#: ../ex_docmd.c:6295
+#: ../ex_docmd.c:6138
 msgid "No swap file"
 msgstr "Keine Auslagerungsdatei"
 
-#: ../ex_docmd.c:6478
+#: ../ex_docmd.c:6321
 #, fuzzy
 msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
 msgstr ""
 "E747: Kann das Verzeichnis nicht wechseln, da der Puffer verändert wurde "
 "(erzwinge mit !)"
 
-#: ../ex_docmd.c:6485
+#: ../ex_docmd.c:6328
 msgid "E186: No previous directory"
 msgstr "E186: Kein vorheriges Verzeichnis"
 
-#: ../ex_docmd.c:6530
+#: ../ex_docmd.c:6373
 msgid "E187: Unknown"
 msgstr "E187: Unbekannt"
 
-#: ../ex_docmd.c:6610
+#: ../ex_docmd.c:6453
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: :winsize benötigt zwei numerische Argumente"
 
-#: ../ex_docmd.c:6655
+#: ../ex_docmd.c:6497
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr ""
 "E188: Die Fensterposition kann für dieses Terminal nicht bestimmt werden"
 
-#: ../ex_docmd.c:6662
+#: ../ex_docmd.c:6504
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: :winpos benötigt zwei numerische Argumente"
 
-#: ../ex_docmd.c:7241
+#: ../ex_docmd.c:7083
 #, c-format
 msgid "E739: Cannot create directory: %s"
 msgstr "E739: Kann Verzeichnis nicht erstellen: %s"
 
-#: ../ex_docmd.c:7268
+#: ../ex_docmd.c:7110
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" existiert (erzwinge mit !)"
 
-#: ../ex_docmd.c:7273
+#: ../ex_docmd.c:7115
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: \"%s\" kann nicht zum Schreiben geöffnet werden"
 
 #. set mark
-#: ../ex_docmd.c:7294
+#: ../ex_docmd.c:7136
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr ""
 "E191: Argument muss ein Buchstabe oder vorwärts/rückwärts-Anführungszeichen "
 "sein"
 
-#: ../ex_docmd.c:7333
+#: ../ex_docmd.c:7175
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Rekursive Verwendung von :normal zu tief"
 
-#: ../ex_docmd.c:7807
+#: ../ex_docmd.c:7649
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Kein anderer Dateiname zur Ersetzung mit '#'"
 
-#: ../ex_docmd.c:7841
+#: ../ex_docmd.c:7683
 msgid "E495: no autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Kein Autokommando-Dateiname zur Ersetzung mit \"<afile>\""
 
-#: ../ex_docmd.c:7850
+#: ../ex_docmd.c:7692
 msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
 msgstr "E496: Keine Autokommando-Puffernummer zur Ersetzung mit \"<abuf>\""
 
-#: ../ex_docmd.c:7861
+#: ../ex_docmd.c:7703
 msgid "E497: no autocommand match name to substitute for \"<amatch>\""
 msgstr ""
 "E497: Kein passender Name eines Autokommandos zur Ersetzung mit \"<amatch>\""
 
-#: ../ex_docmd.c:7870
+#: ../ex_docmd.c:7712
 msgid "E498: no :source file name to substitute for \"<sfile>\""
 msgstr "E498: kein :source Dateiname zur Ersetzung mit \"<sfile>\""
 
-#: ../ex_docmd.c:7876
+#: ../ex_docmd.c:7718
 #, fuzzy
 msgid "E842: no line number to use for \"<slnum>\""
 msgstr "E498: kein :source Dateiname zur Ersetzung mit \"<sfile>\""
 
-#: ../ex_docmd.c:7903
+#: ../ex_docmd.c:7745
 #, c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Leerer Dateiname für '%' oder '#', funktioniert nur mit \":p:h\""
 
-#: ../ex_docmd.c:7905
+#: ../ex_docmd.c:7747
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Ergibt eine leere Zeichenkette"
 
-#: ../ex_docmd.c:8838
+#: ../ex_docmd.c:8675
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: viminfo kann nicht zum Lesen geöffnet werden"
 
-#: ../ex_eval.c:464
+#: ../ex_eval.c:460
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr "E608: Kann nicht :throw Exceptions mit 'Vim' Präfix"
 
 #. always scroll up, don't overwrite
-#: ../ex_eval.c:496
+#: ../ex_eval.c:492
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Ausnahme geworfen: %s"
 
-#: ../ex_eval.c:545
+#: ../ex_eval.c:541
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Ausnahme beendet: %s"
 
-#: ../ex_eval.c:546
+#: ../ex_eval.c:542
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Ausnahme verworfen: %s"
 
-#: ../ex_eval.c:588 ../ex_eval.c:634
+#: ../ex_eval.c:584 ../ex_eval.c:630
 #, c-format
 msgid "%s, line %<PRId64>"
 msgstr "%s, Zeile %<PRId64>"
 
 #. always scroll up, don't overwrite
-#: ../ex_eval.c:608
+#: ../ex_eval.c:604
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Ausnahme gefangen: %s"
 
-#: ../ex_eval.c:676
+#: ../ex_eval.c:672
 #, c-format
 msgid "%s made pending"
 msgstr "%s schwebend gemacht"
 
-#: ../ex_eval.c:679
+#: ../ex_eval.c:675
 #, c-format
 msgid "%s resumed"
 msgstr "%s wieder aufgenommen"
 
-#: ../ex_eval.c:683
+#: ../ex_eval.c:679
 #, c-format
 msgid "%s discarded"
 msgstr "%s verworfen"
 
-#: ../ex_eval.c:708
+#: ../ex_eval.c:704
 msgid "Exception"
 msgstr "Ausnahme"
 
-#: ../ex_eval.c:713
+#: ../ex_eval.c:709
 msgid "Error and interrupt"
 msgstr "Fehler und Unterbrechung"
 
-#: ../ex_eval.c:715
+#: ../ex_eval.c:711
 msgid "Error"
 msgstr "Fehler"
 
 #. if (pending & CSTP_INTERRUPT)
-#: ../ex_eval.c:717
+#: ../ex_eval.c:713
 msgid "Interrupt"
 msgstr "Unterbrechung"
 
-#: ../ex_eval.c:795
+#: ../ex_eval.c:791
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if Schachtelung zu tief"
 
-#: ../ex_eval.c:830
+#: ../ex_eval.c:826
 msgid "E580: :endif without :if"
 msgstr "E580: :endif ohne :if"
 
-#: ../ex_eval.c:873
+#: ../ex_eval.c:869
 msgid "E581: :else without :if"
 msgstr "E581: :else ohne :if"
 
-#: ../ex_eval.c:876
+#: ../ex_eval.c:872
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif ohne :if"
 
-#: ../ex_eval.c:880
+#: ../ex_eval.c:876
 msgid "E583: multiple :else"
 msgstr "E583: Mehrere :else"
 
-#: ../ex_eval.c:883
+#: ../ex_eval.c:879
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif nach :else"
 
-#: ../ex_eval.c:941
+#: ../ex_eval.c:937
 msgid "E585: :while/:for nesting too deep"
 msgstr "E585: :while/:for Schachtelung zu tief"
 
-#: ../ex_eval.c:1028
+#: ../ex_eval.c:1024
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue ohne :while or :for"
 
-#: ../ex_eval.c:1061
+#: ../ex_eval.c:1057
 msgid "E587: :break without :while or :for"
 msgstr "E587: :break ohne :while oder :for"
 
-#: ../ex_eval.c:1102
+#: ../ex_eval.c:1098
 msgid "E732: Using :endfor with :while"
 msgstr "E732: Benützung von :endfor mit :while"
 
-#: ../ex_eval.c:1104
+#: ../ex_eval.c:1100
 msgid "E733: Using :endwhile with :for"
 msgstr "E733: Benützung von :endwhile mit :for"
 
-#: ../ex_eval.c:1247
+#: ../ex_eval.c:1243
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try Schachtelung zu tief"
 
-#: ../ex_eval.c:1317
+#: ../ex_eval.c:1313
 msgid "E603: :catch without :try"
 msgstr "E603: :catch ohne :try"
 
 #. Give up for a ":catch" after ":finally" and ignore it.
 #. * Just parse.
-#: ../ex_eval.c:1332
+#: ../ex_eval.c:1328
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch nach :finally"
 
-#: ../ex_eval.c:1451
+#: ../ex_eval.c:1447
 msgid "E606: :finally without :try"
 msgstr "E606: :finally ohne :try"
 
 #. Give up for a multiple ":finally" and ignore it.
-#: ../ex_eval.c:1467
+#: ../ex_eval.c:1463
 msgid "E607: multiple :finally"
 msgstr "E607: Mehrere :finally"
 
-#: ../ex_eval.c:1571
+#: ../ex_eval.c:1567
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry ohne :try"
 
-#: ../ex_eval.c:2026
+#: ../ex_eval.c:2022
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: :endfunction außerhalb einer Funktion"
 
-#: ../ex_getln.c:1643
+#: ../ex_getln.c:1614
 msgid "E788: Not allowed to edit another buffer now"
 msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
 
-#: ../ex_getln.c:1656
+#: ../ex_getln.c:1627
 #, fuzzy
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E788: Einen weiteren Puffer zu editieren ist im Moment nicht erlaubt"
 
-#: ../ex_getln.c:3178
+#: ../ex_getln.c:3138
 msgid "tagname"
 msgstr "Tag-Name"
 
-#: ../ex_getln.c:3181
+#: ../ex_getln.c:3141
 msgid " kind file\n"
 msgstr " verwandte Datei\n"
 
-#: ../ex_getln.c:4799
+#: ../ex_getln.c:4752
 msgid "'history' option is zero"
 msgstr "Option 'history' ist Null"
 
-#: ../ex_getln.c:5046
+#: ../ex_getln.c:4998
 #, c-format
 msgid ""
 "\n"
@@ -1983,35 +1428,35 @@ msgstr ""
 "\n"
 "# %s Geschichte (neueste bis älteste):\n"
 
-#: ../ex_getln.c:5047
+#: ../ex_getln.c:4999
 msgid "Command Line"
 msgstr "Befehlszeile"
 
-#: ../ex_getln.c:5048
+#: ../ex_getln.c:5000
 msgid "Search String"
 msgstr "Suchausdruck"
 
-#: ../ex_getln.c:5049
+#: ../ex_getln.c:5001
 msgid "Expression"
 msgstr "Ausdruck"
 
-#: ../ex_getln.c:5050
+#: ../ex_getln.c:5002
 msgid "Input Line"
 msgstr "Eingabe-Zeile"
 
-#: ../ex_getln.c:5117
+#: ../ex_getln.c:5069
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar über die Länge des Befehls hinaus"
 
-#: ../ex_getln.c:5279
+#: ../ex_getln.c:5231
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktives Fenster oder Puffer gelöscht"
 
-#: ../file_search.c:203
+#: ../file_search.c:193
 msgid "E854: path too long for completion"
 msgstr ""
 
-#: ../file_search.c:446
+#: ../file_search.c:436
 #, c-format
 msgid ""
 "E343: Invalid path: '**[number]' must be at the end of the path or be "
@@ -2020,215 +1465,215 @@ msgstr ""
 "E343: Ungültiger Pfad: '**[Nummer]' muss am Ende des Pfads sein, oder von "
 "'%s' gefolgt werden. Siehe \":help path\"."
 
-#: ../file_search.c:1505
+#: ../file_search.c:1495
 #, c-format
 msgid "E344: Can't find directory \"%s\" in cdpath"
 msgstr "E344: Kann Verzeichnis \"%s\" nicht im 'cdpath' finden"
 
-#: ../file_search.c:1508
+#: ../file_search.c:1498
 #, c-format
 msgid "E345: Can't find file \"%s\" in path"
 msgstr "E345: Kann Datei \"%s\" nicht im Pfad finden"
 
-#: ../file_search.c:1512
+#: ../file_search.c:1502
 #, c-format
 msgid "E346: No more directory \"%s\" found in cdpath"
 msgstr "E346: Kein weiteres Verzeichnis \"%s\" im 'cdpath' gefunden"
 
-#: ../file_search.c:1515
+#: ../file_search.c:1505
 #, c-format
 msgid "E347: No more file \"%s\" found in path"
 msgstr "E347: Keine weitere Datei \"%s\" im Pfad gefunden"
 
-#: ../fileio.c:137
+#: ../fileio.c:185
 #, fuzzy
 msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E135: *Filter*-Autokommandos dürfen den aktuellen Puffer nicht ändern"
 
-#: ../fileio.c:368
+#: ../fileio.c:416
 msgid "Illegal file name"
 msgstr "Unzulässiger Dateiname"
 
-#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
+#: ../fileio.c:443 ../fileio.c:524 ../fileio.c:2588 ../fileio.c:2623
 msgid "is a directory"
 msgstr "ist ein Verzeichnis"
 
-#: ../fileio.c:397
+#: ../fileio.c:445
 msgid "is not a file"
 msgstr "ist keine Datei"
 
-#: ../fileio.c:508 ../fileio.c:3522
+#: ../fileio.c:556 ../fileio.c:3567
 msgid "[New File]"
 msgstr "[Neue Datei]"
 
-#: ../fileio.c:511
+#: ../fileio.c:559
 msgid "[New DIRECTORY]"
 msgstr "[Neues VERZEICHNIS]"
 
-#: ../fileio.c:529 ../fileio.c:532
+#: ../fileio.c:577 ../fileio.c:580
 msgid "[File too big]"
 msgstr "[Datei zu groß]"
 
-#: ../fileio.c:534
+#: ../fileio.c:582
 msgid "[Permission Denied]"
 msgstr "[Keine Erlaubnis]"
 
-#: ../fileio.c:653
+#: ../fileio.c:701
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr "E200: *ReadPre Autokommandos haben die Datei unlesbar gemacht"
 
-#: ../fileio.c:655
+#: ../fileio.c:703
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr ""
 "E201: *ReadPre Autokommandos dürfen nicht den aktuellen Puffer wechseln"
 
-#: ../fileio.c:672
+#: ../fileio.c:720
 msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Lese von stdin...\n"
 
 #. Re-opening the original file failed!
-#: ../fileio.c:909
+#: ../fileio.c:957
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Datei wurde unlesbar durch Umwandlung"
 
 #. fifo or socket
-#: ../fileio.c:1782
+#: ../fileio.c:1830
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
 #. fifo
-#: ../fileio.c:1788
+#: ../fileio.c:1836
 msgid "[fifo]"
 msgstr "[fifo]"
 
 #. or socket
-#: ../fileio.c:1794
+#: ../fileio.c:1842
 msgid "[socket]"
 msgstr "[socket]"
 
 #. or character special
-#: ../fileio.c:1801
+#: ../fileio.c:1849
 #, fuzzy
 msgid "[character special]"
 msgstr "ein Zeichen"
 
-#: ../fileio.c:1815
+#: ../fileio.c:1863
 msgid "[CR missing]"
 msgstr "[CR fehlt]"
 
-#: ../fileio.c:1819
+#: ../fileio.c:1867
 msgid "[long lines split]"
 msgstr "[lange Zeilen geteilt]"
 
-#: ../fileio.c:1823 ../fileio.c:3512
+#: ../fileio.c:1871 ../fileio.c:3557
 msgid "[NOT converted]"
 msgstr "[NICHT konvertiert]"
 
-#: ../fileio.c:1826 ../fileio.c:3515
+#: ../fileio.c:1874 ../fileio.c:3560
 msgid "[converted]"
 msgstr "[konvertiert]"
 
-#: ../fileio.c:1831
+#: ../fileio.c:1879
 #, c-format
 msgid "[CONVERSION ERROR in line %<PRId64>]"
 msgstr "UMWANDLUNGSFEHLER in Zeile %<PRId64>]"
 
-#: ../fileio.c:1835
+#: ../fileio.c:1883
 #, c-format
 msgid "[ILLEGAL BYTE in line %<PRId64>]"
 msgstr "[UNZULÄSSIGES BYTE in Zeile %<PRId64>]"
 
-#: ../fileio.c:1838
+#: ../fileio.c:1886
 msgid "[READ ERRORS]"
 msgstr "[LESE-FEHLER]"
 
-#: ../fileio.c:2104
+#: ../fileio.c:2149
 msgid "Can't find temp file for conversion"
 msgstr "temporäre Datei kann nicht zum Umwandeln geöffnet werden"
 
-#: ../fileio.c:2110
+#: ../fileio.c:2155
 msgid "Conversion with 'charconvert' failed"
 msgstr "Fehler bei der Umwandlung mit 'charconvert'"
 
-#: ../fileio.c:2113
+#: ../fileio.c:2158
 msgid "can't read output of 'charconvert'"
 msgstr "Ausgabe von 'charconvert' kann nicht gelesen werden"
 
-#: ../fileio.c:2437
+#: ../fileio.c:2482
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Keine übereinstimmenden Autokommandos für acwrite Puffer"
 
-#: ../fileio.c:2466
+#: ../fileio.c:2511
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr ""
 "E203: Autokommandos haben den zu schreibenden Puffer gelöscht oder entladen"
 
-#: ../fileio.c:2486
+#: ../fileio.c:2531
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr ""
 "E204: Autokommandos haben die Anzahl der Zeilen in unerwarteter Weise "
 "verändert"
 
-#: ../fileio.c:2548 ../fileio.c:2565
+#: ../fileio.c:2593 ../fileio.c:2610
 msgid "is not a file or writable device"
 msgstr "ist keine Datei oder beschreibbares Device"
 
-#: ../fileio.c:2601
+#: ../fileio.c:2646
 msgid "is read-only (add ! to override)"
 msgstr "ist Schreibgeschützt (erzwinge mit !)"
 
-#: ../fileio.c:2886
+#: ../fileio.c:2931
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr "E506: Sicherungsdatei kann nicht geschrieben werden (erzwinge mit !)"
 
-#: ../fileio.c:2898
+#: ../fileio.c:2943
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Fehler beim Schließen der Sicherungsdatei (erzwinge mit !)"
 
-#: ../fileio.c:2901
+#: ../fileio.c:2946
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr "E508: Sicherungsdatei kann nicht gelesen werden (erzwinge mit !)"
 
-#: ../fileio.c:2923
+#: ../fileio.c:2968
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr "E509: Sicherungsdatei kann nicht angelegt werden (erzwinge mit !)"
 
-#: ../fileio.c:3008
+#: ../fileio.c:3053
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr "E510: Sicherungsdatei kann nicht erstellt werden (erzwinge mit !)"
 
 #. Can't write without a tempfile!
-#: ../fileio.c:3121
+#: ../fileio.c:3166
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Temporäre Datei kann nicht zum Schreiben geöffnet werden"
 
-#: ../fileio.c:3134
+#: ../fileio.c:3179
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr "E213: Fehler bei der Umwandlung (schreibe ohne Umwandlung mit !)"
 
-#: ../fileio.c:3169
+#: ../fileio.c:3214
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Gelinkte Datei kann nicht zum Schreiben geöffnet werden"
 
-#: ../fileio.c:3173
+#: ../fileio.c:3218
 msgid "E212: Can't open file for writing"
 msgstr "E212: Datei kann nicht zum Schreiben geöffnet werden"
 
-#: ../fileio.c:3363
+#: ../fileio.c:3408
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync fehlgeschlagen"
 
-#: ../fileio.c:3398
+#: ../fileio.c:3443
 msgid "E512: Close failed"
 msgstr "E512: Fehler beim Schließen"
 
-#: ../fileio.c:3436
+#: ../fileio.c:3481
 msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr ""
 "E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu "
 "erzwingen)"
 
-#: ../fileio.c:3441
+#: ../fileio.c:3486
 #, fuzzy, c-format
 msgid ""
 "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
@@ -2237,56 +1682,56 @@ msgstr ""
 "E513: Schreibfehler, Umwandlung schlug fehl (leere 'fenc' um sie zu "
 "erzwingen)"
 
-#: ../fileio.c:3448
+#: ../fileio.c:3493
 msgid "E514: write error (file system full?)"
 msgstr "E514: Schreibfehler (Dateisystem voll?)"
 
-#: ../fileio.c:3506
+#: ../fileio.c:3551
 msgid " CONVERSION ERROR"
 msgstr "KONVERTIERUNGSFEHLER"
 
-#: ../fileio.c:3509
+#: ../fileio.c:3554
 #, fuzzy, c-format
 msgid " in line %<PRId64>;"
 msgstr "Zeile %<PRId64>"
 
-#: ../fileio.c:3519
+#: ../fileio.c:3564
 msgid "[Device]"
 msgstr "[Ausgabegerät]"
 
-#: ../fileio.c:3522
+#: ../fileio.c:3567
 msgid "[New]"
 msgstr "[Neu]"
 
-#: ../fileio.c:3535
+#: ../fileio.c:3580
 msgid " [a]"
 msgstr " [a]"
 
-#: ../fileio.c:3535
+#: ../fileio.c:3580
 msgid " appended"
 msgstr " angefügt"
 
-#: ../fileio.c:3537
+#: ../fileio.c:3582
 msgid " [w]"
 msgstr " [w]"
 
-#: ../fileio.c:3537
+#: ../fileio.c:3582
 msgid " written"
 msgstr " geschrieben"
 
-#: ../fileio.c:3579
+#: ../fileio.c:3624
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: patchmode: Original-Datei kann nicht gespeichert werden"
 
-#: ../fileio.c:3602
+#: ../fileio.c:3647
 msgid "E206: patchmode: can't touch empty original file"
 msgstr "E206: patchmode: leere Original-Datei kann nicht verändert werden"
 
-#: ../fileio.c:3616
+#: ../fileio.c:3661
 msgid "E207: Can't delete backup file"
 msgstr "E207: Backup-Datei kann nicht gelöscht werden"
 
-#: ../fileio.c:3672
+#: ../fileio.c:3717
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -2294,96 +1739,96 @@ msgstr ""
 "\n"
 "ACHTUNG: Original-Datei kann verloren oder zerstört sein\n"
 
-#: ../fileio.c:3675
+#: ../fileio.c:3720
 msgid "don't quit the editor until the file is successfully written!"
 msgstr "beende nicht den Editor bis die Datei erfolgreich geschrieben wurde!"
 
-#: ../fileio.c:3795
+#: ../fileio.c:3840
 msgid "[dos]"
 msgstr "[dos]"
 
-#: ../fileio.c:3795
+#: ../fileio.c:3840
 msgid "[dos format]"
 msgstr "[dos Format]"
 
-#: ../fileio.c:3801
+#: ../fileio.c:3845
 msgid "[mac]"
 msgstr "[mac]"
 
-#: ../fileio.c:3801
+#: ../fileio.c:3845
 msgid "[mac format]"
 msgstr "[mac Format]"
 
-#: ../fileio.c:3807
+#: ../fileio.c:3850
 msgid "[unix]"
 msgstr "[unix]"
 
-#: ../fileio.c:3807
+#: ../fileio.c:3850
 msgid "[unix format]"
 msgstr "[unix Format]"
 
-#: ../fileio.c:3831
+#: ../fileio.c:3874
 msgid "1 line, "
 msgstr "eine Zeile, "
 
-#: ../fileio.c:3833
+#: ../fileio.c:3876
 #, c-format
 msgid "%<PRId64> lines, "
 msgstr "%<PRId64> Zeilen, "
 
-#: ../fileio.c:3836
+#: ../fileio.c:3879
 msgid "1 character"
 msgstr "ein Zeichen"
 
-#: ../fileio.c:3838
+#: ../fileio.c:3881
 #, c-format
 msgid "%<PRId64> characters"
 msgstr "%<PRId64> Zeichen"
 
-#: ../fileio.c:3849
+#: ../fileio.c:3892
 msgid "[noeol]"
 msgstr "[noeol]"
 
-#: ../fileio.c:3849
+#: ../fileio.c:3892
 msgid "[Incomplete last line]"
 msgstr "[Unvollständige letzte Zeile]"
 
 #. don't overwrite messages here
 #. must give this prompt
 #. don't use emsg() here, don't want to flush the buffers
-#: ../fileio.c:3865
+#: ../fileio.c:3908
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "ACHTUNG: Die Datei wurde seit dem letzten Lesen geändert!!!"
 
-#: ../fileio.c:3867
+#: ../fileio.c:3910
 msgid "Do you really want to write to it"
 msgstr "Möchten Sie es wirklich schreiben"
 
-#: ../fileio.c:4648
+#: ../fileio.c:4646
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Fehler während des Schreibens nach \"%s\""
 
-#: ../fileio.c:4655
+#: ../fileio.c:4653
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Fehler beim Schließen von \"%s\""
 
-#: ../fileio.c:4657
+#: ../fileio.c:4655
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Fehler beim Lesen von \"%s\""
 
-#: ../fileio.c:4883
+#: ../fileio.c:4881
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell-Autokommando löschte Puffer"
 
-#: ../fileio.c:4894
+#: ../fileio.c:4892
 #, c-format
 msgid "E211: File \"%s\" no longer available"
 msgstr "E211: Datei \"%s\" ist nicht länger vorhanden"
 
-#: ../fileio.c:4906
+#: ../fileio.c:4904
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -2392,44 +1837,44 @@ msgstr ""
 "W12: Achtung: Datei \"%s\" wurde verändert und der Puffer wurde ebenfalls in "
 "Vim verändert"
 
-#: ../fileio.c:4907
+#: ../fileio.c:4905
 msgid "See \":help W12\" for more info."
 msgstr "Siehe \":help W12\" für mehr Information"
 
-#: ../fileio.c:4910
+#: ../fileio.c:4908
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
 "W11: Achtung: Datei \"%s\" wurde verändert, seit mit dem Editieren "
 "angefangen wurde"
 
-#: ../fileio.c:4911
+#: ../fileio.c:4909
 msgid "See \":help W11\" for more info."
 msgstr "Siehe \":help W11\" für mehr Information"
 
-#: ../fileio.c:4914
+#: ../fileio.c:4912
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Achtung: Mode der Datei \"%s\" wurde verändert seit mit dem Editieren "
 "angefangen wurde"
 
-#: ../fileio.c:4915
+#: ../fileio.c:4913
 msgid "See \":help W16\" for more info."
 msgstr "Siehe \":help W16\" für mehr Information"
 
-#: ../fileio.c:4927
+#: ../fileio.c:4925
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Achtung: Datei \"%s\" wurde erstellt, nachdem mit dem Editieren "
 "begonnen wurde"
 
-#: ../fileio.c:4947
+#: ../fileio.c:4945
 msgid "Warning"
 msgstr "Warnung"
 
-#: ../fileio.c:4948
+#: ../fileio.c:4946
 msgid ""
 "&OK\n"
 "&Load File"
@@ -2437,48 +1882,48 @@ msgstr ""
 "&OK\n"
 "&Lies Datei"
 
-#: ../fileio.c:5065
+#: ../fileio.c:5063
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Konnte das Neuladen von \"%s\" nicht vorbereiten"
 
-#: ../fileio.c:5078
+#: ../fileio.c:5076
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: \"%s\" konnte nicht neu geladen werden"
 
-#: ../fileio.c:5601
+#: ../fileio.c:5510
 msgid "--Deleted--"
 msgstr "--gelöscht--"
 
-#: ../fileio.c:5732
+#: ../fileio.c:5641
 #, c-format
 msgid "auto-removing autocommand: %s <buffer=%d>"
 msgstr ""
 
 #. the group doesn't exist
-#: ../fileio.c:5772
+#: ../fileio.c:5679
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Keine solche Gruppe: \"%s\""
 
-#: ../fileio.c:5897
+#: ../fileio.c:5802
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Unzulässiges Zeichen nach *: %s"
 
-#: ../fileio.c:5905
+#: ../fileio.c:5810
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Kein derartiges Ereignis: %s"
 
-#: ../fileio.c:5907
+#: ../fileio.c:5812
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Keine solche Gruppe oder Ereignis: %s"
 
 #. Highlight title
-#: ../fileio.c:6090
+#: ../fileio.c:5993
 msgid ""
 "\n"
 "--- Auto-Commands ---"
@@ -2486,110 +1931,110 @@ msgstr ""
 "\n"
 "--- Autokommandos ---"
 
-#: ../fileio.c:6293
+#: ../fileio.c:6196
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number "
 msgstr "E680: <buffer=%d>: Ungültige Puffer Nummer "
 
-#: ../fileio.c:6370
+#: ../fileio.c:6271
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Autokommandos können nicht für ALL Ereignisse ausgeführt werden"
 
-#: ../fileio.c:6393
+#: ../fileio.c:6294
 msgid "No matching autocommands"
 msgstr "Keine passenden Autokommandos"
 
-#: ../fileio.c:6831
+#: ../fileio.c:6730
 msgid "E218: autocommand nesting too deep"
 msgstr "E218: Autokommando-Schachtelung zu tief"
 
-#: ../fileio.c:7143
+#: ../fileio.c:7042
 #, c-format
 msgid "%s Auto commands for \"%s\""
 msgstr "%s Autokommandos für \"%s\""
 
-#: ../fileio.c:7149
+#: ../fileio.c:7048
 #, c-format
 msgid "Executing %s"
 msgstr "Ausführung von %s"
 
-#: ../fileio.c:7211
+#: ../fileio.c:7110
 #, c-format
 msgid "autocommand %s"
 msgstr "Autokommando %s"
 
-#: ../fileio.c:7795
+#: ../fileio.c:7693
 msgid "E219: Missing {."
 msgstr "E219: Es fehlt ein {."
 
-#: ../fileio.c:7797
+#: ../fileio.c:7695
 msgid "E220: Missing }."
 msgstr "E220: Es fehlt ein }."
 
-#: ../fold.c:93
+#: ../fold.c:90
 msgid "E490: No fold found"
 msgstr "E490: Keine Faltung gefunden"
 
-#: ../fold.c:544
+#: ../fold.c:539
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr ""
 "E350: Faltung kann mit der aktuellen Faltungsmethode nicht erzeugt werden"
 
-#: ../fold.c:546
+#: ../fold.c:541
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr ""
 "E351: Faltung kann mit der aktuellen Faltungsmethode nicht gelöscht werden"
 
-#: ../fold.c:1784
+#: ../fold.c:1770
 #, c-format
 msgid "+--%3ld lines folded "
 msgstr "+--%3ld Zeilen gefaltet "
 
 #. buffer has already been read
-#: ../getchar.c:273
+#: ../getchar.c:259
 msgid "E222: Add to read buffer"
 msgstr "E222: Zum Lesepuffer hinzufügen"
 
-#: ../getchar.c:2040
+#: ../getchar.c:2026
 msgid "E223: recursive mapping"
 msgstr "E223: rekursive Zuordnung"
 
-#: ../getchar.c:2849
+#: ../getchar.c:2835
 #, c-format
 msgid "E224: global abbreviation already exists for %s"
 msgstr "E224: Globale Abkürzung für %s existiert bereits"
 
-#: ../getchar.c:2852
+#: ../getchar.c:2838
 #, c-format
 msgid "E225: global mapping already exists for %s"
 msgstr "E225: Globale Zuordnung für %s existiert bereits"
 
-#: ../getchar.c:2952
+#: ../getchar.c:2938
 #, c-format
 msgid "E226: abbreviation already exists for %s"
 msgstr "E226: Abkürzung für %s existiert bereits"
 
-#: ../getchar.c:2955
+#: ../getchar.c:2941
 #, c-format
 msgid "E227: mapping already exists for %s"
 msgstr "E227: Zuordnung für %s existiert bereits"
 
-#: ../getchar.c:3008
+#: ../getchar.c:2994
 msgid "No abbreviation found"
 msgstr "Keine Abkürzung gefunden"
 
-#: ../getchar.c:3010
+#: ../getchar.c:2996
 msgid "No mapping found"
 msgstr "Keine Zuordnung gefunden"
 
-#: ../getchar.c:3974
+#: ../getchar.c:3952
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Unzulässiger Modus"
 
 #. key value of 'cedit' option
 #. type of cmdline window or 0
 #. result of cmdline window or 0
-#: ../globals.h:924
+#: ../globals.h:923
 msgid "--No lines in buffer--"
 msgstr "--Keine Zeilen im Puffer--"
 
@@ -2597,656 +2042,656 @@ msgstr "--Keine Zeilen im Puffer--"
 #. * The error messages that can be shared are included here.
 #. * Excluded are errors that are only used once and debugging messages.
 #.
-#: ../globals.h:996
+#: ../globals.h:995
 msgid "E470: Command aborted"
 msgstr "E470: Befehl abgebrochen"
 
-#: ../globals.h:997
+#: ../globals.h:996
 msgid "E471: Argument required"
 msgstr "E471: Argument benötigt"
 
-#: ../globals.h:998
+#: ../globals.h:997
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ sollte von /, ? or & gefolgt werden"
 
-#: ../globals.h:1000
+#: ../globals.h:999
 msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
 msgstr "E11: Ungültig im Kommandozeilenfenster; <CR> führt aus, CTRL-C beendet"
 
-#: ../globals.h:1002
+#: ../globals.h:1001
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Befehl nicht zulässig vom exrc/vimrc in der momentanen Verzeichnis- "
 "oder Tag-Suche"
 
-#: ../globals.h:1003
+#: ../globals.h:1002
 msgid "E171: Missing :endif"
 msgstr "E171: Fehlendes :endif"
 
-#: ../globals.h:1004
+#: ../globals.h:1003
 msgid "E600: Missing :endtry"
 msgstr "E600: Fehlendes :endtry"
 
-#: ../globals.h:1005
+#: ../globals.h:1004
 msgid "E170: Missing :endwhile"
 msgstr "E170: fehlendes :endwhile"
 
-#: ../globals.h:1006
+#: ../globals.h:1005
 msgid "E170: Missing :endfor"
 msgstr "E170: Fehlendes :endfor"
 
-#: ../globals.h:1007
+#: ../globals.h:1006
 msgid "E588: :endwhile without :while"
 msgstr "E588: :endwhile ohne :while"
 
-#: ../globals.h:1008
+#: ../globals.h:1007
 msgid "E588: :endfor without :for"
 msgstr "E588: :endfor ohne :for"
 
-#: ../globals.h:1009
+#: ../globals.h:1008
 msgid "E13: File exists (add ! to override)"
 msgstr "E13: Datei existiert bereits (erzwinge mit !)"
 
-#: ../globals.h:1010
+#: ../globals.h:1009
 msgid "E472: Command failed"
 msgstr "E472: Befehl fehlgeschlagen"
 
-#: ../globals.h:1011
+#: ../globals.h:1010
 msgid "E473: Internal error"
 msgstr "E473: Interner Fehler"
 
-#: ../globals.h:1012
+#: ../globals.h:1011
 msgid "Interrupted"
 msgstr "Unterbrochen"
 
-#: ../globals.h:1013
+#: ../globals.h:1012
 msgid "E14: Invalid address"
 msgstr "E14: Ungültige Adresse"
 
-#: ../globals.h:1014
+#: ../globals.h:1013
 msgid "E474: Invalid argument"
 msgstr "E474: Ungültiges Argument"
 
-#: ../globals.h:1015
+#: ../globals.h:1014
 #, c-format
 msgid "E475: Invalid argument: %s"
 msgstr "E475: Ungültiges Argument: %s"
 
-#: ../globals.h:1016
+#: ../globals.h:1015
 #, c-format
 msgid "E15: Invalid expression: %s"
 msgstr "E15: ungültiger Ausdruck: %s"
 
-#: ../globals.h:1017
+#: ../globals.h:1016
 msgid "E16: Invalid range"
 msgstr "E16: Ungültiger Bereich"
 
-#: ../globals.h:1018
+#: ../globals.h:1017
 msgid "E476: Invalid command"
 msgstr "E476: Ungültiger Befehl"
 
-#: ../globals.h:1019
+#: ../globals.h:1018
 #, c-format
 msgid "E17: \"%s\" is a directory"
 msgstr "E17: \"%s\" ist ein Verzeichnis"
 
-#: ../globals.h:1020
+#: ../globals.h:1019
 #, fuzzy
 msgid "E900: Invalid job id"
 msgstr "E49: Ungültige Scroll-Größe"
 
-#: ../globals.h:1021
+#: ../globals.h:1020
 msgid "E901: Job table is full"
 msgstr ""
 
-#: ../globals.h:1022
+#: ../globals.h:1021
 #, c-format
 msgid "E902: \"%s\" is not an executable"
 msgstr ""
 
-#: ../globals.h:1024
+#: ../globals.h:1023
 #, c-format
 msgid "E364: Library call failed for \"%s()\""
 msgstr "E364: Bibliotheksaufruf für \"%s()\" schlug fehl"
 
-#: ../globals.h:1026
+#: ../globals.h:1025
 msgid "E19: Mark has invalid line number"
 msgstr "E19: Marke hat ungültige Zeilennummer"
 
-#: ../globals.h:1027
+#: ../globals.h:1026
 msgid "E20: Mark not set"
 msgstr "E20: Marke nicht gesetzt"
 
-#: ../globals.h:1029
+#: ../globals.h:1028
 msgid "E21: Cannot make changes, 'modifiable' is off"
 msgstr "E21: Kann keine Änderungen machen, 'modifiable' ist aus"
 
-#: ../globals.h:1030
+#: ../globals.h:1029
 msgid "E22: Scripts nested too deep"
 msgstr "E22: Skript ist zu tief verschachtelt"
 
-#: ../globals.h:1031
+#: ../globals.h:1030
 msgid "E23: No alternate file"
 msgstr "E23: Keine alternative Datei"
 
-#: ../globals.h:1032
+#: ../globals.h:1031
 msgid "E24: No such abbreviation"
 msgstr "E24: Keine Abkürzung gefunden"
 
-#: ../globals.h:1033
+#: ../globals.h:1032
 msgid "E477: No ! allowed"
 msgstr "E477: Kein ! erlaubt"
 
-#: ../globals.h:1035
+#: ../globals.h:1034
 msgid "E25: GUI cannot be used: Not enabled at compile time"
 msgstr ""
 "E25: GUI kann nicht benutzt werden: wurde zum Zeitpunkt des Übersetzens "
 "nicht eingeschaltet."
 
-#: ../globals.h:1036
+#: ../globals.h:1035
 #, c-format
 msgid "E28: No such highlight group name: %s"
 msgstr "E28: Hervorhebungsgruppe existiert nicht: %s"
 
-#: ../globals.h:1037
+#: ../globals.h:1036
 msgid "E29: No inserted text yet"
 msgstr "E29: Noch kein eingefügter Text"
 
-#: ../globals.h:1038
+#: ../globals.h:1037
 msgid "E30: No previous command line"
 msgstr "E30: Keine vorherige Befehlszeile"
 
-#: ../globals.h:1039
+#: ../globals.h:1038
 msgid "E31: No such mapping"
 msgstr "E31: Keine Zuordnung gefunden"
 
-#: ../globals.h:1040
+#: ../globals.h:1039
 msgid "E479: No match"
 msgstr "E479: Kein Treffer"
 
-#: ../globals.h:1041
+#: ../globals.h:1040
 #, c-format
 msgid "E480: No match: %s"
 msgstr "E480: Kein Treffer: %s"
 
-#: ../globals.h:1042
+#: ../globals.h:1041
 msgid "E32: No file name"
 msgstr "E32: Kein Dateiname"
 
-#: ../globals.h:1044
+#: ../globals.h:1043
 msgid "E33: No previous substitute regular expression"
 msgstr "E33: Kein vorheriger regulärer Ersetzungsausdruck"
 
-#: ../globals.h:1045
+#: ../globals.h:1044
 msgid "E34: No previous command"
 msgstr "E34: Kein vorheriger Befehl"
 
-#: ../globals.h:1046
+#: ../globals.h:1045
 msgid "E35: No previous regular expression"
 msgstr "E35: Keine vorheriger regulärer Ausdruck"
 
-#: ../globals.h:1047
+#: ../globals.h:1046
 msgid "E481: No range allowed"
 msgstr "E481: Kein Bereich erlaubt"
 
-#: ../globals.h:1048
+#: ../globals.h:1047
 msgid "E36: Not enough room"
 msgstr "E36: Zu wenig Platz"
 
-#: ../globals.h:1049
+#: ../globals.h:1048
 #, c-format
 msgid "E482: Can't create file %s"
 msgstr "E482: Kann Datei %s nicht erzeugen"
 
-#: ../globals.h:1050
+#: ../globals.h:1049
 msgid "E483: Can't get temp file name"
 msgstr "E483: Kann den Namen der temporären Datei nicht ermitteln"
 
-#: ../globals.h:1051
+#: ../globals.h:1050
 #, c-format
 msgid "E484: Can't open file %s"
 msgstr "E484: Kann die Datei %s nicht öffnen"
 
-#: ../globals.h:1052
+#: ../globals.h:1051
 #, c-format
 msgid "E485: Can't read file %s"
 msgstr "E485: Kann Datei %s nicht lesen"
 
-#: ../globals.h:1054
+#: ../globals.h:1053
 msgid "E37: No write since last change (add ! to override)"
 msgstr "E37: Kein Schreibvorgang seit der letzten Änderung (erzwinge mit !)"
 
-#: ../globals.h:1055
+#: ../globals.h:1054
 #, fuzzy
 msgid "E37: No write since last change"
 msgstr "[Kein Schreiben seit der letzten Änderung]\n"
 
-#: ../globals.h:1056
+#: ../globals.h:1055
 msgid "E38: Null argument"
 msgstr "E38: Null-Argument"
 
-#: ../globals.h:1057
+#: ../globals.h:1056
 msgid "E39: Number expected"
 msgstr "E39: Nummer erwartet"
 
-#: ../globals.h:1058
+#: ../globals.h:1057
 #, c-format
 msgid "E40: Can't open errorfile %s"
 msgstr "E40: Fehlerdatei %s kann nicht geöffnet werden"
 
-#: ../globals.h:1059
+#: ../globals.h:1058
 msgid "E41: Out of memory!"
 msgstr "E41: Speicher erschöpft!"
 
-#: ../globals.h:1060
+#: ../globals.h:1059
 msgid "Pattern not found"
 msgstr "Muster nicht gefunden"
 
-#: ../globals.h:1061
+#: ../globals.h:1060
 #, c-format
 msgid "E486: Pattern not found: %s"
 msgstr "E486: Muster nicht gefunden: %s"
 
-#: ../globals.h:1062
+#: ../globals.h:1061
 msgid "E487: Argument must be positive"
 msgstr "E487: Argument muss positiv sein"
 
-#: ../globals.h:1064
+#: ../globals.h:1063
 msgid "E459: Cannot go back to previous directory"
 msgstr "E459: Kann nicht ins vorhergehende Verzeichnis wechseln"
 
-#: ../globals.h:1066
+#: ../globals.h:1065
 msgid "E42: No Errors"
 msgstr "E42: Kein Fehler"
 
-#: ../globals.h:1067
+#: ../globals.h:1066
 msgid "E776: No location list"
 msgstr "E776: Keine Positionsliste"
 
-#: ../globals.h:1068
+#: ../globals.h:1067
 msgid "E43: Damaged match string"
 msgstr "E43: Beschädigter Suchausdruck"
 
-#: ../globals.h:1069
+#: ../globals.h:1068
 msgid "E44: Corrupted regexp program"
 msgstr "E44: schadhaftes regexp Programm"
 
-#: ../globals.h:1071
+#: ../globals.h:1070
 msgid "E45: 'readonly' option is set (add ! to override)"
 msgstr "E45: Die Option 'readonly' ist gesetzt (erzwinge mit !)"
 
-#: ../globals.h:1073
+#: ../globals.h:1072
 #, c-format
 msgid "E46: Cannot change read-only variable \"%s\""
 msgstr "E46: Variable \"%s\" kann nur gelesen werden"
 
-#: ../globals.h:1075
+#: ../globals.h:1074
 #, fuzzy, c-format
 msgid "E794: Cannot set variable in the sandbox: \"%s\""
 msgstr "E46: Variable \"%s\" kann in der Sandbox nur gelesen werden"
 
-#: ../globals.h:1076
+#: ../globals.h:1075
 msgid "E47: Error while reading errorfile"
 msgstr "E47: Fehler während des Lesens der Fehlerdatei"
 
-#: ../globals.h:1078
+#: ../globals.h:1077
 msgid "E48: Not allowed in sandbox"
 msgstr "E48: In einer Sandbox nicht erlaubt"
 
-#: ../globals.h:1080
+#: ../globals.h:1079
 msgid "E523: Not allowed here"
 msgstr "E523: Hier nicht erlaubt"
 
-#: ../globals.h:1082
+#: ../globals.h:1081
 msgid "E359: Screen mode setting not supported"
 msgstr "E359: Bildschirm-Modus wird nicht unterstützt"
 
-#: ../globals.h:1083
+#: ../globals.h:1082
 msgid "E49: Invalid scroll size"
 msgstr "E49: Ungültige Scroll-Größe"
 
-#: ../globals.h:1084
+#: ../globals.h:1083
 msgid "E91: 'shell' option is empty"
 msgstr "E91: Die Option 'shell' ist leer"
 
-#: ../globals.h:1085
+#: ../globals.h:1084
 msgid "E255: Couldn't read in sign data!"
 msgstr "E255: Fehler -- Daten für Debuggersymbol konnten nicht gelesen werden"
 
-#: ../globals.h:1086
+#: ../globals.h:1085
 msgid "E72: Close error on swap file"
 msgstr "E72: Fehler beim Schließen der Auslagerungsdatei"
 
-#: ../globals.h:1087
+#: ../globals.h:1086
 msgid "E73: tag stack empty"
 msgstr "E73: tag Stapel leer."
 
-#: ../globals.h:1088
+#: ../globals.h:1087
 msgid "E74: Command too complex"
 msgstr "E74: Befehl zu kompliziert"
 
-#: ../globals.h:1089
+#: ../globals.h:1088
 msgid "E75: Name too long"
 msgstr "E75: Name zu lang"
 
-#: ../globals.h:1090
+#: ../globals.h:1089
 msgid "E76: Too many ["
 msgstr "E76: Zu viele ["
 
-#: ../globals.h:1091
+#: ../globals.h:1090
 msgid "E77: Too many file names"
 msgstr "E77: Zu viele Dateinamen"
 
-#: ../globals.h:1092
+#: ../globals.h:1091
 msgid "E488: Trailing characters"
 msgstr "E488: Überschüssige Zeichen"
 
-#: ../globals.h:1093
+#: ../globals.h:1092
 msgid "E78: Unknown mark"
 msgstr "E78: Unbekannte Mark"
 
-#: ../globals.h:1094
+#: ../globals.h:1093
 msgid "E79: Cannot expand wildcards"
 msgstr "E79: Kann die Platzhalter nicht erweitern"
 
-#: ../globals.h:1096
+#: ../globals.h:1095
 msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
 msgstr "E591: 'winheight' darf nicht kleiner sein als 'winminheight'"
 
-#: ../globals.h:1098
+#: ../globals.h:1097
 msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
 msgstr "E592: 'winwidth' darf nicht kleiner sein als 'winminwidth'"
 
-#: ../globals.h:1099
+#: ../globals.h:1098
 msgid "E80: Error while writing"
 msgstr "E80: Fehler während des Schreibens"
 
-#: ../globals.h:1100
+#: ../globals.h:1099
 msgid "Zero count"
 msgstr "Null-Zähler"
 
-#: ../globals.h:1101
+#: ../globals.h:1100
 msgid "E81: Using <SID> not in a script context"
 msgstr "E81: <SID> wurde nicht in einer Skript-Umgebung benutzt"
 
-#: ../globals.h:1102
+#: ../globals.h:1101
 #, c-format
 msgid "E685: Internal error: %s"
 msgstr "E685: Interner Fehler: %s"
 
-#: ../globals.h:1104
+#: ../globals.h:1103
 msgid "E363: pattern uses more memory than 'maxmempattern'"
 msgstr "E363: Muster benötigt mehr Speicher als 'maxmempattern'"
 
-#: ../globals.h:1105
+#: ../globals.h:1104
 msgid "E749: empty buffer"
 msgstr "E749: Leerer Puffer"
 
-#: ../globals.h:1108
+#: ../globals.h:1107
 msgid "E682: Invalid search pattern or delimiter"
 msgstr "E682: Ungültiges Suchmuster oder Trennzeichen"
 
-#: ../globals.h:1109
+#: ../globals.h:1108
 msgid "E139: File is loaded in another buffer"
 msgstr "E139: Datei ist in einem anderen Puffer geladen"
 
-#: ../globals.h:1110
+#: ../globals.h:1109
 #, c-format
 msgid "E764: Option '%s' is not set"
 msgstr "E764: Option '%s' ist nicht gesetzt"
 
-#: ../globals.h:1111
+#: ../globals.h:1110
 #, fuzzy
 msgid "E850: Invalid register name"
 msgstr "E354: Ungültiger Register Name: '%s'"
 
-#: ../globals.h:1114
+#: ../globals.h:1113
 msgid "search hit TOP, continuing at BOTTOM"
 msgstr "Suche erreichte den ANFANG und wurde am ENDE fortgesetzt"
 
-#: ../globals.h:1115
+#: ../globals.h:1114
 msgid "search hit BOTTOM, continuing at TOP"
 msgstr "Suche erreichte das ENDE und wurde am ANFANG fortgesetzt"
 
-#: ../hardcopy.c:240
+#: ../hardcopy.c:296
 msgid "E550: Missing colon"
 msgstr "E550: Fehlender Doppelpunkt"
 
-#: ../hardcopy.c:252
+#: ../hardcopy.c:308
 msgid "E551: Illegal component"
 msgstr "E551: Unzulässige Komponente"
 
-#: ../hardcopy.c:259
+#: ../hardcopy.c:315
 msgid "E552: digit expected"
 msgstr "E552: Ziffer erwartet"
 
-#: ../hardcopy.c:473
+#: ../hardcopy.c:529
 #, c-format
 msgid "Page %d"
 msgstr "Seite %d"
 
-#: ../hardcopy.c:597
+#: ../hardcopy.c:653
 msgid "No text to be printed"
 msgstr "Kein Text zum Drucken"
 
-#: ../hardcopy.c:668
+#: ../hardcopy.c:724
 #, c-format
 msgid "Printing page %d (%d%%)"
 msgstr "Drucke Seite %d (%d%%)"
 
-#: ../hardcopy.c:680
+#: ../hardcopy.c:736
 #, c-format
 msgid " Copy %d of %d"
 msgstr " Kopiere %d von %d"
 
-#: ../hardcopy.c:733
+#: ../hardcopy.c:789
 #, c-format
 msgid "Printed: %s"
 msgstr "Gedruckt: %s"
 
-#: ../hardcopy.c:740
+#: ../hardcopy.c:796
 msgid "Printing aborted"
 msgstr "Ausdruck abgebrochen"
 
-#: ../hardcopy.c:1365
+#: ../hardcopy.c:1307
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Fehler beim Schreiben der PostScript-Ausgabedatei"
 
-#: ../hardcopy.c:1747
+#: ../hardcopy.c:1679
 #, c-format
 msgid "E624: Can't open file \"%s\""
 msgstr "E624: Datei \"%s\" kann nicht geöffnet werden"
 
-#: ../hardcopy.c:1756 ../hardcopy.c:2470
+#: ../hardcopy.c:1688 ../hardcopy.c:2401
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
 msgstr "E457: PostScript Ressource-Datei \"%s\" kann nicht gelesen werden"
 
-#: ../hardcopy.c:1772
+#: ../hardcopy.c:1704
 #, c-format
 msgid "E618: file \"%s\" is not a PostScript resource file"
 msgstr "E618: Datei \"%s\" ist keine PostScript Ressource-Datei"
 
-#: ../hardcopy.c:1788 ../hardcopy.c:1805 ../hardcopy.c:1844
+#: ../hardcopy.c:1720 ../hardcopy.c:1737 ../hardcopy.c:1776
 #, c-format
 msgid "E619: file \"%s\" is not a supported PostScript resource file"
 msgstr "E619: Datei \"%s\" ist keine unterstützte PostScript Ressource-Datei"
 
-#: ../hardcopy.c:1856
+#: ../hardcopy.c:1788
 #, c-format
 msgid "E621: \"%s\" resource file has wrong version"
 msgstr "E621: \"%s\" Ressource-Datei hat die falsche Version"
 
-#: ../hardcopy.c:2225
+#: ../hardcopy.c:2157
 msgid "E673: Incompatible multi-byte encoding and character set."
 msgstr "E673: Unzulässiger Multi-Byte Zeichensatz"
 
-#: ../hardcopy.c:2238
+#: ../hardcopy.c:2169
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset darf nicht leer sein mit Multi-Byte Zeichensatz."
 
-#: ../hardcopy.c:2254
+#: ../hardcopy.c:2185
 msgid "E675: No default font specified for multi-byte printing."
 msgstr "E675: Keine Standardschriftart angegeben für Multi-Byte Ausdruck."
 
-#: ../hardcopy.c:2426
+#: ../hardcopy.c:2357
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript Ausgabe-Datei kann nicht geöffnet werden"
 
-#: ../hardcopy.c:2458
+#: ../hardcopy.c:2389
 #, c-format
 msgid "E456: Can't open file \"%s\""
 msgstr "E456: Datei \"%s\" kann nicht geöffnet werden"
 
-#: ../hardcopy.c:2583
+#: ../hardcopy.c:2514
 msgid "E456: Can't find PostScript resource file \"prolog.ps\""
 msgstr "E456: PostScript Ressource-Datei \"prolog.ps\" nicht gefunden"
 
-#: ../hardcopy.c:2593
+#: ../hardcopy.c:2524
 msgid "E456: Can't find PostScript resource file \"cidfont.ps\""
 msgstr "E456: PostScript Ressource-Datei \"cidfont.ps\" nicht gefunden"
 
-#: ../hardcopy.c:2622 ../hardcopy.c:2639 ../hardcopy.c:2665
+#: ../hardcopy.c:2553 ../hardcopy.c:2570 ../hardcopy.c:2596
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
 msgstr "E456: PostScript Ressource-Datei \"%s\" nicht gefunden"
 
-#: ../hardcopy.c:2654
+#: ../hardcopy.c:2585
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
 msgstr ""
 "E620: Umwandlung nach dem Zeichensatz für den Ausdruck \"%s\" fehlgeschlagen"
 
-#: ../hardcopy.c:2877
+#: ../hardcopy.c:2808
 msgid "Sending to printer..."
 msgstr "Schicke zum Drucker..."
 
-#: ../hardcopy.c:2881
+#: ../hardcopy.c:2812
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: Druck der PostScript-Datei schlug fehl"
 
-#: ../hardcopy.c:2883
+#: ../hardcopy.c:2814
 msgid "Print job sent."
 msgstr "Druckauftrag abgeschickt"
 
-#: ../if_cscope.c:85
+#: ../if_cscope.c:49
 msgid "Add a new database"
 msgstr "Eine neue Datenbank hinzufügen"
 
-#: ../if_cscope.c:87
+#: ../if_cscope.c:51
 msgid "Query for a pattern"
 msgstr "Muster suchen"
 
-#: ../if_cscope.c:89
+#: ../if_cscope.c:53
 msgid "Show this message"
 msgstr "diese Nachricht anzeigen"
 
-#: ../if_cscope.c:91
+#: ../if_cscope.c:55
 msgid "Kill a connection"
 msgstr "Verbindung abbrechen"
 
-#: ../if_cscope.c:93
+#: ../if_cscope.c:57
 msgid "Reinit all connections"
 msgstr "Verbindungen reinitialisieren"
 
-#: ../if_cscope.c:95
+#: ../if_cscope.c:59
 msgid "Show connections"
 msgstr "Verbindungen anzeigen"
 
-#: ../if_cscope.c:101
+#: ../if_cscope.c:65
 #, c-format
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Verwendung: cs[cope] %s"
 
-#: ../if_cscope.c:225
+#: ../if_cscope.c:189
 msgid "This cscope command does not support splitting the window.\n"
 msgstr "Dieser cscope-Befehl unterstützt nicht Teilen des Fensters.\n"
 
-#: ../if_cscope.c:266
+#: ../if_cscope.c:230
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Verwendung: cstag <ident>"
 
-#: ../if_cscope.c:313
+#: ../if_cscope.c:277
 msgid "E257: cstag: tag not found"
 msgstr "E257: cstag: Tag nicht gefunden"
 
-#: ../if_cscope.c:461
+#: ../if_cscope.c:425
 #, c-format
 msgid "E563: stat(%s) error: %d"
 msgstr "E563: stat(%s) Fehler: %d"
 
-#: ../if_cscope.c:551
+#: ../if_cscope.c:515
 #, c-format
 msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s ist kein Verzeichnis oder eine gültige cscope Datenbank"
 
-#: ../if_cscope.c:566
+#: ../if_cscope.c:530
 #, c-format
 msgid "Added cscope database %s"
 msgstr "csope Datenbank %s hinzugefügt"
 
-#: ../if_cscope.c:616
+#: ../if_cscope.c:580
 #, c-format
 msgid "E262: error reading cscope connection %<PRId64>"
 msgstr "E262: Fehler beim Lesen aus der cscope Verbindung %<PRId64>"
 
-#: ../if_cscope.c:711
+#: ../if_cscope.c:675
 msgid "E561: unknown cscope search type"
 msgstr "E561: Unbekannter cscope Suchtyp"
 
-#: ../if_cscope.c:752 ../if_cscope.c:789
+#: ../if_cscope.c:716 ../if_cscope.c:753
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: cscope Pipes konnten nicht angelegt werden"
 
-#: ../if_cscope.c:767
+#: ../if_cscope.c:731
 msgid "E622: Could not fork for cscope"
 msgstr "E622: Konnte nicht für cscope verzweigen"
 
-#: ../if_cscope.c:849
+#: ../if_cscope.c:813
 #, fuzzy
 msgid "cs_create_connection setpgid failed"
 msgstr "cs_create_connection exec misslang"
 
-#: ../if_cscope.c:853 ../if_cscope.c:889
+#: ../if_cscope.c:817 ../if_cscope.c:853
 msgid "cs_create_connection exec failed"
 msgstr "cs_create_connection exec misslang"
 
-#: ../if_cscope.c:863 ../if_cscope.c:902
+#: ../if_cscope.c:827 ../if_cscope.c:866
 msgid "cs_create_connection: fdopen for to_fp failed"
 msgstr "cs_create_connection: fdopen von to_fp misslang"
 
-#: ../if_cscope.c:865 ../if_cscope.c:906
+#: ../if_cscope.c:829 ../if_cscope.c:870
 msgid "cs_create_connection: fdopen for fr_fp failed"
 msgstr "cs_create_connection: fdopen von fr_fp misslang"
 
-#: ../if_cscope.c:890
+#: ../if_cscope.c:854
 msgid "E623: Could not spawn cscope process"
 msgstr "E623: Konnte cscope Prozess nicht hervorbringen"
 
-#: ../if_cscope.c:932
+#: ../if_cscope.c:896
 msgid "E567: no cscope connections"
 msgstr "E567: Keine cscope Verbindungen"
 
-#: ../if_cscope.c:1009
+#: ../if_cscope.c:973
 #, c-format
 msgid "E469: invalid cscopequickfix flag %c for %c"
 msgstr "E469: Unzulässiges cscopequickfix Flag %c für %c"
 
-#: ../if_cscope.c:1058
+#: ../if_cscope.c:1022
 #, c-format
 msgid "E259: no matches found for cscope query %s of %s"
 msgstr "E259: keine Übereinstimmungen gefunden für cscope Abfrage %s aus %s"
 
-#: ../if_cscope.c:1142
+#: ../if_cscope.c:1106
 msgid "cscope commands:\n"
 msgstr "cscope Befehle:\n"
 
-#: ../if_cscope.c:1150
+#: ../if_cscope.c:1114
 #, fuzzy, c-format
 msgid "%-5s: %s%*s (Usage: %s)"
 msgstr "%-5s: %-30s (Verwendung: %s)"
 
-#: ../if_cscope.c:1155
+#: ../if_cscope.c:1119
 msgid ""
 "\n"
 "       c: Find functions calling this function\n"
@@ -3259,31 +2704,31 @@ msgid ""
 "       t: Find this text string\n"
 msgstr ""
 
-#: ../if_cscope.c:1226
+#: ../if_cscope.c:1187
 msgid "E568: duplicate cscope database not added"
 msgstr "E568: cscope Datenbank nicht doppelt hinzugefügt"
 
-#: ../if_cscope.c:1335
+#: ../if_cscope.c:1295
 #, c-format
 msgid "E261: cscope connection %s not found"
 msgstr "E261: cscope Verbindung %s nicht gefunden"
 
-#: ../if_cscope.c:1364
+#: ../if_cscope.c:1324
 #, c-format
 msgid "cscope connection %s closed"
 msgstr "cscope Verbindung %s geschlossen"
 
 #. should not reach here
-#: ../if_cscope.c:1486
+#: ../if_cscope.c:1446
 msgid "E570: fatal error in cs_manage_matches"
 msgstr "E570: Fataler Fehler in cs_manage_matches"
 
-#: ../if_cscope.c:1693
+#: ../if_cscope.c:1653
 #, c-format
 msgid "Cscope tag: %s"
 msgstr "Cscope Tag: %s"
 
-#: ../if_cscope.c:1711
+#: ../if_cscope.c:1671
 msgid ""
 "\n"
 "   #   line"
@@ -3291,87 +2736,87 @@ msgstr ""
 "\n"
 "   #   Zeile"
 
-#: ../if_cscope.c:1713
+#: ../if_cscope.c:1673
 msgid "filename / context / line\n"
 msgstr "Dateiname / Kontext / Zeile\n"
 
-#: ../if_cscope.c:1809
+#: ../if_cscope.c:1769
 #, c-format
 msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope Fehler: %s"
 
-#: ../if_cscope.c:2053
+#: ../if_cscope.c:2013
 msgid "All cscope databases reset"
 msgstr "alle cscope Datenbanken zurückgesetzt"
 
-#: ../if_cscope.c:2123
+#: ../if_cscope.c:2083
 msgid "no cscope connections\n"
 msgstr "keine cscope-Verbindungen\n"
 
-#: ../if_cscope.c:2126
+#: ../if_cscope.c:2086
 msgid " # pid    database name                       prepend path\n"
 msgstr " # pid   Datenbank Name\t                    führender Pfad\n"
 
-#: ../main.c:144
+#: ../main.c:120
 msgid "Unknown option argument"
 msgstr "Unbekanntes Optionsargument"
 
-#: ../main.c:146
+#: ../main.c:122
 msgid "Too many edit arguments"
 msgstr "Zu viele Editor-Argumente"
 
-#: ../main.c:148
+#: ../main.c:124
 msgid "Argument missing after"
 msgstr "Argument fehlt nach"
 
-#: ../main.c:150
+#: ../main.c:126
 msgid "Garbage after option argument"
 msgstr "Schrott nach dem Optionsargument"
 
-#: ../main.c:152
+#: ../main.c:128
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
 msgstr "Zu viele \"+command\", \"-c command\" oder \"--cmd command\" Argumente"
 
-#: ../main.c:154
+#: ../main.c:130
 msgid "Invalid argument for"
 msgstr "Ungültiges Argument für"
 
-#: ../main.c:294
+#: ../main.c:270
 #, c-format
 msgid "%d files to edit\n"
 msgstr "%d Dateien zum Editieren\n"
 
-#: ../main.c:1342
+#: ../main.c:1320
 msgid "Attempt to open script file again: \""
 msgstr "Versuche, die Skript-Datei erneut zu öffnen: \""
 
-#: ../main.c:1350
+#: ../main.c:1328
 msgid "Cannot open for reading: \""
 msgstr "kann nicht zum Lesen geöffnet werden: \""
 
-#: ../main.c:1393
+#: ../main.c:1371
 msgid "Cannot open for script output: \""
 msgstr "kann nicht zur Skript-Ausgabe geöffnet werden: \""
 
-#: ../main.c:1622
+#: ../main.c:1600
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: Warnung: Die Ausgabe erfolgt nicht auf einem Terminal\n"
 
-#: ../main.c:1624
+#: ../main.c:1602
 msgid "Vim: Warning: Input is not from a terminal\n"
 msgstr "Vim: Warnung: Die Eingabe kommt nicht von einem Terminal\n"
 
 #. just in case..
-#: ../main.c:1891
+#: ../main.c:1869
 msgid "pre-vimrc command line"
 msgstr "pre-vimrc Befehls-Zeile"
 
-#: ../main.c:1964
+#: ../main.c:1942
 #, c-format
 msgid "E282: Cannot read from \"%s\""
 msgstr "E282: Kann nicht von \"%s\" lesen"
 
-#: ../main.c:2149
+#: ../main.c:2127
 msgid ""
 "\n"
 "More info with: \"vim -h\"\n"
@@ -3379,23 +2824,23 @@ msgstr ""
 "\n"
 "Weitere Informationen mit: \"vim -h\"\n"
 
-#: ../main.c:2178
+#: ../main.c:2156
 msgid "[file ..]       edit specified file(s)"
 msgstr "[Datei ..]      editiere die angegebenen Datei(-en)"
 
-#: ../main.c:2179
+#: ../main.c:2157
 msgid "-               read text from stdin"
 msgstr "-               lese Text von stdin"
 
-#: ../main.c:2180
+#: ../main.c:2158
 msgid "-t tag          edit file where tag is defined"
 msgstr "-t tag          öffne Datei in der der Tag definiert wurde"
 
-#: ../main.c:2181
+#: ../main.c:2159
 msgid "-q [errorfile]  edit file with first error"
 msgstr "-q [Fehler-Datei]  öffne Datei mit erstem Fehler"
 
-#: ../main.c:2187
+#: ../main.c:2165
 msgid ""
 "\n"
 "\n"
@@ -3405,11 +2850,11 @@ msgstr ""
 "\n"
 "Verwendung:"
 
-#: ../main.c:2189
+#: ../main.c:2167
 msgid " vim [arguments] "
 msgstr " vim [Argumente] "
 
-#: ../main.c:2193
+#: ../main.c:2171
 msgid ""
 "\n"
 "   or:"
@@ -3417,7 +2862,7 @@ msgstr ""
 "\n"
 "   oder:"
 
-#: ../main.c:2196
+#: ../main.c:2174
 msgid ""
 "\n"
 "\n"
@@ -3427,190 +2872,194 @@ msgstr ""
 "\n"
 "Argumente:\n"
 
-#: ../main.c:2197
+#: ../main.c:2175
 msgid "--\t\t\tOnly file names after this"
 msgstr "--\t\t\tHiernach nur Dateinamen"
 
-#: ../main.c:2199
+#: ../main.c:2177
 msgid "--literal\t\tDon't expand wildcards"
 msgstr "--literal\t\tPlatzhalter werden nicht ausgewertet"
 
-#: ../main.c:2201
+#: ../main.c:2179
 msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi Modus (wie \"vi\")"
 
-#: ../main.c:2202
+#: ../main.c:2180
 msgid "-e\t\t\tEx mode (like \"ex\")"
 msgstr "-e\t\t\tEx Modus (wie \"ex\")"
 
-#: ../main.c:2203
+#: ../main.c:2181
 msgid "-E\t\t\tImproved Ex mode"
 msgstr ""
 
-#: ../main.c:2204
+#: ../main.c:2182
 msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
 msgstr "-s\t\t\tLeiser (batch) Modus (nur für \"ex\")"
 
-#: ../main.c:2205
+#: ../main.c:2183
 msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
 msgstr "-d\t\t\tDiff Modus (wie \"vimdiff\")"
 
-#: ../main.c:2206
+#: ../main.c:2184
 msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
 msgstr "-y\t\t\tLeichter Modus (wie \"evim\", ohne Modi)"
 
-#: ../main.c:2207
+#: ../main.c:2185
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModus ohne Schreibrechte (wie \"view\")"
 
-#: ../main.c:2208
+#: ../main.c:2186
 msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
 msgstr "-Z\t\t\tEingeschränkter Modus (wie \"rvim\")"
 
-#: ../main.c:2209
+#: ../main.c:2187
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifikationen (beim Schreiben von Dateien) sind nicht erlaubt"
 
-#: ../main.c:2210
+#: ../main.c:2188
 msgid "-M\t\t\tModifications in text not allowed"
 msgstr "-M\t\t\tModifikationen im Text nicht erlaubt"
 
-#: ../main.c:2211
+#: ../main.c:2189
 msgid "-b\t\t\tBinary mode"
 msgstr "-b\t\t\tBinärmodus"
 
-#: ../main.c:2212
+#: ../main.c:2190
 msgid "-l\t\t\tLisp mode"
 msgstr "-l\t\t\tLisp Modus"
 
-#: ../main.c:2213
+#: ../main.c:2191
 msgid "-C\t\t\tCompatible with Vi: 'compatible'"
 msgstr "-C\t\t\tKompatibel zu Vi: 'compatible'"
 
-#: ../main.c:2214
+#: ../main.c:2192
 msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tNicht ganz kompatibel zu Vi: 'nocompatible'"
 
-#: ../main.c:2215
+#: ../main.c:2193
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
 msgstr ""
 
-#: ../main.c:2216
+#: ../main.c:2194
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tDebug-Modus"
 
-#: ../main.c:2217
+#: ../main.c:2195
 msgid "-n\t\t\tNo swap file, use memory only"
 msgstr "-n\t\t\tKeine Auslagerungsdatei, verwende nur Speicher"
 
-#: ../main.c:2218
+#: ../main.c:2196
 msgid "-r\t\t\tList swap files and exit"
 msgstr "-r\t\t\tListe nur Auslagerungsdateien auf"
 
-#: ../main.c:2219
+#: ../main.c:2197
 msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (mit Dateiname)\tStelle abgestürzte Session wieder her"
 
-#: ../main.c:2220
+#: ../main.c:2198
 msgid "-L\t\t\tSame as -r"
 msgstr "-L\t\t\tGenauso wie z -r"
 
-#: ../main.c:2221
+#: ../main.c:2199
 msgid "-A\t\t\tstart in Arabic mode"
 msgstr "-A\t\t\tStart im Arabischen Modus"
 
-#: ../main.c:2222
+#: ../main.c:2200
 msgid "-H\t\t\tStart in Hebrew mode"
 msgstr "-H\t\t\tStart im Hebräischen Modus"
 
-#: ../main.c:2223
+#: ../main.c:2201
 msgid "-F\t\t\tStart in Farsi mode"
 msgstr "-F\t\t\tStart im Farsi Modus"
 
-#: ../main.c:2224
+#: ../main.c:2202
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminal>\tSetze Terminaltyp auf <terminal>"
 
-#: ../main.c:2225
+#: ../main.c:2203
 msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
 msgstr "-u <vimrc>\t\tBenutze <vimrc> anstatt jeglicher .vimrc"
 
-#: ../main.c:2226
+#: ../main.c:2204
 msgid "--noplugin\t\tDon't load plugin scripts"
 msgstr "--noplugin\t\tlade keine \"plugin\"-Skripte"
 
-#: ../main.c:2227
+#: ../main.c:2205
 msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
 msgstr "-p[N]\t\tÖffne N Tabs (Vorgabe: einzeln für jede Datei)"
 
-#: ../main.c:2228
+#: ../main.c:2206
 msgid "-o[N]\t\tOpen N windows (default: one for each file)"
 msgstr "-o[N]\t\tÖffne N Fenster (Vorgabe: einzeln für jede Datei)"
 
-#: ../main.c:2229
+#: ../main.c:2207
 msgid "-O[N]\t\tLike -o but split vertically"
 msgstr "-O[N]\t\tWie -o, aber teile vertikal"
 
-#: ../main.c:2230
+#: ../main.c:2208
 msgid "+\t\t\tStart at end of file"
 msgstr "+\t\t\tStarte am Ende der Datei"
 
-#: ../main.c:2231
+#: ../main.c:2209
 msgid "+<lnum>\t\tStart at line <lnum>"
 msgstr "+<lnum>\t\tStart in Zeile <lnum>"
 
-#: ../main.c:2232
+#: ../main.c:2210
 msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
 msgstr "--cmd <Befehl>\tFühre <Befehl> vor dem Laden jeglicher vimrc-Datei aus"
 
-#: ../main.c:2233
+#: ../main.c:2211
 msgid "-c <command>\t\tExecute <command> after loading the first file"
 msgstr "-c <Befehl>\t\tFühre <Befehl> nach dem Laden der ersten Datei aus"
 
-#: ../main.c:2235
+#: ../main.c:2213
 msgid "-S <session>\t\tSource file <session> after loading the first file"
 msgstr "-S <session>\t\tLese Datei <session> nach dem Laden der ersten Datei"
 
-#: ../main.c:2236
+#: ../main.c:2214
 msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
 msgstr ""
 "-s <scriptin>\tLese Normal-Modus Befehle aus der Skript-Datei <scriptin>"
 
-#: ../main.c:2237
+#: ../main.c:2215
 msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
 msgstr "-w <scriptout>\tBefehle am Ende der Skript-Datei <scriptout> anfügen"
 
-#: ../main.c:2238
+#: ../main.c:2216
 msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
 msgstr "-W <scriptout>\tSchreibe Befehle in die Skript-Datei <scriptout>"
 
-#: ../main.c:2240
+#: ../main.c:2218
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 
-#: ../main.c:2242
+#: ../main.c:2220
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tBenutze <viminfo> statt .viminfo"
 
-#: ../main.c:2243
+#: ../main.c:2221
+msgid "--api-msgpack-metadata\tDump API metadata information and exit"
+msgstr ""
+
+#: ../main.c:2222
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h  or  --help\tAnzeigen der Hilfe (diesen Text) und beenden"
 
-#: ../main.c:2244
+#: ../main.c:2223
 msgid "--version\t\tPrint version information and exit"
 msgstr "--version\t\tVersionsinformation anzeigen und beenden"
 
-#: ../mark.c:676
+#: ../mark.c:673
 msgid "No marks set"
 msgstr "Keine Markierungen gesetzt"
 
-#: ../mark.c:678
+#: ../mark.c:675
 #, c-format
 msgid "E283: No marks matching \"%s\""
 msgstr "E283: Keine Markierungen passen zu \"%s\""
 
 #. Highlight title
-#: ../mark.c:687
+#: ../mark.c:684
 msgid ""
 "\n"
 "mark line  col file/text"
@@ -3619,7 +3068,7 @@ msgstr ""
 "Mark Zeile Sp  Datei/Text"
 
 #. Highlight title
-#: ../mark.c:789
+#: ../mark.c:786
 msgid ""
 "\n"
 " jump line  col file/text"
@@ -3628,7 +3077,7 @@ msgstr ""
 " Sprung Zeile Sp Datei/Text"
 
 #. Highlight title
-#: ../mark.c:831
+#: ../mark.c:828
 msgid ""
 "\n"
 "change line  col text"
@@ -3636,7 +3085,7 @@ msgstr ""
 "\n"
 "Änder. Zeile Sp  Text"
 
-#: ../mark.c:1238
+#: ../mark.c:1235
 msgid ""
 "\n"
 "# File marks:\n"
@@ -3645,7 +3094,7 @@ msgstr ""
 "# Datei-Marken:\n"
 
 #. Write the jumplist with -'
-#: ../mark.c:1271
+#: ../mark.c:1268
 msgid ""
 "\n"
 "# Jumplist (newest first):\n"
@@ -3653,7 +3102,7 @@ msgstr ""
 "\n"
 "# Geschichte (neueste zuerst):\n"
 
-#: ../mark.c:1352
+#: ../mark.c:1348
 msgid ""
 "\n"
 "# History of marks within files (newest to oldest):\n"
@@ -3661,88 +3110,88 @@ msgstr ""
 "\n"
 "# Geschichte der Markierungen innerhalb von Dateien (neueste zuerst):\n"
 
-#: ../mark.c:1431
+#: ../mark.c:1426
 msgid "Missing '>'"
 msgstr "'>' fehlt"
 
-#: ../memfile.c:426
+#: ../memfile.c:406
 msgid "E293: block was not locked"
 msgstr "E293: Block war nicht gesperrt"
 
-#: ../memfile.c:799
+#: ../memfile.c:779
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Positionierungsfehler beim Lesen der Auslagerungsdatei"
 
-#: ../memfile.c:803
+#: ../memfile.c:783
 msgid "E295: Read error in swap file"
 msgstr "E295: Lesefehler in der Auslagerungsdatei"
 
-#: ../memfile.c:849
+#: ../memfile.c:829
 msgid "E296: Seek error in swap file write"
 msgstr "E296: Positionierungsfehler beim Schreiben in die Auslagerungsdatei"
 
-#: ../memfile.c:865
+#: ../memfile.c:845
 msgid "E297: Write error in swap file"
 msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei"
 
-#: ../memfile.c:1036
+#: ../memfile.c:1016
 msgid "E300: Swap file already exists (symlink attack?)"
 msgstr "E300: Auslagerungsdatei ist bereits vorhanden (symlink Attacke?)"
 
-#: ../memline.c:318
+#: ../memline.c:296
 msgid "E298: Didn't get block nr 0?"
 msgstr "E298: Block Nr. 0 nicht erhalten?"
 
-#: ../memline.c:361
+#: ../memline.c:338
 msgid "E298: Didn't get block nr 1?"
 msgstr "E298: Block Nr. 1 nicht erhalten?"
 
-#: ../memline.c:377
+#: ../memline.c:354
 msgid "E298: Didn't get block nr 2?"
 msgstr "E298: Block Nr. 2 nicht erhalten?"
 
 #. could not (re)open the swap file, what can we do????
-#: ../memline.c:465
+#: ../memline.c:442
 msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Ups, Verlust der Auslagerungsdatei!!!"
 
-#: ../memline.c:477
+#: ../memline.c:454
 msgid "E302: Could not rename swap file"
 msgstr "E302: Auslagerungsdatei konnte nicht umbenannt werden"
 
-#: ../memline.c:554
+#: ../memline.c:531
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
 msgstr ""
 "E303: Auslagerungsdatei für \"%s\" konnte nicht geöffnet werden, "
 "Wiederherstellung unmöglich"
 
-#: ../memline.c:666
+#: ../memline.c:643
 msgid "E304: ml_upd_block0(): Didn't get block 0??"
 msgstr "E304: ml_upd_block0(): Block Nr. 0 nicht erhalten?"
 
 #. no swap files found
-#: ../memline.c:830
+#: ../memline.c:806
 #, c-format
 msgid "E305: No swap file found for %s"
 msgstr "E305: Keine Auslagerungsdatei für %s gefunden"
 
-#: ../memline.c:839
+#: ../memline.c:815
 msgid "Enter number of swap file to use (0 to quit): "
 msgstr ""
 "Geben Sie die Nummer der Auslagerungsdatei ein die verwendet werden soll (0 "
 "um abzubrechen): "
 
-#: ../memline.c:879
+#: ../memline.c:855
 #, c-format
 msgid "E306: Cannot open %s"
 msgstr "E306: %s kann nicht geöffnet werden"
 
-#: ../memline.c:897
+#: ../memline.c:873
 msgid "Unable to read block 0 from "
 msgstr "Block 0 kann nicht gelesen werden aus "
 
-#: ../memline.c:900
+#: ../memline.c:876
 msgid ""
 "\n"
 "Maybe no changes were made or Vim did not update the swap file."
@@ -3751,28 +3200,28 @@ msgstr ""
 "Vielleicht wurden keine Änderungen vorgenommen oder Vim hatte die "
 "Auslagerungsdatei nicht aktualisiert."
 
-#: ../memline.c:909
+#: ../memline.c:885
 msgid " cannot be used with this version of Vim.\n"
 msgstr " kann nicht zusammen mit dieser Vim Version verwendet werden.\n"
 
-#: ../memline.c:911
+#: ../memline.c:887
 msgid "Use Vim version 3.0.\n"
 msgstr "Benutze Vim Version 3.0.\n"
 
-#: ../memline.c:916
+#: ../memline.c:892
 #, c-format
 msgid "E307: %s does not look like a Vim swap file"
 msgstr "E307: %s sieht nicht wie eine Vim Auslagerungsdatei aus"
 
-#: ../memline.c:922
+#: ../memline.c:898
 msgid " cannot be used on this computer.\n"
 msgstr " kann auf diesem Rechner nicht verwendet werden.\n"
 
-#: ../memline.c:924
+#: ../memline.c:900
 msgid "The file was created on "
 msgstr "Die Datei wurde erstellt um "
 
-#: ../memline.c:928
+#: ../memline.c:904
 msgid ""
 ",\n"
 "or the file has been damaged."
@@ -3780,86 +3229,86 @@ msgstr ""
 ",\n"
 "oder die Datei wurde zerstört."
 
-#: ../memline.c:945
+#: ../memline.c:921
 msgid " has been damaged (page size is smaller than minimum value).\n"
 msgstr ""
 
-#: ../memline.c:974
+#: ../memline.c:950
 #, c-format
 msgid "Using swap file \"%s\""
 msgstr "Verwende Auslagerungsdatei \"%s\""
 
-#: ../memline.c:980
+#: ../memline.c:956
 #, c-format
 msgid "Original file \"%s\""
 msgstr "Original-Datei \"%s\""
 
-#: ../memline.c:995
+#: ../memline.c:971
 msgid "E308: Warning: Original file may have been changed"
 msgstr "E308: Warnung: Die Originaldatei könnte verändert worden sein"
 
-#: ../memline.c:1061
+#: ../memline.c:1037
 #, c-format
 msgid "E309: Unable to read block 1 from %s"
 msgstr "E309: Block 1 kann nicht nicht von %s gelesen werden"
 
-#: ../memline.c:1065
+#: ../memline.c:1041
 msgid "???MANY LINES MISSING"
 msgstr "???VIELE ZEILEN FEHLEN"
 
-#: ../memline.c:1076
+#: ../memline.c:1052
 msgid "???LINE COUNT WRONG"
 msgstr "???ZEILEN ZÄHLER FALSCH"
 
-#: ../memline.c:1082
+#: ../memline.c:1058
 msgid "???EMPTY BLOCK"
 msgstr "???LEERER BLOCK"
 
-#: ../memline.c:1103
+#: ../memline.c:1079
 msgid "???LINES MISSING"
 msgstr "???ZEILEN FEHLEN"
 
-#: ../memline.c:1128
+#: ../memline.c:1104
 #, c-format
 msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
 msgstr "E310: Block 1 ID falsch (ist %s keine .swp-Datei?)"
 
-#: ../memline.c:1133
+#: ../memline.c:1109
 msgid "???BLOCK MISSING"
 msgstr "???BLOCK FEHLT"
 
-#: ../memline.c:1147
+#: ../memline.c:1123
 msgid "??? from here until ???END lines may be messed up"
 msgstr "??? von hier bis ???ENDE könnten die Zeilen falsch sein"
 
-#: ../memline.c:1164
+#: ../memline.c:1140
 msgid "??? from here until ???END lines may have been inserted/deleted"
 msgstr "??? von hier bis ???ENDE könnten Zeilen eingefügt oder gelöscht sein"
 
-#: ../memline.c:1181
+#: ../memline.c:1157
 msgid "???END"
 msgstr "???ENDE"
 
-#: ../memline.c:1238
+#: ../memline.c:1214
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Wiederherstellung unterbrochen"
 
-#: ../memline.c:1243
+#: ../memline.c:1219
 msgid ""
 "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr ""
 "E312: Fehler wurden festgestellt während der Wiederherstellung: suche nach "
 "Zeilen die mit ??? beginnen"
 
-#: ../memline.c:1245
+#: ../memline.c:1221
 msgid "See \":help E312\" for more information."
 msgstr "Lesen Sie \":help E312\" für weitere Informationen."
 
-#: ../memline.c:1249
+#: ../memline.c:1225
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Wiederherstellung beendet. Prüfen Sie, ob alles alles OK ist."
 
-#: ../memline.c:1251
+#: ../memline.c:1227
 msgid ""
 "\n"
 "(You might want to write out this file under another name\n"
@@ -3867,16 +3316,16 @@ msgstr ""
 "\n"
 "(Wollen Sie vielleicht diese Datei unter einem neuen Namen speichern\n"
 
-#: ../memline.c:1252
+#: ../memline.c:1228
 #, fuzzy
 msgid "and run diff with the original file to check for changes)"
 msgstr "und \"diff\" zur Original-Datei machen, um Änderungen zu prüfen)\n"
 
-#: ../memline.c:1254
+#: ../memline.c:1230
 msgid "Recovery completed. Buffer contents equals file contents."
 msgstr ""
 
-#: ../memline.c:1255
+#: ../memline.c:1231
 #, fuzzy
 msgid ""
 "\n"
@@ -3887,51 +3336,51 @@ msgstr ""
 "\n"
 
 #. use msg() to start the scrolling properly
-#: ../memline.c:1327
+#: ../memline.c:1303
 msgid "Swap files found:"
 msgstr "Auslagerungsdateien gefunden:"
 
-#: ../memline.c:1446
+#: ../memline.c:1422
 msgid "   In current directory:\n"
 msgstr "   Im laufenden Verzeichnis:\n"
 
-#: ../memline.c:1448
+#: ../memline.c:1424
 msgid "   Using specified name:\n"
 msgstr "   Benutze gegebenen Namen:\n"
 
-#: ../memline.c:1450
+#: ../memline.c:1426
 msgid "   In directory "
 msgstr "   Im Verzeichnis "
 
-#: ../memline.c:1465
+#: ../memline.c:1441
 msgid "      -- none --\n"
 msgstr "      -- Nichts --\n"
 
-#: ../memline.c:1527
+#: ../memline.c:1503
 msgid "          owned by: "
 msgstr "      Eigentum von: "
 
-#: ../memline.c:1529
+#: ../memline.c:1505
 msgid "   dated: "
 msgstr "     vom: "
 
-#: ../memline.c:1532 ../memline.c:3231
+#: ../memline.c:1508 ../memline.c:3188
 msgid "             dated: "
 msgstr "               vom: "
 
-#: ../memline.c:1548
+#: ../memline.c:1524
 msgid "         [from Vim version 3.0]"
 msgstr "         [von Vim Version 3.0]"
 
-#: ../memline.c:1550
+#: ../memline.c:1526
 msgid "         [does not look like a Vim swap file]"
 msgstr "         [sieht nicht wie eine Vim Auslagerungsdatei aus]"
 
-#: ../memline.c:1552
+#: ../memline.c:1528
 msgid "         file name: "
 msgstr "         Dateiname: "
 
-#: ../memline.c:1558
+#: ../memline.c:1534
 msgid ""
 "\n"
 "          modified: "
@@ -3939,15 +3388,15 @@ msgstr ""
 "\n"
 "         verändert: "
 
-#: ../memline.c:1559
+#: ../memline.c:1535
 msgid "YES"
 msgstr "JA"
 
-#: ../memline.c:1559
+#: ../memline.c:1535
 msgid "no"
 msgstr "nein"
 
-#: ../memline.c:1562
+#: ../memline.c:1538
 msgid ""
 "\n"
 "         user name: "
@@ -3955,11 +3404,11 @@ msgstr ""
 "\n"
 "     Benutzer-Name: "
 
-#: ../memline.c:1568
+#: ../memline.c:1544
 msgid "   host name: "
 msgstr "   Host-Name: "
 
-#: ../memline.c:1570
+#: ../memline.c:1546
 msgid ""
 "\n"
 "         host name: "
@@ -3967,7 +3416,7 @@ msgstr ""
 "\n"
 "         Host-Name: "
 
-#: ../memline.c:1575
+#: ../memline.c:1551
 msgid ""
 "\n"
 "        process ID: "
@@ -3975,11 +3424,11 @@ msgstr ""
 "\n"
 "        Process-ID: "
 
-#: ../memline.c:1579
+#: ../memline.c:1555
 msgid " (still running)"
 msgstr " (läuft noch)"
 
-#: ../memline.c:1586
+#: ../memline.c:1562
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3987,98 +3436,98 @@ msgstr ""
 "\n"
 "         [nicht verwendbar auf diesem Rechner]"
 
-#: ../memline.c:1590
+#: ../memline.c:1566
 msgid "         [cannot be read]"
 msgstr "         [kann nicht gelesen werden]"
 
-#: ../memline.c:1593
+#: ../memline.c:1569
 msgid "         [cannot be opened]"
 msgstr "         [kann nicht geöffnet werden]"
 
-#: ../memline.c:1698
+#: ../memline.c:1674
 msgid "E313: Cannot preserve, there is no swap file"
 msgstr "E313: Kann nicht absichern, es gibt keine Auslagerungsdatei"
 
-#: ../memline.c:1747
+#: ../memline.c:1723
 msgid "File preserved"
 msgstr "Datei gesichert"
 
-#: ../memline.c:1749
+#: ../memline.c:1725
 msgid "E314: Preserve failed"
 msgstr "E314: Absicherung fehlgeschlagen"
 
-#: ../memline.c:1819
+#: ../memline.c:1778
 #, c-format
 msgid "E315: ml_get: invalid lnum: %<PRId64>"
 msgstr "E315: ml_get: unzulässige lnum: %<PRId64>"
 
-#: ../memline.c:1851
+#: ../memline.c:1810
 #, c-format
 msgid "E316: ml_get: cannot find line %<PRId64>"
 msgstr "E316: ml_get: kann Zeile %<PRId64> nicht finden"
 
-#: ../memline.c:2236
+#: ../memline.c:2195
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Zeiger Block id falsch 3"
 
-#: ../memline.c:2311
+#: ../memline.c:2270
 msgid "stack_idx should be 0"
 msgstr "stack_idx sollte 0 sein"
 
-#: ../memline.c:2369
+#: ../memline.c:2328
 msgid "E318: Updated too many blocks?"
 msgstr "E318: Zu viele Blocks aktualisiert?"
 
-#: ../memline.c:2511
+#: ../memline.c:2469
 msgid "E317: pointer block id wrong 4"
 msgstr "E317: Zeiger Block id falsch 4"
 
-#: ../memline.c:2536
+#: ../memline.c:2494
 msgid "deleted block 1?"
 msgstr "Block 1 gelöscht?"
 
-#: ../memline.c:2707
+#: ../memline.c:2665
 #, c-format
 msgid "E320: Cannot find line %<PRId64>"
 msgstr "E320: Kann Zeile %<PRId64> nicht finden"
 
-#: ../memline.c:2916
+#: ../memline.c:2874
 msgid "E317: pointer block id wrong"
 msgstr "E317: Zeiger Block id ist falsch"
 
-#: ../memline.c:2930
+#: ../memline.c:2888
 msgid "pe_line_count is zero"
 msgstr "pe_line_count ist Null"
 
-#: ../memline.c:2955
+#: ../memline.c:2913
 #, c-format
 msgid "E322: line number out of range: %<PRId64> past the end"
 msgstr ""
 "E322: Zeilennummer nicht im zulässigen Bereich: %<PRId64> nach dem Ende"
 
-#: ../memline.c:2959
+#: ../memline.c:2917
 #, c-format
 msgid "E323: line count wrong in block %<PRId64>"
 msgstr "E323: Zeilen Zähler falsch in Block %<PRId64>"
 
-#: ../memline.c:2999
+#: ../memline.c:2957
 msgid "Stack size increases"
 msgstr "Stapel Größe wächst"
 
-#: ../memline.c:3038
+#: ../memline.c:2996
 msgid "E317: pointer block id wrong 2"
 msgstr "E317: Zeiger Block id falsch 2"
 
-#: ../memline.c:3070
+#: ../memline.c:3028
 #, c-format
 msgid "E773: Symlink loop for \"%s\""
 msgstr "E773: Symlink Schleife für \"%s\""
 
-#: ../memline.c:3221
+#: ../memline.c:3178
 msgid "E325: ATTENTION"
 msgstr "E325: ACHTUNG"
 
-#: ../memline.c:3222
+#: ../memline.c:3179
 msgid ""
 "\n"
 "Found a swap file by the name \""
@@ -4086,15 +3535,15 @@ msgstr ""
 "\n"
 "Auslagerungsdatei mit folgendem Namen gefunden: \""
 
-#: ../memline.c:3226
+#: ../memline.c:3183
 msgid "While opening file \""
 msgstr "Beim Öffnen der Datei \""
 
-#: ../memline.c:3239
+#: ../memline.c:3196
 msgid "      NEWER than swap file!\n"
 msgstr "      neuer als Auslagerungsdatei!\n"
 
-#: ../memline.c:3244
+#: ../memline.c:3201
 #, fuzzy
 msgid ""
 "\n"
@@ -4107,24 +3556,24 @@ msgstr ""
 "    Wenn dies der Fall ist, sollten Sie vorsichtig sein, damit\n"
 "    es nicht zu Überschneidungen kommt.\n"
 
-#: ../memline.c:3245
+#: ../memline.c:3202
 #, fuzzy
 msgid "  Quit, or continue with caution.\n"
 msgstr "    Ende, oder Fortsetzung mit Vorsicht.\n"
 
-#: ../memline.c:3246
+#: ../memline.c:3203
 #, fuzzy
 msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 "\n"
 "(2) Eine Editiersitzung für diese Datei ist abgestürzt.\n"
 
-#: ../memline.c:3247
+#: ../memline.c:3204
 msgid "    If this is the case, use \":recover\" or \"vim -r "
 msgstr ""
 "    Wenn dies der Fall ist, so verwenden Sie \":recover\" oder \"vim -r "
 
-#: ../memline.c:3249
+#: ../memline.c:3206
 msgid ""
 "\"\n"
 "    to recover the changes (see \":help recovery\").\n"
@@ -4132,12 +3581,12 @@ msgstr ""
 "\"\n"
 "    um die Änderungen wiederherzustellen (siehe \":help recovery\").\n"
 
-#: ../memline.c:3250
+#: ../memline.c:3207
 msgid "    If you did this already, delete the swap file \""
 msgstr ""
 "    Wenn dies bereits geschehen ist, löschen Sie die Auslagerungsdatei \""
 
-#: ../memline.c:3252
+#: ../memline.c:3209
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -4145,23 +3594,23 @@ msgstr ""
 "\"\n"
 "    um diese Nachricht zu vermeiden.\n"
 
-#: ../memline.c:3450 ../memline.c:3452
+#: ../memline.c:3406 ../memline.c:3408
 msgid "Swap file \""
 msgstr "Auslagerungsdatei \""
 
-#: ../memline.c:3451 ../memline.c:3455
+#: ../memline.c:3407 ../memline.c:3411
 msgid "\" already exists!"
 msgstr "\" ist bereits vorhanden!"
 
-#: ../memline.c:3457
+#: ../memline.c:3413
 msgid "VIM - ATTENTION"
 msgstr "VIM - ACHTUNG"
 
-#: ../memline.c:3459
+#: ../memline.c:3415
 msgid "Swap file already exists!"
 msgstr "Auslagerungsdatei ist bereits vorhanden!"
 
-#: ../memline.c:3464
+#: ../memline.c:3420
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -4175,7 +3624,7 @@ msgstr ""
 "&Beenden\n"
 "&Abbrechen"
 
-#: ../memline.c:3467
+#: ../memline.c:3423
 msgid ""
 "&Open Read-Only\n"
 "&Edit anyway\n"
@@ -4199,49 +3648,49 @@ msgstr ""
 #.
 #. ".s?a"
 #. ".saa": tried enough, give up
-#: ../memline.c:3528
+#: ../memline.c:3484
 msgid "E326: Too many swap files found"
 msgstr "E326: Zu viele Auslagerungsdateien gefunden"
 
-#: ../memory.c:227
+#: ../memory.c:363
 #, c-format
 msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
 msgstr "E342: Kein Speicherplatz mehr vorhanden (%<PRIu64> Bytes reserviert)"
 
-#: ../menu.c:62
+#: ../menu.c:47
 msgid "E327: Part of menu-item path is not sub-menu"
 msgstr "E327: Teil des Menüpunkt-Pfades muss zum Untermenü führen"
 
-#: ../menu.c:63
+#: ../menu.c:48
 msgid "E328: Menu only exists in another mode"
 msgstr "E328: Menü existiert nur in anderen Modus"
 
-#: ../menu.c:64
+#: ../menu.c:49
 #, c-format
 msgid "E329: No menu \"%s\""
 msgstr "E329: Kein Menü \"%s\""
 
 #. Only a mnemonic or accelerator is not valid.
-#: ../menu.c:329
+#: ../menu.c:306
 #, fuzzy
 msgid "E792: Empty menu name"
 msgstr "E749: Leerer Puffer"
 
-#: ../menu.c:340
+#: ../menu.c:317
 msgid "E330: Menu path must not lead to a sub-menu"
 msgstr "E330: Menü-Pfad darf nicht zum Untermenü führen"
 
-#: ../menu.c:365
+#: ../menu.c:342
 msgid "E331: Must not add menu items directly to menu bar"
 msgstr "E331: Menüpunkt können nicht direkt zum Menü-Balken hinzugefügt werden"
 
-#: ../menu.c:370
+#: ../menu.c:347
 msgid "E332: Separator cannot be part of a menu path"
 msgstr "E332: Trenner kann nicht Teil des Menü-Pfades sein"
 
 #. Now we have found the matching menu, and we list the mappings
 #. Highlight title
-#: ../menu.c:762
+#: ../menu.c:739
 msgid ""
 "\n"
 "--- Menus ---"
@@ -4249,75 +3698,79 @@ msgstr ""
 "\n"
 "--- Menüs ---"
 
-#: ../menu.c:1313
+#: ../menu.c:1286
 msgid "E333: Menu path must lead to a menu item"
 msgstr "E333: Menü-Pfad muss zu einem Menüpunkt führen"
 
-#: ../menu.c:1330
+#: ../menu.c:1303
 #, c-format
 msgid "E334: Menu not found: %s"
 msgstr "E334: Menü nicht gefunden: %s"
 
-#: ../menu.c:1396
+#: ../menu.c:1369
 #, c-format
 msgid "E335: Menu not defined for %s mode"
 msgstr "E335: Menü ist für %s Modus nicht definiert"
 
-#: ../menu.c:1426
+#: ../menu.c:1399
 msgid "E336: Menu path must lead to a sub-menu"
 msgstr "E336: Menü-Pfad muss zum Untermenü führen"
 
-#: ../menu.c:1447
+#: ../menu.c:1420
 msgid "E337: Menu not found - check menu names"
 msgstr "E337: Menü nicht gefunden - überprüfe Menü-Namen"
 
-#: ../message.c:423
+#: ../message.c:383
 #, c-format
 msgid "Error detected while processing %s:"
 msgstr "Fehler beim Ausführen von \"%s\":"
 
-#: ../message.c:445
+#: ../message.c:405
 #, c-format
 msgid "line %4ld:"
 msgstr "Zeile %4ld:"
 
-#: ../message.c:617
+#: ../message.c:577
 #, c-format
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ungültiger Register Name: '%s'"
 
-#: ../message.c:745
+#: ../message.c:705
 msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
 msgstr "Übersetzt von Georg Dahn <gorgyd@yahoo.co.uk>"
 
-#: ../message.c:986
+#: ../message.c:946
 msgid "Interrupt: "
 msgstr "Unterbrechung: "
 
-#: ../message.c:988
+#: ../message.c:948
 msgid "Press ENTER or type command to continue"
 msgstr "Betätigen Sie die EINGABETASTE oder geben Sie einen Befehl ein"
 
-#: ../message.c:1843
+#: ../message.c:1799 ../eval.c:16205 ../eval.c:16210
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: ../message.c:1803
 #, c-format
 msgid "%s line %<PRId64>"
 msgstr "%s Zeile %<PRId64>"
 
-#: ../message.c:2392
+#: ../message.c:2334
 msgid "-- More --"
 msgstr "-- Mehr --"
 
-#: ../message.c:2398
+#: ../message.c:2340
 msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
 msgstr ""
 " LEERZEICHEN/d/j: Seite/halbe Seite/Zeile vorwärts, b/u/k: rückwärts, q: "
 "Ende "
 
-#: ../message.c:3021 ../message.c:3031
+#: ../message.c:2981 ../message.c:2991
 msgid "Question"
 msgstr "Frage"
 
-#: ../message.c:3023
+#: ../message.c:2983
 msgid ""
 "&Yes\n"
 "&No"
@@ -4325,7 +3778,7 @@ msgstr ""
 "&Ja\n"
 "&Nein"
 
-#: ../message.c:3033
+#: ../message.c:2993
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4335,7 +3788,7 @@ msgstr ""
 "&Nein\n"
 "&Abbrechen"
 
-#: ../message.c:3045
+#: ../message.c:3005
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4349,181 +3802,186 @@ msgstr ""
 "Alle &Verwerfen\n"
 "&Abbrechen"
 
-#: ../message.c:3058
+#: ../message.c:3017
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Zu wenige Argumente für printf()"
 
-#: ../message.c:3119
+#: ../message.c:3074
 #, fuzzy
 msgid "E807: Expected Float argument for printf()"
 msgstr "E766: Zu wenige Argumente für printf()"
 
-#: ../message.c:3873
+#: ../message.c:3827
 msgid "E767: Too many arguments to printf()"
 msgstr "E767: Zu viele Argumente für printf()"
 
-#: ../misc1.c:2256
+#: ../misc1.c:2235
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Warnung: Ändern einer schreibgeschützten Datei"
 
-#: ../misc1.c:2537
+#: ../misc1.c:2516
 #, fuzzy
 msgid "Type number and <Enter> or click with mouse (empty cancels): "
 msgstr ""
 "Bitte Nummer eingeben oder mit der Maus auswählen (abbrechen mit <Enter>)"
 
-#: ../misc1.c:2539
+#: ../misc1.c:2518
 #, fuzzy
 msgid "Type number and <Enter> (empty cancels): "
 msgstr "Gewünschte Nummer (abbrechen mit <Enter>)"
 
-#: ../misc1.c:2585
+#: ../misc1.c:2564
 msgid "1 more line"
 msgstr "eine Zeile mehr"
 
-#: ../misc1.c:2588
+#: ../misc1.c:2566
 msgid "1 line less"
 msgstr "eine Zeile weniger"
 
-#: ../misc1.c:2593
+#: ../misc1.c:2570
 #, c-format
 msgid "%<PRId64> more lines"
 msgstr "%<PRId64> Zeilen mehr"
 
-#: ../misc1.c:2596
+#: ../misc1.c:2573
 #, c-format
 msgid "%<PRId64> fewer lines"
 msgstr "%<PRId64> Zeilen weniger"
 
-#: ../misc1.c:2599
+#: ../misc1.c:2576
 msgid " (Interrupted)"
 msgstr " (Unterbrochen)"
 
-#: ../misc1.c:2635
+#: ../misc1.c:2612
 msgid "Beep!"
 msgstr "Beep!"
 
-#: ../misc2.c:738
+#: ../misc2.c:297
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Rufe Shell auf, um \"%s\" auszuführen"
 
 # Identifizierungszeichen/merkmal, Bezeichner
-#: ../normal.c:183
+#.
+#. * nv_*(): functions called to handle Normal and Visual mode commands.
+#. * n_*(): functions called to handle Normal mode commands.
+#. * v_*(): functions called to handle Visual mode commands.
+#.
+#: ../normal.c:80
 msgid "E349: No identifier under cursor"
 msgstr "E349: Kein Merkmal unter dem Cursor"
 
-#: ../normal.c:1866
+#: ../normal.c:1763
 msgid "E774: 'operatorfunc' is empty"
 msgstr "E774: 'operatorfunc' is empty"
 
-#: ../normal.c:2637
+#: ../normal.c:2534
 msgid "Warning: terminal cannot highlight"
 msgstr "Achtung: Terminal unterstützt keine Hervorhebung"
 
-#: ../normal.c:2807
+#: ../normal.c:2704
 msgid "E348: No string under cursor"
 msgstr "E348: Keine Zeichenkette unter dem Cursor"
 
-#: ../normal.c:3937
+#: ../normal.c:3834
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr ""
 "E352: Faltung kann mit der eingestellten Faltungsmethode nicht gelöscht "
 "werden"
 
-#: ../normal.c:5897
+#: ../normal.c:5794
 msgid "E664: changelist is empty"
 msgstr "E664: Liste der Änderungen ist leer"
 
-#: ../normal.c:5899
+#: ../normal.c:5796
 msgid "E662: At start of changelist"
 msgstr "E662: Am Anfang der Liste der Änderungen"
 
-#: ../normal.c:5901
+#: ../normal.c:5798
 msgid "E663: At end of changelist"
 msgstr "E663: Am Ende der Liste der Änderungen"
 
-#: ../normal.c:7053
+#: ../normal.c:6950
 msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Bitte  :quit<Enter>  eingeben um Vim zu verlassen"
 
-#: ../ops.c:248
+#: ../ops.c:229
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "eine Zeile ein Mal %s"
 
-#: ../ops.c:250
+#: ../ops.c:231
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "eine Zeile %s %d Mal"
 
-#: ../ops.c:253
+#: ../ops.c:234
 #, c-format
 msgid "%<PRId64> lines %sed 1 time"
 msgstr "%<PRId64> Zeilen %s ein Mal"
 
-#: ../ops.c:256
+#: ../ops.c:237
 #, c-format
 msgid "%<PRId64> lines %sed %d times"
 msgstr "%<PRId64> Zeilen %s %d Mal"
 
-#: ../ops.c:592
+#: ../ops.c:571
 #, c-format
 msgid "%<PRId64> lines to indent... "
 msgstr "%<PRId64> Zeilen zum Einrücken... "
 
-#: ../ops.c:634
+#: ../ops.c:613
 msgid "1 line indented "
 msgstr "eine Zeile eingerückt... "
 
-#: ../ops.c:636
+#: ../ops.c:615
 #, c-format
 msgid "%<PRId64> lines indented "
 msgstr "%<PRId64> Zeilen eingerückt... "
 
-#: ../ops.c:938
+#: ../ops.c:917
 msgid "E748: No previously used register"
 msgstr "E748: Kein bereits verwendetes Register"
 
 #. must display the prompt
-#: ../ops.c:1433
+#: ../ops.c:1408
 msgid "cannot yank; delete anyway"
 msgstr "kann nicht kopieren; lösche trotzdem"
 
-#: ../ops.c:1929
+#: ../ops.c:1904
 msgid "1 line changed"
 msgstr "eine Zeile geändert"
 
-#: ../ops.c:1931
+#: ../ops.c:1906
 #, c-format
 msgid "%<PRId64> lines changed"
 msgstr "%<PRId64> Zeilen geändert"
 
-#: ../ops.c:2521
+#: ../ops.c:2496
 msgid "block of 1 line yanked"
 msgstr "Block von einer Zeile kopiert"
 
-#: ../ops.c:2523
+#: ../ops.c:2498
 msgid "1 line yanked"
 msgstr "eine Zeile kopiert"
 
-#: ../ops.c:2525
+#: ../ops.c:2500
 #, c-format
 msgid "block of %<PRId64> lines yanked"
 msgstr "Block von %<PRId64> Zeilen kopiert"
 
-#: ../ops.c:2528
+#: ../ops.c:2503
 #, c-format
 msgid "%<PRId64> lines yanked"
 msgstr "%<PRId64> Zeilen kopiert"
 
-#: ../ops.c:2710
+#: ../ops.c:2685
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Register %s ist leer"
 
 #. Highlight title
-#: ../ops.c:3185
+#: ../ops.c:3160
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4531,11 +3989,11 @@ msgstr ""
 "\n"
 "--- Register ---"
 
-#: ../ops.c:4455
+#: ../ops.c:4435
 msgid "Illegal register name"
 msgstr "Unzulässiger Register Name"
 
-#: ../ops.c:4533
+#: ../ops.c:4513
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4543,17 +4001,17 @@ msgstr ""
 "\n"
 "# Register:\n"
 
-#: ../ops.c:4575
+#: ../ops.c:4555
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Unbekannter Register Typ %d"
 
-#: ../ops.c:5089
+#: ../ops.c:5095
 #, c-format
 msgid "%<PRId64> Cols; "
 msgstr "%<PRId64> Spalten; "
 
-#: ../ops.c:5097
+#: ../ops.c:5103
 #, c-format
 msgid ""
 "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
@@ -4562,7 +4020,7 @@ msgstr ""
 "%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> "
 "von %<PRId64> Bytes"
 
-#: ../ops.c:5105
+#: ../ops.c:5111
 #, c-format
 msgid ""
 "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
@@ -4571,7 +4029,7 @@ msgstr ""
 "%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> "
 "von %<PRId64> Zeichen; %<PRId64> von %<PRId64> Bytes"
 
-#: ../ops.c:5123
+#: ../ops.c:5129
 #, c-format
 msgid ""
 "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
@@ -4580,7 +4038,7 @@ msgstr ""
 "Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; "
 "Byte %<PRId64> von %<PRId64>"
 
-#: ../ops.c:5133
+#: ../ops.c:5139
 #, c-format
 msgid ""
 "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
@@ -4589,135 +4047,135 @@ msgstr ""
 "Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; "
 "Zeichen %<PRId64> von %<PRId64>; Byte %<PRId64> von %<PRId64>"
 
-#: ../ops.c:5146
+#: ../ops.c:5152
 #, c-format
 msgid "(+%<PRId64> for BOM)"
 msgstr "(+%<PRId64> für BOM)"
 
-#: ../option.c:1238
+#: ../option.c:1236
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Seite %N"
 
-#: ../option.c:1574
+#: ../option.c:1572
 msgid "Thanks for flying Vim"
 msgstr "Danke für die Benutzung von Vim"
 
 #. found a mismatch: skip
-#: ../option.c:2698
+#: ../option.c:2644
 msgid "E518: Unknown option"
 msgstr "E518: Unbekannte Option"
 
-#: ../option.c:2709
+#: ../option.c:2655
 msgid "E519: Option not supported"
 msgstr "E519: Option nicht unterstützt"
 
-#: ../option.c:2740
+#: ../option.c:2686
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Nicht erlaubt in einer Modeline"
 
-#: ../option.c:2815
+#: ../option.c:2761
 msgid "E846: Key code not set"
 msgstr ""
 
-#: ../option.c:2924
+#: ../option.c:2870
 msgid "E521: Number required after ="
 msgstr "E521: Zahl benötigt nach ="
 
-#: ../option.c:3226 ../option.c:3864
+#: ../option.c:3172 ../option.c:3809
 msgid "E522: Not found in termcap"
 msgstr "E522: Nicht gefunden in 'termcap'"
 
-#: ../option.c:3335
+#: ../option.c:3281
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Unzulässiges Zeichen <%s>"
 
-#: ../option.c:3862
+#: ../option.c:3807
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: 'term' darf keine leere Zeichenkette sein"
 
-#: ../option.c:3885
+#: ../option.c:3830
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' und 'patchmode' sind gleich"
 
-#: ../option.c:3964
+#: ../option.c:3909
 msgid "E834: Conflicts with value of 'listchars'"
 msgstr ""
 
-#: ../option.c:3966
+#: ../option.c:3911
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr ""
 
-#: ../option.c:4163
+#: ../option.c:4096
 msgid "E524: Missing colon"
 msgstr "E524: Fehlender Doppelpunkt"
 
-#: ../option.c:4165
+#: ../option.c:4098
 msgid "E525: Zero length string"
 msgstr "E525: Zeichenkette der Länge Null"
 
-#: ../option.c:4220
+#: ../option.c:4153
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Fehlende Zahl nach <%s>"
 
-#: ../option.c:4232
+#: ../option.c:4165
 msgid "E527: Missing comma"
 msgstr "E527: Fehlendes Komma"
 
-#: ../option.c:4239
+#: ../option.c:4172
 msgid "E528: Must specify a ' value"
 msgstr "E528: Ein ' Wert muss angegeben werden"
 
-#: ../option.c:4271
+#: ../option.c:4204
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: Enthält nicht-druckbare oder Multi-Byte Zeichen"
 
-#: ../option.c:4469
+#: ../option.c:4402
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ungültiges Zeichen nach <%c>"
 
-#: ../option.c:4534
+#: ../option.c:4467
 msgid "E536: comma required"
 msgstr "E536: Komma benötigt"
 
-#: ../option.c:4543
+#: ../option.c:4476
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: 'commentstring' muss leer sein oder %s enthalten"
 
-#: ../option.c:4928
+#: ../option.c:4861
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Nicht-geschlossene Ausdrucksfolge"
 
-#: ../option.c:4932
+#: ../option.c:4865
 msgid "E541: too many items"
 msgstr "E541: Zu viele Elemente"
 
-#: ../option.c:4934
+#: ../option.c:4867
 msgid "E542: unbalanced groups"
 msgstr "E542: Unausgewogene Gruppen"
 
-#: ../option.c:5148
+#: ../option.c:5081
 msgid "E590: A preview window already exists"
 msgstr "E590: Ein Voransichtsfenster existiert bereits"
 
-#: ../option.c:5311
+#: ../option.c:5244
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Arabisch benötigt UTF-8, bitte ':set encoding=utf-8' ausführen"
 
-#: ../option.c:5623
+#: ../option.c:5556
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Mindestens %d Zeilen werden benötigt"
 
-#: ../option.c:5631
+#: ../option.c:5564
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Mindestens %d Spalten werden benötigt"
 
-#: ../option.c:6011
+#: ../option.c:5944
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Unbekannte Option: %s"
@@ -4725,12 +4183,12 @@ msgstr "E355: Unbekannte Option: %s"
 #. There's another character after zeros or the string
 #. * is empty.  In both cases, we are trying to set a
 #. * num option using a string.
-#: ../option.c:6037
+#: ../option.c:5970
 #, fuzzy, c-format
 msgid "E521: Number required: &%s = '%s'"
 msgstr "E521: Zahl benötigt nach ="
 
-#: ../option.c:6149
+#: ../option.c:6082
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4738,7 +4196,7 @@ msgstr ""
 "\n"
 "--- Terminal Codes ---"
 
-#: ../option.c:6151
+#: ../option.c:6084
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4746,7 +4204,7 @@ msgstr ""
 "\n"
 "--- Werte globaler Optionen ---"
 
-#: ../option.c:6153
+#: ../option.c:6086
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4754,7 +4212,7 @@ msgstr ""
 "\n"
 "--- Werte lokaler Optionen ---"
 
-#: ../option.c:6155
+#: ../option.c:6088
 msgid ""
 "\n"
 "--- Options ---"
@@ -4762,260 +4220,244 @@ msgstr ""
 "\n"
 "--- Optionen ---"
 
-#: ../option.c:6816
+#: ../option.c:6749
 msgid "E356: get_varp ERROR"
 msgstr "E356: get_varp FEHLER"
 
-#: ../option.c:7696
+#: ../option.c:7619
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Passendes Zeichen fehlt für %s"
 
-#: ../option.c:7715
+#: ../option.c:7638
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Überschüssige Zeichen nach dem Semikolon: %s"
 
-#: ../os/shell.c:194
-msgid ""
-"\n"
-"Cannot execute shell "
-msgstr ""
-"\n"
-"Shell kann nicht ausführt werden "
-
-#: ../os/shell.c:439
-msgid ""
-"\n"
-"shell returned "
-msgstr ""
-"\n"
-"Shell beendet "
-
-#: ../os_unix.c:465 ../os_unix.c:471
+#: ../os_unix.c:462 ../os_unix.c:468
 msgid ""
 "\n"
 "Could not get security context for "
 msgstr ""
 
-#: ../os_unix.c:479
+#: ../os_unix.c:476
 msgid ""
 "\n"
 "Could not set security context for "
 msgstr ""
 
-#: ../os_unix.c:1558 ../os_unix.c:1647
+#: ../os_unix.c:1540 ../os_unix.c:1629
 #, c-format
 msgid "dlerror = \"%s\""
 msgstr "dlerror = \"%s\""
 
-#: ../path.c:1449
+#: ../path.c:1458
 #, c-format
 msgid "E447: Can't find file \"%s\" in path"
 msgstr "E447: Kann Datei \"%s\" nicht im Pfad finden"
 
-#: ../quickfix.c:359
+#: ../quickfix.c:327
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Zu viele %%%c im Format"
 
-#: ../quickfix.c:371
+#: ../quickfix.c:339
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Unerwartetes %%%c im Format"
 
-#: ../quickfix.c:420
+#: ../quickfix.c:388
 msgid "E374: Missing ] in format string"
 msgstr "E374: Fehlende ] im Format"
 
-#: ../quickfix.c:431
+#: ../quickfix.c:399
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c wird im Format nicht unterstützt"
 
-#: ../quickfix.c:448
+#: ../quickfix.c:416
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Unzulässiges %%%c im Prefix des Formats"
 
-#: ../quickfix.c:454
+#: ../quickfix.c:422
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Unzulässiges %%%c im Format"
 
 #. nothing found
-#: ../quickfix.c:477
+#: ../quickfix.c:445
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: 'errorformat' enthält kein Muster"
 
-#: ../quickfix.c:695
+#: ../quickfix.c:663
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Fehlender oder leerer Verzeichnisname"
 
-#: ../quickfix.c:1305
+#: ../quickfix.c:1273
 msgid "E553: No more items"
 msgstr "E553: Keine weiteren Einträge"
 
-#: ../quickfix.c:1674
+#: ../quickfix.c:1642
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d aus %d)%s%s: "
 
-#: ../quickfix.c:1676
+#: ../quickfix.c:1644
 msgid " (line deleted)"
 msgstr " (Zeile gelöscht)"
 
-#: ../quickfix.c:1863
+#: ../quickfix.c:1831
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Am Anfang der quickfix Liste"
 
-#: ../quickfix.c:1869
+#: ../quickfix.c:1837
 msgid "E381: At top of quickfix stack"
 msgstr "E381: An Ende der quickfix Liste"
 
-#: ../quickfix.c:1880
+#: ../quickfix.c:1848
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "Fehlerliste %d aus %d; %d Fehler"
 
-#: ../quickfix.c:2427
+#: ../quickfix.c:2395
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Kann nicht schreiben, 'buftype'-Option ist gesetzt"
 
-#: ../quickfix.c:2812
+#: ../quickfix.c:2780
 msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Dateiname fehlt oder ungültiges Muster"
 
-#: ../quickfix.c:2911
+#: ../quickfix.c:2879
 #, c-format
 msgid "Cannot open file \"%s\""
 msgstr "Kann Datei \"%s\" nicht öffnen"
 
-#: ../quickfix.c:3429
+#: ../quickfix.c:3396
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Buffer ist nicht geladen"
 
-#: ../quickfix.c:3487
+#: ../quickfix.c:3454
 msgid "E777: String or List expected"
 msgstr "E777: Zeichenkette oder Liste erwartet"
 
-#: ../regexp.c:359
+#: ../regexp.c:465
 #, c-format
 msgid "E369: invalid item in %s%%[]"
 msgstr "E369: Ungültiges Element in %s%%[]"
 
-#: ../regexp.c:374
+#: ../regexp.c:477
 #, c-format
 msgid "E769: Missing ] after %s["
 msgstr "E769: Fehlende ] nach %s["
 
-#: ../regexp.c:375
+#: ../regexp.c:478
 #, c-format
 msgid "E53: Unmatched %s%%("
 msgstr "E53: %s%%( ohne Gegenstück"
 
-#: ../regexp.c:376
+#: ../regexp.c:479
 #, c-format
 msgid "E54: Unmatched %s("
 msgstr "E54: %s( ohne Gegenstück"
 
-#: ../regexp.c:377
+#: ../regexp.c:480
 #, c-format
 msgid "E55: Unmatched %s)"
 msgstr "E55: %s) ohne Gegenstück"
 
-#: ../regexp.c:378
+#: ../regexp.c:481
 msgid "E66: \\z( not allowed here"
 msgstr "E66: \\z( ist hier nicht erlaubt"
 
-#: ../regexp.c:379
+#: ../regexp.c:482
 msgid "E67: \\z1 et al. not allowed here"
 msgstr "E67: \\z1 usw. ist hier nicht erlaubt"
 
-#: ../regexp.c:380
+#: ../regexp.c:483
 #, c-format
 msgid "E69: Missing ] after %s%%["
 msgstr "E69: Fehlende ] nach %s%%["
 
-#: ../regexp.c:381
+#: ../regexp.c:484
 #, c-format
 msgid "E70: Empty %s%%[]"
 msgstr "E70: %s%%[] ist leer"
 
-#: ../regexp.c:1209 ../regexp.c:1224
+#: ../regexp.c:1259 ../regexp.c:1274
 msgid "E339: Pattern too long"
 msgstr "E339: Muster zu lang"
 
-#: ../regexp.c:1371
+#: ../regexp.c:1421
 msgid "E50: Too many \\z("
 msgstr "E50: Zu viele \\z("
 
-#: ../regexp.c:1378
+#: ../regexp.c:1428
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Zu viele %s("
 
-#: ../regexp.c:1427
+#: ../regexp.c:1477
 msgid "E52: Unmatched \\z("
 msgstr "E52: \\z( ohne Gegenstück"
 
-#: ../regexp.c:1637
+#: ../regexp.c:1687
 #, c-format
 msgid "E59: invalid character after %s@"
 msgstr "E59: Ungültiges Zeichen nach %s@"
 
-#: ../regexp.c:1672
+#: ../regexp.c:1722
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Zu viele komplexe %s{...}s"
 
-#: ../regexp.c:1687
+#: ../regexp.c:1737
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: Verschachteltes %s*"
 
-#: ../regexp.c:1690
+#: ../regexp.c:1740
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: Verschachteltes %s%c"
 
-#: ../regexp.c:1800
+#: ../regexp.c:1850
 msgid "E63: invalid use of \\_"
 msgstr "E63: Ungültige Verwendung von \\_"
 
-#: ../regexp.c:1850
+#: ../regexp.c:1900
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c nach Nichts"
 
-#: ../regexp.c:1902
+#: ../regexp.c:1952
 msgid "E65: Illegal back reference"
 msgstr "E65: Ungültige Rückreferenz"
 
-#: ../regexp.c:1943
+#: ../regexp.c:1993
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Ungültiges Zeichen nach \\z"
 
-#: ../regexp.c:2049 ../regexp_nfa.c:1296
+#: ../regexp.c:2099 ../regexp_nfa.c:1323
 #, c-format
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Ungültiges Zeichen nach %s%%[dxouU]"
 
-#: ../regexp.c:2107
+#: ../regexp.c:2157
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Ungültiges Zeichen nach %s%%"
 
-#: ../regexp.c:3017
+#: ../regexp.c:3067
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaxfehler in %s{...}"
 
-#: ../regexp.c:3805
+#: ../regexp.c:3746
 msgid "External submatches:\n"
 msgstr "Externe 'submatches':\n"
 
-#: ../regexp.c:7022
+#: ../regexp.c:6946
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used "
@@ -5035,225 +4477,225 @@ msgstr ""
 msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
 msgstr ""
 
-#: ../regexp_nfa.c:1261
+#: ../regexp_nfa.c:1288
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\z%c'"
 msgstr ""
 
-#: ../regexp_nfa.c:1387
+#: ../regexp_nfa.c:1414
 #, c-format
 msgid "E867: (NFA) Unknown operator '\\%%%c'"
 msgstr ""
 
-#: ../regexp_nfa.c:1802
+#: ../regexp_nfa.c:1829
 #, c-format
 msgid "E869: (NFA) Unknown operator '\\@%c'"
 msgstr ""
 
-#: ../regexp_nfa.c:1831
+#: ../regexp_nfa.c:1858
 msgid "E870: (NFA regexp) Error reading repetition limits"
 msgstr ""
 
 #. Can't have a multi follow a multi.
-#: ../regexp_nfa.c:1895
+#: ../regexp_nfa.c:1922
 msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
 msgstr ""
 
 #. Too many `('
-#: ../regexp_nfa.c:2037
+#: ../regexp_nfa.c:2064
 msgid "E872: (NFA regexp) Too many '('"
 msgstr ""
 
-#: ../regexp_nfa.c:2042
+#: ../regexp_nfa.c:2069
 #, fuzzy
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E50: Zu viele \\z("
 
-#: ../regexp_nfa.c:2066
+#: ../regexp_nfa.c:2093
 msgid "E873: (NFA regexp) proper termination error"
 msgstr ""
 
-#: ../regexp_nfa.c:2599
+#: ../regexp_nfa.c:2605
 msgid "E874: (NFA) Could not pop the stack !"
 msgstr ""
 
-#: ../regexp_nfa.c:3298
+#: ../regexp_nfa.c:3304
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
 msgstr ""
 
-#: ../regexp_nfa.c:3302
+#: ../regexp_nfa.c:3308
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
 msgstr ""
 
-#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
+#: ../regexp_nfa.c:4532 ../regexp_nfa.c:4827
 msgid ""
 "Could not open temporary log file for writing, displaying on stderr ... "
 msgstr ""
 
-#: ../regexp_nfa.c:4840
+#: ../regexp_nfa.c:4798
 #, c-format
 msgid "(NFA) COULD NOT OPEN %s !"
 msgstr ""
 
-#: ../regexp_nfa.c:6049
+#: ../regexp_nfa.c:6007
 #, fuzzy
 msgid "Could not open temporary log file for writing "
 msgstr "E214: Temporäre Datei kann nicht zum Schreiben geöffnet werden"
 
-#: ../screen.c:7435
+#: ../screen.c:7365
 msgid " VREPLACE"
 msgstr " V-ERSETZEN"
 
-#: ../screen.c:7437
+#: ../screen.c:7367
 msgid " REPLACE"
 msgstr " ERSETZEN"
 
-#: ../screen.c:7440
+#: ../screen.c:7370
 msgid " REVERSE"
 msgstr " INVERTIERT"
 
-#: ../screen.c:7441
+#: ../screen.c:7371
 msgid " INSERT"
 msgstr " EINFÜGEN"
 
-#: ../screen.c:7443
+#: ../screen.c:7373
 msgid " (insert)"
 msgstr " (einfügen)"
 
-#: ../screen.c:7445
+#: ../screen.c:7375
 msgid " (replace)"
 msgstr " (ersetzen)"
 
-#: ../screen.c:7447
+#: ../screen.c:7377
 msgid " (vreplace)"
 msgstr " (v-ersetzen)"
 
-#: ../screen.c:7449
+#: ../screen.c:7379
 msgid " Hebrew"
 msgstr " Hebräisch"
 
-#: ../screen.c:7454
+#: ../screen.c:7384
 msgid " Arabic"
 msgstr " Arabisch"
 
-#: ../screen.c:7456
+#: ../screen.c:7386
 msgid " (lang)"
 msgstr " (Sprache)"
 
-#: ../screen.c:7459
+#: ../screen.c:7389
 msgid " (paste)"
 msgstr " (paste)"
 
-#: ../screen.c:7469
+#: ../screen.c:7399
 msgid " VISUAL"
 msgstr " VISUELL"
 
-#: ../screen.c:7470
+#: ../screen.c:7400
 msgid " VISUAL LINE"
 msgstr " VISUELL ZEILE"
 
-#: ../screen.c:7471
+#: ../screen.c:7401
 msgid " VISUAL BLOCK"
 msgstr " VISUELL BLOCK"
 
-#: ../screen.c:7472
+#: ../screen.c:7402
 msgid " SELECT"
 msgstr " AUSWAHL"
 
-#: ../screen.c:7473
+#: ../screen.c:7403
 msgid " SELECT LINE"
 msgstr " AUSWAHL ZEILE"
 
-#: ../screen.c:7474
+#: ../screen.c:7404
 msgid " SELECT BLOCK"
 msgstr " AUSWAHL BLOCK"
 
-#: ../screen.c:7486 ../screen.c:7541
+#: ../screen.c:7416 ../screen.c:7471
 msgid "recording"
 msgstr "aufzeichnen"
 
-#: ../search.c:487
+#: ../search.c:472
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Unzulässiges Suchmuster: %s"
 
-#: ../search.c:832
+#: ../search.c:817
 #, c-format
 msgid "E384: search hit TOP without match for: %s"
 msgstr "E384: Suche erreichte den ANFANG ohne Treffer für: %s"
 
-#: ../search.c:835
+#: ../search.c:820
 #, c-format
 msgid "E385: search hit BOTTOM without match for: %s"
 msgstr "E385: Suche erreichte das ENDE ohne Treffer für: %s"
 
-#: ../search.c:1200
+#: ../search.c:1186
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Erwarte '?' oder '/'  nach ';'"
 
-#: ../search.c:4085
+#: ../search.c:4062
 msgid " (includes previously listed match)"
 msgstr " (enthält bereits vorher aufgezählte Treffer)"
 
 #. cursor at status line
-#: ../search.c:4104
+#: ../search.c:4081
 msgid "--- Included files "
 msgstr "--- Eingefügte Dateien "
 
-#: ../search.c:4106
+#: ../search.c:4083
 msgid "not found "
 msgstr "nicht gefunden "
 
-#: ../search.c:4107
+#: ../search.c:4084
 msgid "in path ---\n"
 msgstr "im Pfad ---\n"
 
-#: ../search.c:4168
+#: ../search.c:4145
 msgid "  (Already listed)"
 msgstr "  (Bereits aufgelistet)"
 
-#: ../search.c:4170
+#: ../search.c:4147
 msgid "  NOT FOUND"
 msgstr "  NICHT GEFUNDEN"
 
-#: ../search.c:4211
+#: ../search.c:4188
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Durchsuche inkludierte Datei: %s"
 
-#: ../search.c:4216
+#: ../search.c:4193
 #, c-format
 msgid "Searching included file %s"
 msgstr "Suche inkludierte Datei %s"
 
-#: ../search.c:4405
+#: ../search.c:4382
 msgid "E387: Match is on current line"
 msgstr "E387: Treffer ist auf der momentanen Zeile"
 
-#: ../search.c:4517
+#: ../search.c:4494
 msgid "All included files were found"
 msgstr "Alle inkludierten Dateien wurden gefunden"
 
-#: ../search.c:4519
+#: ../search.c:4496
 msgid "No included files"
 msgstr "Keine inkludierten Dateien"
 
-#: ../search.c:4527
+#: ../search.c:4504
 msgid "E388: Couldn't find definition"
 msgstr "E388: Konnte Definition nicht finden"
 
-#: ../search.c:4529
+#: ../search.c:4506
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Konnte Muster nicht finden"
 
-#: ../search.c:4668
+#: ../search.c:4645
 #, fuzzy
 msgid "Substitute "
 msgstr "eine Ersetzung"
 
-#: ../search.c:4681
+#: ../search.c:4658
 #, c-format
 msgid ""
 "\n"
@@ -5264,98 +4706,98 @@ msgstr ""
 "# Letztes %sSuchmuster:\n"
 "~"
 
-#: ../spell.c:951
+#: ../spell.c:1035
 msgid "E759: Format error in spell file"
 msgstr "E759: Format-Fehler im Rechtschreibwörterbuch"
 
-#: ../spell.c:952
+#: ../spell.c:1036
 msgid "E758: Truncated spell file"
 msgstr "E758: Abgeschnittenes Rechtschreibwörterbuch"
 
-#: ../spell.c:953
+#: ../spell.c:1037
 #, c-format
 msgid "Trailing text in %s line %d: %s"
 msgstr "Angehängter Text in %s Zeile %d: %s"
 
-#: ../spell.c:954
+#: ../spell.c:1038
 #, c-format
 msgid "Affix name too long in %s line %d: %s"
 msgstr "Affix Name zu lang in %s Zeile %d: %s"
 
-#: ../spell.c:955
+#: ../spell.c:1039
 msgid "E761: Format error in affix file FOL, LOW or UPP"
 msgstr "E761: Format-Fehler in Affix-Datei FOL, LOW oder UPP"
 
-#: ../spell.c:957
+#: ../spell.c:1041
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Zeichen in FOL, LOW oder UPP außerhalb des zulässigen Bereichs"
 
-#: ../spell.c:958
+#: ../spell.c:1042
 msgid "Compressing word tree..."
 msgstr "Komprimiere Wörter-Baum..."
 
-#: ../spell.c:1951
+#: ../spell.c:2033
 msgid "E756: Spell checking is not enabled"
 msgstr "E756: Rechtschreibprüfung ist nicht aktiviert"
 
-#: ../spell.c:2249
+#: ../spell.c:2324
 #, c-format
 msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
 msgstr ""
 "Achtung: Kann Wortliste \"%s.%s.spl\" oder \"%s.ascii.spl\" nicht finden"
 
-#: ../spell.c:2473
+#: ../spell.c:2549
 #, c-format
 msgid "Reading spell file \"%s\""
 msgstr "Lese Rechtschreibwörterbuch \"%s\" ein"
 
-#: ../spell.c:2496
+#: ../spell.c:2572
 msgid "E757: This does not look like a spell file"
 msgstr "E757: Das sieht nicht nach einem Rechtschreibwörterbuch aus"
 
-#: ../spell.c:2501
+#: ../spell.c:2577
 msgid "E771: Old spell file, needs to be updated"
 msgstr "E771: Altes Rechtschreibwörterbuch, benötigt Aktualisierung"
 
-#: ../spell.c:2504
+#: ../spell.c:2580
 msgid "E772: Spell file is for newer version of Vim"
 msgstr "E772: Rechtschreibwörterbuch ist für eine neuere Version von Vim"
 
-#: ../spell.c:2602
+#: ../spell.c:2678
 msgid "E770: Unsupported section in spell file"
 msgstr "E770: Nicht unterstützter Abschnitt im Rechtschreibwörterbuch"
 
-#: ../spell.c:3762
+#: ../spell.c:3831
 #, c-format
 msgid "Warning: region %s not supported"
 msgstr "Achtung: Region %s nicht unterstützt"
 
-#: ../spell.c:4550
+#: ../spell.c:4364
 #, c-format
 msgid "Reading affix file %s ..."
 msgstr "Lese Affix-Datei %s ..."
 
-#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
+#: ../spell.c:4403 ../spell.c:5449 ../spell.c:5954
 #, c-format
 msgid "Conversion failure for word in %s line %d: %s"
 msgstr "Umwandlungsfehler beim Wort in %s Zeile %d: %s"
 
-#: ../spell.c:4630 ../spell.c:6170
+#: ../spell.c:4444 ../spell.c:5984
 #, c-format
 msgid "Conversion in %s not supported: from %s to %s"
 msgstr "Umwandlung in %s nicht unterstützt: von %s nach %s"
 
-#: ../spell.c:4642
+#: ../spell.c:4456
 #, c-format
 msgid "Invalid value for FLAG in %s line %d: %s"
 msgstr "Ungültiger Wert von FLAG in %s Zeile %d: %s"
 
-#: ../spell.c:4655
+#: ../spell.c:4469
 #, c-format
 msgid "FLAG after using flags in %s line %d: %s"
 msgstr "FLAG nach dem Gebrauch von Flags in %s Zeile %d: %s"
 
-#: ../spell.c:4723
+#: ../spell.c:4537
 #, c-format
 msgid ""
 "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
@@ -5364,7 +4806,7 @@ msgstr ""
 "Die Definition von COMPOUNDFORBIDFLAG nach dem PFX Element kann falsches "
 "Ergebnis in Zeile %s ergeben %d"
 
-#: ../spell.c:4731
+#: ../spell.c:4545
 #, c-format
 msgid ""
 "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
@@ -5373,44 +4815,44 @@ msgstr ""
 "Die Definition von COMPOUNDPERMITFLAG nach dem PFX Element kann falsches "
 "Ergebnis in Zeile %s ergeben %d"
 
-#: ../spell.c:4747
+#: ../spell.c:4561
 #, fuzzy, c-format
 msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
 msgstr "Falscher COMPOUNDMIN-Wert in %s Zeile %d: %s"
 
-#: ../spell.c:4771
+#: ../spell.c:4585
 #, c-format
 msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
 msgstr "Falscher COMPOUNDWORDMAX-Wert in %s Zeile %d: %s"
 
-#: ../spell.c:4777
+#: ../spell.c:4591
 #, c-format
 msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
 msgstr "Falscher COMPOUNDMIN-Wert in %s Zeile %d: %s"
 
-#: ../spell.c:4783
+#: ../spell.c:4597
 #, c-format
 msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
 msgstr "Falscher COMPOUNDSYLMAX-Wert in %s Zeile %d: %s"
 
-#: ../spell.c:4795
+#: ../spell.c:4609
 #, c-format
 msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
 msgstr "Falscher CHECKCOMPOUNDPATTERN-Wert in %s Zeile %d: %s"
 
-#: ../spell.c:4847
+#: ../spell.c:4661
 #, c-format
 msgid "Different combining flag in continued affix block in %s line %d: %s"
 msgstr ""
 "Unterschiedliches verknüpfendes Flag im fortgesetzten Affix-Block in %s "
 "Zeile %d: %s"
 
-#: ../spell.c:4850
+#: ../spell.c:4664
 #, c-format
 msgid "Duplicate affix in %s line %d: %s"
 msgstr "Doppeltes Affix in %s Zeile %d: %s"
 
-#: ../spell.c:4871
+#: ../spell.c:4685
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5419,337 +4861,337 @@ msgstr ""
 "Affix wird auch für BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
 "verwendet in %s Zeile %d: %s"
 
-#: ../spell.c:4893
+#: ../spell.c:4707
 #, c-format
 msgid "Expected Y or N in %s line %d: %s"
 msgstr "Y oder N erwartet in %s Zeile %d: %s"
 
-#: ../spell.c:4968
+#: ../spell.c:4782
 #, c-format
 msgid "Broken condition in %s line %d: %s"
 msgstr "Bedingung verletzt in %s Zeile %d: %s"
 
-#: ../spell.c:5091
+#: ../spell.c:4905
 #, c-format
 msgid "Expected REP(SAL) count in %s line %d"
 msgstr "Erwartetes REP(SAL) gezählt in %s Zeile %d"
 
-#: ../spell.c:5120
+#: ../spell.c:4934
 #, c-format
 msgid "Expected MAP count in %s line %d"
 msgstr "Erwartetes MAP gezählt in %s Zeile %d"
 
-#: ../spell.c:5132
+#: ../spell.c:4946
 #, c-format
 msgid "Duplicate character in MAP in %s line %d"
 msgstr "Doppeltes Zeichen in MAP in %s Zeile %d"
 
-#: ../spell.c:5176
+#: ../spell.c:4990
 #, c-format
 msgid "Unrecognized or duplicate item in %s line %d: %s"
 msgstr "Nicht erkanntes oder doppeltes Element in %s Zeile %d: %s"
 
-#: ../spell.c:5197
+#: ../spell.c:5011
 #, c-format
 msgid "Missing FOL/LOW/UPP line in %s"
 msgstr "Fehlende FOL/LOW/UPP Zeile in %s"
 
-#: ../spell.c:5220
+#: ../spell.c:5034
 msgid "COMPOUNDSYLMAX used without SYLLABLE"
 msgstr "COMPOUNDSYLMAX ohne SYLLABLE verwendet"
 
-#: ../spell.c:5236
+#: ../spell.c:5050
 msgid "Too many postponed prefixes"
 msgstr "Zu viele zurück gestellte Präfixe"
 
-#: ../spell.c:5238
+#: ../spell.c:5052
 msgid "Too many compound flags"
 msgstr "Zu viele zusammengesetzte Flags"
 
-#: ../spell.c:5240
+#: ../spell.c:5054
 msgid "Too many postponed prefixes and/or compound flags"
 msgstr "Zu viele zurück gestellte Präfixe und/oder zusammengesetzte Flags"
 
-#: ../spell.c:5250
+#: ../spell.c:5064
 #, c-format
 msgid "Missing SOFO%s line in %s"
 msgstr "Fehlende SOFO%s Zeile in %s"
 
-#: ../spell.c:5253
+#: ../spell.c:5067
 #, c-format
 msgid "Both SAL and SOFO lines in %s"
 msgstr "Sowohl SAL als auch SOFO Zeilen in %s"
 
-#: ../spell.c:5331
+#: ../spell.c:5145
 #, c-format
 msgid "Flag is not a number in %s line %d: %s"
 msgstr "Flag ist keine Zahl in %s Zeile %d: %s"
 
-#: ../spell.c:5334
+#: ../spell.c:5148
 #, c-format
 msgid "Illegal flag in %s line %d: %s"
 msgstr "Unerlaubtes Flag in %s Zeile %d: %s"
 
-#: ../spell.c:5493 ../spell.c:5501
+#: ../spell.c:5307 ../spell.c:5315
 #, c-format
 msgid "%s value differs from what is used in another .aff file"
 msgstr ""
 "%s Wert unterscheidet sich von dem, was in einer anderen .aff Datei "
 "verwendet wird"
 
-#: ../spell.c:5602
+#: ../spell.c:5416
 #, c-format
 msgid "Reading dictionary file %s ..."
 msgstr "Lese Wörterbuch-Datei %s ..."
 
-#: ../spell.c:5611
+#: ../spell.c:5425
 #, c-format
 msgid "E760: No word count in %s"
 msgstr "E760: Keine Wörter gezählt in %s"
 
-#: ../spell.c:5669
+#: ../spell.c:5483
 #, c-format
 msgid "line %6d, word %6d - %s"
 msgstr "Zeile %6d, Wort %6d - %s"
 
-#: ../spell.c:5691
+#: ../spell.c:5505
 #, c-format
 msgid "Duplicate word in %s line %d: %s"
 msgstr "Doppeltes Wort in %s Zeile %d: %s"
 
-#: ../spell.c:5694
+#: ../spell.c:5508
 #, c-format
 msgid "First duplicate word in %s line %d: %s"
 msgstr "Erstes doppeltes Wort in %s Zeile %d: %s"
 
-#: ../spell.c:5746
+#: ../spell.c:5560
 #, c-format
 msgid "%d duplicate word(s) in %s"
 msgstr "%d doppelte(s) Wort(e) in %s"
 
-#: ../spell.c:5748
+#: ../spell.c:5562
 #, c-format
 msgid "Ignored %d word(s) with non-ASCII characters in %s"
 msgstr "%d Wort(e) mit nicht-ASCII Zeichen ignoriert in %s"
 
-#: ../spell.c:6115
+#: ../spell.c:5929
 #, c-format
 msgid "Reading word file %s ..."
 msgstr "Lese Wort-Datei %s ..."
 
-#: ../spell.c:6155
+#: ../spell.c:5969
 #, c-format
 msgid "Duplicate /encoding= line ignored in %s line %d: %s"
 msgstr "Doppelte /encoding= Zeile ignoriert in %s Zeile %d: %s"
 
-#: ../spell.c:6159
+#: ../spell.c:5973
 #, c-format
 msgid "/encoding= line after word ignored in %s line %d: %s"
 msgstr "/encoding= Zeile nach Wort ignoriert in %s Zeile %d: %s"
 
-#: ../spell.c:6180
+#: ../spell.c:5994
 #, c-format
 msgid "Duplicate /regions= line ignored in %s line %d: %s"
 msgstr "Doppelte /regions= Zeile ignoriert in %s Zeile %d: %s"
 
-#: ../spell.c:6185
+#: ../spell.c:5999
 #, c-format
 msgid "Too many regions in %s line %d: %s"
 msgstr "Zu viele Regionen in %s Zeile %d: %s"
 
-#: ../spell.c:6198
+#: ../spell.c:6012
 #, c-format
 msgid "/ line ignored in %s line %d: %s"
 msgstr "/ Zeile ignoriert in %s Zeile %d: %s"
 
-#: ../spell.c:6224
+#: ../spell.c:6038
 #, c-format
 msgid "Invalid region nr in %s line %d: %s"
 msgstr "Ungültige Regionsnummer in %s Zeile %d: %s"
 
-#: ../spell.c:6230
+#: ../spell.c:6044
 #, c-format
 msgid "Unrecognized flags in %s line %d: %s"
 msgstr "Nicht erkanntes Flag in %s Zeile %d: %s"
 
-#: ../spell.c:6257
+#: ../spell.c:6071
 #, c-format
 msgid "Ignored %d words with non-ASCII characters"
 msgstr "%d Wörter mit nicht-ASCII Zeichen ignoriert"
 
-#: ../spell.c:6656
+#: ../spell.c:6470
 #, c-format
 msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
 msgstr "%d von %d Knoten komprimiert; %d (%d%%) übrig"
 
-#: ../spell.c:7340
+#: ../spell.c:7153
 msgid "Reading back spell file..."
 msgstr "Lese Rechtschreibwörterbuch zurück..."
 
 #. Go through the trie of good words, soundfold each word and add it to
 #. the soundfold trie.
-#: ../spell.c:7357
+#: ../spell.c:7170
 msgid "Performing soundfolding..."
 msgstr "Führe 'Soundfolding' durch..."
 
-#: ../spell.c:7368
+#: ../spell.c:7181
 #, c-format
 msgid "Number of words after soundfolding: %<PRId64>"
 msgstr "Anzahl der Wörter nach 'Soundfolding': %<PRId64>"
 
-#: ../spell.c:7476
+#: ../spell.c:7289
 #, c-format
 msgid "Total number of words: %d"
 msgstr "Gesamte Anzahl von Wörtern: %d"
 
-#: ../spell.c:7655
+#: ../spell.c:7468
 #, c-format
 msgid "Writing suggestion file %s ..."
 msgstr "Schreibe Datei %s für Vorschläge ..."
 
-#: ../spell.c:7707 ../spell.c:7927
+#: ../spell.c:7520 ../spell.c:7740
 #, c-format
 msgid "Estimated runtime memory use: %d bytes"
 msgstr "Geschätzter Speicher zur Laufzeit: %d Bytes"
 
-#: ../spell.c:7820
+#: ../spell.c:7633
 msgid "E751: Output file name must not have region name"
 msgstr "E751: Ausgabedatei darf keinen Regionsnamen haben"
 
-#: ../spell.c:7822
+#: ../spell.c:7635
 msgid "E754: Only up to 8 regions supported"
 msgstr "E754: Maximal 8 Regionen unterstützt"
 
-#: ../spell.c:7846
+#: ../spell.c:7659
 #, c-format
 msgid "E755: Invalid region in %s"
 msgstr "E755: Ungültige Region in %s"
 
-#: ../spell.c:7907
+#: ../spell.c:7720
 msgid "Warning: both compounding and NOBREAK specified"
 msgstr "Achtung: Sowohl zusammengesetzte Wörter als auch NOBREAK angegeben"
 
-#: ../spell.c:7920
+#: ../spell.c:7733
 #, c-format
 msgid "Writing spell file %s ..."
 msgstr "Schreibe Rechtschreibwörterbuch %s ..."
 
-#: ../spell.c:7925
+#: ../spell.c:7738
 msgid "Done!"
 msgstr "Fertig!"
 
-#: ../spell.c:8034
+#: ../spell.c:7847
 #, c-format
 msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' hat nicht %<PRId64> Einträge"
 
-#: ../spell.c:8074
+#: ../spell.c:7887
 #, fuzzy, c-format
 msgid "Word '%.*s' removed from %s"
 msgstr "Wort entfernt von %s"
 
-#: ../spell.c:8117
+#: ../spell.c:7930
 #, fuzzy, c-format
 msgid "Word '%.*s' added to %s"
 msgstr "Wort zu %s hinzugefügt"
 
-#: ../spell.c:8381
+#: ../spell.c:8194
 msgid "E763: Word characters differ between spell files"
 msgstr ""
 "E763: 'Word Characters' unterscheiden sich zwischen Rechtschreibwörterbüchern"
 
-#: ../spell.c:8684
+#: ../spell.c:8495
 msgid "Sorry, no suggestions"
 msgstr "Leider keine Vorschläge"
 
-#: ../spell.c:8687
+#: ../spell.c:8498
 #, c-format
 msgid "Sorry, only %<PRId64> suggestions"
 msgstr "Leider nur %<PRId64> Vorschläge"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
-#: ../spell.c:8704
+#: ../spell.c:8515
 #, c-format
 msgid "Change \"%.*s\" to:"
 msgstr "Ändere \"%.*s\" nach:"
 
-#: ../spell.c:8737
+#: ../spell.c:8548
 #, c-format
 msgid " < \"%.*s\""
 msgstr " < \"%.*s\""
 
-#: ../spell.c:8882
+#: ../spell.c:8693
 msgid "E752: No previous spell replacement"
 msgstr "E752: Keine vorhergehende Ersetzung"
 
-#: ../spell.c:8925
+#: ../spell.c:8736
 #, c-format
 msgid "E753: Not found: %s"
 msgstr "E753: Nicht gefunden: %s"
 
-#: ../spell.c:9276
+#: ../spell.c:9084
 #, c-format
 msgid "E778: This does not look like a .sug file: %s"
 msgstr "E778: Das sieht nicht nach einer .sug Datei aus: %s"
 
-#: ../spell.c:9282
+#: ../spell.c:9090
 #, c-format
 msgid "E779: Old .sug file, needs to be updated: %s"
 msgstr "E779: Veraltete .sug Datei; Aktualisierung erforderlich: %s"
 
-#: ../spell.c:9286
+#: ../spell.c:9094
 #, c-format
 msgid "E780: .sug file is for newer version of Vim: %s"
 msgstr "E780: .sug Datei ist für eine neuere Version von Vim: %s"
 
-#: ../spell.c:9295
+#: ../spell.c:9103
 #, c-format
 msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug Datei passt nicht zur .spl Datei: %s"
 
-#: ../spell.c:9305
+#: ../spell.c:9113
 #, c-format
 msgid "E782: error while reading .sug file: %s"
 msgstr "E782: Fehler beim Lesen der .sug Datei: %s"
 
 #. This should have been checked when generating the .spl
 #. file.
-#: ../spell.c:11575
+#: ../spell.c:11370
 msgid "E783: duplicate char in MAP entry"
 msgstr "E783: Doppeltes Zeichen im MAP Eintrag"
 
-#: ../syntax.c:266
+#: ../syntax.c:317
 msgid "No Syntax items defined for this buffer"
 msgstr "Keine Syntax-Elemente für diesen Puffer definiert"
 
-#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
+#: ../syntax.c:2985 ../syntax.c:3006 ../syntax.c:3029
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Unerlaubtes Argument: %s"
 
-#: ../syntax.c:3299
+#: ../syntax.c:3201
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Kein solcher Syntax Cluster: %s"
 
-#: ../syntax.c:3433
+#: ../syntax.c:3333
 msgid "syncing on C-style comments"
 msgstr "Synchronisation an C-Stil Kommentaren"
 
-#: ../syntax.c:3439
+#: ../syntax.c:3339
 msgid "no syncing"
 msgstr "keine Synchronisation"
 
-#: ../syntax.c:3441
+#: ../syntax.c:3341
 msgid "syncing starts "
 msgstr "Synchronisation beginnt "
 
-#: ../syntax.c:3443 ../syntax.c:3506
+#: ../syntax.c:3343 ../syntax.c:3408
 msgid " lines before top line"
 msgstr " Zeilen vor der obersten Zeile"
 
-#: ../syntax.c:3448
+#: ../syntax.c:3348
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5757,7 +5199,7 @@ msgstr ""
 "\n"
 "--- Syntax Synchronisations-Elemente ---"
 
-#: ../syntax.c:3452
+#: ../syntax.c:3352
 msgid ""
 "\n"
 "syncing on items"
@@ -5765,7 +5207,7 @@ msgstr ""
 "\n"
 "Synchronisation an Elementen"
 
-#: ../syntax.c:3457
+#: ../syntax.c:3357
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5773,275 +5215,275 @@ msgstr ""
 "\n"
 "--- Syntax-Elemente ---"
 
-#: ../syntax.c:3475
+#: ../syntax.c:3377
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Kein solcher Syntax-Cluster: %s"
 
-#: ../syntax.c:3497
+#: ../syntax.c:3399
 msgid "minimal "
 msgstr "minimal "
 
-#: ../syntax.c:3503
+#: ../syntax.c:3405
 msgid "maximal "
 msgstr "maximal "
 
-#: ../syntax.c:3513
+#: ../syntax.c:3415
 msgid "; match "
 msgstr "; Treffer "
 
-#: ../syntax.c:3515
+#: ../syntax.c:3417
 msgid " line breaks"
 msgstr " Zeilenumbrüche"
 
-#: ../syntax.c:4076
+#: ../syntax.c:3969
 msgid "E395: contains argument not accepted here"
 msgstr "E395: \"contains\"-Argument ist an dieser Stelle ungültig"
 
-#: ../syntax.c:4096
+#: ../syntax.c:3989
 #, fuzzy
 msgid "E844: invalid cchar value"
 msgstr "E474: Ungültiges Argument"
 
-#: ../syntax.c:4107
+#: ../syntax.c:4000
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: \"group[t]here\" ist an dieser Stelle ungültig"
 
-#: ../syntax.c:4126
+#: ../syntax.c:4020
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Konnte kein \"region\"-Element für \"%s\" finden"
 
-#: ../syntax.c:4188
+#: ../syntax.c:4082
 msgid "E397: Filename required"
 msgstr "E397: Dateiname wird benötigt"
 
-#: ../syntax.c:4221
+#: ../syntax.c:4115
 #, fuzzy
 msgid "E847: Too many syntax includes"
 msgstr "E77: Zu viele Dateinamen"
 
-#: ../syntax.c:4303
+#: ../syntax.c:4197
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: Fehlende ']': %s"
 
-#: ../syntax.c:4531
+#: ../syntax.c:4419
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Fehlendes '=': %s"
 
-#: ../syntax.c:4666
+#: ../syntax.c:4554
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Nicht ausreichend viele Argumente: syntax region %s"
 
-#: ../syntax.c:4870
+#: ../syntax.c:4754
 #, fuzzy
 msgid "E848: Too many syntax clusters"
 msgstr "E391: Kein solcher Syntax Cluster: %s"
 
-#: ../syntax.c:4954
+#: ../syntax.c:4838
 msgid "E400: No cluster specified"
 msgstr "E400: Kein Cluster angegeben"
 
 #. end delimiter not found
-#: ../syntax.c:4986
+#: ../syntax.c:4870
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Muster-Abgrenzer nicht gefunden: %s"
 
-#: ../syntax.c:5049
+#: ../syntax.c:4933
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Schrott nach Muster: %s"
 
-#: ../syntax.c:5120
+#: ../syntax.c:5004
 msgid "E403: syntax sync: line continuations pattern specified twice"
 msgstr "E403: Syntax sync: Zeilen-Fortsetzungsmuster zweifach angegeben"
 
-#: ../syntax.c:5169
+#: ../syntax.c:5053
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Unzulässige Argumente; %s"
 
-#: ../syntax.c:5217
+#: ../syntax.c:5100
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Gleichheitszeichen fehlt: %s"
 
-#: ../syntax.c:5222
+#: ../syntax.c:5105
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Leeres Argument: %s"
 
-#: ../syntax.c:5240
+#: ../syntax.c:5123
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s ist hier nicht erlaubt"
 
-#: ../syntax.c:5246
+#: ../syntax.c:5129
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr ""
 "E408: %s muss als Erstes in der Liste der enthaltenen Elemente auftreten"
 
-#: ../syntax.c:5304
+#: ../syntax.c:5187
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Unbekannter Gruppenname: %s"
 
-#: ../syntax.c:5512
+#: ../syntax.c:5395
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Ungültiger :syntax Befehl: %s"
 
-#: ../syntax.c:5854
+#: ../syntax.c:5726
 msgid ""
 "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
 msgstr ""
 
-#: ../syntax.c:6146
+#: ../syntax.c:6018
 msgid "E679: recursive loop loading syncolor.vim"
 msgstr "E679: Rekursive Schleife beim Laden von syncolor.vim"
 
-#: ../syntax.c:6256
+#: ../syntax.c:6128
 #, c-format
 msgid "E411: highlight group not found: %s"
 msgstr "E411: Hervorhebungsgruppe nicht gefunden: %s"
 
-#: ../syntax.c:6278
+#: ../syntax.c:6150
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Nicht ausreichend viele Argumente: \":highlight link %s\""
 
-#: ../syntax.c:6284
+#: ../syntax.c:6156
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Zu viele Argumente: \":highlight link %s\""
 
-#: ../syntax.c:6302
+#: ../syntax.c:6174
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Gruppe hat Einstellungen, highlight link ignorieren"
 
-#: ../syntax.c:6367
+#: ../syntax.c:6240
 #, c-format
 msgid "E415: unexpected equal sign: %s"
 msgstr "E415: Unerwartetes Gleichheitszeichen: %s"
 
-#: ../syntax.c:6395
+#: ../syntax.c:6268
 #, c-format
 msgid "E416: missing equal sign: %s"
 msgstr "E416: fehlendes Gleichheitszeichen: %s"
 
-#: ../syntax.c:6418
+#: ../syntax.c:6291
 #, c-format
 msgid "E417: missing argument: %s"
 msgstr "E417: Fehlendes Argument: %s"
 
-#: ../syntax.c:6446
+#: ../syntax.c:6319
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Unzulässiger Wert: %s"
 
-#: ../syntax.c:6496
+#: ../syntax.c:6369
 msgid "E419: FG color unknown"
 msgstr "E419: FG Farbe unbekannt"
 
-#: ../syntax.c:6504
+#: ../syntax.c:6377
 msgid "E420: BG color unknown"
 msgstr "E420: BG Farbe unbekannt"
 
-#: ../syntax.c:6564
+#: ../syntax.c:6437
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Unbekannte Farbbezeichnung oder -Nummer: %s"
 
-#: ../syntax.c:6714
+#: ../syntax.c:6587
 #, c-format
 msgid "E422: terminal code too long: %s"
 msgstr "E422: Terminal-Code zu lang: %s"
 
-#: ../syntax.c:6753
+#: ../syntax.c:6626
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Unzulässiges Argument: %s"
 
-#: ../syntax.c:6925
+#: ../syntax.c:6795
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Zu viele verschieden Hervorhebungsattribute in Gebrauch"
 
-#: ../syntax.c:7427
+#: ../syntax.c:7297
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Nicht druckbare Zeichen im Namen der Gruppe"
 
-#: ../syntax.c:7434
+#: ../syntax.c:7304
 msgid "W18: Invalid character in group name"
 msgstr "W18: Ungültiges Zeichen im Namen der Gruppe"
 
-#: ../syntax.c:7448
+#: ../syntax.c:7318
 msgid "E849: Too many highlight and syntax groups"
 msgstr ""
 
-#: ../tag.c:104
+#: ../tag.c:109
 msgid "E555: at bottom of tag stack"
 msgstr "E555: Am Ende des Tag-Stacks"
 
-#: ../tag.c:105
+#: ../tag.c:110
 msgid "E556: at top of tag stack"
 msgstr "E556: Am Anfang des Tag-Stacks"
 
-#: ../tag.c:380
+#: ../tag.c:385
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Kann nicht vor den ersten passenden Tag hinausgehen"
 
-#: ../tag.c:504
+#: ../tag.c:509
 #, c-format
 msgid "E426: tag not found: %s"
 msgstr "E426: Konnte Tag \"%s\" nicht finden"
 
-#: ../tag.c:528
+#: ../tag.c:533
 msgid "  # pri kind tag"
 msgstr "   # pri verw. tag"
 
-#: ../tag.c:531
+#: ../tag.c:536
 msgid "file\n"
 msgstr "Datei\n"
 
-#: ../tag.c:829
+#: ../tag.c:832
 msgid "E427: There is only one matching tag"
 msgstr "E427: Es gibt nur einen passenden Tag"
 
-#: ../tag.c:831
+#: ../tag.c:834
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Kann nicht über den letzten passenden Tag hinausgehen"
 
-#: ../tag.c:850
+#: ../tag.c:853
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Die Datei \"%s\" existiert nicht"
 
 #. Give an indication of the number of matching tags
-#: ../tag.c:859
+#: ../tag.c:862
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "Tag %d aus %d%s"
 
-#: ../tag.c:862
+#: ../tag.c:865
 msgid " or more"
 msgstr " oder mehr"
 
-#: ../tag.c:864
+#: ../tag.c:867
 msgid "  Using tag with different case!"
 msgstr "  Verwendung eines Tags mit abgewandelter Groß-/Klein-Schreibung"
 
-#: ../tag.c:909
+#: ../tag.c:912
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Die Datei \"%s\" existiert nicht"
 
 #. Highlight title
-#: ../tag.c:960
+#: ../tag.c:963
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -6049,80 +5491,80 @@ msgstr ""
 "\n"
 "  # NACH TAG       VON Zeile  in Datei/Text"
 
-#: ../tag.c:1303
+#: ../tag.c:1286
 #, c-format
 msgid "Searching tags file %s"
 msgstr "tags file %s wird durchsucht"
 
-#: ../tag.c:1545
+#: ../tag.c:1528
 msgid "Ignoring long line in tags file"
 msgstr ""
 
-#: ../tag.c:1915
+#: ../tag.c:1898
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Format Fehler in Tag-Datei \"%s\""
 
-#: ../tag.c:1917
+#: ../tag.c:1900
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "Vor byte %<PRId64>"
 
-#: ../tag.c:1929
+#: ../tag.c:1912
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tag-Datei ist nicht sortiert: %s"
 
 #. never opened any tags file
-#: ../tag.c:1960
+#: ../tag.c:1943
 msgid "E433: No tags file"
 msgstr "E433: Keine Tag-Datei"
 
-#: ../tag.c:2536
+#: ../tag.c:2518
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Kann Tag-Muster nicht finden"
 
-#: ../tag.c:2544
+#: ../tag.c:2526
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Konnte Tag möglicherweise nicht finden!"
 
-#: ../tag.c:2797
+#: ../tag.c:2777
 #, fuzzy, c-format
 msgid "Duplicate field name: %s"
 msgstr "Doppeltes Affix in %s Zeile %d: %s"
 
-#: ../term.c:1442
+#: ../term.c:1431
 msgid "' not known. Available builtin terminals are:"
 msgstr ""
 "' nicht bekannt. Die folgenden eingebauten Terminals stehen zur Verfügung:"
 
-#: ../term.c:1463
+#: ../term.c:1452
 msgid "defaulting to '"
 msgstr "Voreinstellung '"
 
-#: ../term.c:1731
+#: ../term.c:1720
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Termcap-Datei kann nicht geöffnet werden"
 
-#: ../term.c:1735
+#: ../term.c:1724
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Kein Terminal-Eintrag in der Terminfo-Datenbank gefunden"
 
-#: ../term.c:1737
+#: ../term.c:1726
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Kein Terminal-Eintrag in der Termcap-Datei gefunden"
 
-#: ../term.c:1878
+#: ../term.c:1867
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Kein \"%s\" Eintrag in der Termcap-Datei"
 
-#: ../term.c:2249
+#: ../term.c:2232
 msgid "E437: terminal capability \"cm\" required"
 msgstr "E437: Terminalfähigkeit \"cm\" wird benötigt"
 
 #. Highlight title
-#: ../term.c:4376
+#: ../term.c:4355
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -6130,168 +5572,168 @@ msgstr ""
 "\n"
 "--- Terminal Tasten ---"
 
-#: ../ui.c:481
+#: ../ui.c:477
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Fehler beim Lesen der Eingabe, Abbruch...\n"
 
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
-#: ../undo.c:379
+#: ../undo.c:355
 msgid "E881: Line count changed unexpectedly"
 msgstr ""
 
-#: ../undo.c:627
+#: ../undo.c:603
 #, fuzzy, c-format
 msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E212: Datei kann nicht zum Schreiben geöffnet werden"
 
-#: ../undo.c:717
+#: ../undo.c:693
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
 msgstr ""
 
-#: ../undo.c:1039
+#: ../undo.c:1015
 msgid "Cannot write undo file in any directory in 'undodir'"
 msgstr ""
 
-#: ../undo.c:1074
+#: ../undo.c:1050
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
 msgstr ""
 
-#: ../undo.c:1092
+#: ../undo.c:1068
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
 msgstr ""
 
-#: ../undo.c:1108
+#: ../undo.c:1084
 msgid "Skipping undo file write, nothing to undo"
 msgstr ""
 
-#: ../undo.c:1121
+#: ../undo.c:1097
 #, fuzzy, c-format
 msgid "Writing undo file: %s"
 msgstr "Schreiben der viminfo-Datei \"%s\""
 
-#: ../undo.c:1213
+#: ../undo.c:1189
 #, fuzzy, c-format
 msgid "E829: write error in undo file: %s"
 msgstr "E297: Fehler beim Schreiben in die Auslagerungsdatei"
 
-#: ../undo.c:1280
+#: ../undo.c:1256
 #, c-format
 msgid "Not reading undo file, owner differs: %s"
 msgstr ""
 
-#: ../undo.c:1292
+#: ../undo.c:1268
 #, fuzzy, c-format
 msgid "Reading undo file: %s"
 msgstr "Lese Wort-Datei %s ..."
 
-#: ../undo.c:1299
+#: ../undo.c:1275
 #, fuzzy, c-format
 msgid "E822: Cannot open undo file for reading: %s"
 msgstr "E195: viminfo kann nicht zum Lesen geöffnet werden"
 
-#: ../undo.c:1308
+#: ../undo.c:1284
 #, fuzzy, c-format
 msgid "E823: Not an undo file: %s"
 msgstr "E753: Nicht gefunden: %s"
 
-#: ../undo.c:1313
+#: ../undo.c:1289
 #, fuzzy, c-format
 msgid "E824: Incompatible undo file: %s"
 msgstr "E484: Kann die Datei %s nicht öffnen"
 
-#: ../undo.c:1328
+#: ../undo.c:1304
 msgid "File contents changed, cannot use undo info"
 msgstr ""
 
-#: ../undo.c:1497
+#: ../undo.c:1473
 #, fuzzy, c-format
 msgid "Finished reading undo file %s"
 msgstr "Lesen von %s beendet"
 
-#: ../undo.c:1586 ../undo.c:1812
+#: ../undo.c:1562 ../undo.c:1788
 msgid "Already at oldest change"
 msgstr "Bereits bei der ältesten Änderung"
 
-#: ../undo.c:1597 ../undo.c:1814
+#: ../undo.c:1573 ../undo.c:1790
 msgid "Already at newest change"
 msgstr "Bereits bei der jüngsten Änderung"
 
-#: ../undo.c:1806
+#: ../undo.c:1782
 #, fuzzy, c-format
 msgid "E830: Undo number %<PRId64> not found"
 msgstr "Nummer %<PRId64> zur Wiederherstellung nicht gefunden"
 
-#: ../undo.c:1979
+#: ../undo.c:1955
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: Zeilennummer falsch"
 
-#: ../undo.c:2183
+#: ../undo.c:2159
 msgid "more line"
 msgstr "Zeile mehr"
 
-#: ../undo.c:2185
+#: ../undo.c:2161
 msgid "more lines"
 msgstr "Zeilen mehr"
 
-#: ../undo.c:2187
+#: ../undo.c:2163
 msgid "line less"
 msgstr "Zeile weniger"
 
-#: ../undo.c:2189
+#: ../undo.c:2165
 msgid "fewer lines"
 msgstr "Zeilen weniger"
 
-#: ../undo.c:2193
+#: ../undo.c:2169
 msgid "change"
 msgstr "Änderung"
 
-#: ../undo.c:2195
+#: ../undo.c:2171
 msgid "changes"
 msgstr "Änderungen"
 
-#: ../undo.c:2225
+#: ../undo.c:2201
 #, c-format
 msgid "%<PRId64> %s; %s #%<PRId64>  %s"
 msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
-#: ../undo.c:2228
+#: ../undo.c:2204
 msgid "before"
 msgstr "vor"
 
-#: ../undo.c:2228
+#: ../undo.c:2204
 msgid "after"
 msgstr "nach"
 
-#: ../undo.c:2325
+#: ../undo.c:2300
 msgid "Nothing to undo"
 msgstr "Nichts wiederherzustellen"
 
-#: ../undo.c:2330
+#: ../undo.c:2305
 msgid "number changes  when               saved"
 msgstr ""
 
-#: ../undo.c:2360
+#: ../undo.c:2335
 #, c-format
 msgid "%<PRId64> seconds ago"
 msgstr "vor %<PRId64> Sekunden"
 
-#: ../undo.c:2372
+#: ../undo.c:2347
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: 'undojoin' ist nicht erlaubt nach 'undo'"
 
-#: ../undo.c:2466
+#: ../undo.c:2441
 msgid "E439: undo list corrupt"
 msgstr "E439: Liste der Wiederherstellungen fehlerhaft"
 
-#: ../undo.c:2495
+#: ../undo.c:2470
 msgid "E440: undo line missing"
 msgstr "E440: Wiederherstellungszeile fehlt"
 
-#: ../version.c:600
+#: ../version.c:643
 msgid ""
 "\n"
 "Included patches: "
@@ -6299,18 +5741,18 @@ msgstr ""
 "\n"
 "Inklusive der Korrekturen: "
 
-#: ../version.c:627
+#: ../version.c:670
 #, fuzzy
 msgid ""
 "\n"
 "Extra patches: "
 msgstr "Externe 'submatches':\n"
 
-#: ../version.c:639 ../version.c:864
+#: ../version.c:682 ../version.c:906
 msgid "Modified by "
 msgstr "Verändert von "
 
-#: ../version.c:646
+#: ../version.c:689
 msgid ""
 "\n"
 "Compiled "
@@ -6318,11 +5760,11 @@ msgstr ""
 "\n"
 "Übersetzt "
 
-#: ../version.c:649
+#: ../version.c:692
 msgid "by "
 msgstr "von "
 
-#: ../version.c:660
+#: ../version.c:703
 msgid ""
 "\n"
 "Huge version "
@@ -6330,165 +5772,742 @@ msgstr ""
 "\n"
 "Riesige Version "
 
-#: ../version.c:661
+#: ../version.c:704
 msgid "without GUI."
 msgstr "ohne GUI."
 
-#: ../version.c:662
+#: ../version.c:705
 msgid "  Features included (+) or not (-):\n"
 msgstr " Ein- (+) oder ausschließlich (-) der Eigenschaften:\n"
 
-#: ../version.c:667
+#: ../version.c:710
 msgid "   system vimrc file: \""
 msgstr "          System-vimrc-Datei: \""
 
-#: ../version.c:672
+#: ../version.c:715
 msgid "     user vimrc file: \""
 msgstr "        Benutzer-vimrc-Datei: \""
 
-#: ../version.c:677
+#: ../version.c:720
 msgid " 2nd user vimrc file: \""
 msgstr " zweite Benutzer-vimrc-Datei: \""
 
-#: ../version.c:682
+#: ../version.c:725
 msgid " 3rd user vimrc file: \""
 msgstr " dritte Benutzer-vimrc-Datei: \""
 
-#: ../version.c:687
+#: ../version.c:730
 msgid "      user exrc file: \""
 msgstr "         Benutzer-exrc-Datei: \""
 
-#: ../version.c:692
+#: ../version.c:735
 msgid "  2nd user exrc file: \""
 msgstr " zweite Benutzer-exrc-Datei: \""
 
-#: ../version.c:699
+#: ../version.c:742
 msgid "  fall-back for $VIM: \""
 msgstr "     Voreinstellung für $VIM: \""
 
-#: ../version.c:705
+#: ../version.c:748
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "         und für $VIMRUNTIME: \""
 
-#: ../version.c:709
+#: ../version.c:752
 msgid "Compilation: "
 msgstr "Übersetzt: "
 
-#: ../version.c:712
+#: ../version.c:755
 msgid "Linking: "
 msgstr "Linken: "
 
-#: ../version.c:717
+#: ../version.c:760
 msgid "  DEBUG BUILD"
 msgstr "  DEBUG-VERSION"
 
-#: ../version.c:767
+#: ../version.c:809
 msgid "VIM - Vi IMproved"
 msgstr "VIM - verbesserter Vi"
 
-#: ../version.c:769
+#: ../version.c:811
 msgid "version "
 msgstr "Version "
 
-#: ../version.c:770
+#: ../version.c:812
 msgid "by Bram Moolenaar et al."
 msgstr "von Bram Moolenaar und Anderen"
 
-#: ../version.c:774
+#: ../version.c:816
 msgid "Vim is open source and freely distributable"
 msgstr "Vim ist Open Source und kann frei weitergegeben werden"
 
-#: ../version.c:776
+#: ../version.c:818
 msgid "Help poor children in Uganda!"
 msgstr "Helfen Sie armen Kindern in Uganda!"
 
-#: ../version.c:777
+#: ../version.c:819
 msgid "type  :help iccf<Enter>       for information "
 msgstr "Tippe  :help iccf<Enter>        für Informationen darüber "
 
-#: ../version.c:779
+#: ../version.c:821
 msgid "type  :q<Enter>               to exit         "
 msgstr "Tippe  :q<Enter>                zum Beenden               "
 
-#: ../version.c:780
+#: ../version.c:822
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr "Tippe  :help<Enter>  oder <F1>  für Online Hilfe          "
 
-#: ../version.c:781
+#: ../version.c:823
 msgid "type  :help version7<Enter>   for version info"
 msgstr "Tippe  :help version7<Enter>    für Versions-Informationen"
 
-#: ../version.c:784
+#: ../version.c:826
 msgid "Running in Vi compatible mode"
 msgstr "Vi kompatible Einstellung"
 
-#: ../version.c:785
+#: ../version.c:827
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "Tippe  :set nocp<Enter>         für Vim-Voreinstellungen  "
 
-#: ../version.c:786
+#: ../version.c:828
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "Tippe  :help cp-default<Enter>  für Informationen darüber "
 
-#: ../version.c:827
+#: ../version.c:869
 msgid "Sponsor Vim development!"
 msgstr "Unterstützen Sie die Entwicklung von Vim"
 
-#: ../version.c:828
+#: ../version.c:870
 msgid "Become a registered Vim user!"
 msgstr "Werden Sie ein registrierter Benutzer von Vim!"
 
-#: ../version.c:831
+#: ../version.c:873
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "Tippe  :help sponsor<Enter>     für mehr Informationen    "
 
-#: ../version.c:832
+#: ../version.c:874
 msgid "type  :help register<Enter>   for information "
 msgstr "Tippe  :help register<Enter>    für mehr Informationen    "
 
-#: ../version.c:834
+#: ../version.c:876
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "Menü   Hilfe->Sponsor/Register  für mehr Informationen    "
 
-#: ../window.c:119
+#: ../window.c:65
 msgid "Already only one window"
 msgstr "Bereits nur ein Fenster"
 
-#: ../window.c:224
+#: ../window.c:170
 msgid "E441: There is no preview window"
 msgstr "E441: Es gibt kein Fenster zur Voransicht"
 
 # should read: topleft / botright
-#: ../window.c:559
+#: ../window.c:505
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr "E442: topleft und botright können nicht gleichzeitig verwendet werden"
 
-#: ../window.c:1228
+#: ../window.c:1174
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Rotieren nicht möglich wenn ein anderes Fenster geteilt ist"
 
-#: ../window.c:1803
+#: ../window.c:1749
 msgid "E444: Cannot close last window"
 msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
 
-#: ../window.c:1810
+#: ../window.c:1756
 #, fuzzy
 msgid "E813: Cannot close autocmd window"
 msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
 
-#: ../window.c:1814
+#: ../window.c:1760
 #, fuzzy
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E444: Letztes Fenster kann nicht geschlossen werden"
 
-#: ../window.c:2717
+#: ../window.c:2663
 msgid "E445: Other window contains changes"
 msgstr "E445: Anderes Fenster enthält Änderungen"
 
 # Cursor: Schreibmarke Positionsmarke
-#: ../window.c:4805
+#: ../window.c:4759
 msgid "E446: No file name under cursor"
 msgstr "E446: Kein Dateiname unter dem Cursor"
+
+#: ../eval.c:138
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: Unerwartete Zeichen in :let"
+
+#: ../eval.c:139
+#, c-format
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Index der Liste außerhalb des zulässigen Bereichs: %<PRId64>"
+
+#: ../eval.c:140
+#, c-format
+msgid "E121: Undefined variable: %s"
+msgstr "E121: Undefinierte Variable: %s"
+
+#: ../eval.c:141
+msgid "E111: Missing ']'"
+msgstr "E111: Fehlende ']'"
+
+#: ../eval.c:142
+#, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "E686: Argument von %s muss eine Liste sein"
+
+#: ../eval.c:144
+#, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E712: Argument von %s muss eine Liste oder ein Wörterbuch"
+
+#: ../eval.c:145
+msgid "E713: Cannot use empty key for Dictionary"
+msgstr "E713: Der Schlüssel für das Wörterbuch darf nicht leer sein"
+
+#: ../eval.c:146
+msgid "E714: List required"
+msgstr "E714: Liste benötigt"
+
+#: ../eval.c:147
+msgid "E715: Dictionary required"
+msgstr "E715: Wörterbuch benötigt"
+
+#: ../eval.c:148
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Zu viele Argumente für Funktion: %s"
+
+#: ../eval.c:149
+#, c-format
+msgid "E716: Key not present in Dictionary: %s"
+msgstr "E716: Schlüssel nicht vorhanden im Wörterbuch: %s"
+
+#: ../eval.c:151
+#, c-format
+msgid "E122: Function %s already exists, add ! to replace it"
+msgstr "E122: Funktion %s existiert bereits; zum Ersetzen ! hinzufügen"
+
+#: ../eval.c:152
+msgid "E717: Dictionary entry already exists"
+msgstr "E717: Wörterbuch-Eintrag existiert bereits"
+
+#: ../eval.c:153
+msgid "E718: Funcref required"
+msgstr "E718: Funktionsreferenz benötigt"
+
+#: ../eval.c:154
+msgid "E719: Cannot use [:] with a Dictionary"
+msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
+
+#: ../eval.c:155
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr "E734: Falscher Typ der Variable für %s="
+
+#: ../eval.c:156
+#, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E130: Unbekannte Funktion: %s"
+
+#: ../eval.c:157
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: Unzulässiger Name der Variable: %s"
+
+#: ../eval.c:158
+#, fuzzy
+msgid "E806: using Float as a String"
+msgstr "E730: Liste als String verwendet"
+
+#: ../eval.c:1381
+msgid "E687: Less targets than List items"
+msgstr "E687: Weniger Ziele als Einträge der Liste"
+
+#: ../eval.c:1385
+msgid "E688: More targets than List items"
+msgstr "E688: Mehr Ziele als Einträge der Liste"
+
+#: ../eval.c:1455
+msgid "Double ; in list of variables"
+msgstr "Doppeltes ; in der Liste von Variablen"
+
+#: ../eval.c:1627
+#, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E738: Kann Variablen nicht auflisten: %s"
+
+#: ../eval.c:1940
+msgid "E689: Can only index a List or Dictionary"
+msgstr "E689: Kann nur Listen und Wörterbücher indizieren"
+
+#: ../eval.c:1945
+msgid "E708: [:] must come last"
+msgstr "E708: [:] muss am Schluss kommen"
+
+#: ../eval.c:1988
+msgid "E709: [:] requires a List value"
+msgstr "E709: [:] benötigt eine Liste als Wert"
+
+#: ../eval.c:2223
+msgid "E710: List value has more items than target"
+msgstr "E710: Listenwert hat mehr Einträge als das Ziel"
+
+#: ../eval.c:2227
+msgid "E711: List value has not enough items"
+msgstr "E711: Listenwert hat nicht genügend Einträge"
+
+#: ../eval.c:2414
+msgid "E690: Missing \"in\" after :for"
+msgstr "E690: Fehlendes \"in\" nach :for"
+
+#: ../eval.c:2610
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: Fehlende Klammern: %s"
+
+#: ../eval.c:2810
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: Keine solche Variable: \"%s\""
+
+#: ../eval.c:2880
+msgid "E743: variable nested too deep for (un)lock"
+msgstr "E743: Variable ist zu tief verschachtelt für (un)lock"
+
+#: ../eval.c:3172
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: Fehlender ':' nach '?'"
+
+#: ../eval.c:3435
+msgid "E691: Can only compare List with List"
+msgstr "E691: Kann nur eine Liste mit einer Liste vergleichen"
+
+#: ../eval.c:3437
+#, fuzzy
+msgid "E692: Invalid operation for List"
+msgstr "E692: Unzulässige Operation für Listen"
+
+#: ../eval.c:3458
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr "E735: Kann nur ein Wörterbuch mit einem Wörterbuch vergleichen"
+
+#: ../eval.c:3460
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E736: Unzulässige Operation für ein Wörterbuch"
+
+#: ../eval.c:3475
+msgid "E693: Can only compare Funcref with Funcref"
+msgstr ""
+"E693: Kann nur eine Funktionsreferenz mit einer Funktionsreferenz vergleichen"
+
+#: ../eval.c:3477
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E694: Unzulässige Operation für Funktionsreferenzen"
+
+#: ../eval.c:3820
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E719: Kann [:] nicht mit einem Wörterbuch verwenden"
+
+#: ../eval.c:4021
+msgid "E110: Missing ')'"
+msgstr "E110: Fehlende ')'"
+
+#: ../eval.c:4152
+msgid "E695: Cannot index a Funcref"
+msgstr "E695: Kann keine Funktionsreferenz indizieren"
+
+#: ../eval.c:4380
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: Bezeichnung der Option fehlt: %s"
+
+#: ../eval.c:4396
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: Unbekannte Option: %s"
+
+#: ../eval.c:4445
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: Fehlendes Anführungszeichen: %s"
+
+#: ../eval.c:4561
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: Fehlendes Anführungszeichen: %s"
+
+#: ../eval.c:4620
+#, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E696: Fehlendes Komma in der Liste: %s"
+
+#: ../eval.c:4627
+#, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E697: Fehlendes Ende der Liste ']': %s"
+
+#: ../eval.c:5979
+#, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E720: Fehlender Doppelpunkt im Wörterbuch: %s"
+
+#: ../eval.c:6003
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr "E721: Doppelter Schlüssel im Wörterbuch: \"%s\""
+
+#: ../eval.c:6020
+#, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E722: Fehlendes Komma im Wörterbuch: %s"
+
+#: ../eval.c:6027
+#, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E723: Fehlendes Ende des Wörterbuchs '}': %s"
+
+#: ../eval.c:6058
+msgid "E724: variable nested too deep for displaying"
+msgstr "E724: Variable ist zu tief verschachtelt für die Anzeige"
+
+#: ../eval.c:6686
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: Zu viele Argumente für Funktion: %s"
+
+#: ../eval.c:6688
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: Ungültige Argumente für die Funktion %s"
+
+#: ../eval.c:6875
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Unbekannte Funktion: %s"
+
+#: ../eval.c:6881
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Zu wenige Argumente für Funktion: %s"
+
+#: ../eval.c:6885
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> wurde nicht in einer Skript-Umgebung benutzt: %s"
+
+#: ../eval.c:6889
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E725: Aufruf der 'dict' Funktion ohne Wörterbuch: %s"
+
+#: ../eval.c:6950
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: Zahl benötigt nach ="
+
+#: ../eval.c:7000
+#, fuzzy
+msgid "add() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:7402
+msgid "E699: Too many arguments"
+msgstr "E699: Zu viele Argumente"
+
+#: ../eval.c:7568
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E785: complete() kann nur im Einfüge-Modus verwendet werden"
+
+#: ../eval.c:7651
+msgid "&Ok"
+msgstr "&Ok"
+
+#: ../eval.c:8171
+#, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E737: Schlüssel existiert bereits: %s"
+
+#: ../eval.c:8187
+#, fuzzy
+msgid "extend() argument"
+msgstr "--cmd Argument"
+
+#: ../eval.c:8404
+#, fuzzy
+msgid "map() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:8405
+#, fuzzy
+msgid "filter() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:8717
+#, c-format
+msgid "+-%s%3ld lines: "
+msgstr "+-%s%3ld Zeilen: "
+
+#: ../eval.c:8779
+#, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E700: Unbekannte Funktion: %s"
+
+#: ../eval.c:10212
+msgid "called inputrestore() more often than inputsave()"
+msgstr "inputrestore() wurde öfter als inputsave() aufgerufen"
+
+#: ../eval.c:10254
+#, fuzzy
+msgid "insert() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:10324
+msgid "E786: Range not allowed"
+msgstr "E786: Bereich nicht erlaubt"
+
+#: ../eval.c:10621
+msgid "E701: Invalid type for len()"
+msgstr "E701: Unzulässiger Typ für len()"
+
+#: ../eval.c:11459
+msgid "E726: Stride is zero"
+msgstr "E726: Stride ist Null"
+
+#: ../eval.c:11461
+msgid "E727: Start past end"
+msgstr "E727: Start hinter dem Ende"
+
+#: ../eval.c:11502 ../eval.c:14739
+msgid "<empty>"
+msgstr "<leer>"
+
+#: ../eval.c:11709
+#, fuzzy
+msgid "remove() argument"
+msgstr "--cmd Argument"
+
+#: ../eval.c:11890
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: Zu viele symbolische Links (zirkulär?)"
+
+#: ../eval.c:12010
+#, fuzzy
+msgid "reverse() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:12565
+msgid "Error converting the call result"
+msgstr ""
+
+#: ../eval.c:13186
+#, fuzzy
+msgid "sort() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:13186
+#, fuzzy
+msgid "uniq() argument"
+msgstr "-c Argument"
+
+#: ../eval.c:13241
+msgid "E702: Sort compare function failed"
+msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
+
+#: ../eval.c:13271
+#, fuzzy
+msgid "E882: Uniq compare function failed"
+msgstr "E702: Die Vergleichsfunktion der Sortierung ist fehlgeschlagen"
+
+#: ../eval.c:13545
+msgid "(Invalid)"
+msgstr "(Ungültig)"
+
+#: ../eval.c:14048
+msgid "E677: Error writing temp file"
+msgstr "E677: Fehler beim Schreiben einer temporären Datei"
+
+#: ../eval.c:15601
+#, fuzzy
+msgid "E805: Using a Float as a Number"
+msgstr "E745: Liste als Zahl verwendet"
+
+#: ../eval.c:15604
+msgid "E703: Using a Funcref as a Number"
+msgstr "E703: Funktionsreferenz als Zahl verwendet"
+
+#: ../eval.c:15612
+msgid "E745: Using a List as a Number"
+msgstr "E745: Liste als Zahl verwendet"
+
+#: ../eval.c:15615
+msgid "E728: Using a Dictionary as a Number"
+msgstr "E728: Wörterbuch als Zahl verwendet"
+
+#: ../eval.c:15701
+msgid "E729: using Funcref as a String"
+msgstr "E729: Funktionsreferenz als String verwendet"
+
+#: ../eval.c:15704
+msgid "E730: using List as a String"
+msgstr "E730: Liste als String verwendet"
+
+#: ../eval.c:15707
+msgid "E731: using Dictionary as a String"
+msgstr "E731: Wörterbuch als String verwendet"
+
+#: ../eval.c:16060
+#, c-format
+msgid "E706: Variable type mismatch for: %s"
+msgstr "E706: Typ der Variable falsch zugeordnet: %s"
+
+#: ../eval.c:16146
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %s"
+msgstr "E738: Kann Variablen nicht auflisten: %s"
+
+#: ../eval.c:16166
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr ""
+"E704: Funktionsreferenz-Variable muss mit einem Großbuchstaben beginnen: %s"
+
+#: ../eval.c:16173
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Konflikt eines Variablennamens mit bestehender Funktion: %s"
+
+#: ../eval.c:16204
+#, c-format
+msgid "E741: Value is locked: %s"
+msgstr "E741: Wert ist gesperrt: %s"
+
+#: ../eval.c:16209
+#, c-format
+msgid "E742: Cannot change value of %s"
+msgstr "E742: Kann Wert nicht ändern: %s"
+
+#: ../eval.c:16279
+msgid "E698: variable nested too deep for making a copy"
+msgstr "E698: Variable ist zu tief verschachtelt für eine Kopie"
+
+#: ../eval.c:16688
+#, fuzzy, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E130: Unbekannte Funktion: %s"
+
+#: ../eval.c:16699
+#, c-format
+msgid "E124: Missing '(': %s"
+msgstr "E124: Fehlendes '(': %s"
+
+#: ../eval.c:16729
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: Kann die IC Werte nicht setzen"
+
+#: ../eval.c:16748
+#, c-format
+msgid "E125: Illegal argument: %s"
+msgstr "E125: Unzulässiges Argument: %s"
+
+#: ../eval.c:16759
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: Doppelter Tag \"%s\" in der Datei %s"
+
+#: ../eval.c:16852
+msgid "E126: Missing :endfunction"
+msgstr "E126: Fehlendes :endfunction"
+
+#: ../eval.c:16973
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr ""
+"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
+
+#: ../eval.c:16985
+#, fuzzy, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
+
+#: ../eval.c:17038
+#, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr ""
+"E746: Funktionsname stimmt mit dem Namen der Skript-Datei nicht überein: %s"
+
+#: ../eval.c:17146
+msgid "E129: Function name required"
+msgstr "E129: Funktionsname wird verlangt"
+
+#: ../eval.c:17254
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr ""
+"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
+"Doppelpunkt enthalten: %s"
+
+#: ../eval.c:17263
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr ""
+"E128: Funktionsname muss mit einem Großbuchstaben beginnen oder einen "
+"Doppelpunkt enthalten: %s"
+
+#: ../eval.c:17761
+#, c-format
+msgid "E131: Cannot delete function %s: It is in use"
+msgstr "E131: Funktion %s kann nicht gelöscht werden: sie ist in Verwendung"
+
+#: ../eval.c:17865
+msgid "E132: Function call depth is higher than 'maxfuncdepth'"
+msgstr "E132: Funktionsaufrufstiefe überschreitet 'maxfuncdepth'"
+
+#: ../eval.c:17992
+#, c-format
+msgid "calling %s"
+msgstr "rufe %s auf"
+
+#: ../eval.c:18075
+#, c-format
+msgid "%s aborted"
+msgstr "%s abgebrochen"
+
+#: ../eval.c:18077
+#, c-format
+msgid "%s returning #%<PRId64>"
+msgstr "%s lieferte #%<PRId64> zurück"
+
+#: ../eval.c:18094
+#, c-format
+msgid "%s returning %s"
+msgstr "%s lieferte \"%s\" zurück"
+
+#: ../eval.c:18219
+msgid "E133: :return not inside a function"
+msgstr "E133: :return außerhalb einer Funktion"
+
+#: ../eval.c:18575
+msgid ""
+"\n"
+"# global variables:\n"
+msgstr ""
+"\n"
+"# globale Variablen:\n"
+
+#: ../eval.c:18665
+msgid ""
+"\n"
+"\tLast set from "
+msgstr ""
+"\n"
+"\tZuletzt gesetzt von "
+
+#: ../eval.c:18682
+#, fuzzy
+msgid "No old files"
+msgstr "Keine inkludierten Dateien"
 
 #~ msgid "Patch file"
 #~ msgstr "Patch-Datei"


### PR DESCRIPTION
Following the steps in #767, I updated the German translation. All strings (incl. fuzzy) are now translated;  `make de.ck` reports no errors. I also changed a few obvious things when I saw them (e.g. fixing some [Leerzeichen in Komposita](https://de.wikipedia.org/wiki/Leerzeichen_in_Komposita)). I did not go through the translations line-by-line.

For vimscript-related messages, I changed the translations to use Dictionary, Number, List, etc. for the data types instead of a translation. Afaik, there is no German vimscript reference, and translating the data types might be a bit confusing and introduce ambiguity.

Most of the undo-related terms had not yet been translated, but the existing ones used "Wiederherstellung" for "undo". I don't think that really describes what undo does, but then again, I didn't want to call "undo file" "Rückgängig-Datei" or something. I used "Wiederherstellungsdatei" to be consistent, but maybe someone has a better idea for that.

Unfortunately, executing `make de` changed most of the po file (line numbers were updated), which makes this commit very big and probably hard to review :-(
