### PR TITLE
[WIP/RFC] Redraw events

### DIFF
--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -224,6 +224,28 @@ void redraw_ruler(uint64_t channel_id, win_T *window, bool empty, char *relpos)
   channel_send_event(0, "redraw:ruler", DICTIONARY_OBJ(event_data));
 }
 
+void redraw_foreground_color(uint64_t channel_id)
+{
+  if (false) {
+    return;
+  }
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "color", STRING_OBJ(cstr_to_string(cterm_normal_gui_fg)));
+  channel_send_event(0, "redraw:foreground_color", DICTIONARY_OBJ(event_data));
+}
+
+void redraw_background_color(uint64_t channel_id)
+{
+  if (false) {
+    return;
+  }
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "color", STRING_OBJ(cstr_to_string(cterm_normal_gui_bg)));
+  channel_send_event(0, "redraw:background_color", DICTIONARY_OBJ(event_data));
+}
+
 static void add_line_char(LineData *ldata, size_t screen_offset)
 {
   size_t char_len;  // length in bytes of the utf8-encoded character

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -102,6 +102,33 @@ void redraw_delete_line(uint64_t channel_id, win_T *window, int row, int count)
                      DICTIONARY_OBJ(event_data));
 }
 
+void redraw_win_end(uint64_t channel_id,
+                    win_T *window,
+                    char marker,
+                    char fill,
+                    int row,
+                    int endrow)
+{
+  if (false) {
+    return;
+  }
+
+  char marker_str[] = {marker, NUL};
+  char fill_str[] = {fill, NUL};
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(window->handle));
+  PUT(event_data, "marker", STRING_OBJ(
+        cstr_to_string((const char *)&marker_str)));
+  PUT(event_data, "fill", STRING_OBJ(
+        cstr_to_string((const char *)&fill_str)));
+  PUT(event_data, "row", INTEGER_OBJ(row));
+  PUT(event_data, "endrow", INTEGER_OBJ(endrow));
+  channel_send_event(channel_id,
+                     "redraw:win_end",
+                     DICTIONARY_OBJ(event_data));
+}
+
 void redraw_update_line(uint64_t channel_id,
                         win_T *window,
                         UpdateLineWidths *widths,

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -176,6 +176,39 @@ void redraw_update_line(uint64_t channel_id,
                      DICTIONARY_OBJ(event_data));
 }
 
+void redraw_status(uint64_t channel_id, win_T *window)
+{
+  if (false) {
+    return;
+  }
+
+  // Put the buffer name in NameBuff
+  get_trans_bufname(window->w_buffer);
+
+  // Prepare the event data
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(window->handle));
+  PUT(event_data, "name", STRING_OBJ(cstr_to_string((char *)NameBuff)));
+
+  if (window->w_buffer->b_help) {
+    PUT(event_data, "help", BOOLEAN_OBJ(true));
+  }
+
+  if (window->w_p_pvw) {
+    PUT(event_data, "preview", BOOLEAN_OBJ(true));
+  }
+
+  if (bufIsChanged(window->w_buffer)) {
+    PUT(event_data, "modified", BOOLEAN_OBJ(true));
+  }
+
+  if (window->w_buffer->b_p_ro) {
+    PUT(event_data, "readonly", BOOLEAN_OBJ(true));
+  }
+
+  channel_send_event(0, "redraw:status_line", DICTIONARY_OBJ(event_data));
+}
+
 static void add_line_char(LineData *ldata, size_t screen_offset)
 {
   size_t char_len;  // length in bytes of the utf8-encoded character

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -462,7 +462,7 @@ static void add_line_section(LineData *ldata,
     Dictionary section = {0, 0, 0};
     PUT(section, "type", STRING_OBJ(cstr_to_string(section_type)));
     char str[sizeof(ldata->buffer)];
-    xstrlcpy(str, ldata->buffer + ldata->offset, section_width);
+    xstrlcpy(str, ldata->buffer + ldata->offset, sizeof(str) > section_width + 1 ? section_width + 1 : sizeof(str));
     PUT(section, "content", STRING_OBJ(cstr_to_string(str)));
     ADD(*target, DICTIONARY_OBJ(section));
   }

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -302,6 +302,24 @@ void redraw_background_color(uint64_t channel_id)
   channel_send_event(0, "redraw:background_color", DICTIONARY_OBJ(event_data));
 }
 
+void redraw_start(uint64_t channel_id)
+{
+  if (false) {
+    return;
+  }
+
+  channel_send_event(0, "redraw:start", NIL);
+}
+
+void redraw_end(uint64_t channel_id)
+{
+  if (false) {
+    return;
+  }
+
+  channel_send_event(0, "redraw:end", NIL);
+}
+
 static void add_line_char(LineData *ldata, size_t screen_offset)
 {
   size_t char_len;  // length in bytes of the utf8-encoded character

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -5,6 +5,7 @@
 #include "nvim/undo.h"
 #include "nvim/screen.h"
 #include "nvim/path.h"
+#include "nvim/buffer_defs.h"
 #include "nvim/os/channel.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/redraw.h"
@@ -61,4 +62,19 @@ void redraw_tabs(uint64_t channel_id)
   }
 
   channel_send_event(channel_id, "redraw:tabs", ARRAY_OBJ(event_data));
+}
+
+void redraw_insert_line(uint64_t channel_id, win_T *window, int row, int count)
+{
+  if (false) {
+    return;
+  }
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(window->handle));
+  PUT(event_data, "row", INTEGER_OBJ(row - window->w_winrow));
+  PUT(event_data, "count", INTEGER_OBJ(count));
+  channel_send_event(channel_id,
+                     "redraw:insert_line",
+                     DICTIONARY_OBJ(event_data));
 }

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -1,0 +1,64 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "nvim/vim.h"
+#include "nvim/undo.h"
+#include "nvim/screen.h"
+#include "nvim/path.h"
+#include "nvim/os/channel.h"
+#include "nvim/api/private/defs.h"
+#include "nvim/api/private/redraw.h"
+#include "nvim/api/private/helpers.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/private/redraw.c.generated.h"
+#endif
+
+
+void redraw_tabs(uint64_t channel_id)
+{
+  if (false) {
+    return;
+  }
+
+  // Array containing the tab state for the redraw event
+  Array event_data = {0, 0, 0};
+  size_t tabcount = 0;
+
+  for (tabpage_T *tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+    tabcount++;
+  }
+
+  for (tabpage_T *tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+    win_T *wp, *cwp;
+    Dictionary tab_data = {0, 0, 0};
+    PUT(tab_data, "tabpage_id", INTEGER_OBJ(tp->handle));
+    PUT(tab_data, "selected", BOOLEAN_OBJ(tp->tp_topframe == topframe));
+
+    if (tp == curtab) {
+      cwp = curwin;
+      wp = firstwin;
+    } else {
+      cwp = tp->tp_curwin;
+      wp = tp->tp_firstwin;
+    }
+
+    bool modified = false;
+    size_t wincount;
+    for (wincount = 0; wp != NULL; wp = wp->w_next, wincount++) {
+      if (bufIsChanged(wp->w_buffer)) {
+        modified = true;
+      }
+    }
+
+    PUT(tab_data, "window_count", INTEGER_OBJ(wincount));
+    PUT(tab_data, "modified", BOOLEAN_OBJ(modified));
+    // Get buffer name in NameBuff[]
+    get_trans_bufname(cwp->w_buffer);
+    shorten_dir(NameBuff);
+    PUT(tab_data, "text", STRING_OBJ(cstr_to_string((char *)NameBuff)));
+    ADD(event_data, DICTIONARY_OBJ(tab_data));
+  }
+
+  channel_send_event(channel_id, "redraw:tabs", ARRAY_OBJ(event_data));
+}

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -209,6 +209,21 @@ void redraw_status(uint64_t channel_id, win_T *window)
   channel_send_event(0, "redraw:status_line", DICTIONARY_OBJ(event_data));
 }
 
+void redraw_ruler(uint64_t channel_id, win_T *window, bool empty, char *relpos)
+{
+  if (false) {
+    return;
+  }
+
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(window->handle));
+  PUT(event_data, "lnum", INTEGER_OBJ(window->w_cursor.lnum));
+  PUT(event_data, "col", INTEGER_OBJ(empty ? 0: window->w_cursor.col + 1));
+  PUT(event_data, "relpos", STRING_OBJ(cstr_to_string(relpos)));
+  channel_send_event(0, "redraw:ruler", DICTIONARY_OBJ(event_data));
+}
+
 static void add_line_char(LineData *ldata, size_t screen_offset)
 {
   size_t char_len;  // length in bytes of the utf8-encoded character

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -237,6 +237,22 @@ void redraw_layout(uint64_t channel_id)
   update_screen(CLEAR);
 }
 
+void redraw_cursor(uint64_t channel_id)
+{
+  if (false) {
+    return;
+  }
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(curwin->handle));
+  PUT(event_data, "lnum", INTEGER_OBJ(curwin->w_cursor.lnum));
+  PUT(event_data, "row", INTEGER_OBJ(curwin->w_wrow));
+  // TODO(stefan991): there is a special case for RTL languages which
+  // is not handled here, see setcursor()
+  PUT(event_data, "col", INTEGER_OBJ(curwin->w_wcol));
+  channel_send_event(0, "redraw:cursor", DICTIONARY_OBJ(event_data));
+}
+
 void redraw_foreground_color(uint64_t channel_id)
 {
   if (false) {

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -78,3 +78,18 @@ void redraw_insert_line(uint64_t channel_id, win_T *window, int row, int count)
                      "redraw:insert_line",
                      DICTIONARY_OBJ(event_data));
 }
+
+void redraw_delete_line(uint64_t channel_id, win_T *window, int row, int count)
+{
+  if (false) {
+    return;
+  }
+
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(window->handle));
+  PUT(event_data, "row", INTEGER_OBJ(row - window->w_winrow));
+  PUT(event_data, "count", INTEGER_OBJ(count));
+  channel_send_event(channel_id,
+                     "redraw:delete_line",
+                     DICTIONARY_OBJ(event_data));
+}

--- a/src/nvim/api/private/redraw.c
+++ b/src/nvim/api/private/redraw.c
@@ -3,13 +3,21 @@
 
 #include "nvim/vim.h"
 #include "nvim/undo.h"
+#include "nvim/syntax.h"
 #include "nvim/screen.h"
+#include "nvim/ascii.h"
 #include "nvim/path.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/os/channel.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/redraw.h"
 #include "nvim/api/private/helpers.h"
+
+typedef struct {
+  char buffer[4096];
+  size_t offset, prev_offset;
+  Dictionary attributes;
+} LineData;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/redraw.c.generated.h"
@@ -92,4 +100,228 @@ void redraw_delete_line(uint64_t channel_id, win_T *window, int row, int count)
   channel_send_event(channel_id,
                      "redraw:delete_line",
                      DICTIONARY_OBJ(event_data));
+}
+
+void redraw_update_line(uint64_t channel_id,
+                        win_T *window,
+                        UpdateLineWidths *widths,
+                        size_t row,
+                        size_t startcol,
+                        size_t endcol,
+                        size_t off_from,
+                        size_t max_off_from)
+{
+  if (false) {
+    return;
+  }
+
+  // Check for illegal row and col, just in case.
+  if (row >= (size_t)Rows) {
+    row = Rows - 1;
+  }
+
+  if (endcol > (size_t)Columns) {
+    endcol = Columns;
+  }
+
+  size_t col = 0;
+  size_t off_to = LineOffset[row] + startcol;
+  size_t char_cells;
+  LineData ldata = {
+    .attributes = {0, 0, 0},
+    .offset = 0,
+    .prev_offset = 0
+  };
+
+  while (col < endcol) {
+    if (has_mbyte && (col + 1 < endcol)) {
+      char_cells = (*mb_off2cells)(off_from, max_off_from);
+    } else {
+      char_cells = 1;
+    }
+
+    add_line_char(&ldata, off_to);
+
+    off_to += char_cells;
+    off_from += char_cells;
+    col += char_cells;
+  }
+
+  // Prepare to emit the 'redraw:update_line' event
+  // Start by terminating the line buffer
+  ldata.buffer[ldata.offset] = NUL;
+  // Now split the logical sections of the line into the sections array
+  Array line = {0, 0, 0};
+  ldata.offset = 0;
+  add_line_section(&ldata, "colon", widths->colon, &line);
+  add_line_section(&ldata, "fold", widths->fold, &line);
+  add_line_section(&ldata, "sign", widths->sign, &line);
+  add_line_section(&ldata, "number", widths->number, &line);
+  add_line_section(&ldata, "deleted", widths->deleted, &line);
+  add_line_section(&ldata, "linebreak", widths->linebreak, &line);
+  size_t user_section_width = strlen(ldata.buffer + ldata.offset);
+  add_line_section(&ldata, "user", user_section_width, &line);
+  // Broadcast the event
+  Dictionary event_data = {0, 0, 0};
+  PUT(event_data, "window_id", INTEGER_OBJ(window->handle));
+  PUT(event_data, "row", INTEGER_OBJ(row - window->w_winrow));
+  PUT(event_data, "line", ARRAY_OBJ(line));
+
+  if (ldata.attributes.size) {
+    PUT(event_data, "attributes", DICTIONARY_OBJ(ldata.attributes));
+  }
+
+  channel_send_event(channel_id,
+                     "redraw:update_line",
+                     DICTIONARY_OBJ(event_data));
+}
+
+static void add_line_char(LineData *ldata, size_t screen_offset)
+{
+  size_t char_len;  // length in bytes of the utf8-encoded character
+  // Put text and attributes to the line data object for the next
+  // redraw event
+  if (enc_utf8 && ScreenLinesUC[screen_offset]) {
+    uint8_t *text = (uint8_t *)(ldata->buffer + ldata->offset);
+    char_len = utfc_char2bytes(screen_offset, text);
+  } else {
+    ldata->buffer[ldata->offset] = ScreenLines[screen_offset];
+    char_len = 1;
+  }
+
+  // Now parse the character attributes
+  int attr = ScreenAttrs[screen_offset];
+  attrentry_T *aep = NULL;
+
+  if (attr > HL_ALL) {
+    aep = syn_cterm_attr2entry(attr);
+    attr = aep ? aep->ae_attr : 0;
+  }
+
+  if (attr & HL_BOLD) {
+    add_line_attribute(ldata, "bold", char_len);
+  }
+
+  if (attr & HL_STANDOUT) {
+    add_line_attribute(ldata, "standout", char_len);
+  }
+
+  if (attr & HL_UNDERLINE) {
+    add_line_attribute(ldata, "underline", char_len);
+  }
+
+  if (attr & HL_UNDERCURL) {
+    add_line_attribute(ldata, "undercurl", char_len);
+  }
+
+  if (attr & HL_ITALIC) {
+    add_line_attribute(ldata, "italic", char_len);
+  }
+
+  if (attr & HL_INVERSE) {
+    add_line_attribute(ldata, "inverse", char_len);
+  }
+
+#define COLOR_BUFFER_SIZE 11  // fg:#000000 + NUL
+
+  if (aep && aep->ae_u.cterm.gui_fg
+      && (!cterm_normal_gui_fg
+        || STRICMP(cterm_normal_gui_fg, aep->ae_u.cterm.gui_fg))) {
+    char buf[COLOR_BUFFER_SIZE];
+    snprintf(buf, COLOR_BUFFER_SIZE, "fg:%s", aep->ae_u.cterm.gui_fg);
+    add_line_attribute(ldata, buf, char_len);
+  }
+
+  if (aep && aep->ae_u.cterm.gui_bg
+      && (!cterm_normal_gui_bg
+        || STRICMP(cterm_normal_gui_bg, aep->ae_u.cterm.gui_bg))) {
+    char buf[COLOR_BUFFER_SIZE];
+    snprintf(buf, COLOR_BUFFER_SIZE, "bg:%s", aep->ae_u.cterm.gui_bg);
+    add_line_attribute(ldata, buf, char_len);
+  }
+
+  ldata->prev_offset = ldata->offset;
+  ldata->offset += char_len;
+}
+
+static void add_line_attribute(LineData *ldata, char *name, size_t char_len)
+{
+  // Attributes are arrays, where each element specifies where the attribute
+  // should be applied in the line. Elements can have one of two types:
+  // - Integer: A line index
+  // - [start, end) array: A range of line indexes
+  Array attribute;
+  size_t idx;
+
+  // previous, current and next offsets
+  int cur_offset = (int)ldata->offset;
+  int prev_offset = (int)ldata->prev_offset;
+  int next_offset = cur_offset + char_len;
+
+  for (idx = 0; idx < ldata->attributes.size; idx++) {
+    String key = ldata->attributes.items[idx].key;
+    if (!STRNICMP(key.data, name, key.size)) {
+      break;
+    }
+  }
+
+  bool found = idx < ldata->attributes.size;
+
+  if (!found) {
+    attribute = (Array) {0, 0, 0};
+    // Add the current buffer offset
+    ADD(attribute, INTEGER_OBJ(cur_offset));
+    // and put the array into the attributes dictionary
+    PUT(ldata->attributes, name, ARRAY_OBJ(attribute));
+    return;
+  }
+
+  // attribute array
+  attribute = ldata->attributes.items[idx].value.data.array;
+  // last location where this attribute was applied
+  Object last_applied = attribute.items[attribute.size - 1];
+  // There are 3 possible cases:
+  if (last_applied.type == kObjectTypeInteger
+      && last_applied.data.integer == prev_offset) {
+    // The last location is the previous offset in the line buffer, so
+    // promote it to a range
+    last_applied.type = kObjectTypeArray;
+    last_applied.data.array = (Array){0, 0, 0};
+    ADD(last_applied.data.array, INTEGER_OBJ(prev_offset));
+    ADD(last_applied.data.array, INTEGER_OBJ(next_offset));
+
+    // update the attribute array with the range
+    attribute.items[attribute.size - 1] = last_applied;
+  } else if (last_applied.type == kObjectTypeArray
+      && last_applied.data.array.items[1].data.integer == cur_offset) {
+    // The last location is a range with the end boundary equal to the
+    // current offset, so all we need is increase the range by `char_len
+    last_applied.data.array.items[1].data.integer += char_len;
+    attribute.items[attribute.size - 1] = last_applied;
+  } else {
+    // In all other cases, the last location where the attribute was applied
+    // is not adjacent to the current location, so we need a new element in the
+    // attribute's array
+    ADD(attribute, INTEGER_OBJ(cur_offset));
+  }
+  // The attribute *items pointer might have changed by reallocs, to
+  // be safe we update the dictionary entry
+  ldata->attributes.items[idx].value.data.array = attribute;
+}
+
+static void add_line_section(LineData *ldata,
+                             const char *section_type,
+                             size_t section_width,
+                             Array *target)
+{
+  if (section_width) {
+    Dictionary section = {0, 0, 0};
+    PUT(section, "type", STRING_OBJ(cstr_to_string(section_type)));
+    char str[sizeof(ldata->buffer)];
+    xstrlcpy(str, ldata->buffer + ldata->offset, section_width);
+    PUT(section, "content", STRING_OBJ(cstr_to_string(str)));
+    ADD(*target, DICTIONARY_OBJ(section));
+  }
+
+  ldata->offset += section_width;
 }

--- a/src/nvim/api/private/redraw.h
+++ b/src/nvim/api/private/redraw.h
@@ -8,6 +8,10 @@
 #include "nvim/vim.h"
 #include "nvim/buffer_defs.h"
 
+typedef struct {
+  size_t colon, fold, sign, number, deleted, linebreak;
+} UpdateLineWidths;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/redraw.h.generated.h"
 #endif

--- a/src/nvim/api/private/redraw.h
+++ b/src/nvim/api/private/redraw.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 
 #include "nvim/api/private/defs.h"
+#include "nvim/vim.h"
+#include "nvim/buffer_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/redraw.h.generated.h"

--- a/src/nvim/api/private/redraw.h
+++ b/src/nvim/api/private/redraw.h
@@ -1,0 +1,13 @@
+#ifndef NVIM_API_PRIVATE_REDRAW_H
+#define NVIM_API_PRIVATE_REDRAW_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "nvim/api/private/defs.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/private/redraw.h.generated.h"
+#endif
+
+#endif  // NVIM_API_PRIVATE_REDRAW_H

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -103,6 +103,19 @@ String vim_replace_termcodes(String str, Boolean from_part, Boolean do_lt,
   return cstr_as_string(ptr);
 }
 
+String vim_command_output(String str, Error *err)
+{
+  do_cmdline_cmd((char_u *)"redir => v:command_output");
+  vim_command(str, err);
+  do_cmdline_cmd((char_u *)"redir END");
+
+  if (err->set) {
+    return (String) STRING_INIT;
+  }
+
+  return cstr_to_string((char *)get_vim_var_str(VV_COMMAND_OUTPUT));
+}
+
 /// Evaluates the expression str using the vim internal expression
 /// evaluator (see |expression|).
 /// Dictionaries and lists are recursively expanded.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -7,6 +7,7 @@
 #include "nvim/api/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/private/redraw.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/buffer.h"
 #include "nvim/os/channel.h"
@@ -515,6 +516,13 @@ void vim_register_provider(uint64_t channel_id, String method, Error *err)
   if (!provider_register(buf, channel_id)) {
     set_api_error("Provider already registered", err);
   }
+}
+
+/// Forces a complete redraw. This can be used by UI clients to get a full
+/// state of the screen when connecting through redraw:* events
+void vim_request_screen(uint64_t channel_id)
+{
+  redraw_layout(channel_id);
 }
 
 /// Writes a message to vim output or error buffer. The string is split

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -419,7 +419,8 @@ static struct vimvar {
   {VV_NAME("oldfiles",         VAR_LIST), 0},
   {VV_NAME("windowid",         VAR_NUMBER), VV_RO},
   {VV_NAME("progpath",         VAR_STRING), VV_RO},
-  {VV_NAME("job_data",         VAR_LIST), 0}
+  {VV_NAME("job_data",         VAR_LIST), 0},
+  {VV_NAME("command_output",   VAR_STRING), 0}
 };
 
 /* shorthand */

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -64,6 +64,7 @@ enum {
     VV_WINDOWID,
     VV_PROGPATH,
     VV_JOB_DATA,
+    VV_COMMAND_OUTPUT,
     VV_LEN, /* number of v: vars */
 };
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -451,6 +451,8 @@ EXTERN int highlight_attr[HLF_COUNT];       /* Highl. attr for each context. */
 EXTERN int highlight_user[9];                   /* User[1-9] attributes */
 EXTERN int highlight_stlnc[9];                  /* On top of user */
 #endif
+EXTERN char *cterm_normal_gui_fg INIT(= NULL);
+EXTERN char *cterm_normal_gui_bg INIT(= NULL);
 EXTERN int cterm_normal_fg_color INIT(= 0);
 EXTERN int cterm_normal_fg_bold INIT(= 0);
 EXTERN int cterm_normal_bg_color INIT(= 0);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -575,7 +575,6 @@ void update_screen(int type)
   if (!did_intro)
     maybe_intro_message();
   did_intro = TRUE;
-
 }
 
 /*
@@ -809,6 +808,7 @@ static void win_update(win_T *wp)
     wp->w_redr_type = 0;
     return;
   }
+  redraw_start(0);
   // Set a pointer to the window being updated
   current_window = wp;
   init_search_hl(wp);
@@ -1696,6 +1696,7 @@ static void win_update(win_T *wp)
     got_int = save_got_int;
 
   current_window = NULL;
+  redraw_end(0);
 }
 
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7882,6 +7882,9 @@ static void win_redr_ruler(win_T *wp, int always)
      */
     i = (int)STRLEN(buffer);
     get_rel_pos(wp, buffer + i + 1, RULER_BUF_LEN - i - 1);
+
+    redraw_ruler(0, wp, empty_line, (char *)buffer + i + 1);
+
     o = i + vim_strsize(buffer + i + 1);
     if (wp->w_status_height == 0)       /* can't use last char of screen */
       ++o;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -134,6 +134,7 @@
 #include "nvim/version.h"
 #include "nvim/window.h"
 
+static win_T *current_window = NULL;
 #define MB_FILLER_CHAR '<'  /* character used when a double-width character
                              * doesn't fit. */
 #define W_ENDCOL(wp)   (wp->w_wincol + wp->w_width)
@@ -806,7 +807,8 @@ static void win_update(win_T *wp)
     wp->w_redr_type = 0;
     return;
   }
-
+  // Set a pointer to the window being updated
+  current_window = wp;
   init_search_hl(wp);
 
   /* Force redraw when width of 'number' or 'relativenumber' column
@@ -1690,6 +1692,8 @@ static void win_update(win_T *wp)
   /* restore got_int, unless CTRL-C was hit while redrawing */
   if (!got_int)
     got_int = save_got_int;
+
+  current_window = NULL;
 }
 
 
@@ -7107,6 +7111,10 @@ screen_ins_lines (
       out_str(T_CE);
       screen_start();               /* don't know where cursor is now */
     }
+  }
+
+  if (current_window) {
+    redraw_insert_line(0, current_window, row, line_count);
   }
 
   return OK;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1781,6 +1781,11 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
                 c1, c2, hl_attr(hl));
   }
   set_empty_rows(wp, row);
+
+  if (current_window) {
+    // TODO(stefan991): handle higlight (parameter hl)
+    redraw_win_end(0, current_window, c1, c2, row, wp->w_height);
+  }
 }
 
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7297,6 +7297,9 @@ screen_del_lines (
     }
   }
 
+  if (current_window) {
+    redraw_delete_line(0, current_window, row, line_count);
+  }
 
   return OK;
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4820,6 +4820,8 @@ void win_redr_status(win_T *wp)
     return;
   busy = TRUE;
 
+  redraw_status(0, wp);
+
   wp->w_redr_status = FALSE;
   if (wp->w_status_height == 0) {
     /* no status line, can only be last window */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6370,6 +6370,8 @@ retry:
   screen_Rows = Rows;
   screen_Columns = Columns;
 
+  redraw_layout(0);
+
   must_redraw = CLEAR;          /* need to clear the screen later */
   if (doclear)
     screenclear2();

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -91,6 +91,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "nvim/api/private/redraw.h"
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/arabic.h"
@@ -7504,6 +7505,7 @@ static void draw_tabline(void)
                        );
 
   redraw_tabline = FALSE;
+  redraw_tabs(0);
 
 
   if (tabline_height() < 1)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6758,6 +6758,8 @@ void setcursor(void)
                                && vim_isprintc(gchar_cursor())) ? 2 :
                               1)) :
           curwin->w_wcol));
+
+    redraw_cursor(0);
   }
 }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "nvim/api/private/redraw.h"
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/syntax.h"
@@ -6533,6 +6534,7 @@ do_highlight (
 
           if (is_normal_group) {
             cterm_normal_gui_fg = (char *)HL_TABLE()[idx].sg_gui_fg_name;
+            redraw_foreground_color(0);
           }
         }
       } else if (STRCMP(key, "GUIBG") == 0)   {
@@ -6548,6 +6550,7 @@ do_highlight (
 
           if (is_normal_group) {
             cterm_normal_gui_bg = (char *)HL_TABLE()[idx].sg_gui_bg_name;
+            redraw_background_color(0);
           }
         }
       } else if (STRCMP(key, "GUISP") == 0)   {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6047,6 +6047,7 @@ int load_colors(char_u *name)
 
   recursive = FALSE;
 
+  redraw_layout(0);
   return retval;
 }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6044,10 +6044,10 @@ int load_colors(char_u *name)
   retval = source_runtime(buf, FALSE);
   free(buf);
   apply_autocmds(EVENT_COLORSCHEME, name, curbuf->b_fname, FALSE, curbuf);
+  redraw_layout(0);
 
   recursive = FALSE;
 
-  redraw_layout(0);
   return retval;
 }
 
@@ -6790,7 +6790,11 @@ static int get_attr_entry(garray_T *table, attrentry_T *aep)
                      && aep->ae_u.cterm.fg_color
                      == taep->ae_u.cterm.fg_color
                      && aep->ae_u.cterm.bg_color
-                     == taep->ae_u.cterm.bg_color)
+                     == taep->ae_u.cterm.bg_color
+                     && aep->ae_u.cterm.gui_fg
+                     == taep->ae_u.cterm.gui_fg
+                     && aep->ae_u.cterm.gui_bg
+                     == taep->ae_u.cterm.gui_bg)
                  ))
 
       return i + ATTR_OFF;

--- a/src/nvim/syntax_defs.h
+++ b/src/nvim/syntax_defs.h
@@ -79,6 +79,8 @@ typedef struct attr_entry {
       /* These colors need to be > 8 bits to hold 256. */
       uint16_t fg_color;                /* foreground color number */
       uint16_t bg_color;                /* background color number */
+      char *gui_fg;
+      char *gui_bg;
     } cterm;
   } ae_u;
 } attrentry_T;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 
 #include "nvim/api/private/handle.h"
+#include "nvim/api/private/redraw.h"
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/window.h"
@@ -903,6 +904,8 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     p_wiw = i;
   else
     p_wh = i;
+
+  redraw_layout(0);
 
   return OK;
 }
@@ -1901,6 +1904,7 @@ int win_close(win_T *win, int free_buf)
 
 
   redraw_all_later(NOT_VALID);
+  redraw_layout(0);
   return OK;
 }
 
@@ -3024,6 +3028,7 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_au
   firstwin = tp->tp_firstwin;
   lastwin = tp->tp_lastwin;
   topframe = tp->tp_topframe;
+  redraw_layout(0);
 
   /* We would like doing the TabEnter event first, but we don't have a
    * valid current window yet, which may break some commands.


### PR DESCRIPTION
After taking some beating by reading screen.c, I  finally started to understand of how it works. This PR will implement redraw events, which will enable the development of UIs and headless functional tests.

While vim uses a static font grid for layout, the data sent from the redraw events assumes little about how it will be displayed and should be very structured. For example, here's some data from the `redraw:tabs` event:

``` python
['redraw:tabs', [{'text': '[No Name]', 'selected': False, 'window_count': 4, 'id': 3, 'modified': False}, {'text': '[No Name]', 'selected': True, 'window_count': 5, 'id': 8, 'modified': False}, {'text': '[No Name]', 'selected': False, 'window_count': 5, 'id': 15, 'modified': True}]]
```

The idea is to follow the [presentation model](http://martinfowler.com/eaaDev/PresentationModel.html) pattern, allowing the UI to have as much flexibility as possible. With time we may even enable the allocation of additional "virtual screens" for fonts of different sizes.

The colons in event names is because we will have namespaced event listening, eg:

``` python
vim.subscribe('redraw:*')
```
