### PR TITLE
[RFC] system() prefer pipes over tmpfiles

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14037,88 +14037,68 @@ static void f_synstack(typval_T *argvars, typval_T *rettv)
   }
 }
 
-/*
- * "system()" function
- */
+#include "nvim/log.h"
+
+/// f_system - the VimL system() function
 static void f_system(typval_T *argvars, typval_T *rettv)
 {
-  char_u      *res = NULL;
-  char_u      *p;
-  char_u      *infile = NULL;
-  char_u buf[NUMBUFLEN];
-  int err = FALSE;
-  FILE        *fd;
-
-  if (check_restricted() || check_secure())
-    goto done;
-
-  if (argvars[1].v_type != VAR_UNKNOWN) {
-    /*
-     * Write the string to a temp file, to be used for input of the shell
-     * command.
-     */
-    if ((infile = vim_tempname('i')) == NULL) {
-      EMSG(_(e_notmp));
-      goto done;
-    }
-
-    fd = mch_fopen((char *)infile, WRITEBIN);
-    if (fd == NULL) {
-      EMSG2(_(e_notopen), infile);
-      goto done;
-    }
-    p = get_tv_string_buf_chk(&argvars[1], buf);
-    if (p == NULL) {
-      fclose(fd);
-      goto done;                /* type error; errmsg already given */
-    }
-    if (fwrite(p, STRLEN(p), 1, fd) != 1)
-      err = TRUE;
-    if (fclose(fd) != 0)
-      err = TRUE;
-    if (err) {
-      EMSG(_("E677: Error writing temp file"));
-      goto done;
-    }
+  if (check_restricted() || check_secure()) {
+    return;
   }
 
-  res = get_cmd_output(get_tv_string(&argvars[0]), infile,
-      kShellOptSilent | kShellOptCooked);
+  // get input to the shell command (if any), and its length
+  char_u buf[NUMBUFLEN];
+  const char *input = (argvars[1].v_type != VAR_UNKNOWN)
+      ? (char *) get_tv_string_buf_chk(&argvars[1], buf): NULL;
+  size_t input_len = input ? strlen(input) : 0;
+
+  // get shell command to execute
+  const char *cmd = (char *) get_tv_string(&argvars[0]);
+
+  DLOG("os_system -> %s, input: %s", cmd, input);
+
+  // execute the command
+  size_t nread = 0;
+  char *res = NULL;
+  int status = os_system(cmd, input, input_len, &res, &nread);
+
+  set_vim_var_nr(VV_SHELL_ERROR, (long) status);
+
+  if (res) {
+    DLOG("os_system <- %.*s\n", nread, res);
+  } else {
+    DLOG("os_system <- (null)");
+  }
 
 #ifdef USE_CR
-  /* translate <CR> into <NL> */
+  // translate <CR> into <NL>
   if (res != NULL) {
-    char_u  *s;
-
-    for (s = res; *s; ++s) {
-      if (*s == CAR)
+    for (char *s = res; *s; ++s) {
+      if (*s == CAR) {
         *s = NL;
+      }
     }
   }
 #else
 # ifdef USE_CRNL
-  /* translate <CR><NL> into <NL> */
+  // translate <CR><NL> into <NL>
   if (res != NULL) {
-    char_u  *s, *d;
-
-    d = res;
-    for (s = res; *s; ++s) {
-      if (s[0] == CAR && s[1] == NL)
+    char *d = res;
+    for (char *s = res; *s; ++s) {
+      if (s[0] == CAR && s[1] == NL) {
         ++s;
+      }
+
       *d++ = *s;
     }
+
     *d = NUL;
   }
 # endif
 #endif
 
-done:
-  if (infile != NULL) {
-    os_remove((char *)infile);
-    free(infile);
-  }
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = res;
+  rettv->vval.v_string = (char_u *) res;
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14037,8 +14037,6 @@ static void f_synstack(typval_T *argvars, typval_T *rettv)
   }
 }
 
-#include "nvim/log.h"
-
 /// f_system - the VimL system() function
 static void f_system(typval_T *argvars, typval_T *rettv)
 {
@@ -14055,20 +14053,12 @@ static void f_system(typval_T *argvars, typval_T *rettv)
   // get shell command to execute
   const char *cmd = (char *) get_tv_string(&argvars[0]);
 
-  DLOG("os_system -> %s, input: %s", cmd, input);
-
   // execute the command
   size_t nread = 0;
   char *res = NULL;
   int status = os_system(cmd, input, input_len, &res, &nread);
 
   set_vim_var_nr(VV_SHELL_ERROR, (long) status);
-
-  if (res) {
-    DLOG("os_system <- %.*s\n", nread, res);
-  } else {
-    DLOG("os_system <- (null)");
-  }
 
 #ifdef USE_CR
   // translate <CR> into <NL>

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -47,16 +47,13 @@ typedef struct {
 /// @param extra_shell_opt Extra argument to the shell. If NULL it is ignored
 /// @return A newly allocated argument vector. It must be freed with
 ///         `shell_free_argv` when no longer needed.
-char ** shell_build_argv(char_u *cmd, char_u *extra_shell_opt)
+char **shell_build_argv(const char_u *cmd, const char_u *extra_shell_opt)
 {
-  int i;
-  char **rv;
   int argc = tokenize(p_sh, NULL) + tokenize(p_shcf, NULL);
-
-  rv = (char **)xmalloc((unsigned)((argc + 4) * sizeof(char *)));
+  char **rv = xmalloc((unsigned)((argc + 4) * sizeof(char *)));
 
   // Split 'shell'
-  i = tokenize(p_sh, rv);
+  int i = tokenize(p_sh, rv);
 
   if (extra_shell_opt != NULL) {
     // Push a copy of `extra_shell_opt`
@@ -244,10 +241,10 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 /// @param argv The vector that will be filled with copies of the parsed
 ///        words. It can be NULL if the caller only needs to count words.
 /// @return The number of words parsed.
-static int tokenize(char_u *str, char **argv)
+static int tokenize(const char_u *str, char **argv)
 {
   int argc = 0, len;
-  char_u *p = str;
+  char_u *p = (char_u *) str;
 
   while (*p != NUL) {
     len = word_length(p);
@@ -271,9 +268,9 @@ static int tokenize(char_u *str, char **argv)
 ///
 /// @param str A pointer to the first character of the word
 /// @return The offset from `str` at which the word ends.
-static int word_length(char_u *str)
+static int word_length(const char_u *str)
 {
-  char_u *p = str;
+  const char_u *p = str;
   bool inquote = false;
   int length = 0;
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -507,8 +507,6 @@ typedef struct {
   scratch_buffer_t scratch[4];  // scratch buffers for libu
 } read_data_t;
 
-#include "nvim/log.h"
-
 static void run_write_cb(uv_write_t *req, int status)
 {
   write_data_t *wr = (write_data_t *) req;
@@ -558,7 +556,6 @@ static void run_alloc_cb(uv_handle_t *handle, size_t suggested, uv_buf_t *buf)
 
 static void run_read_cb(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
 {
-  DLOG("READ DONE, result: %zd, buflen: %zu", nread, buf->len);
   read_data_t *rd = (read_data_t *) stream;
 
   // handle possible errors (including failure to allocate)
@@ -706,7 +703,6 @@ int os_run_sync(char *const argv[],
     pd.exited = &exited;
     pd.status = 127;
 
-    DLOG("starting process, %s", options.args[0]);
     if (uv_spawn(loop, &pd.proc, &options)) {
       // failure, the program might not be executable
       if (!emsg_silent) {

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -31,11 +31,9 @@ typedef struct {
   garray_T ga;
 } ProcessData;
 
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/shell.c.generated.h"
 #endif
-
 
 // Callbacks for libuv
 
@@ -476,7 +474,8 @@ static void exit_cb(uv_process_t *proc, int64_t status, int term_signal)
 #define NELEMS(x) \
   ((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
 #define ROUNDUP32(x) \
-  (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+  (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, \
+  ++(x))
 
 typedef struct {
   uv_process_t proc;
@@ -504,8 +503,8 @@ typedef struct {
 typedef struct {
   uv_pipe_t pipe;
   int *exited;
-  dyn_buffer_t buf;            // buffer in which to assemble all the read data
-  scratch_buffer_t scratch[4]; // scratch buffers for libu
+  dyn_buffer_t buf;             // buffer in which to assemble the read data
+  scratch_buffer_t scratch[4];  // scratch buffers for libu
 } read_data_t;
 
 #include "nvim/log.h"
@@ -588,7 +587,7 @@ static void on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
   // grow the dynamic buffer if necessary
   // TODO(aktau): extract into an ensure() function
   if (rd->buf.cap < rd->buf.len + (size_t) nread) {
-    rd->buf.cap = rd->buf.len + (size_t) nread + 1; // 1 byte for NUL
+    rd->buf.cap = rd->buf.len + (size_t) nread + 1;  // 1 byte for NUL
     ROUNDUP32(rd->buf.cap);
     rd->buf.data = xrealloc(rd->buf.data, rd->buf.cap);
   }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -698,13 +698,13 @@ int os_run_sync(char *const argv[],
   State = EXTERNCMD;
 
   int expected_exits = 0;
-  bool success = true;
 
   // start the process
   process_data_t pd;
   {
     memset(&pd, 0, sizeof(pd));
     pd.exited = &exited;
+    pd.status = 127;
 
     DLOG("starting process, %s", options.args[0]);
     if (uv_spawn(loop, &pd.proc, &options)) {
@@ -715,7 +715,6 @@ int os_run_sync(char *const argv[],
         msg_putchar('\n');
       }
 
-      success = false;
       goto cleanup;
     }
     expected_exits++;


### PR DESCRIPTION
As mentioned by @tarruda, it's a bit nasty that `system()` has to use tempfiles, we can remove that. This is a proof of concept for that.

@Shougo, if you feel up for it, you can benchmark this branch to see if this gains us anything. I might have to turn off the debugging messages though, they might be slowing everything down (I suspect so).

ref #473
