### PR TITLE
[RFC] Add optional third tab character in "listchars"

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4691,11 +4691,25 @@ A jump table for the options with a short description can be found at |Q_op|.
 			omitted, there is no extra character at the end of the
 			line.
 	  						*lcs-tab*
-	  tab:xy	Two characters to be used to show a tab.  The first
-			char is used once.  The second char is repeated to
-			fill the space that the tab normally occupies.
+	  tab:xy[z]	Two or three characters to be used to show a tab.
+			The third character is optional.
+
+			If the tab is at least two characters wide then:
+			 - the first character is used once at the beginning
+			 - the second character is repeated to fill the tab
+			 - if the third character is specified, it is used
+			   once at the end
+
+			If the tab is one character wide then:
+			 - if the third character is specified, then
+			   the third character is used
+			 - if the third character is not specified, then
+			   the first character is used
+
 			"tab:>-" will show a tab that takes four spaces as
-			">---".  When omitted, a tab is show as ^I.
+			">---".  "tab:<->" will show a tab as that takes
+			four spaces as "<-->".  When omitted, a tab is shown
+			as ^I.
 	  						*lcs-trail*
 	  trail:c	Character to show for trailing spaces.  When omitted,
 			trailing spaces are blank.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1017,6 +1017,7 @@ EXTERN int lcs_prec INIT(= NUL);
 EXTERN int lcs_nbsp INIT(= NUL);
 EXTERN int lcs_tab1 INIT(= NUL);
 EXTERN int lcs_tab2 INIT(= NUL);
+EXTERN int lcs_tab3 INIT(= NUL);
 EXTERN int lcs_trail INIT(= NUL);
 EXTERN int lcs_conceal INIT(= '-');
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1368,6 +1368,7 @@ void msg_prt_line(char_u *s, int list)
   int col = 0;
   int n_extra = 0;
   int c_extra = 0;
+  int c_final = 0;
   char_u      *p_extra = NULL;              /* init to make SASC shut up */
   int n;
   int attr = 0;
@@ -1393,7 +1394,9 @@ void msg_prt_line(char_u *s, int list)
   while (!got_int) {
     if (n_extra > 0) {
       --n_extra;
-      if (c_extra)
+      if (n_extra == 0 && c_final)
+        c = c_final;
+      else if (c_extra)
         c = c_extra;
       else
         c = *p_extra++;
@@ -1418,9 +1421,11 @@ void msg_prt_line(char_u *s, int list)
         if (!list) {
           c = ' ';
           c_extra = ' ';
+          c_final = NUL;
         } else {
-          c = lcs_tab1;
+          c = (n_extra == 0 && lcs_tab3) ? lcs_tab3 : lcs_tab1;
           c_extra = lcs_tab2;
+          c_final = lcs_tab3;
           attr = hl_attr(HLF_8);
         }
       } else if (c == 160 && list && lcs_nbsp != NUL) {
@@ -1429,6 +1434,7 @@ void msg_prt_line(char_u *s, int list)
       } else if (c == NUL && list && lcs_eol != NUL) {
         p_extra = (char_u *)"";
         c_extra = NUL;
+        c_final = NUL;
         n_extra = 1;
         c = lcs_eol;
         attr = hl_attr(HLF_AT);
@@ -1437,6 +1443,7 @@ void msg_prt_line(char_u *s, int list)
         n_extra = n - 1;
         p_extra = transchar_byte(c);
         c_extra = NUL;
+        c_final = NUL;
         c = *p_extra++;
         /* Use special coloring to be able to distinguish <hex> from
          * the same in plain text. */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4712,7 +4712,7 @@ static char_u *set_chars_option(char_u **varp)
 {
   int round, i, len, entries;
   char_u      *p, *s;
-  int c1, c2 = 0;
+  int c1 = 0, c2 = 0, c3 = 0;
   struct charstab {
     int     *cp;
     char    *name;
@@ -4754,7 +4754,7 @@ static char_u *set_chars_option(char_u **varp)
         if (tab[i].cp != NULL)
           *(tab[i].cp) = (varp == &p_lcs ? NUL : ' ');
       if (varp == &p_lcs)
-        lcs_tab1 = NUL;
+        lcs_tab1 = lcs_tab3 = NUL;
       else
         fill_diff = '-';
     }
@@ -4775,12 +4775,20 @@ static char_u *set_chars_option(char_u **varp)
             c2 = mb_ptr2char_adv(&s);
             if (mb_char2cells(c2) > 1)
               continue;
+            if (!(*s == ',' || *s == NUL)) {
+              c3 = mb_ptr2char_adv(&s);
+              if (mb_char2cells(c3) > 1)
+                continue;
+            } else {
+              c3 = NUL;
+            }
           }
           if (*s == ',' || *s == NUL) {
             if (round) {
               if (tab[i].cp == &lcs_tab2) {
                 lcs_tab1 = c1;
                 lcs_tab2 = c2;
+                lcs_tab3 = c3;
               } else if (tab[i].cp != NULL)
                 *(tab[i].cp) = c1;
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2190,6 +2190,7 @@ win_line (
   char_u      *p_extra = NULL;          /* string of extra chars, plus NUL */
   char_u      *p_extra_free = NULL;     /* p_extra needs to be freed */
   int c_extra = NUL;                    /* extra chars, all the same */
+  int c_final = NUL;                    /* final char, compulsory if set */
   int extra_attr = 0;                   /* attributes when n_extra != 0 */
   static char_u *at_end_str = (char_u *)"";   /* used for p_extra when
                                                  displaying lcs_eol at end-of-line */
@@ -2200,6 +2201,7 @@ win_line (
   int saved_n_extra = 0;
   char_u      *saved_p_extra = NULL;
   int saved_c_extra = 0;
+  int saved_c_final = 0;
   int saved_char_attr = 0;
 
   int n_attr = 0;                       /* chars with special attr */
@@ -2721,6 +2723,7 @@ win_line (
           /* Draw the cmdline character. */
           n_extra = 1;
           c_extra = cmdwin_type;
+          c_final = NUL;
           char_attr = hl_attr(HLF_AT);
         }
       }
@@ -2734,6 +2737,7 @@ win_line (
           p_extra = extra;
           p_extra[n_extra] = NUL;
           c_extra = NUL;
+          c_final = NUL;
           char_attr = hl_attr(HLF_FC);
         }
       }
@@ -2747,6 +2751,7 @@ win_line (
               int text_sign;
               /* Draw two cells with the sign value or blank. */
               c_extra = ' ';
+              c_final = NUL;
               char_attr = hl_attr(HLF_SC);
               n_extra = 2;
 
@@ -2756,6 +2761,7 @@ win_line (
                       p_extra = sign_get_text(text_sign);
                       if (p_extra != NULL) {
                           c_extra = NUL;
+                          c_final = NUL;
                           n_extra = (int)STRLEN(p_extra);
                       }
                       char_attr = sign_get_attr(text_sign, FALSE);
@@ -2801,8 +2807,11 @@ win_line (
               rl_mirror(extra);
             p_extra = extra;
             c_extra = NUL;
-          } else
+            c_final = NUL;
+          } else {
             c_extra = ' ';
+            c_final = NUL;
+          }
           n_extra = number_width(wp) + 1;
           char_attr = hl_attr(HLF_N);
           /* When 'cursorline' is set highlight the line number of
@@ -2838,6 +2847,7 @@ win_line (
           }
           p_extra = NULL;
           c_extra = ' ';
+          c_final = NUL;
           n_extra = get_breakindent_win(wp, ml_get_buf(wp->w_buffer, lnum, FALSE));
           /* Correct end of highlighted area for 'breakindent',
              required wen 'linebreak' is also set. */
@@ -2850,10 +2860,14 @@ win_line (
         draw_state = WL_SBR;
         if (filler_todo > 0) {
           /* Draw "deleted" diff line(s). */
-          if (char2cells(fill_diff) > 1)
+          if (char2cells(fill_diff) > 1) {
             c_extra = '-';
-          else
+            c_final = NUL;
+          }
+          else {
             c_extra = fill_diff;
+            c_final = NUL;
+          }
           if (wp->w_p_rl)
             n_extra = col + 1;
           else
@@ -2864,6 +2878,7 @@ win_line (
           /* Draw 'showbreak' at the start of each broken line. */
           p_extra = p_sbr;
           c_extra = NUL;
+          c_final = NUL;
           n_extra = (int)STRLEN(p_sbr);
           char_attr = hl_attr(HLF_AT);
           need_showbreak = FALSE;
@@ -2884,6 +2899,7 @@ win_line (
           /* Continue item from end of wrapped line. */
           n_extra = saved_n_extra;
           c_extra = saved_c_extra;
+          c_final = saved_c_final;
           p_extra = saved_p_extra;
           char_attr = saved_char_attr;
         } else
@@ -3053,13 +3069,14 @@ win_line (
      * The "p_extra" points to the extra stuff that is inserted to
      * represent special characters (non-printable stuff) and other
      * things.  When all characters are the same, c_extra is used.
+     * If c_final is set, it will compulsorily be used at the end.
      * "p_extra" must end in a NUL to avoid mb_ptr2len() reads past
      * "p_extra[n_extra]".
      * For the '$' of the 'list' option, n_extra == 1, p_extra == "".
      */
     if (n_extra > 0) {
-      if (c_extra != NUL) {
-        c = c_extra;
+      if (c_extra != NUL || (n_extra == 1 && c_final != NUL)) {
+        c = (n_extra == 1 && c_final != NUL) ? c_final : c_extra;
         mb_c = c;               /* doesn't handle non-utf-8 multi-byte! */
         if (enc_utf8 && (*mb_char2len)(c) > 1) {
           mb_utf8 = TRUE;
@@ -3186,6 +3203,7 @@ win_line (
             mb_utf8 = (c >= 0x80);
             n_extra = (int)STRLEN(p_extra);
             c_extra = NUL;
+            c_final = NUL;
             if (area_attr == 0 && search_attr == 0) {
               n_attr = n_extra + 1;
               extra_attr = hl_attr(HLF_8);
@@ -3238,6 +3256,7 @@ win_line (
               p_extra = extra;
               n_extra = (int)STRLEN(extra) - 1;
               c_extra = NUL;
+              c_final = NUL;
               c = *p_extra++;
               if (area_attr == 0 && search_attr == 0) {
                 n_attr = n_extra + 1;
@@ -3272,6 +3291,7 @@ win_line (
         if (n_skip > 0 && mb_l > 1 && n_extra == 0) {
           n_extra = 1;
           c_extra = MB_FILLER_CHAR;
+          c_final = NUL;
           c = ' ';
           if (area_attr == 0 && search_attr == 0) {
             n_attr = n_extra + 1;
@@ -3429,6 +3449,7 @@ win_line (
           // TODO: is passing p for start of the line OK?
           n_extra = win_lbr_chartabsize(wp, line, p, (colnr_T)vcol, NULL) - 1;
           c_extra = ' ';
+          c_final = NUL;
           if (vim_iswhite(c)) {
             if (c == TAB)
               /* See "Tab alignment" below. */
@@ -3505,11 +3526,13 @@ win_line (
           FIX_FOR_BOGUSCOLS;
           mb_utf8 = FALSE;              /* don't draw as UTF-8 */
           if (wp->w_p_list) {
-            c = lcs_tab1;
+            c = (n_extra == 0 && lcs_tab3) ? lcs_tab3 : lcs_tab1;
             if (wp->w_p_lbr) {
               c_extra = NUL; /* using p_extra from above */
+              c_final = NUL;
             } else {
               c_extra = lcs_tab2;
+              c_final = lcs_tab3;
             }
             n_attr = tab_len + 1;
             extra_attr = hl_attr(HLF_8);
@@ -3521,6 +3544,7 @@ win_line (
               c = 0xc0;
             }
           } else {
+            c_final = NUL;
             c_extra = ' ';
             c = ' ';
           }
@@ -3550,6 +3574,7 @@ win_line (
               p_extra = at_end_str;
               n_extra = 1;
               c_extra = NUL;
+              c_final = NUL;
             }
           }
           if (wp->w_p_list)
@@ -3577,6 +3602,7 @@ win_line (
           if ((dy_flags & DY_UHEX) && wp->w_p_rl)
             rl_mirror(p_extra);                 /* reverse "<12>" */
           c_extra = NUL;
+          c_final = NUL;
           if (wp->w_p_lbr) {
             char_u *p;
 
@@ -3722,6 +3748,7 @@ win_line (
         /* Double-width character being overwritten by the "precedes"
          * character, need to fill up half the character. */
         c_extra = MB_FILLER_CHAR;
+        c_final = NUL;
         n_extra = 1;
         n_attr = 2;
         extra_attr = hl_attr(HLF_AT);
@@ -4211,6 +4238,7 @@ win_line (
       saved_n_extra = n_extra;
       saved_p_extra = p_extra;
       saved_c_extra = c_extra;
+      saved_c_final = c_final;
       saved_char_attr = char_attr;
       n_extra = 0;
       lcs_prec_todo = lcs_prec;


### PR DESCRIPTION
This pull request adds a new feature: a third (optional) character for the "tab" suboption of the "listchars" option. It enables the user to specify a third character for tab, which in turn enables vim to display tabs as '<-->' or '--->' (if the tab takes four spaces).

See issue: https://github.com/neovim/neovim/issues/820

Update to the documentation: https://github.com/neovim/docs/pull/27
