### PR TITLE
[RDY] Fix #838: build with "USE_BUNDLED=OFF" fails to find dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required (VERSION 2.8.7)
 project (NEOVIM)
 
-set(CMAKE_SYSTEM_PROCESSOR i386)
-set(CMAKE_SYSTEM_LIBRARY_PATH /lib32 /usr/lib32 /usr/local/lib32)
-set(FIND_LIBRARY_USE_LIB64_PATHS OFF)
-set(CMAKE_IGNORE_PATH /lib /usr/lib /usr/local/lib)
-
 # Point CMake at any custom modules we may ship
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -173,7 +173,13 @@ elif [ "$TRAVIS_BUILD_TYPE" = "gcc/ia32" ]; then
 	# correctly.
 	sudo apt-get install libncurses5-dev:i386
 
-	$MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP -DCMAKE_TOOLCHAIN_FILE=cmake/i386-linux-gnu.toolchain.cmake" unittest
+	CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP \
+		-DCMAKE_SYSTEM_PROCESSOR=i386 \
+		-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \
+		-DFIND_LIBRARY_USE_LIB64_PATHS=OFF \
+		-DCMAKE_IGNORE_PATH=/lib:/usr/lib:/usr/local/lib \
+		-DCMAKE_TOOLCHAIN_FILE=cmake/i386-linux-gnu.toolchain.cmake"
+	$MAKE_CMD CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" unittest
 	$MAKE_CMD test
 elif [ "$TRAVIS_BUILD_TYPE" = "clint" ]; then
 	./scripts/clint.sh


### PR DESCRIPTION
Stop forcing some platform setting that are really intended to be used
for Travis CI.  Under other systems, like Arch Linux, it prevents
dependencies from being correctly located.
