### PR TITLE
[RDY] Prevent null-pointer deference during vim_eval

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -57,6 +57,10 @@ Object vim_eval(String str, Error *err)
   typval_T *expr_result = eval_expr((char_u *)expr_str, NULL);
   free(expr_str);
 
+  if (!expr_result) {
+    set_api_error("Failed to eval expression", err);
+  }
+
   if (!try_end(err)) {
     // No errors, convert the result
     rv = vim_to_object(expr_result);


### PR DESCRIPTION
If the `eval_expr` call in `vim_eval` returns NULL, a null-pointer deference would happen a few frames down, in `vim_to_object_rec`

Unfortunately, I did not see an easy way to capture the actual error message from `eval_expr`.  Doing so could be a future TODO item.
