### PR TITLE
[RFC] Make gendeclarations.lua more friendly to incremental builds

### DIFF
--- a/scripts/gendeclarations.lua
+++ b/scripts/gendeclarations.lua
@@ -227,6 +227,18 @@ F = io.open(static_fname, 'w')
 F:write(static)
 F:close()
 
+-- Before generating the non-static headers, check if the current file(if
+-- exists) is different from the new one. If they are the same, we won't touch
+-- the current version to avoid triggering an unnecessary rebuilds of modules
+-- that depend on this one
+F = io.open(non_static_fname, 'r')
+if F ~= nil then
+  if F:read('*a') == non_static then
+    os.exit(0)
+  end
+  io.close(F)
+end
+
 F = io.open(non_static_fname, 'w')
 F:write(non_static)
 F:close()


### PR DESCRIPTION
Modify gendeclarations.lua to check if the generated non-static declaration header changed before rewriting it with a new version. This is to prevent unnecessary rebuilds of modules that depend on the public interface of modules that suffered private changes.
