### PR TITLE
[RDY] GA_APPEND() and GA_APPEND_VIA_PTR()

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1619,12 +1619,10 @@ void putdigraph(char_u *str)
 
     // Add a new digraph to the table.
     if (i == user_digraphs.ga_len) {
-      ga_grow(&user_digraphs, 1);
-      dp = (digr_T *)user_digraphs.ga_data + user_digraphs.ga_len;
+      dp = GA_APPEND_VIA_PTR(digr_T, &user_digraphs);
       dp->char1 = char1;
       dp->char2 = char2;
       dp->result = n;
-      ++user_digraphs.ga_len;
     }
   }
 }
@@ -1772,7 +1770,6 @@ void ex_loadkeymap(exarg_T *eap)
   char_u *line;
   char_u *p;
   char_u *s;
-  kmap_T *kp;
 
 #define KMAP_LLEN 200  // max length of "to" and "from" together
   char_u buf[KMAP_LLEN + 11];
@@ -1803,8 +1800,7 @@ void ex_loadkeymap(exarg_T *eap)
     p = skipwhite(line);
 
     if ((*p != '"') && (*p != NUL)) {
-      ga_grow(&curbuf->b_kmap_ga, 1);
-      kp = (kmap_T *)curbuf->b_kmap_ga.ga_data + curbuf->b_kmap_ga.ga_len;
+      kmap_T *kp = GA_APPEND_VIA_PTR(kmap_T, &curbuf->b_kmap_ga);
       s = skiptowhite(p);
       kp->from = vim_strnsave(p, (int)(s - p));
       p = skipwhite(s);
@@ -1819,8 +1815,7 @@ void ex_loadkeymap(exarg_T *eap)
         }
         free(kp->from);
         free(kp->to);
-      } else {
-        ++curbuf->b_kmap_ga.ga_len;
+        --curbuf->b_kmap_ga.ga_len;
       }
     }
     free(line);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14414,8 +14414,7 @@ error:
     }
   }
 
-  /* add a terminating NUL */
-  ga_grow(&ga, 1);
+  // add a terminating NUL
   ga_append(&ga, NUL);
 
   rettv->vval.v_string = ga.ga_data;
@@ -17634,8 +17633,7 @@ script_autoload (
   else {
     /* Remember the name if it wasn't loaded already. */
     if (i == ga_loaded.ga_len) {
-      ga_grow(&ga_loaded, 1);
-      ((char_u **)ga_loaded.ga_data)[ga_loaded.ga_len++] = scriptname;
+      GA_APPEND(char_u *, &ga_loaded, scriptname);
       tofree = NULL;
     }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5289,8 +5289,7 @@ list_join_inner (
     len = (int)STRLEN(s);
     sumlen += len;
 
-    ga_grow(join_gap, 1);
-    p = ((join_T *)join_gap->ga_data) + (join_gap->ga_len++);
+    p = GA_APPEND_VIA_PTR(join_T, join_gap);
     if (tofree != NULL || s != numbuf) {
       p->s = s;
       p->tofree = tofree;
@@ -10219,11 +10218,9 @@ static void f_inputrestore(typval_T *argvars, typval_T *rettv)
  */
 static void f_inputsave(typval_T *argvars, typval_T *rettv)
 {
-  /* Add an entry to the stack of typeahead storage. */
-  ga_grow(&ga_userinput, 1);
-  save_typeahead((tasave_T *)(ga_userinput.ga_data)
-          + ga_userinput.ga_len);
-  ++ga_userinput.ga_len;
+  // Add an entry to the stack of typeahead storage.
+  tasave_T *p = GA_APPEND_VIA_PTR(tasave_T, &ga_userinput);
+  save_typeahead(p);
 }
 
 /*

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5446,11 +5446,9 @@ helptags_one (
   ga_init(&ga, (int)sizeof(char_u *), 100);
   if (add_help_tags || path_full_compare((char_u *)"$VIMRUNTIME/doc",
           dir, FALSE) == kEqualFiles) {
-    ga_grow(&ga, 1);
     s = xmalloc(18 + STRLEN(tagfname));
     sprintf((char *)s, "help-tags\t%s\t1\n", tagfname);
-    ((char_u **)ga.ga_data)[ga.ga_len] = s;
-    ++ga.ga_len;
+    GA_APPEND(char_u *, &ga, s);
   }
 
   /*
@@ -5517,10 +5515,8 @@ helptags_one (
                   || s[1] == '\0')) {
             *p2 = '\0';
             ++p1;
-            ga_grow(&ga, 1);
             s = xmalloc((p2 - p1) + STRLEN(fname) + 2);
-            ((char_u **)ga.ga_data)[ga.ga_len] = s;
-            ++ga.ga_len;
+            GA_APPEND(char_u *, &ga, s);
             sprintf((char *)s, "%s\t%s", p1, fname);
 
             /* find next '*' */

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1525,8 +1525,7 @@ void get_arglist(garray_T *gap, char_u *str)
 {
   ga_init(gap, (int)sizeof(char_u *), 20);
   while (*str != NUL) {
-    ga_grow(gap, 1);
-    ((char_u **)gap->ga_data)[gap->ga_len++] = str;
+    GA_APPEND(char_u *, gap, str);
 
     /* Isolate one argument, change it in-place, put a NUL after it. */
     str = do_one_arg(str);
@@ -3334,13 +3333,12 @@ static char_u **find_locales(void)
   loc = (char_u *)strtok((char *)locale_a, "\n");
 
   while (loc != NULL) {
-    ga_grow(&locales_ga, 1);
     loc = vim_strsave(loc);
-
-    ((char_u **)locales_ga.ga_data)[locales_ga.ga_len++] = loc;
+    GA_APPEND(char_u *, &locales_ga, loc);
     loc = (char_u *)strtok(NULL, "\n");
   }
   free(locale_a);
+  // Guarantee that .ga_data is NULL terminated
   ga_grow(&locales_ga, 1);
   ((char_u **)locales_ga.ga_data)[locales_ga.ga_len] = NULL;
   return (char_u **)locales_ga.ga_data;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2792,7 +2792,7 @@ char_u *getsourceline(int c, void *cookie, int indent)
         /* Adjust the growsize to the current length to speed up
          * concatenating many lines. */
         if (ga.ga_len > 400) {
-          ga.ga_growsize = (ga.ga_len > 8000) ? 8000 : ga.ga_len;
+          ga_set_growsize(&ga, (ga.ga_len > 8000) ? 8000 : ga.ga_len);
         }
         ga_concat(&ga, p + 1);
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1037,10 +1037,9 @@ static char_u *get_loop_line(int c, void *cookie, int indent)
  */
 static void store_loop_line(garray_T *gap, char_u *line)
 {
-  ga_grow(gap, 1);
-  ((wcmd_T *)(gap->ga_data))[gap->ga_len].line = vim_strsave(line);
-  ((wcmd_T *)(gap->ga_data))[gap->ga_len].lnum = sourcing_lnum;
-  ++gap->ga_len;
+  wcmd_T *p = GA_APPEND_VIA_PTR(wcmd_T, gap);
+  p->line = vim_strsave(line);
+  p->lnum = sourcing_lnum;
 }
 
 /*

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4000,10 +4000,7 @@ static int ExpandUserDefined(expand_T *xp, regmatch_T *regmatch, int *num_file, 
       continue;
     }
 
-    ga_grow(&ga, 1);
-
-    ((char_u **)ga.ga_data)[ga.ga_len] = vim_strnsave(s, (int)(e - s));
-    ++ga.ga_len;
+    GA_APPEND(char_u *, &ga, vim_strnsave(s, (int)(e - s)));
 
     *e = keep;
     if (*e != NUL)
@@ -4034,11 +4031,7 @@ static int ExpandUserList(expand_T *xp, int *num_file, char_u ***file)
     if (li->li_tv.v_type != VAR_STRING || li->li_tv.vval.v_string == NULL)
       continue;        /* Skip non-string items and empty strings */
 
-    ga_grow(&ga, 1);
-
-    ((char_u **)ga.ga_data)[ga.ga_len] =
-      vim_strsave(li->li_tv.vval.v_string);
-    ++ga.ga_len;
+    GA_APPEND(char_u *, &ga, vim_strsave(li->li_tv.vval.v_string));
   }
   list_unref(retlist);
 

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -197,10 +197,7 @@ void ga_concat(garray_T *gap, const char_u *restrict s)
 /// @param c
 void ga_append(garray_T *gap, char c)
 {
-  ga_grow(gap, 1);
-  char *str = gap->ga_data;
-  str[gap->ga_len] = c;
-  gap->ga_len++;
+  GA_APPEND(char, gap, c);
 }
 
 #if defined(UNIX) || defined(WIN3264) || defined(PROTO)

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -12,7 +12,7 @@ typedef struct growarray {
   void *ga_data;                    // pointer to the first item
 } garray_T;
 
-#define GA_EMPTY_INIT_VALUE { 0, 0, 0, 0, NULL }
+#define GA_EMPTY_INIT_VALUE { 0, 0, 0, 1, NULL }
 
 #define GA_EMPTY(ga_ptr) ((ga_ptr)->ga_len <= 0)
 

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -1,6 +1,8 @@
 #ifndef NVIM_GARRAY_H
 #define NVIM_GARRAY_H
 
+#include "nvim/log.h"
+
 /// Structure used for growing arrays.
 /// This is used to store information that only grows, is deleted all at
 /// once, and needs to be accessed by index.  See ga_clear() and ga_grow().
@@ -22,7 +24,20 @@ typedef struct growarray {
     ((item_type *)(gap)->ga_data)[(gap)->ga_len++] = (item);               \
   } while (0)
 
+#define GA_APPEND_VIA_PTR(item_type, gap) \
+  ga_append_via_ptr(gap, sizeof(item_type))
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "garray.h.generated.h"
 #endif
+
+static inline void *ga_append_via_ptr(garray_T *gap, size_t item_size)
+{
+  if ((int)item_size != gap->ga_itemsize) {
+    ELOG("wrong item size in garray(%d), should be %d", item_size);
+  }
+  ga_grow(gap, 1);
+  return ((char *)gap->ga_data) + (item_size * (size_t)gap->ga_len++);
+}
+
 #endif  // NVIM_GARRAY_H

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -16,6 +16,12 @@ typedef struct growarray {
 
 #define GA_EMPTY(ga_ptr) ((ga_ptr)->ga_len <= 0)
 
+#define GA_APPEND(item_type, gap, item)                                    \
+  do {                                                                     \
+    ga_grow(gap, 1);                                                       \
+    ((item_type *)(gap)->ga_data)[(gap)->ga_len++] = (item);               \
+  } while (0)
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "garray.h.generated.h"
 #endif

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -982,7 +982,7 @@ EXTERN int need_cursor_line_redraw INIT(= FALSE);
 /* Grow array to collect error messages in until they can be displayed. */
 EXTERN garray_T error_ga
 # ifdef DO_INIT
-  = {0, 0, 0, 0, NULL}
+  = GA_EMPTY_INIT_VALUE
 # endif
 ;
 #endif

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -1285,7 +1285,7 @@ static int prt_collate;
  * Buffers used when generating PostScript output
  */
 static char_u prt_line_buffer[257];
-static garray_T prt_ps_buffer;
+static garray_T prt_ps_buffer = GA_EMPTY_INIT_VALUE;
 
 static int prt_do_conv;
 static vimconv_T prt_conv;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1444,7 +1444,6 @@ static garray_T menutrans_ga = GA_EMPTY_INIT_VALUE;
 void ex_menutranslate(exarg_T *eap)
 {
   char_u              *arg = eap->arg;
-  menutrans_T         *tp;
   char_u              *from, *from_noamp, *to;
 
   if (menutrans_ga.ga_itemsize == 0)
@@ -1454,7 +1453,7 @@ void ex_menutranslate(exarg_T *eap)
    * ":menutrans clear": clear all translations.
    */
   if (STRNCMP(arg, "clear", 5) == 0 && ends_excmd(*skipwhite(arg + 5))) {
-    tp = (menutrans_T *)menutrans_ga.ga_data;
+    menutrans_T *tp = (menutrans_T *)menutrans_ga.ga_data;
     for (int i = 0; i < menutrans_ga.ga_len; ++i) {
       free(tp[i].from);
       free(tp[i].from_noamp);
@@ -1473,8 +1472,6 @@ void ex_menutranslate(exarg_T *eap)
     if (arg == to)
       EMSG(_(e_invarg));
     else {
-      ga_grow(&menutrans_ga, 1);
-      tp = (menutrans_T *)menutrans_ga.ga_data;
       from = vim_strsave(from);
       from_noamp = menu_text(from, NULL, NULL);
       to = vim_strnsave(to, (int)(arg - to));
@@ -1483,10 +1480,10 @@ void ex_menutranslate(exarg_T *eap)
         menu_translate_tab_and_shift(to);
         menu_unescape_name(from);
         menu_unescape_name(to);
-        tp[menutrans_ga.ga_len].from = from;
-        tp[menutrans_ga.ga_len].from_noamp = from_noamp;
-        tp[menutrans_ga.ga_len].to = to;
-        ++menutrans_ga.ga_len;
+        menutrans_T* tp = GA_APPEND_VIA_PTR(menutrans_T, &menutrans_ga);
+        tp->from = from;
+        tp->from_noamp = from_noamp;
+        tp->to = to;
       } else {
         free(from);
         free(from_noamp);

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1434,7 +1434,7 @@ typedef struct {
   char_u      *to;              /* translated name */
 } menutrans_T;
 
-static garray_T menutrans_ga = {0, 0, 0, 0, NULL};
+static garray_T menutrans_ga = GA_EMPTY_INIT_VALUE;
 
 /*
  * ":menutrans".

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2257,8 +2257,8 @@ void mch_errmsg(char *str)
   emsg_on_display = FALSE;
 
   len = (int)STRLEN(str) + 1;
-  if (error_ga.ga_growsize == 0) {
-    error_ga.ga_growsize = 80;
+  if (error_ga.ga_data == NULL) {
+    ga_set_growsize(&error_ga, 80);
     error_ga.ga_itemsize = 1;
   }
   ga_grow(&error_ga, len);

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -58,7 +58,7 @@
 # include "misc1.c.generated.h"
 #endif
 /* All user names (for ~user completion as done by shell). */
-static garray_T ga_users;
+static garray_T ga_users = GA_EMPTY_INIT_VALUE;
 
 /*
  * open_line: Add a new line below or above the current line.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7499,7 +7499,7 @@ typedef struct {
   int to;
 } langmap_entry_T;
 
-static garray_T langmap_mapga;
+static garray_T langmap_mapga = GA_EMPTY_INIT_VALUE;
 
 /*
  * Search for an entry in "langmap_mapga" for "from".  If found set the "to"

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -21,16 +21,13 @@ int os_get_usernames(garray_T *users)
   ga_init(users, sizeof(char *), 20);
 
 # if defined(HAVE_GETPWENT) && defined(HAVE_PWD_H)
-  char *user;
   struct passwd *pw;
 
   setpwent();
   while ((pw = getpwent()) != NULL) {
     // pw->pw_name shouldn't be NULL but just in case...
     if (pw->pw_name != NULL) {
-      ga_grow(users, 1);
-      user = xstrdup(pw->pw_name);
-      ((char **)(users->ga_data))[users->ga_len++] = user;
+      GA_APPEND(char *, users, xstrdup(pw->pw_name));
     }
   }
   endpwent();

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -625,7 +625,6 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
   char_u      *path_option = *curbuf->b_p_path == NUL
                              ? p_path : curbuf->b_p_path;
   char_u      *buf;
-  char_u      *p;
   int len;
 
   buf = xmalloc(MAXPATHL);
@@ -639,7 +638,7 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
        * "/path/file"  + "./subdir" -> "/path/subdir" */
       if (curbuf->b_ffname == NULL)
         continue;
-      p = path_tail(curbuf->b_ffname);
+      char_u *p = path_tail(curbuf->b_ffname);
       len = (int)(p - curbuf->b_ffname);
       if (len + (int)STRLEN(buf) >= MAXPATHL)
         continue;
@@ -666,10 +665,7 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
       simplify_filename(buf);
     }
 
-    ga_grow(gap, 1);
-
-    p = vim_strsave(buf);
-    ((char_u **)gap->ga_data)[gap->ga_len++] = p;
+    GA_APPEND(char_u *, gap, vim_strsave(buf));
   }
 
   free(buf);
@@ -1194,7 +1190,6 @@ addfile (
     int flags
 )
 {
-  char_u      *p;
   bool isdir;
 
   /* if the file/dir doesn't exist, may not add it */
@@ -1215,10 +1210,7 @@ addfile (
   if (!isdir && (flags & EW_EXEC) && !os_can_exe(f))
     return;
 
-  /* Make room for another item in the file list. */
-  ga_grow(gap, 1);
-
-  p = xmalloc(STRLEN(f) + 1 + isdir);
+  char_u *p = xmalloc(STRLEN(f) + 1 + isdir);
 
   STRCPY(p, f);
 #ifdef BACKSLASH_IN_FILENAME
@@ -1231,7 +1223,7 @@ addfile (
   if (isdir && (flags & EW_ADDSLASH))
     add_pathsep(p);
 #endif
-  ((char_u **)gap->ga_data)[gap->ga_len++] = p;
+  GA_APPEND(char_u *, gap, p);
 }
 #endif /* !NO_EXPANDPATH */
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3180,8 +3180,8 @@ static int reg_line_lbr;                    /* "\n" in string is line break */
  * or regbehind_T.
  * "backpos_T" is a table with backpos_T for BACK
  */
-static garray_T regstack = {0, 0, 0, 0, NULL};
-static garray_T backpos = {0, 0, 0, 0, NULL};
+static garray_T regstack = GA_EMPTY_INIT_VALUE;
+static garray_T backpos = GA_EMPTY_INIT_VALUE;
 
 /*
  * Both for regstack and backpos tables we use the following strategy of
@@ -3319,13 +3319,13 @@ static long bt_regexec_both(char_u *line,
      * onto the regstack. */
     ga_init(&regstack, 1, REGSTACK_INITIAL);
     ga_grow(&regstack, REGSTACK_INITIAL);
-    regstack.ga_growsize = REGSTACK_INITIAL * 8;
+    ga_set_growsize(&regstack, REGSTACK_INITIAL * 8);
   }
 
   if (backpos.ga_data == NULL) {
     ga_init(&backpos, sizeof(backpos_T), BACKPOS_INITIAL);
     ga_grow(&backpos, BACKPOS_INITIAL);
-    backpos.ga_growsize = BACKPOS_INITIAL * 8;
+    ga_set_growsize(&backpos, BACKPOS_INITIAL * 8);
   }
 
   if (REG_MULTI) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4177,7 +4177,6 @@ regmatch (
         case BACK:
         {
           int i;
-          backpos_T       *bp;
 
           /*
            * When we run into BACK we need to check if we don't keep
@@ -4187,17 +4186,13 @@ regmatch (
            * The positions are stored in "backpos" and found by the
            * current value of "scan", the position in the RE program.
            */
-          bp = (backpos_T *)backpos.ga_data;
+          backpos_T *bp = (backpos_T *)backpos.ga_data;
           for (i = 0; i < backpos.ga_len; ++i)
             if (bp[i].bp_scan == scan)
               break;
           if (i == backpos.ga_len) {
-            /* First time at this BACK, make room to store the pos. */
-            ga_grow(&backpos, 1);
-            /* get "ga_data" again, it may have changed */
-            bp = (backpos_T *)backpos.ga_data;
-            bp[i].bp_scan = scan;
-            ++backpos.ga_len;
+            backpos_T *p = GA_APPEND_VIA_PTR(backpos_T, &backpos);
+            p->bp_scan = scan;
           } else if (reg_save_equal(&bp[i].bp_pos))
             /* Still at same position as last time, fail. */
             status = RA_NOMATCH;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -9138,8 +9138,7 @@ someerror:
           if (c < 0) {
             goto someerror;
           }
-          ga_grow(&ga, 1);
-          ((char_u *)ga.ga_data)[ga.ga_len++] = c;
+          GA_APPEND(char_u, &ga, c);
           if (c == NUL)
             break;
         }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3335,7 +3335,6 @@ static int init_syl_tab(slang_T *slang)
   char_u      *p;
   char_u      *s;
   int l;
-  syl_item_T  *syl;
 
   ga_init(&slang->sl_syl_items, sizeof(syl_item_T), 4);
   p = vim_strchr(slang->sl_syllable, '/');
@@ -3351,9 +3350,8 @@ static int init_syl_tab(slang_T *slang)
       l = (int)(p - s);
     if (l >= SY_MAXLEN)
       return SP_FORMERROR;
-    ga_grow(&slang->sl_syl_items, 1);
-    syl = ((syl_item_T *)slang->sl_syl_items.ga_data)
-          + slang->sl_syl_items.ga_len++;
+
+    syl_item_T *syl = GA_APPEND_VIA_PTR(syl_item_T, &slang->sl_syl_items);
     STRLCPY(syl->sy_chars, s, l + 1);
     syl->sy_len = l;
   }
@@ -3835,10 +3833,10 @@ char_u *did_set_spelllang(win_T *wp)
         }
 
         if (region_mask != 0) {
-          ga_grow(&ga, 1);
-          LANGP_ENTRY(ga, ga.ga_len)->lp_slang = slang;
-          LANGP_ENTRY(ga, ga.ga_len)->lp_region = region_mask;
-          ++ga.ga_len;
+          langp_T *p = GA_APPEND_VIA_PTR(langp_T, &ga);
+          p->lp_slang = slang;
+          p->lp_region = region_mask;
+
           use_midword(slang, wp);
           if (slang->sl_nobreak)
             nobreak = TRUE;
@@ -3896,7 +3894,6 @@ char_u *did_set_spelllang(win_T *wp)
         slang->sl_nobreak = TRUE;
     }
     if (slang != NULL) {
-      ga_grow(&ga, 1);
       region_mask = REGION_ALL;
       if (use_region != NULL && !dont_use_region) {
         // find region in sl_regions
@@ -3909,11 +3906,12 @@ char_u *did_set_spelllang(win_T *wp)
       }
 
       if (region_mask != 0) {
-        LANGP_ENTRY(ga, ga.ga_len)->lp_slang = slang;
-        LANGP_ENTRY(ga, ga.ga_len)->lp_sallang = NULL;
-        LANGP_ENTRY(ga, ga.ga_len)->lp_replang = NULL;
-        LANGP_ENTRY(ga, ga.ga_len)->lp_region = region_mask;
-        ++ga.ga_len;
+        langp_T *p = GA_APPEND_VIA_PTR(langp_T, &ga);
+        p->lp_slang = slang;
+        p->lp_sallang = NULL;
+        p->lp_replang = NULL;
+        p->lp_region = region_mask;
+
         use_midword(slang, wp);
       }
     }
@@ -4851,16 +4849,11 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
                   break;
               }
               if (idx < 0) {
-                ga_grow(&spin->si_prefcond, 1);
                 // Not found, add a new condition.
-                idx = spin->si_prefcond.ga_len++;
-                pp = ((char_u **)spin->si_prefcond.ga_data)
-                     + idx;
-                if (aff_entry->ae_cond == NULL)
-                  *pp = NULL;
-                else
-                  *pp = getroom_save(spin,
-                      aff_entry->ae_cond);
+                idx = spin->si_prefcond.ga_len;
+                pp = GA_APPEND_VIA_PTR(char_u *, &spin->si_prefcond);
+                *pp = (aff_entry->ae_cond == NULL) ?
+                  NULL : getroom_save(spin, aff_entry->ae_cond);
               }
 
               // Add the prefix to the prefix tree.
@@ -5328,16 +5321,13 @@ static int str_equal(char_u *s1, char_u *s2)
 // They are stored case-folded.
 static void add_fromto(spellinfo_T *spin, garray_T *gap, char_u *from, char_u *to)
 {
-  fromto_T    *ftp;
   char_u word[MAXWLEN];
 
-  ga_grow(gap, 1);
-  ftp = ((fromto_T *)gap->ga_data) + gap->ga_len;
+  fromto_T *ftp = GA_APPEND_VIA_PTR(fromto_T, gap);
   (void)spell_casefold(from, (int)STRLEN(from), word, MAXWLEN);
   ftp->ft_from = getroom_save(spin, word);
   (void)spell_casefold(to, (int)STRLEN(to), word, MAXWLEN);
   ftp->ft_to = getroom_save(spin, word);
-  ++gap->ga_len;
 }
 
 // Convert a boolean argument in a SAL line to TRUE or FALSE;
@@ -11503,9 +11493,8 @@ add_suggestion (
   }
 
   if (i < 0) {
-    ga_grow(gap, 1);
     // Add a suggestion.
-    stp = &SUG(*gap, gap->ga_len);
+    stp = GA_APPEND_VIA_PTR(suggest_T, gap);
     stp->st_word = vim_strnsave(goodword, goodlen);
     stp->st_wordlen = goodlen;
     stp->st_score = score;
@@ -11513,7 +11502,6 @@ add_suggestion (
     stp->st_had_bonus = had_bonus;
     stp->st_orglen = badlen;
     stp->st_slang = slang;
-    ++gap->ga_len;
 
     // If we have too many suggestions now, sort the list and keep
     // the best suggestions.

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -1963,9 +1963,7 @@ syn_current_attr (
             /* Add the index to a list, so that we can check
              * later that we don't match it again (and cause an
              * endless loop). */
-            ga_grow(&zero_width_next_ga, 1);
-            ((int *)(zero_width_next_ga.ga_data))
-            [zero_width_next_ga.ga_len++] = next_match_idx;
+            GA_APPEND(int, &zero_width_next_ga, next_match_idx);
             next_match_idx = -1;
           } else
             cur_si = push_next_match(cur_si);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -75,7 +75,8 @@ struct hl_group {
 #define SG_GUI          4       /* gui has been set */
 #define SG_LINK         8       /* link has been set */
 
-static garray_T highlight_ga;   /* highlight groups for 'highlight' option */
+// highlight groups for 'highlight' option
+static garray_T highlight_ga = GA_EMPTY_INIT_VALUE;
 
 #define HL_TABLE() ((struct hl_group *)((highlight_ga.ga_data)))
 
@@ -360,7 +361,7 @@ static int current_state_stored = 0;      /* TRUE if stored current state
                                            * after setting current_finished */
 static int current_finished = 0;        /* current line has been finished */
 static garray_T current_state           /* current stack of state_items */
-  = {0, 0, 0, 0, NULL};
+  = GA_EMPTY_INIT_VALUE;
 static short    *current_next_list = NULL; /* when non-zero, nextgroup list */
 static int current_next_flags = 0;      /* flags for current_next_list */
 static int current_line_id = 0;         /* unique number for current line */
@@ -1452,7 +1453,7 @@ static void invalidate_current_state(void)
 static void validate_current_state(void)
 {
   current_state.ga_itemsize = sizeof(stateitem_T);
-  current_state.ga_growsize = 3;
+  ga_set_growsize(&current_state, 3);
 }
 
 /*
@@ -4746,7 +4747,7 @@ static int syn_add_cluster(char_u *name)
    */
   if (curwin->w_s->b_syn_clusters.ga_data == NULL) {
     curwin->w_s->b_syn_clusters.ga_itemsize = sizeof(syn_cluster_T);
-    curwin->w_s->b_syn_clusters.ga_growsize = 10;
+    ga_set_growsize(&curwin->w_s->b_syn_clusters, 10);
   }
 
   int len = curwin->w_s->b_syn_clusters.ga_len;
@@ -4846,7 +4847,7 @@ static void syn_cmd_cluster(exarg_T *eap, int syncing)
 static void init_syn_patterns(void)
 {
   curwin->w_s->b_syn_patterns.ga_itemsize = sizeof(synpat_T);
-  curwin->w_s->b_syn_patterns.ga_growsize = 10;
+  ga_set_growsize(&curwin->w_s->b_syn_patterns, 10);
 }
 
 /*
@@ -6731,11 +6732,11 @@ static void highlight_clear(int idx)
  * Note that this table is used by ALL buffers.  This is required because the
  * GUI can redraw at any time for any buffer.
  */
-static garray_T term_attr_table = {0, 0, 0, 0, NULL};
+static garray_T term_attr_table = GA_EMPTY_INIT_VALUE;
 
 #define TERM_ATTR_ENTRY(idx) ((attrentry_T *)term_attr_table.ga_data)[idx]
 
-static garray_T cterm_attr_table = {0, 0, 0, 0, NULL};
+static garray_T cterm_attr_table = GA_EMPTY_INIT_VALUE;
 
 #define CTERM_ATTR_ENTRY(idx) ((attrentry_T *)cterm_attr_table.ga_data)[idx]
 
@@ -6755,7 +6756,7 @@ static int get_attr_entry(garray_T *table, attrentry_T *aep)
    * Init the table, in case it wasn't done yet.
    */
   table->ga_itemsize = sizeof(attrentry_T);
-  table->ga_growsize = 7;
+  ga_set_growsize(table, 7);
 
   /*
    * Try to find an entry with the same specifications.
@@ -7311,7 +7312,7 @@ static int syn_add_group(char_u *name)
    */
   if (highlight_ga.ga_data == NULL) {
     highlight_ga.ga_itemsize = sizeof(struct hl_group);
-    highlight_ga.ga_growsize = 10;
+    ga_set_growsize(&highlight_ga, 10);
   }
 
   if (highlight_ga.ga_len >= MAX_HL_ID) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1995,8 +1995,7 @@ static garray_T tag_fnames = GA_EMPTY_INIT_VALUE;
  */
 static void found_tagfile_cb(char_u *fname, void *cookie)
 {
-  ga_grow(&tag_fnames, 1);
-  ((char_u **)(tag_fnames.ga_data))[tag_fnames.ga_len++] = vim_strsave(fname);
+  GA_APPEND(char_u *, &tag_fnames, vim_strsave(fname));
 }
 
 #if defined(EXITFREE) || defined(PROTO)

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2249,7 +2249,6 @@ void ex_undolist(exarg_T *eap)
   while (uhp != NULL) {
     if (uhp->uh_prev.ptr == NULL && uhp->uh_walk != nomark
         && uhp->uh_walk != mark) {
-      ga_grow(&ga, 1);
       vim_snprintf((char *)IObuff, IOSIZE, "%6ld %7ld  ",
           uhp->uh_seq, changes);
       u_add_time(IObuff + STRLEN(IObuff), IOSIZE - STRLEN(IObuff),
@@ -2260,7 +2259,7 @@ void ex_undolist(exarg_T *eap)
         vim_snprintf_add((char *)IObuff, IOSIZE,
             "  %3ld", uhp->uh_save_nr);
       }
-      ((char_u **)(ga.ga_data))[ga.ga_len++] = vim_strsave(IObuff);
+      GA_APPEND(char_u *, &ga, vim_strsave(IObuff));
     }
 
     uhp->uh_walk = mark;


### PR DESCRIPTION
Using `GA_APPEND` is easier than:

``` c
ga_grow(&ga, 1);
((item_type *)ga.ga_data)[ga.ga_len] = item;
++ga.ga_len;
```

`GA_APPEND_VIA_PTR` is used to replace this common pattern:

``` c
ga_grow(&ga, 1);
item_type *p = ((item_type *)ga.ga_data) + ga.ga_len;
p->field1 = v1;
p->field2 = v2;
ga.ga_len++;
```
