### PR TITLE
[RFC] Redefine `Map(T)` as a more generic `Map(T, U)` macro

### DIFF
--- a/src/nvim/api/private/handle.c
+++ b/src/nvim/api/private/handle.c
@@ -4,26 +4,26 @@
 #include "nvim/map.h"
 #include "nvim/api/private/handle.h"
 
-#define HANDLE_INIT(name) name##_handles = map_new(uint64_t)()
+#define HANDLE_INIT(name) name##_handles = pmap_new(uint64_t)()
 
 #define HANDLE_IMPL(type, name)                                               \
-  static Map(uint64_t) *name##_handles = NULL;                                \
+  static PMap(uint64_t) *name##_handles = NULL;                               \
                                                                               \
   type *handle_get_##name(uint64_t handle)                                    \
   {                                                                           \
-    return map_get(uint64_t)(name##_handles, handle);                         \
+    return pmap_get(uint64_t)(name##_handles, handle);                        \
   }                                                                           \
                                                                               \
   void handle_register_##name(type *name)                                     \
   {                                                                           \
     assert(!name->handle);                                                    \
     name->handle = next_handle++;                                             \
-    map_put(uint64_t)(name##_handles, name->handle, name);                    \
+    pmap_put(uint64_t)(name##_handles, name->handle, name);                   \
   }                                                                           \
                                                                               \
   void handle_unregister_##name(type *name)                                   \
   {                                                                           \
-    map_del(uint64_t)(name##_handles, name->handle);                          \
+    pmap_del(uint64_t)(name##_handles, name->handle);                         \
   }
 
 static uint64_t next_handle = 1;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -21,7 +21,7 @@
 /// @param obj The source object
 /// @param lookup Lookup table containing pointers to all processed objects
 /// @return The converted value
-static Object vim_to_object_rec(typval_T *obj, Map(ptr_t) *lookup);
+static Object vim_to_object_rec(typval_T *obj, PMap(ptr_t) *lookup);
 
 static bool object_to_vim(Object obj, typval_T *tv, Error *err);
 
@@ -278,10 +278,10 @@ Object vim_to_object(typval_T *obj)
 {
   Object rv;
   // We use a lookup table to break out of cyclic references
-  Map(ptr_t) *lookup = map_new(ptr_t)();
+  PMap(ptr_t) *lookup = pmap_new(ptr_t)();
   rv = vim_to_object_rec(obj, lookup);
   // Free the table
-  map_free(ptr_t)(lookup);
+  pmap_free(ptr_t)(lookup);
   return rv;
 }
 
@@ -422,18 +422,18 @@ static bool object_to_vim(Object obj, typval_T *tv, Error *err)
   return true;
 }
 
-static Object vim_to_object_rec(typval_T *obj, Map(ptr_t) *lookup)
+static Object vim_to_object_rec(typval_T *obj, PMap(ptr_t) *lookup)
 {
   Object rv = {.type = kObjectTypeNil};
 
   if (obj->v_type == VAR_LIST || obj->v_type == VAR_DICT) {
     // Container object, add it to the lookup table
-    if (map_has(ptr_t)(lookup, obj)) {
+    if (pmap_has(ptr_t)(lookup, obj)) {
       // It's already present, meaning we alredy processed it so just return
       // nil instead.
       return rv;
     }
-    map_put(ptr_t)(lookup, obj, NULL);
+    pmap_put(ptr_t)(lookup, obj, NULL);
   }
 
   switch (obj->v_type) {

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -5,30 +5,37 @@
 
 #include "nvim/map_defs.h"
 
-#define MAP_DECLS(T)                                                          \
-  KHASH_DECLARE(T##_map, T, void *)                                           \
+#define MAP_DECLS(T, U)                                                       \
+  KHASH_DECLARE(T##_##U##_map, T, U)                                          \
                                                                               \
   typedef struct {                                                            \
-    khash_t(T##_map) *table;                                                  \
-  } Map(T);                                                                   \
+    khash_t(T##_##U##_map) *table;                                            \
+  } Map(T, U);                                                                \
                                                                               \
-  Map(T) *map_##T##_new(void);                                                \
-  void map_##T##_free(Map(T) *map);                                           \
-  void *map_##T##_get(Map(T) *map, T key);                                    \
-  bool map_##T##_has(Map(T) *map, T key);                                     \
-  void* map_##T##_put(Map(T) *map, T key, void *value);                       \
-  void* map_##T##_del(Map(T) *map, T key);
+  Map(T, U) *map_##T##_##U##_new(void);                                       \
+  void map_##T##_##U##_free(Map(T, U) *map);                                  \
+  U map_##T##_##U##_get(Map(T, U) *map, T key);                               \
+  bool map_##T##_##U##_has(Map(T, U) *map, T key);                            \
+  U map_##T##_##U##_put(Map(T, U) *map, T key, U value);                      \
+  U map_##T##_##U##_del(Map(T, U) *map, T key);
 
-MAP_DECLS(cstr_t)
-MAP_DECLS(ptr_t)
-MAP_DECLS(uint64_t)
+MAP_DECLS(cstr_t, ptr_t)
+MAP_DECLS(ptr_t, ptr_t)
+MAP_DECLS(uint64_t, ptr_t)
 
-#define map_new(T) map_##T##_new
-#define map_free(T) map_##T##_free
-#define map_get(T) map_##T##_get
-#define map_has(T) map_##T##_has
-#define map_put(T) map_##T##_put
-#define map_del(T) map_##T##_del
+#define map_new(T, U) map_##T##_##U##_new
+#define map_free(T, U) map_##T##_##U##_free
+#define map_get(T, U) map_##T##_##U##_get
+#define map_has(T, U) map_##T##_##U##_has
+#define map_put(T, U) map_##T##_##U##_put
+#define map_del(T, U) map_##T##_##U##_del
+
+#define pmap_new(T) map_new(T, ptr_t)
+#define pmap_free(T) map_free(T, ptr_t)
+#define pmap_get(T) map_get(T, ptr_t)
+#define pmap_has(T) map_has(T, ptr_t)
+#define pmap_put(T) map_put(T, ptr_t)
+#define pmap_del(T) map_del(T, ptr_t)
 
 #define map_foreach(map, key, value, block) \
   kh_foreach(map->table, key, value, block)

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -7,8 +7,8 @@
 typedef const char * cstr_t;
 typedef void * ptr_t;
 
-#define Map(T) Map_##T
-
+#define Map(T, U) Map_##T##_##U
+#define PMap(T) Map(T, ptr_t)
 
 #endif  // NVIM_MAP_DEFS_H
 

--- a/src/nvim/os/server.c
+++ b/src/nvim/os/server.c
@@ -40,7 +40,7 @@ typedef struct {
   } socket;
 } Server;
 
-static Map(cstr_t) *servers = NULL;
+static PMap(cstr_t) *servers = NULL;
 
 static void connection_cb(uv_stream_t *server, int status);
 static void free_client(uv_handle_t *handle);
@@ -48,7 +48,7 @@ static void free_server(uv_handle_t *handle);
 
 void server_init()
 {
-  servers = map_new(cstr_t)();
+  servers = pmap_new(cstr_t)();
 
   if (!os_getenv("NEOVIM_LISTEN_ADDRESS")) {
     char *listen_address = (char *)vim_tempname('s');
@@ -88,7 +88,7 @@ void server_start(char *endpoint)
   }
 
   // Check if the server already exists
-  if (map_has(cstr_t)(servers, addr)) {
+  if (pmap_has(cstr_t)(servers, addr)) {
     EMSG2("Already listening on %s", addr);
     return;
   }
@@ -172,7 +172,7 @@ void server_start(char *endpoint)
   server->type = server_type;
 
   // Add the server to the hash table
-  map_put(cstr_t)(servers, addr, server);
+  pmap_put(cstr_t)(servers, addr, server);
 }
 
 void server_stop(char *endpoint)
@@ -183,7 +183,7 @@ void server_stop(char *endpoint)
   // Trim to `ADDRESS_MAX_SIZE`
   xstrlcpy(addr, endpoint, sizeof(addr));
 
-  if ((server = map_get(cstr_t)(servers, addr)) == NULL) {
+  if ((server = pmap_get(cstr_t)(servers, addr)) == NULL) {
     EMSG2("Not listening on %s", addr);
     return;
   }
@@ -194,7 +194,7 @@ void server_stop(char *endpoint)
     uv_close((uv_handle_t *)&server->socket.pipe.handle, free_server);
   }
 
-  map_del(cstr_t)(servers, addr);
+  pmap_del(cstr_t)(servers, addr);
 }
 
 static void connection_cb(uv_stream_t *server, int status)


### PR DESCRIPTION
The VMap(T, U) can receive the value type as argument, for cases where one to store scalar values
