### PR TITLE
[RFC] Remove dead #ifdefed code

### DIFF
--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -8,14 +8,7 @@
 #ifndef NVIM_ASCII_H
 #define NVIM_ASCII_H
 
-/*
- * Definitions of various common control characters.
- * For EBCDIC we have to use different values.
- */
-
-
-/* IF_EB(ASCII_constant, EBCDIC_constant) */
-#define IF_EB(a, b)     a
+// Definitions of various common control characters.
 
 #define CharOrd(x)      ((x) < 'a' ? (x) - 'A' : (x) - 'a')
 #define CharOrdLow(x)   ((x) - 'a')

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -89,9 +89,6 @@ int buf_init_chartab(buf_T *buf, int global)
     // Set the default size for printable characters:
     // From <Space> to '~' is 1 (printable), others are 2 (not printable).
     // This also inits all 'isident' and 'isfname' flags to FALSE.
-    //
-    // EBCDIC: all chars below ' ' are not printable, all others are
-    // printable.
     c = 0;
 
     while (c < ' ') {
@@ -583,11 +580,8 @@ void transchar_nonprint(char_u *buf, int c)
     buf[2] = NUL;
   } else {
     // 0x80 - 0x9f and 0xff
-    // TODO: EBCDIC I don't know what to do with this chars, so I display
-    // them as '~?' for now
     buf[0] = '~';
     buf[1] = (c - 0x80) ^ 0x40;
-    // 0xff displayed as ~?
     buf[2] = NUL;
   }
 }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6072,8 +6072,8 @@ stuff_inserted (
     /* a trailing "0" is inserted as "<C-V>048", "^" as "<C-V>^" */
     if (last)
       stuffReadbuff((char_u *)(last == '0'
-                               ? IF_EB("\026\060\064\070", CTRL_V_STR "xf0")
-                               : IF_EB("\026^", CTRL_V_STR "^")));
+                               ? "\026\060\064\070"
+                               : "\026^"));
   } while (--count > 0);
 
   if (last)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9742,9 +9742,6 @@ static void f_has(typval_T *argvars, typval_T *rettv)
 #endif
     "tag_binary",
     "tag_old_static",
-#ifdef FEAT_TAG_ANYWHITE
-    "tag_any_white",
-#endif
 #ifdef TERMINFO
     "terminfo",
 #endif

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1933,7 +1933,7 @@ void viminfo_writestring(FILE *fd, char_u *p)
    * the string (e.g., variable name).  Add something to the length for the
    * '<', NL and trailing NUL. */
   if (len > LSIZE / 2)
-    fprintf(fd, IF_EB("\026%d\n<", CTRL_V_STR "%d\n<"), len + 3);
+    fprintf(fd, "\026%d\n<", len + 3);
 
   while ((c = *p++) != NUL) {
     if (c == Ctrl_V || c == '\n') {

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -409,7 +409,6 @@ vim_findfile_init (
      * The octet after a '**' is used as a (binary) counter.
      * So '**3' is transposed to '**^C' ('^C' is ASCII value 3)
      * or '**76' is transposed to '**N'( 'N' is ASCII value 76).
-     * For EBCDIC you get different character values.
      * If no restrict is given after '**' the default is used.
      * Due to this technique the path looks awful if you print it as a
      * string.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -7185,45 +7185,8 @@ match_file_pat (
 {
   regmatch_T regmatch;
   int result = FALSE;
-#ifdef FEAT_OSFILETYPE
-  int no_pattern = FALSE;           /* TRUE if check is filetype only */
-  char_u      *type_start;
-  char_u c;
-  int match = FALSE;
-#endif
 
   regmatch.rm_ic = p_fic;   /* ignore case if 'fileignorecase' is set */
-#ifdef FEAT_OSFILETYPE
-  if (*pattern == '<') {
-    /* There is a filetype condition specified with this pattern.
-     * Check the filetype matches first. If not, don't bother with the
-     * pattern (set regprog to NULL).
-     * Always use magic for the regexp.
-     */
-
-    for (type_start = pattern + 1; (c = *pattern); pattern++) {
-      if ((c == ';' || c == '>') && match == FALSE) {
-        *pattern = NUL;             /* Terminate the string */
-        /* TODO: match with 'filetype' of buffer that "fname" comes
-         * from. */
-        match = mch_check_filetype(fname, type_start);
-        *pattern = c;               /* Restore the terminator */
-        type_start = pattern + 1;
-      }
-      if (c == '>')
-        break;
-    }
-
-    /* (c should never be NUL, but check anyway) */
-    if (match == FALSE || c == NUL)
-      regmatch.regprog = NULL;          /* Doesn't match - don't check pat. */
-    else if (*pattern == NUL) {
-      regmatch.regprog = NULL;          /* Vim will try to free regprog later */
-      no_pattern = TRUE;        /* Always matches - don't check pat. */
-    } else
-      regmatch.regprog = vim_regcomp(pattern + 1, RE_MAGIC);
-  } else
-#endif
   {
     if (prog != NULL)
       regmatch.regprog = prog;
@@ -7238,12 +7201,6 @@ match_file_pat (
    * 3. the tail of the file name, when the pattern has no '/'.
    */
   if (
-#ifdef FEAT_OSFILETYPE
-    /* If the check is for a filetype only and we don't care
-     * about the path then skip all the regexp stuff.
-     */
-    no_pattern ||
-#endif
     (regmatch.regprog != NULL
      && ((allow_dirs
           && (vim_regexec(&regmatch, fname, (colnr_T)0)
@@ -7296,9 +7253,6 @@ int match_file_list(char_u *list, char_u *sfname, char_u *ffname)
  * allow_dirs, otherwise FALSE is put there -- webb.
  * Handle backslashes before special characters, like "\*" and "\ ".
  *
- * If FEAT_OSFILETYPE defined then pass initial <type> through unchanged. Eg:
- * '<html>myfile' becomes '<html>^myfile$' -- leonard.
- *
  * Returns NULL on failure.
  */
 char_u *
@@ -7316,38 +7270,13 @@ file_pat_to_reg_pat (
   int i;
   int nested = 0;
   int add_dollar = TRUE;
-#ifdef FEAT_OSFILETYPE
-  int check_length = 0;
-#endif
 
   if (allow_dirs != NULL)
     *allow_dirs = FALSE;
   if (pat_end == NULL)
     pat_end = pat + STRLEN(pat);
 
-#ifdef FEAT_OSFILETYPE
-  /* Find out how much of the string is the filetype check */
-  if (*pat == '<') {
-    /* Count chars until the next '>' */
-    for (p = pat + 1; p < pat_end && *p != '>'; p++)
-      ;
-    if (p < pat_end) {
-      /* Pattern is of the form <.*>.*  */
-      check_length = p - pat + 1;
-      if (p + 1 >= pat_end) {
-        /* The 'pattern' is a filetype check ONLY */
-        reg_pat = xmemdupz(pat, (size_t)check_length);
-        return reg_pat;
-      }
-    }
-    /* else: there was no closing '>' - assume it was a normal pattern */
-
-  }
-  pat += check_length;
-  size = 2 + (size_t)check_length;
-#else
   size = 2;             /* '^' at start, '$' at end */
-#endif
 
   for (p = pat; p < pat_end; p++) {
     switch (*p) {
@@ -7376,14 +7305,7 @@ file_pat_to_reg_pat (
   }
   reg_pat = xmalloc(size + 1);
 
-#ifdef FEAT_OSFILETYPE
-  /* Copy the type check in to the start. */
-  if (check_length)
-    memmove(reg_pat, pat - check_length, (size_t)check_length);
-  i = check_length;
-#else
   i = 0;
-#endif
 
   if (pat[0] == '*')
     while (pat[0] == '*' && pat < pat_end - 1)

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4076,7 +4076,7 @@ int put_escstr(FILE *fd, char_u *strstart, int what)
      */
     if (c == NL) {
       if (what == 2) {
-        if (fprintf(fd, IF_EB("\\\026\n", "\\" CTRL_V_STR "\n")) < 0)
+        if (fprintf(fd, "\\\026\n") < 0)
           return FAIL;
       } else {
         if (fprintf(fd, "<NL>") < 0)

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -543,9 +543,7 @@ AppendToRedobuffLit (
     /* Put a string of normal characters in the redo buffer (that's
      * faster). */
     start = s;
-    while (*s >= ' '
-           && *s < DEL          /* EBCDIC: all chars above space are normal */
-           && (len < 0 || s - str < len))
+    while (*s >= ' ' && *s < DEL && (len < 0 || s - str < len))
       ++s;
 
     /* Don't put '0' or '^' as last character, just in case a CTRL-D is
@@ -567,7 +565,7 @@ AppendToRedobuffLit (
     if (c < ' ' || c == DEL || (*s == NUL && (c == '0' || c == '^')))
       add_char_buff(&redobuff, Ctrl_V);
 
-    /* CTRL-V '0' must be inserted as CTRL-V 048 (EBCDIC: xf0) */
+    /* CTRL-V '0' must be inserted as CTRL-V 048 */
     if (*s == NUL && c == '0')
       add_buff(&redobuff, (char_u *)"048", 3L);
     else

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -2801,7 +2801,7 @@ void mch_print_end(prt_settings_T *psettings)
 
   /* Write CTRL-D to close serial communication link if used.
    * NOTHING MUST BE WRITTEN AFTER THIS! */
-  prt_write_file((char_u *)IF_EB("\004", "\067"));
+  prt_write_file((char_u *)"\004");
 
   if (!prt_file_error && psettings->outfile == NULL
       && !got_int && !psettings->user_abort) {
@@ -3031,16 +3031,16 @@ int mch_print_text_out(char_u *p, int len)
        * sequence, ensures PS sent over a serial line does not interfere
        * with the comms protocol.
        */
-      ga_append(&prt_ps_buffer, IF_EB('\\', 0134));
+      ga_append(&prt_ps_buffer, '\\');
       switch (ch) {
-      case BS:   ga_append(&prt_ps_buffer, IF_EB('b', 0142)); break;
-      case TAB:  ga_append(&prt_ps_buffer, IF_EB('t', 0164)); break;
-      case NL:   ga_append(&prt_ps_buffer, IF_EB('n', 0156)); break;
-      case FF:   ga_append(&prt_ps_buffer, IF_EB('f', 0146)); break;
-      case CAR:  ga_append(&prt_ps_buffer, IF_EB('r', 0162)); break;
-      case '(':  ga_append(&prt_ps_buffer, IF_EB('(', 0050)); break;
-      case ')':  ga_append(&prt_ps_buffer, IF_EB(')', 0051)); break;
-      case '\\': ga_append(&prt_ps_buffer, IF_EB('\\', 0134)); break;
+      case BS:   ga_append(&prt_ps_buffer, 'b'); break;
+      case TAB:  ga_append(&prt_ps_buffer, 't'); break;
+      case NL:   ga_append(&prt_ps_buffer, 'n'); break;
+      case FF:   ga_append(&prt_ps_buffer, 'f'); break;
+      case CAR:  ga_append(&prt_ps_buffer, 'r'); break;
+      case '(':  ga_append(&prt_ps_buffer, '('); break;
+      case ')':  ga_append(&prt_ps_buffer, ')'); break;
+      case '\\': ga_append(&prt_ps_buffer, '\\'); break;
 
       default:
         sprintf((char *)ch_buff, "%03o", (unsigned int)ch);

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -1502,9 +1502,7 @@ static void prt_flush_buffer(void)
       prt_write_real(prt_text_run, 2);
       prt_write_string("ul\n");
     }
-    /* Draw the text
-     * Note: we write text out raw - EBCDIC conversion is handled in the
-     * PostScript world via the font encoding vector. */
+    // Draw the text
     if (prt_out_mbyte)
       prt_write_string("<");
     else
@@ -3031,9 +3029,7 @@ int mch_print_text_out(char_u *p, int len)
     if (ch < 32 || ch == '(' || ch == ')' || ch == '\\') {
       /* Convert non-printing characters to either their escape or octal
        * sequence, ensures PS sent over a serial line does not interfere
-       * with the comms protocol.  Note: For EBCDIC we need to write out
-       * the escape sequences as ASCII codes!
-       * Note 2: Char codes < 32 are identical in EBCDIC and ASCII AFAIK!
+       * with the comms protocol.
        */
       ga_append(&prt_ps_buffer, IF_EB('\\', 0134));
       switch (ch) {

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -8,9 +8,6 @@
  * (a normal mark is a lnum/col pair, the same as a file position)
  */
 
-/* (Note: for EBCDIC there are more than 26, because there are gaps in the
- * alphabet coding.  To minimize changes to the code, I decided to just
- * increase the number of possible marks. */
 #define NMARKS          ('z' - 'a' + 1) /* max. # of named marks */
 #define JUMPLISTSIZE    100             /* max. # of marks in jump list */
 #define TAGSTACKSIZE    20              /* max. # of tags in tag stack */

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1185,21 +1185,7 @@ static char_u *menu_text(char_u *str, int *mnemonic, char_u **actext)
       if (p[1] == NUL)              /* trailing "&" */
         break;
       if (mnemonic != NULL && p[1] != '&')
-#if !defined(__MVS__) || defined(MOTIF390_MNEMONIC_FIXED)
         *mnemonic = p[1];
-#else
-      {
-        /*
-         * Well there is a bug in the Motif libraries on OS390 Unix.
-         * The mnemonic keys needs to be converted to ASCII values
-         * first.
-         * This behavior has been seen in 2.8 and 2.9.
-         */
-        char c = p[1];
-        __etoa_l(&c, 1);
-        *mnemonic = c;
-      }
-#endif
       STRMOVE(p, p + 1);
       p = p + 1;
     }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1147,10 +1147,7 @@ static void stuffescaped(char_u *arg, int literally)
      * stuff K_SPECIAL to get the effect of a special key when "literally"
      * is TRUE. */
     start = arg;
-    while ((*arg >= ' '
-            && *arg < DEL         /* EBCDIC: chars above space are normal */
-            )
-           || (*arg == K_SPECIAL && !literally))
+    while ((*arg >= ' ' && *arg < DEL) || (*arg == K_SPECIAL && !literally))
       ++arg;
     if (arg > start)
       stuffReadbuffLen(start, (long)(arg - start));

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1995,7 +1995,7 @@ void set_init_1(void)
     }
   }
 
-#if defined(MSWIN) || defined(EBCDIC) || defined(MAC)
+#if defined(MSWIN) || defined(MAC)
   /* Set print encoding on platforms that don't default to latin1 */
   set_string_default("penc",
       (char_u *)"hp-roman8"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1933,26 +1933,15 @@ void set_init_1(void)
    */
   opt_idx = findoption((char_u *)"maxmemtot");
   if (opt_idx >= 0) {
-#ifndef HAVE_TOTAL_MEM
-    if (options[opt_idx].def_val[VI_DEFAULT] == (char_u *)0L)
-#endif
     {
-#ifdef HAVE_TOTAL_MEM
       /* Use half of amount of memory available to Vim. */
       /* If too much to fit in long_u, get long_u max */
       uint64_t available_kib = os_get_total_mem_kib();
       n = available_kib / 2 > ULONG_MAX ? ULONG_MAX
                                         : (long_u)(available_kib /2);
-#else
-      n = (0x7fffffff >> 11);
-#endif
       options[opt_idx].def_val[VI_DEFAULT] = (char_u *)n;
       opt_idx = findoption((char_u *)"maxmem");
       if (opt_idx >= 0) {
-#ifndef HAVE_TOTAL_MEM
-        if ((long)options[opt_idx].def_val[VI_DEFAULT] > (long)n
-            || (long)options[opt_idx].def_val[VI_DEFAULT] == 0L)
-#endif
         options[opt_idx].def_val[VI_DEFAULT] = (char_u *)n;
       }
     }

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -16,15 +16,6 @@
  * changed beyond recognition.
  */
 
-/*
- * Some systems have a prototype for select() that has (int *) instead of
- * (fd_set *), which is wrong. This define removes that prototype. We define
- * our own prototype below.
- * Don't use it for the Mac, it causes a warning for precompiled headers.
- * TODO: use a configure check for precompiled headers?
- */
-# define select select_declared_wrong
-
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -753,16 +753,16 @@ void mch_setmouse(int on)
   if (ttym_flags == TTYM_URXVT) {
     out_str_nf((char_u *)
         (on
-         ? IF_EB("\033[?1015h", ESC_STR "[?1015h")
-         : IF_EB("\033[?1015l", ESC_STR "[?1015l")));
+         ? "\033[?1015h"
+         : "\033[?1015l"));
     ison = on;
   }
 
   if (ttym_flags == TTYM_SGR) {
     out_str_nf((char_u *)
         (on
-         ? IF_EB("\033[?1006h", ESC_STR "[?1006h")
-         : IF_EB("\033[?1006l", ESC_STR "[?1006l")));
+         ? "\033[?1006h"
+         : "\033[?1006l"));
     ison = on;
   }
 
@@ -770,13 +770,13 @@ void mch_setmouse(int on)
     if (on)     /* enable mouse events, use mouse tracking if available */
       out_str_nf((char_u *)
           (xterm_mouse_vers > 1
-           ? IF_EB("\033[?1002h", ESC_STR "[?1002h")
-           : IF_EB("\033[?1000h", ESC_STR "[?1000h")));
+           ? "\033[?1002h"
+           : "\033[?1000h"));
     else        /* disable mouse events, could probably always send the same */
       out_str_nf((char_u *)
           (xterm_mouse_vers > 1
-           ? IF_EB("\033[?1002l", ESC_STR "[?1002l")
-           : IF_EB("\033[?1000l", ESC_STR "[?1000l")));
+           ? "\033[?1002l"
+           : "\033[?1000l"));
     ison = on;
   } else if (ttym_flags == TTYM_DEC) {
     if (on)     /* enable mouse events */
@@ -797,8 +797,8 @@ void check_mouse_termcode(void)
       && use_xterm_mouse() != 3
       ) {
     set_mouse_termcode(KS_MOUSE, (char_u *)(term_is_8bit(T_NAME)
-                                            ? IF_EB("\233M", CSI_STR "M")
-                                            : IF_EB("\033[M", ESC_STR "[M")));
+                                            ? "\233M"
+                                            : "\033[M"));
     if (*p_mouse != NUL) {
       /* force mouse off and maybe on to send possibly new mouse
        * activation sequence to the xterm, with(out) drag tracing. */
@@ -814,7 +814,7 @@ void check_mouse_termcode(void)
   if (!use_xterm_mouse()
       )
     set_mouse_termcode(KS_NETTERM_MOUSE,
-        (char_u *)IF_EB("\033}", ESC_STR "}"));
+        (char_u *)"\033}");
   else
     del_mouse_termcode(KS_NETTERM_MOUSE);
 
@@ -822,17 +822,15 @@ void check_mouse_termcode(void)
   if (!use_xterm_mouse()
       )
     set_mouse_termcode(KS_DEC_MOUSE, (char_u *)(term_is_8bit(T_NAME)
-                                                ? IF_EB("\233",
-                                                    CSI_STR) : IF_EB("\033[",
-                                                    ESC_STR "[")));
+                                                ? "\233" : "\033["));
   else
     del_mouse_termcode(KS_DEC_MOUSE);
   /* same as the dec mouse */
   if (use_xterm_mouse() == 3
       ) {
     set_mouse_termcode(KS_URXVT_MOUSE, (char_u *)(term_is_8bit(T_NAME)
-                                                  ? IF_EB("\233", CSI_STR)
-                                                  : IF_EB("\033[", ESC_STR "[")));
+                                                  ? "\233"
+                                                  : "\033["));
 
     if (*p_mouse != NUL) {
       mch_setmouse(FALSE);
@@ -844,8 +842,8 @@ void check_mouse_termcode(void)
   if (use_xterm_mouse() == 4
       ) {
     set_mouse_termcode(KS_SGR_MOUSE, (char_u *)(term_is_8bit(T_NAME)
-                                                ? IF_EB("\233<", CSI_STR "<")
-                                                : IF_EB("\033[<", ESC_STR "[<")));
+                                                ? "\233<"
+                                                : "\033[<"));
 
     if (*p_mouse != NUL) {
       mch_setmouse(FALSE);

--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -24,10 +24,6 @@
 # include <unistd.h>
 #endif
 
-#ifdef HAVE_LIBC_H
-# include <libc.h>                  /* for NeXT */
-#endif
-
 #ifdef HAVE_SYS_PARAM_H
 # include <sys/param.h>     /* defines BSD, if it's a BSD system */
 #endif

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1225,10 +1225,8 @@ addfile (
   /*
    * Append a slash or backslash after directory names if none is present.
    */
-#ifndef DONT_ADD_PATHSEP_TO_DIR
   if (isdir && (flags & EW_ADDSLASH))
     add_pathsep(p);
-#endif
   GA_APPEND(char_u *, gap, p);
 }
 #endif /* !NO_EXPANDPATH */

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1256,12 +1256,6 @@ static regprog_T *bt_regcomp(char_u *expr, int re_flags)
   if (reg(REG_NOPAREN, &flags) == NULL)
     return NULL;
 
-  /* Small enough for pointer-storage convention? */
-#ifdef SMALL_MALLOC             /* 16 bit storage allocation */
-  if (regsize >= 65536L - 256L)
-    EMSG_RET_NULL(_("E339: Pattern too long"));
-#endif
-
   /* Allocate space. */
   bt_regprog_T *r = xmalloc(sizeof(bt_regprog_T) + regsize);
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -8009,7 +8009,6 @@ static void init_spellfile(void)
 }
 
 // Init the chartab used for spelling for ASCII.
-// EBCDIC is not supported!
 static void clear_spell_chartab(spelltab_T *sp)
 {
   int i;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1516,13 +1516,8 @@ parse_line:
         if (orgpat.headlen
             ) {
           tagp.tagname = lbuf;
-#ifdef FEAT_TAG_ANYWHITE
-          tagp.tagname_end = skiptowhite(lbuf);
-          if (*tagp.tagname_end == NUL)
-#else
           tagp.tagname_end = vim_strchr(lbuf, TAB);
           if (tagp.tagname_end == NULL)
-#endif
           {
             if (vim_strchr(lbuf, NL) == NULL) {
               /* Truncated line, ignore it.  Has been reported for
@@ -1557,17 +1552,9 @@ parse_line:
           for (p = lbuf; p < tagp.tagname_end; ++p) {
             if (*p == ':') {
               if (tagp.fname == NULL)
-#ifdef FEAT_TAG_ANYWHITE
-                tagp.fname = skipwhite(tagp.tagname_end);
-#else
                 tagp.fname = tagp.tagname_end + 1;
-#endif
               if (       fnamencmp(lbuf, tagp.fname, p - lbuf) == 0
-#ifdef FEAT_TAG_ANYWHITE
-                         && vim_iswhite(tagp.fname[p - lbuf])
-#else
                          && tagp.fname[p - lbuf] == TAB
-#endif
                          ) {
                 /* found one */
                 tagp.tagname = p + 1;
@@ -1675,20 +1662,10 @@ parse_line:
            * Can be a matching tag, isolate the file name and command.
            */
           if (tagp.fname == NULL)
-#ifdef FEAT_TAG_ANYWHITE
-            tagp.fname = skipwhite(tagp.tagname_end);
-#else
             tagp.fname = tagp.tagname_end + 1;
-#endif
-#ifdef FEAT_TAG_ANYWHITE
-          tagp.fname_end = skiptowhite(tagp.fname);
-          tagp.command = skipwhite(tagp.fname_end);
-          if (*tagp.command == NUL)
-#else
           tagp.fname_end = vim_strchr(tagp.fname, TAB);
           tagp.command = tagp.fname_end + 1;
           if (tagp.fname_end == NULL)
-#endif
             i = FAIL;
           else
             i = OK;
@@ -2152,39 +2129,23 @@ parse_tag_line (
 
   /* Isolate the tagname, from lbuf up to the first white */
   tagp->tagname = lbuf;
-#ifdef FEAT_TAG_ANYWHITE
-  p = skiptowhite(lbuf);
-#else
   p = vim_strchr(lbuf, TAB);
   if (p == NULL)
     return FAIL;
-#endif
   tagp->tagname_end = p;
 
   /* Isolate file name, from first to second white space */
-#ifdef FEAT_TAG_ANYWHITE
-  p = skipwhite(p);
-#else
   if (*p != NUL)
     ++p;
-#endif
   tagp->fname = p;
-#ifdef FEAT_TAG_ANYWHITE
-  p = skiptowhite(p);
-#else
   p = vim_strchr(p, TAB);
   if (p == NULL)
     return FAIL;
-#endif
   tagp->fname_end = p;
 
   /* find start of search command, after second white space */
-#ifdef FEAT_TAG_ANYWHITE
-  p = skipwhite(p);
-#else
   if (*p != NUL)
     ++p;
-#endif
   if (*p == NUL)
     return FAIL;
   tagp->command = p;

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -309,9 +309,6 @@ static struct builtin_term builtin_termcaps[] =
 #  else
   {(int)KS_CRI,       "\033[%dC"},
 #  endif
-#if defined(BEOS_DR8)
-  {(int)KS_DB,        ""},              /* hack! see screen.c */
-#endif
 
   {K_UP,              "\033[A"},
   {K_DOWN,            "\033[B"},

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -265,13 +265,6 @@ static struct builtin_term builtin_termcaps[] =
 #  else
   {(int)KS_CDL,       "\033[%dM"},
 #  endif
-#ifdef BEOS_PR_OR_BETTER
-#  ifdef TERMINFO
-  {(int)KS_CS,        "\033[%i%p1%d;%p2%dr"},
-#  else
-  {(int)KS_CS,        "\033[%i%d;%dr"},         /* scroll region */
-#  endif
-#endif
   {(int)KS_CL,        "\033[H\033[2J"},
 #ifdef notyet
   {(int)KS_VI,        "[VI]"},   /* cursor invisible, VT320: CSI ? 25 l */

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -314,34 +314,34 @@ static struct builtin_term builtin_termcaps[] =
    * standard ANSI terminal, default for unix
    */
   {(int)KS_NAME,      "ansi"},
-  {(int)KS_CE,        IF_EB("\033[K", ESC_STR "[K")},
-  {(int)KS_AL,        IF_EB("\033[L", ESC_STR "[L")},
+  {(int)KS_CE,        "\033[K"},
+  {(int)KS_AL,        "\033[L"},
 #  ifdef TERMINFO
-  {(int)KS_CAL,       IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
+  {(int)KS_CAL,       "\033[%p1%dL"},
 #  else
-  {(int)KS_CAL,       IF_EB("\033[%dL", ESC_STR "[%dL")},
+  {(int)KS_CAL,       "\033[%dL"},
 #  endif
-  {(int)KS_DL,        IF_EB("\033[M", ESC_STR "[M")},
+  {(int)KS_DL,        "\033[M"},
 #  ifdef TERMINFO
-  {(int)KS_CDL,       IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
+  {(int)KS_CDL,       "\033[%p1%dM"},
 #  else
-  {(int)KS_CDL,       IF_EB("\033[%dM", ESC_STR "[%dM")},
+  {(int)KS_CDL,       "\033[%dM"},
 #  endif
-  {(int)KS_CL,        IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
-  {(int)KS_ME,        IF_EB("\033[0m", ESC_STR "[0m")},
-  {(int)KS_MR,        IF_EB("\033[7m", ESC_STR "[7m")},
+  {(int)KS_CL,        "\033[H\033[2J"},
+  {(int)KS_ME,        "\033[0m"},
+  {(int)KS_MR,        "\033[7m"},
   {(int)KS_MS,        "y"},
   {(int)KS_UT,        "y"},             /* guessed */
   {(int)KS_LE,        "\b"},
 #  ifdef TERMINFO
-  {(int)KS_CM,        IF_EB("\033[%i%p1%d;%p2%dH", ESC_STR "[%i%p1%d;%p2%dH")},
+  {(int)KS_CM,        "\033[%i%p1%d;%p2%dH"},
 #  else
-  {(int)KS_CM,        IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
+  {(int)KS_CM,        "\033[%i%d;%dH"},
 #  endif
 #  ifdef TERMINFO
-  {(int)KS_CRI,       IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
+  {(int)KS_CRI,       "\033[%p1%dC"},
 #  else
-  {(int)KS_CRI,       IF_EB("\033[%dC", ESC_STR "[%dC")},
+  {(int)KS_CRI,       "\033[%dC"},
 #  endif
 # endif
 
@@ -556,83 +556,82 @@ static struct builtin_term builtin_termcaps[] =
    *      - keyboard languages (CSI ? 26 n)
    */
   {(int)KS_NAME,      "vt320"},
-  {(int)KS_CE,        IF_EB("\033[K", ESC_STR "[K")},
-  {(int)KS_AL,        IF_EB("\033[L", ESC_STR "[L")},
+  {(int)KS_CE,        "\033[K"},
+  {(int)KS_AL,        "\033[L"},
 #  ifdef TERMINFO
-  {(int)KS_CAL,       IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
+  {(int)KS_CAL,       "\033[%p1%dL"},
 #  else
-  {(int)KS_CAL,       IF_EB("\033[%dL", ESC_STR "[%dL")},
+  {(int)KS_CAL,       "\033[%dL"},
 #  endif
-  {(int)KS_DL,        IF_EB("\033[M", ESC_STR "[M")},
+  {(int)KS_DL,        "\033[M"},
 #  ifdef TERMINFO
-  {(int)KS_CDL,       IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
+  {(int)KS_CDL,       "\033[%p1%dM"},
 #  else
-  {(int)KS_CDL,       IF_EB("\033[%dM", ESC_STR "[%dM")},
+  {(int)KS_CDL,       "\033[%dM"},
 #  endif
-  {(int)KS_CL,        IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
-  {(int)KS_CD,        IF_EB("\033[J", ESC_STR "[J")},
+  {(int)KS_CL,        "\033[H\033[2J"},
+  {(int)KS_CD,        "\033[J"},
   {(int)KS_CCO,       "8"},                     /* allow 8 colors */
-  {(int)KS_ME,        IF_EB("\033[0m", ESC_STR "[0m")},
-  {(int)KS_MR,        IF_EB("\033[7m", ESC_STR "[7m")},
-  {(int)KS_MD,        IF_EB("\033[1m", ESC_STR "[1m")},    /* bold mode */
-  {(int)KS_SE,        IF_EB("\033[22m", ESC_STR "[22m")},  /* normal mode */
-  {(int)KS_UE,        IF_EB("\033[24m", ESC_STR "[24m")},  /* exit underscore mode */
-  {(int)KS_US,        IF_EB("\033[4m", ESC_STR "[4m")},    /* underscore mode */
-  {(int)KS_CZH,       IF_EB("\033[34;43m", ESC_STR "[34;43m")},    /* italic mode: blue text on yellow */
-  {(int)KS_CZR,       IF_EB("\033[0m", ESC_STR "[0m")},             /* italic mode end */
-  {(int)KS_CAB,       IF_EB("\033[4%dm", ESC_STR "[4%dm")},         /* set background color (ANSI) */
-  {(int)KS_CAF,       IF_EB("\033[3%dm", ESC_STR "[3%dm")},         /* set foreground color (ANSI) */
-  {(int)KS_CSB,       IF_EB("\033[102;%dm", ESC_STR "[102;%dm")},       /* set screen background color */
-  {(int)KS_CSF,       IF_EB("\033[101;%dm", ESC_STR "[101;%dm")},       /* set screen foreground color */
+  {(int)KS_ME,        "\033[0m"},
+  {(int)KS_MR,        "\033[7m"},
+  {(int)KS_MD,        "\033[1m"},    /* bold mode */
+  {(int)KS_SE,        "\033[22m"},  /* normal mode */
+  {(int)KS_UE,        "\033[24m"},  /* exit underscore mode */
+  {(int)KS_US,        "\033[4m"},    /* underscore mode */
+  {(int)KS_CZH,       "\033[34;43m"},    /* italic mode: blue text on yellow */
+  {(int)KS_CZR,       "\033[0m"},             /* italic mode end */
+  {(int)KS_CAB,       "\033[4%dm"},         /* set background color (ANSI) */
+  {(int)KS_CAF,       "\033[3%dm"},         /* set foreground color (ANSI) */
+  {(int)KS_CSB,       "\033[102;%dm"},       /* set screen background color */
+  {(int)KS_CSF,       "\033[101;%dm"},       /* set screen foreground color */
   {(int)KS_MS,        "y"},
   {(int)KS_UT,        "y"},
   {(int)KS_LE,        "\b"},
 #  ifdef TERMINFO
-  {(int)KS_CM,        IF_EB("\033[%i%p1%d;%p2%dH",
-       ESC_STR "[%i%p1%d;%p2%dH")},
+  {(int)KS_CM,        "\033[%i%p1%d;%p2%dH"},
 #  else
-  {(int)KS_CM,        IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
+  {(int)KS_CM,        "\033[%i%d;%dH"},
 #  endif
 #  ifdef TERMINFO
-  {(int)KS_CRI,       IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
+  {(int)KS_CRI,       "\033[%p1%dC"},
 #  else
-  {(int)KS_CRI,       IF_EB("\033[%dC", ESC_STR "[%dC")},
+  {(int)KS_CRI,       "\033[%dC"},
 #  endif
-  {K_UP,              IF_EB("\033[A", ESC_STR "[A")},
-  {K_DOWN,            IF_EB("\033[B", ESC_STR "[B")},
-  {K_RIGHT,           IF_EB("\033[C", ESC_STR "[C")},
-  {K_LEFT,            IF_EB("\033[D", ESC_STR "[D")},
-  {K_F1,              IF_EB("\033[11~", ESC_STR "[11~")},
-  {K_F2,              IF_EB("\033[12~", ESC_STR "[12~")},
-  {K_F3,              IF_EB("\033[13~", ESC_STR "[13~")},
-  {K_F4,              IF_EB("\033[14~", ESC_STR "[14~")},
-  {K_F5,              IF_EB("\033[15~", ESC_STR "[15~")},
-  {K_F6,              IF_EB("\033[17~", ESC_STR "[17~")},
-  {K_F7,              IF_EB("\033[18~", ESC_STR "[18~")},
-  {K_F8,              IF_EB("\033[19~", ESC_STR "[19~")},
-  {K_F9,              IF_EB("\033[20~", ESC_STR "[20~")},
-  {K_F10,             IF_EB("\033[21~", ESC_STR "[21~")},
-  {K_F11,             IF_EB("\033[23~", ESC_STR "[23~")},
-  {K_F12,             IF_EB("\033[24~", ESC_STR "[24~")},
-  {K_F13,             IF_EB("\033[25~", ESC_STR "[25~")},
-  {K_F14,             IF_EB("\033[26~", ESC_STR "[26~")},
-  {K_F15,             IF_EB("\033[28~", ESC_STR "[28~")},       /* Help */
-  {K_F16,             IF_EB("\033[29~", ESC_STR "[29~")},       /* Select */
-  {K_F17,             IF_EB("\033[31~", ESC_STR "[31~")},
-  {K_F18,             IF_EB("\033[32~", ESC_STR "[32~")},
-  {K_F19,             IF_EB("\033[33~", ESC_STR "[33~")},
-  {K_F20,             IF_EB("\033[34~", ESC_STR "[34~")},
-  {K_INS,             IF_EB("\033[2~", ESC_STR "[2~")},
-  {K_DEL,             IF_EB("\033[3~", ESC_STR "[3~")},
-  {K_HOME,            IF_EB("\033[1~", ESC_STR "[1~")},
-  {K_END,             IF_EB("\033[4~", ESC_STR "[4~")},
-  {K_PAGEUP,          IF_EB("\033[5~", ESC_STR "[5~")},
-  {K_PAGEDOWN,        IF_EB("\033[6~", ESC_STR "[6~")},
-  {K_KPLUS,           IF_EB("\033Ok", ESC_STR "Ok")},   /* keypad plus */
-  {K_KMINUS,          IF_EB("\033Om", ESC_STR "Om")},   /* keypad minus */
-  {K_KDIVIDE,         IF_EB("\033Oo", ESC_STR "Oo")},   /* keypad / */
-  {K_KMULTIPLY,       IF_EB("\033Oj", ESC_STR "Oj")},   /* keypad * */
-  {K_KENTER,          IF_EB("\033OM", ESC_STR "OM")},   /* keypad Enter */
+  {K_UP,              "\033[A"},
+  {K_DOWN,            "\033[B"},
+  {K_RIGHT,           "\033[C"},
+  {K_LEFT,            "\033[D"},
+  {K_F1,              "\033[11~"},
+  {K_F2,              "\033[12~"},
+  {K_F3,              "\033[13~"},
+  {K_F4,              "\033[14~"},
+  {K_F5,              "\033[15~"},
+  {K_F6,              "\033[17~"},
+  {K_F7,              "\033[18~"},
+  {K_F8,              "\033[19~"},
+  {K_F9,              "\033[20~"},
+  {K_F10,             "\033[21~"},
+  {K_F11,             "\033[23~"},
+  {K_F12,             "\033[24~"},
+  {K_F13,             "\033[25~"},
+  {K_F14,             "\033[26~"},
+  {K_F15,             "\033[28~"},       /* Help */
+  {K_F16,             "\033[29~"},       /* Select */
+  {K_F17,             "\033[31~"},
+  {K_F18,             "\033[32~"},
+  {K_F19,             "\033[33~"},
+  {K_F20,             "\033[34~"},
+  {K_INS,             "\033[2~"},
+  {K_DEL,             "\033[3~"},
+  {K_HOME,            "\033[1~"},
+  {K_END,             "\033[4~"},
+  {K_PAGEUP,          "\033[5~"},
+  {K_PAGEDOWN,        "\033[6~"},
+  {K_KPLUS,           "\033Ok"},   /* keypad plus */
+  {K_KMINUS,          "\033Om"},   /* keypad minus */
+  {K_KDIVIDE,         "\033Oo"},   /* keypad / */
+  {K_KMULTIPLY,       "\033Oj"},   /* keypad * */
+  {K_KENTER,          "\033OM"},   /* keypad Enter */
   {K_BS,              "\x7f"},          /* for some reason 0177 doesn't work */
 # endif
 
@@ -641,160 +640,156 @@ static struct builtin_term builtin_termcaps[] =
    * Ordinary vt52
    */
   {(int)KS_NAME,      "vt52"},
-  {(int)KS_CE,        IF_EB("\033K", ESC_STR "K")},
-  {(int)KS_CD,        IF_EB("\033J", ESC_STR "J")},
-  {(int)KS_CM,        IF_EB("\033Y%+ %+ ", ESC_STR "Y%+ %+ ")},
+  {(int)KS_CE,        "\033K"},
+  {(int)KS_CD,        "\033J"},
+  {(int)KS_CM,        "\033Y%+ %+ "},
   {(int)KS_LE,        "\b"},
-  {(int)KS_AL,        IF_EB("\033T", ESC_STR "T")},
-  {(int)KS_DL,        IF_EB("\033U", ESC_STR "U")},
-  {(int)KS_CL,        IF_EB("\033H\033J", ESC_STR "H" ESC_STR_nc "J")},
-  {(int)KS_ME,        IF_EB("\033SO", ESC_STR "SO")},
-  {(int)KS_MR,        IF_EB("\033S2", ESC_STR "S2")},
+  {(int)KS_AL,        "\033T"},
+  {(int)KS_DL,        "\033U"},
+  {(int)KS_CL,        "\033H\033J"},
+  {(int)KS_ME,        "\033SO"},
+  {(int)KS_MR,        "\033S2"},
   {(int)KS_MS,        "y"},
 # endif
 
 # if defined(UNIX) || defined(ALL_BUILTIN_TCAPS) || defined(SOME_BUILTIN_TCAPS)
   {(int)KS_NAME,      "xterm"},
-  {(int)KS_CE,        IF_EB("\033[K", ESC_STR "[K")},
-  {(int)KS_AL,        IF_EB("\033[L", ESC_STR "[L")},
+  {(int)KS_CE,        "\033[K"},
+  {(int)KS_AL,        "\033[L"},
 #  ifdef TERMINFO
-  {(int)KS_CAL,       IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
+  {(int)KS_CAL,       "\033[%p1%dL"},
 #  else
-  {(int)KS_CAL,       IF_EB("\033[%dL", ESC_STR "[%dL")},
+  {(int)KS_CAL,       "\033[%dL"},
 #  endif
-  {(int)KS_DL,        IF_EB("\033[M", ESC_STR "[M")},
+  {(int)KS_DL,        "\033[M"},
 #  ifdef TERMINFO
-  {(int)KS_CDL,       IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
+  {(int)KS_CDL,       "\033[%p1%dM"},
 #  else
-  {(int)KS_CDL,       IF_EB("\033[%dM", ESC_STR "[%dM")},
+  {(int)KS_CDL,       "\033[%dM"},
 #  endif
 #  ifdef TERMINFO
-  {(int)KS_CS,        IF_EB("\033[%i%p1%d;%p2%dr",
-       ESC_STR "[%i%p1%d;%p2%dr")},
+  {(int)KS_CS,        "\033[%i%p1%d;%p2%dr"},
 #  else
-  {(int)KS_CS,        IF_EB("\033[%i%d;%dr", ESC_STR "[%i%d;%dr")},
+  {(int)KS_CS,        "\033[%i%d;%dr"},
 #  endif
-  {(int)KS_CL,        IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
-  {(int)KS_CD,        IF_EB("\033[J", ESC_STR "[J")},
-  {(int)KS_ME,        IF_EB("\033[m", ESC_STR "[m")},
-  {(int)KS_MR,        IF_EB("\033[7m", ESC_STR "[7m")},
-  {(int)KS_MD,        IF_EB("\033[1m", ESC_STR "[1m")},
-  {(int)KS_UE,        IF_EB("\033[m", ESC_STR "[m")},
-  {(int)KS_US,        IF_EB("\033[4m", ESC_STR "[4m")},
+  {(int)KS_CL,        "\033[H\033[2J"},
+  {(int)KS_CD,        "\033[J"},
+  {(int)KS_ME,        "\033[m"},
+  {(int)KS_MR,        "\033[7m"},
+  {(int)KS_MD,        "\033[1m"},
+  {(int)KS_UE,        "\033[m"},
+  {(int)KS_US,        "\033[4m"},
   {(int)KS_MS,        "y"},
   {(int)KS_UT,        "y"},
   {(int)KS_LE,        "\b"},
 #  ifdef TERMINFO
-  {(int)KS_CM,        IF_EB("\033[%i%p1%d;%p2%dH",
-       ESC_STR "[%i%p1%d;%p2%dH")},
+  {(int)KS_CM,        "\033[%i%p1%d;%p2%dH"},
 #  else
-  {(int)KS_CM,        IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
+  {(int)KS_CM,        "\033[%i%d;%dH"},
 #  endif
-  {(int)KS_SR,        IF_EB("\033M", ESC_STR "M")},
+  {(int)KS_SR,        "\033M"},
 #  ifdef TERMINFO
-  {(int)KS_CRI,       IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
+  {(int)KS_CRI,       "\033[%p1%dC"},
 #  else
-  {(int)KS_CRI,       IF_EB("\033[%dC", ESC_STR "[%dC")},
+  {(int)KS_CRI,       "\033[%dC"},
 #  endif
-  {(int)KS_KS,        IF_EB("\033[?1h\033=", ESC_STR "[?1h" ESC_STR_nc "=")},
-  {(int)KS_KE,        IF_EB("\033[?1l\033>", ESC_STR "[?1l" ESC_STR_nc ">")},
-  {(int)KS_CIS,       IF_EB("\033]1;", ESC_STR "]1;")},
+  {(int)KS_KS,        "\033[?1h\033="},
+  {(int)KS_KE,        "\033[?1l\033>"},
+  {(int)KS_CIS,       "\033]1;"},
   {(int)KS_CIE,       "\007"},
-  {(int)KS_TS,        IF_EB("\033]2;", ESC_STR "]2;")},
+  {(int)KS_TS,        "\033]2;"},
   {(int)KS_FS,        "\007"},
 #  ifdef TERMINFO
-  {(int)KS_CWS,       IF_EB("\033[8;%p1%d;%p2%dt",
-       ESC_STR "[8;%p1%d;%p2%dt")},
-  {(int)KS_CWP,       IF_EB("\033[3;%p1%d;%p2%dt",
-       ESC_STR "[3;%p1%d;%p2%dt")},
+  {(int)KS_CWS,       "\033[8;%p1%d;%p2%dt"},
+  {(int)KS_CWP,       "\033[3;%p1%d;%p2%dt"},
 #  else
-  {(int)KS_CWS,       IF_EB("\033[8;%d;%dt", ESC_STR "[8;%d;%dt")},
-  {(int)KS_CWP,       IF_EB("\033[3;%d;%dt", ESC_STR "[3;%d;%dt")},
+  {(int)KS_CWS,       "\033[8;%d;%dt"},
+  {(int)KS_CWP,       "\033[3;%d;%dt"},
 #  endif
-  {(int)KS_CRV,       IF_EB("\033[>c", ESC_STR "[>c")},
-  {(int)KS_U7,        IF_EB("\033[6n", ESC_STR "[6n")},
+  {(int)KS_CRV,       "\033[>c"},
+  {(int)KS_U7,        "\033[6n"},
 
-  {K_UP,              IF_EB("\033O*A", ESC_STR "O*A")},
-  {K_DOWN,            IF_EB("\033O*B", ESC_STR "O*B")},
-  {K_RIGHT,           IF_EB("\033O*C", ESC_STR "O*C")},
-  {K_LEFT,            IF_EB("\033O*D", ESC_STR "O*D")},
+  {K_UP,              "\033O*A"},
+  {K_DOWN,            "\033O*B"},
+  {K_RIGHT,           "\033O*C"},
+  {K_LEFT,            "\033O*D"},
   /* An extra set of cursor keys for vt100 mode */
-  {K_XUP,             IF_EB("\033[1;*A", ESC_STR "[1;*A")},
-  {K_XDOWN,           IF_EB("\033[1;*B", ESC_STR "[1;*B")},
-  {K_XRIGHT,          IF_EB("\033[1;*C", ESC_STR "[1;*C")},
-  {K_XLEFT,           IF_EB("\033[1;*D", ESC_STR "[1;*D")},
+  {K_XUP,             "\033[1;*A"},
+  {K_XDOWN,           "\033[1;*B"},
+  {K_XRIGHT,          "\033[1;*C"},
+  {K_XLEFT,           "\033[1;*D"},
   /* An extra set of function keys for vt100 mode */
-  {K_XF1,             IF_EB("\033O*P", ESC_STR "O*P")},
-  {K_XF2,             IF_EB("\033O*Q", ESC_STR "O*Q")},
-  {K_XF3,             IF_EB("\033O*R", ESC_STR "O*R")},
-  {K_XF4,             IF_EB("\033O*S", ESC_STR "O*S")},
-  {K_F1,              IF_EB("\033[11;*~", ESC_STR "[11;*~")},
-  {K_F2,              IF_EB("\033[12;*~", ESC_STR "[12;*~")},
-  {K_F3,              IF_EB("\033[13;*~", ESC_STR "[13;*~")},
-  {K_F4,              IF_EB("\033[14;*~", ESC_STR "[14;*~")},
-  {K_F5,              IF_EB("\033[15;*~", ESC_STR "[15;*~")},
-  {K_F6,              IF_EB("\033[17;*~", ESC_STR "[17;*~")},
-  {K_F7,              IF_EB("\033[18;*~", ESC_STR "[18;*~")},
-  {K_F8,              IF_EB("\033[19;*~", ESC_STR "[19;*~")},
-  {K_F9,              IF_EB("\033[20;*~", ESC_STR "[20;*~")},
-  {K_F10,             IF_EB("\033[21;*~", ESC_STR "[21;*~")},
-  {K_F11,             IF_EB("\033[23;*~", ESC_STR "[23;*~")},
-  {K_F12,             IF_EB("\033[24;*~", ESC_STR "[24;*~")},
-  {K_S_TAB,           IF_EB("\033[Z", ESC_STR "[Z")},
-  {K_HELP,            IF_EB("\033[28;*~", ESC_STR "[28;*~")},
-  {K_UNDO,            IF_EB("\033[26;*~", ESC_STR "[26;*~")},
-  {K_INS,             IF_EB("\033[2;*~", ESC_STR "[2;*~")},
-  {K_HOME,            IF_EB("\033[1;*H", ESC_STR "[1;*H")},
-  /* {K_S_HOME,		IF_EB("\033O2H", ESC_STR "O2H")}, */
-  /* {K_C_HOME,		IF_EB("\033O5H", ESC_STR "O5H")}, */
-  {K_KHOME,           IF_EB("\033[1;*~", ESC_STR "[1;*~")},
-  {K_XHOME,           IF_EB("\033O*H", ESC_STR "O*H")},         /* other Home */
-  {K_ZHOME,           IF_EB("\033[7;*~", ESC_STR "[7;*~")},     /* other Home */
-  {K_END,             IF_EB("\033[1;*F", ESC_STR "[1;*F")},
-  /* {K_S_END,		IF_EB("\033O2F", ESC_STR "O2F")}, */
-  /* {K_C_END,		IF_EB("\033O5F", ESC_STR "O5F")}, */
-  {K_KEND,            IF_EB("\033[4;*~", ESC_STR "[4;*~")},
-  {K_XEND,            IF_EB("\033O*F", ESC_STR "O*F")},         /* other End */
-  {K_ZEND,            IF_EB("\033[8;*~", ESC_STR "[8;*~")},
-  {K_PAGEUP,          IF_EB("\033[5;*~", ESC_STR "[5;*~")},
-  {K_PAGEDOWN,        IF_EB("\033[6;*~", ESC_STR "[6;*~")},
-  {K_KPLUS,           IF_EB("\033O*k", ESC_STR "O*k")},         /* keypad plus */
-  {K_KMINUS,          IF_EB("\033O*m", ESC_STR "O*m")},         /* keypad minus */
-  {K_KDIVIDE,         IF_EB("\033O*o", ESC_STR "O*o")},         /* keypad / */
-  {K_KMULTIPLY,       IF_EB("\033O*j", ESC_STR "O*j")},         /* keypad * */
-  {K_KENTER,          IF_EB("\033O*M", ESC_STR "O*M")},         /* keypad Enter */
-  {K_KPOINT,          IF_EB("\033O*n", ESC_STR "O*n")},         /* keypad . */
-  {K_KDEL,            IF_EB("\033[3;*~", ESC_STR "[3;*~")},     /* keypad Del */
+  {K_XF1,             "\033O*P"},
+  {K_XF2,             "\033O*Q"},
+  {K_XF3,             "\033O*R"},
+  {K_XF4,             "\033O*S"},
+  {K_F1,              "\033[11;*~"},
+  {K_F2,              "\033[12;*~"},
+  {K_F3,              "\033[13;*~"},
+  {K_F4,              "\033[14;*~"},
+  {K_F5,              "\033[15;*~"},
+  {K_F6,              "\033[17;*~"},
+  {K_F7,              "\033[18;*~"},
+  {K_F8,              "\033[19;*~"},
+  {K_F9,              "\033[20;*~"},
+  {K_F10,             "\033[21;*~"},
+  {K_F11,             "\033[23;*~"},
+  {K_F12,             "\033[24;*~"},
+  {K_S_TAB,           "\033[Z"},
+  {K_HELP,            "\033[28;*~"},
+  {K_UNDO,            "\033[26;*~"},
+  {K_INS,             "\033[2;*~"},
+  {K_HOME,            "\033[1;*H"},
+  /* {K_S_HOME,		"\033O2H"}, */
+  /* {K_C_HOME,		"\033O5H"}, */
+  {K_KHOME,           "\033[1;*~"},
+  {K_XHOME,           "\033O*H"},         /* other Home */
+  {K_ZHOME,           "\033[7;*~"},     /* other Home */
+  {K_END,             "\033[1;*F"},
+  /* {K_S_END,		"\033O2F"}, */
+  /* {K_C_END,		"\033O5F"}, */
+  {K_KEND,            "\033[4;*~"},
+  {K_XEND,            "\033O*F"},         /* other End */
+  {K_ZEND,            "\033[8;*~"},
+  {K_PAGEUP,          "\033[5;*~"},
+  {K_PAGEDOWN,        "\033[6;*~"},
+  {K_KPLUS,           "\033O*k"},         /* keypad plus */
+  {K_KMINUS,          "\033O*m"},         /* keypad minus */
+  {K_KDIVIDE,         "\033O*o"},         /* keypad / */
+  {K_KMULTIPLY,       "\033O*j"},         /* keypad * */
+  {K_KENTER,          "\033O*M"},         /* keypad Enter */
+  {K_KPOINT,          "\033O*n"},         /* keypad . */
+  {K_KDEL,            "\033[3;*~"},     /* keypad Del */
 
   {BT_EXTRA_KEYS,   ""},
-  {TERMCAP2KEY('k', '0'), IF_EB("\033[10;*~", ESC_STR "[10;*~")},   /* F0 */
-  {TERMCAP2KEY('F', '3'), IF_EB("\033[25;*~", ESC_STR "[25;*~")},   /* F13 */
+  {TERMCAP2KEY('k', '0'), "\033[10;*~"},   /* F0 */
+  {TERMCAP2KEY('F', '3'), "\033[25;*~"},   /* F13 */
   /* F14 and F15 are missing, because they send the same codes as the undo
    * and help key, although they don't work on all keyboards. */
-  {TERMCAP2KEY('F', '6'), IF_EB("\033[29;*~", ESC_STR "[29;*~")},   /* F16 */
-  {TERMCAP2KEY('F', '7'), IF_EB("\033[31;*~", ESC_STR "[31;*~")},   /* F17 */
-  {TERMCAP2KEY('F', '8'), IF_EB("\033[32;*~", ESC_STR "[32;*~")},   /* F18 */
-  {TERMCAP2KEY('F', '9'), IF_EB("\033[33;*~", ESC_STR "[33;*~")},   /* F19 */
-  {TERMCAP2KEY('F', 'A'), IF_EB("\033[34;*~", ESC_STR "[34;*~")},   /* F20 */
+  {TERMCAP2KEY('F', '6'), "\033[29;*~"},   /* F16 */
+  {TERMCAP2KEY('F', '7'), "\033[31;*~"},   /* F17 */
+  {TERMCAP2KEY('F', '8'), "\033[32;*~"},   /* F18 */
+  {TERMCAP2KEY('F', '9'), "\033[33;*~"},   /* F19 */
+  {TERMCAP2KEY('F', 'A'), "\033[34;*~"},   /* F20 */
 
-  {TERMCAP2KEY('F', 'B'), IF_EB("\033[42;*~", ESC_STR "[42;*~")},   /* F21 */
-  {TERMCAP2KEY('F', 'C'), IF_EB("\033[43;*~", ESC_STR "[43;*~")},   /* F22 */
-  {TERMCAP2KEY('F', 'D'), IF_EB("\033[44;*~", ESC_STR "[44;*~")},   /* F23 */
-  {TERMCAP2KEY('F', 'E'), IF_EB("\033[45;*~", ESC_STR "[45;*~")},   /* F24 */
-  {TERMCAP2KEY('F', 'F'), IF_EB("\033[46;*~", ESC_STR "[46;*~")},   /* F25 */
-  {TERMCAP2KEY('F', 'G'), IF_EB("\033[47;*~", ESC_STR "[47;*~")},   /* F26 */
-  {TERMCAP2KEY('F', 'H'), IF_EB("\033[48;*~", ESC_STR "[48;*~")},   /* F27 */
-  {TERMCAP2KEY('F', 'I'), IF_EB("\033[49;*~", ESC_STR "[49;*~")},   /* F28 */
-  {TERMCAP2KEY('F', 'J'), IF_EB("\033[50;*~", ESC_STR "[50;*~")},   /* F29 */
-  {TERMCAP2KEY('F', 'K'), IF_EB("\033[51;*~", ESC_STR "[51;*~")},   /* F30 */
+  {TERMCAP2KEY('F', 'B'), "\033[42;*~"},   /* F21 */
+  {TERMCAP2KEY('F', 'C'), "\033[43;*~"},   /* F22 */
+  {TERMCAP2KEY('F', 'D'), "\033[44;*~"},   /* F23 */
+  {TERMCAP2KEY('F', 'E'), "\033[45;*~"},   /* F24 */
+  {TERMCAP2KEY('F', 'F'), "\033[46;*~"},   /* F25 */
+  {TERMCAP2KEY('F', 'G'), "\033[47;*~"},   /* F26 */
+  {TERMCAP2KEY('F', 'H'), "\033[48;*~"},   /* F27 */
+  {TERMCAP2KEY('F', 'I'), "\033[49;*~"},   /* F28 */
+  {TERMCAP2KEY('F', 'J'), "\033[50;*~"},   /* F29 */
+  {TERMCAP2KEY('F', 'K'), "\033[51;*~"},   /* F30 */
 
-  {TERMCAP2KEY('F', 'L'), IF_EB("\033[52;*~", ESC_STR "[52;*~")},   /* F31 */
-  {TERMCAP2KEY('F', 'M'), IF_EB("\033[53;*~", ESC_STR "[53;*~")},   /* F32 */
-  {TERMCAP2KEY('F', 'N'), IF_EB("\033[54;*~", ESC_STR "[54;*~")},   /* F33 */
-  {TERMCAP2KEY('F', 'O'), IF_EB("\033[55;*~", ESC_STR "[55;*~")},   /* F34 */
-  {TERMCAP2KEY('F', 'P'), IF_EB("\033[56;*~", ESC_STR "[56;*~")},   /* F35 */
-  {TERMCAP2KEY('F', 'Q'), IF_EB("\033[57;*~", ESC_STR "[57;*~")},   /* F36 */
-  {TERMCAP2KEY('F', 'R'), IF_EB("\033[58;*~", ESC_STR "[58;*~")},   /* F37 */
+  {TERMCAP2KEY('F', 'L'), "\033[52;*~"},   /* F31 */
+  {TERMCAP2KEY('F', 'M'), "\033[53;*~"},   /* F32 */
+  {TERMCAP2KEY('F', 'N'), "\033[54;*~"},   /* F33 */
+  {TERMCAP2KEY('F', 'O'), "\033[55;*~"},   /* F34 */
+  {TERMCAP2KEY('F', 'P'), "\033[56;*~"},   /* F35 */
+  {TERMCAP2KEY('F', 'Q'), "\033[57;*~"},   /* F36 */
+  {TERMCAP2KEY('F', 'R'), "\033[58;*~"},   /* F37 */
 # endif
 
 # if defined(UNIX) || defined(ALL_BUILTIN_TCAPS)
@@ -1090,10 +1085,9 @@ static struct builtin_term builtin_termcaps[] =
   {(int)KS_NAME,      "dumb"},
   {(int)KS_CL,        "\014"},
 #ifdef TERMINFO
-  {(int)KS_CM,        IF_EB("\033[%i%p1%d;%p2%dH",
-       ESC_STR "[%i%p1%d;%p2%dH")},
+  {(int)KS_CM,        "\033[%i%p1%d;%p2%dH"},
 #else
-  {(int)KS_CM,        IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
+  {(int)KS_CM,        "\033[%i%d;%dH"},
 #endif
 
   /*
@@ -2154,7 +2148,7 @@ static void term_color(char_u *s, int n)
 #endif
     sprintf(buf,
         fmt,
-        i == 2 ? IF_EB("\033[", ESC_STR "[") : "\233",
+        i == 2 ? "\033[" : "\233",
         s[i] == '3' ? (n >= 16 ? "38;5;" : "9")
         : (n >= 16 ? "48;5;" : "10"));
     OUT_STR(tgoto(buf, 0, n >= 16 ? n : n - 8));

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -61,11 +61,7 @@ static char *(features[]) = {
   "+conceal",
   "+cscope",
   "+cursorbind",
-#ifdef CURSOR_SHAPE
   "+cursorshape",
-#else  // ifdef CURSOR_SHAPE
-  "-cursorshape",
-#endif  // ifdef CURSOR_SHAPE
   "+dialog_con",
   "+diff",
   "+digraphs",

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -141,11 +141,7 @@ static char *(features[]) = {
   "+syntax",
   "+tag_binary",
   "+tag_old_static",
-#ifdef FEAT_TAG_ANYWHITE
-  "+tag_any_white",
-#else  // ifdef FEAT_TAG_ANYWHITE
   "-tag_any_white",
-#endif  // ifdef FEAT_TAG_ANYWHITE
 #if defined(UNIX)
 
   // only Unix can have terminfo instead of termcap


### PR DESCRIPTION
I made a simple [analyzer](https://gist.github.com/Hinidu/2a75fd1caca953435914) to find symbols which are tested in `#ifdef`s but are not defined explicitly.
Now I want to go through [the resulting list](http://sprunge.us/RQKf) step by step and remove dead code related to legacy systems and other stuff which we will not use in the future.
Inspired by #808
