### PR TITLE
[RFC] Testdir and top-level Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,23 +12,23 @@ BUILD_TYPE ?= $(shell (type ninja > /dev/null 2>&1 && echo "Ninja") || \
 
 ifeq (,$(BUILD_TOOL))
   ifeq (Ninja,$(BUILD_TYPE))
-      ifneq ($(shell cmake --help 2>/dev/null | grep Ninja),)
-          BUILD_TOOL := ninja
-      else
-          # User's version of CMake doesn't support Ninja
-          BUILD_TOOL = $(MAKE)
-          BUILD_TYPE := Unix Makefiles
-      endif
-  else
+    ifneq ($(shell cmake --help 2>/dev/null | grep Ninja),)
+      BUILD_TOOL := ninja
+    else
+      # User's version of CMake doesn't support Ninja
       BUILD_TOOL = $(MAKE)
+      BUILD_TYPE := Unix Makefiles
+    endif
+  else
+    BUILD_TOOL = $(MAKE)
   endif
 endif
 
 ifneq ($(VERBOSE),)
-    # Only need to handle Ninja here.  Make will inherit the VERBOSE variable.
-    ifeq ($(BUILD_TYPE),Ninja)
-        VERBOSE_FLAG := -v
-    endif
+  # Only need to handle Ninja here.  Make will inherit the VERBOSE variable.
+  ifeq ($(BUILD_TYPE),Ninja)
+    VERBOSE_FLAG := -v
+  endif
 endif
 
 BUILD_CMD = $(BUILD_TOOL) $(VERBOSE_FLAG)
@@ -39,7 +39,7 @@ DEPS_CMAKE_FLAGS ?=
 USE_BUNDLED_DEPS ?=
 
 ifneq (,$(USE_BUNDLED_DEPS))
-    BUNDLED_CMAKE_FLAG := -DUSE_BUNDLED=$(USE_BUNDLED_DEPS)
+  BUNDLED_CMAKE_FLAG := -DUSE_BUNDLED=$(USE_BUNDLED_DEPS)
 endif
 
 # For use where we want to make sure only a single job is run.  This does issue 

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ ifneq (,$(USE_BUNDLED_DEPS))
     BUNDLED_CMAKE_FLAG := -DUSE_BUNDLED=$(USE_BUNDLED_DEPS)
 endif
 
-# For use where we want to make sure only a single job is run.  This also avoids
-# any warnings from the sub-make.
+# For use where we want to make sure only a single job is run.  This does issue 
+# a warning, but we need to keep SCRIPTS argument.
 SINGLE_MAKE = export MAKEFLAGS= ; $(MAKE)
 
 all: nvim
@@ -75,7 +75,7 @@ endif
 	touch $@
 
 test: | nvim
-	+$(SINGLE_MAKE) -C src/nvim/testdir
+	+$(SINGLE_MAKE) -C src/nvim/testdir $(MAKEOVERRIDES)
 
 unittest: | nvim
 	+$(BUILD_CMD) -C build unittest

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -59,7 +59,7 @@ set_environment() {
 	eval $($prefix/bin/luarocks path)
 	export PATH="$prefix/bin:$PATH"
 	export PKG_CONFIG_PATH="$prefix/lib/pkgconfig"
-	export DEPS_CMAKE_FLAGS="-DUSE_BUNDLED=OFF"
+	export USE_BUNDLED_DEPS=OFF
 }
 
 # install prebuilt dependencies

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -8,7 +8,7 @@ VIMPROG := ../../../build/bin/nvim
 
 SCRIPTS := test_autoformat_join.out                                    \
            test_eval.out                                               \
-           test1.out   test2.out   test3.out   test4.out   test5.out   \
+                       test2.out   test3.out   test4.out   test5.out   \
            test6.out   test7.out   test8.out   test9.out   test10.out  \
            test11.out  test12.out  test13.out  test14.out  test15.out  \
                        test17.out  test18.out  test19.out  test20.out  \
@@ -80,7 +80,9 @@ report:
 	                 echo ALL DONE;        \
 	             fi"
 
-$(SCRIPTS) $(SCRIPTS_GUI): $(VIMPROG)
+test1.out: $(VIMPROG)
+
+$(SCRIPTS) $(SCRIPTS_GUI): $(VIMPROG) test1.out
 
 RM_ON_RUN   := test.out X* viminfo
 RM_ON_START := tiny.vim small.vim mbyte.vim mzscheme.vim lua.vim test.ok


### PR DESCRIPTION
There are 3 of them:
1. Avoid ever creating .deps directory with lots of unneeded cmake stuff within. `make USE_BUNDLED_DEPS=OFF` is also better syntax then `make DEPS_CMAKE_FLAGS='-DUSE_BUNDLED=OFF'`.
2. Make each test depend on `test1.out`. Reason: `test1.out` is really not a test, it is a script that creates a number of files necessary for other tests.
3. Allow SCRIPTS and TESTNUM arguments be passed to SINGLE_MAKE. Requires `sed` to be installed.
