### PR TITLE
[RDY] Remove USE_CR and tag_fgets.

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -50,9 +50,6 @@ static int diff_a_works = MAYBE;
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "diff.c.generated.h"
 #endif
-#ifndef USE_CR
-# define tag_fgets vim_fgets
-#endif  // ifndef USE_CR
 
 /// Called when deleting or unloading a buffer: No longer make a diff with it.
 ///
@@ -702,7 +699,7 @@ void ex_diffupdate(exarg_T *eap)
 
           for (;;) {
             // There must be a line that contains "1c1".
-            if (tag_fgets(linebuf, LBUFLEN, fd)) {
+            if (vim_fgets(linebuf, LBUFLEN, fd)) {
               break;
             }
 
@@ -1209,7 +1206,7 @@ static void diff_read(int idx_orig, int idx_new, char_u *fname)
   }
 
   for (;;) {
-    if (tag_fgets(linebuf, LBUFLEN, fd)) {
+    if (vim_fgets(linebuf, LBUFLEN, fd)) {
       // end of file
       break;
     }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14085,18 +14085,7 @@ static void f_system(typval_T *argvars, typval_T *rettv)
   res = get_cmd_output(get_tv_string(&argvars[0]), infile,
       kShellOptSilent | kShellOptCooked);
 
-#ifdef USE_CR
-  /* translate <CR> into <NL> */
-  if (res != NULL) {
-    char_u  *s;
-
-    for (s = res; *s; ++s) {
-      if (*s == CAR)
-        *s = NL;
-    }
-  }
-#else
-# ifdef USE_CRNL
+#ifdef USE_CRNL
   /* translate <CR><NL> into <NL> */
   if (res != NULL) {
     char_u  *s, *d;
@@ -14109,7 +14098,6 @@ static void f_system(typval_T *argvars, typval_T *rettv)
     }
     *d = NUL;
   }
-# endif
 #endif
 
 done:

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1992,9 +1992,6 @@ static void msg_puts_printf(char_u *str, int maxlen)
       p = &buf[0];
       if (*s == '\n' && !info_message)
         *p++ = '\r';
-#if defined(USE_CR) && !defined(MACOS_X_UNIX)
-      else
-#endif
       *p++ = *s;
       *p = '\0';
       if (info_message)         /* informative message, not an error */

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -39,15 +39,9 @@
 # define DFLT_FFS_VIM   "dos,unix"
 # define DFLT_FFS_VI    "dos,unix"      /* also autodetect in compatible mode */
 #else
-# ifdef USE_CR
-#  define DFLT_FF       "mac"
-#  define DFLT_FFS_VIM  "mac,unix,dos"
-#  define DFLT_FFS_VI   "mac,unix,dos"
-# else
 #  define DFLT_FF       "unix"
 #  define DFLT_FFS_VIM  "unix,dos"
 #   define DFLT_FFS_VI  ""
-# endif
 #endif
 
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -987,13 +987,6 @@ void do_tags(exarg_T *eap)
     MSG_PUTS("\n>");
 }
 
-/* When not using a CR for line separator, use vim_fgets() to read tag lines.
- * For the Mac use tag_fgets().  It can handle any line separator, but is much
- * slower than vim_fgets().
- */
-#ifndef USE_CR
-# define tag_fgets vim_fgets
-#endif
 
 
 /*
@@ -1355,7 +1348,7 @@ find_tags (
 #else
           fseek(fp, (long)search_info.curr_offset, SEEK_SET);
 #endif
-          eof = tag_fgets(lbuf, LSIZE, fp);
+          eof = vim_fgets(lbuf, LSIZE, fp);
           if (!eof && search_info.curr_offset != 0) {
             /* The explicit cast is to work around a bug in gcc 3.4.2
              * (repeated below). */
@@ -1369,12 +1362,12 @@ find_tags (
 #endif
               search_info.curr_offset = search_info.low_offset;
             }
-            eof = tag_fgets(lbuf, LSIZE, fp);
+            eof = vim_fgets(lbuf, LSIZE, fp);
           }
           /* skip empty and blank lines */
           while (!eof && vim_isblankline(lbuf)) {
             search_info.curr_offset = ftell(fp);
-            eof = tag_fgets(lbuf, LSIZE, fp);
+            eof = vim_fgets(lbuf, LSIZE, fp);
           }
           if (eof) {
             /* Hit end of file.  Skip backwards. */
@@ -1393,7 +1386,7 @@ find_tags (
             if (use_cscope)
               eof = cs_fgets(lbuf, LSIZE);
             else
-              eof = tag_fgets(lbuf, LSIZE, fp);
+              eof = vim_fgets(lbuf, LSIZE, fp);
           } while (!eof && vim_isblankline(lbuf));
 
           if (eof) {


### PR DESCRIPTION
These features are only used by legacy Mac OS.
