### PR TITLE
[RFC] Fixes and improvements for jobs/streams/events/api

### DIFF
--- a/scripts/msgpack-gen.lua
+++ b/scripts/msgpack-gen.lua
@@ -186,7 +186,7 @@ for i = 1, #api.functions do
     if #args > 0 then
       output:write('channel_id, '..call_args)
     else
-      output:write('channel_id)')
+      output:write('channel_id')
     end
   else
     output:write(call_args)

--- a/scripts/run-api-tests.exp
+++ b/scripts/run-api-tests.exp
@@ -5,7 +5,7 @@ if {$argc < 2} {
   exit 1
 }
 
-set timeout 10
+set timeout 60
 set run_tests [split [lindex $argv 0] " "]
 set run_nvim [split [lindex $argv 1] " "]
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -31,7 +31,7 @@
 /// @return The line count
 Integer buffer_get_length(Buffer buffer, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return 0;
@@ -100,7 +100,7 @@ StringArray buffer_get_slice(Buffer buffer,
                              Error *err)
 {
   StringArray rv = ARRAY_DICT_INIT;
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return rv;
@@ -160,7 +160,7 @@ void buffer_set_slice(Buffer buffer,
                       StringArray replacement,
                       Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return;
@@ -283,7 +283,7 @@ end:
 /// @return The variable value
 Object buffer_get_var(Buffer buffer, String name, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return (Object) OBJECT_INIT;
@@ -301,7 +301,7 @@ Object buffer_get_var(Buffer buffer, String name, Error *err)
 /// @return The old value
 Object buffer_set_var(Buffer buffer, String name, Object value, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return (Object) OBJECT_INIT;
@@ -318,7 +318,7 @@ Object buffer_set_var(Buffer buffer, String name, Object value, Error *err)
 /// @return The option value
 Object buffer_get_option(Buffer buffer, String name, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return (Object) OBJECT_INIT;
@@ -336,7 +336,7 @@ Object buffer_get_option(Buffer buffer, String name, Error *err)
 /// @param[out] err Details of an error that may have occurred
 void buffer_set_option(Buffer buffer, String name, Object value, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return;
@@ -353,7 +353,7 @@ void buffer_set_option(Buffer buffer, String name, Object value, Error *err)
 Integer buffer_get_number(Buffer buffer, Error *err)
 {
   Integer rv = 0;
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return rv;
@@ -370,7 +370,7 @@ Integer buffer_get_number(Buffer buffer, Error *err)
 String buffer_get_name(Buffer buffer, Error *err)
 {
   String rv = STRING_INIT;
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf || buf->b_ffname == NULL) {
     return rv;
@@ -386,7 +386,7 @@ String buffer_get_name(Buffer buffer, Error *err)
 /// @param[out] err Details of an error that may have occurred
 void buffer_set_name(Buffer buffer, String name, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return;
@@ -416,7 +416,7 @@ void buffer_set_name(Buffer buffer, String name, Error *err)
 Boolean buffer_is_valid(Buffer buffer)
 {
   Error stub = {.set = false};
-  return find_buffer(buffer, &stub) != NULL;
+  return find_buffer_by_handle(buffer, &stub) != NULL;
 }
 
 /// Inserts a sequence of lines to a buffer at a certain index
@@ -440,7 +440,7 @@ void buffer_insert(Buffer buffer, Integer lnum, StringArray lines, Error *err)
 Position buffer_get_mark(Buffer buffer, String name, Error *err)
 {
   Position rv = POSITION_INIT;
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return rv;

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -49,14 +49,14 @@ typedef struct {
 
 typedef struct {
   Object *items;
-  size_t size;
+  size_t size, capacity;
 } Array;
 
 typedef struct key_value_pair KeyValuePair;
 
 typedef struct {
   KeyValuePair *items;
-  size_t size;
+  size_t size, capacity;
 } Dictionary;
 
 typedef enum {

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -288,12 +288,7 @@ Object vim_to_object(typval_T *obj)
   return rv;
 }
 
-/// Finds the pointer for a window number
-///
-/// @param window the window number
-/// @param[out] err Details of an error that may have occurred
-/// @return the window pointer
-buf_T *find_buffer(Buffer buffer, Error *err)
+buf_T *find_buffer_by_handle(Buffer buffer, Error *err)
 {
   buf_T *rv = handle_get_buffer(buffer);
 
@@ -304,12 +299,7 @@ buf_T *find_buffer(Buffer buffer, Error *err)
   return rv;
 }
 
-/// Finds the pointer for a window number
-///
-/// @param window the window number
-/// @param[out] err Details of an error that may have occurred
-/// @return the window pointer
-win_T * find_window(Window window, Error *err)
+win_T * find_window_by_handle(Window window, Error *err)
 {
   win_T *rv = handle_get_window(window);
 
@@ -320,12 +310,7 @@ win_T * find_window(Window window, Error *err)
   return rv;
 }
 
-/// Finds the pointer for a tabpage number
-///
-/// @param tabpage the tabpage number
-/// @param[out] err Details of an error that may have occurred
-/// @return the tabpage pointer
-tabpage_T * find_tab(Tabpage tabpage, Error *err)
+tabpage_T * find_tab_by_handle(Tabpage tabpage, Error *err)
 {
   tabpage_T *rv = handle_get_tabpage(tabpage);
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -6,12 +6,55 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/vim.h"
 #include "nvim/memory.h"
+#include "nvim/lib/kvec.h"
 
 #define set_api_error(message, err)                \
   do {                                             \
     xstrlcpy(err->msg, message, sizeof(err->msg)); \
     err->set = true;                               \
   } while (0)
+
+#define BOOL_OBJ(b) ((Object) {                                               \
+  .type = kObjectTypeBoolean,                                                 \
+  .data.boolean = b                                                           \
+  })
+
+#define INTEGER_OBJ(i) ((Object) {                                            \
+  .type = kObjectTypeInteger,                                                 \
+  .data.integer = i                                                           \
+  })
+
+#define STRING_OBJ(s) ((Object) {                                             \
+  .type = kObjectTypeString,                                                  \
+  .data.string = cstr_to_string(s)                                            \
+  })
+
+#define STRINGL_OBJ(d, s) ((Object) {                                         \
+  .type = kObjectTypeString,                                                  \
+  .data.string = (String) {                                                   \
+    .size = s,                                                                \
+    .data = xmemdup(d, s)                                                     \
+  }})
+
+#define ARRAY_OBJ(a) ((Object) {                                              \
+  .type = kObjectTypeArray,                                                   \
+  .data.array = a                                                             \
+  })
+
+#define DICTIONARY_OBJ(d) ((Object) {                                         \
+  .type = kObjectTypeDictionary,                                              \
+  .data.dictionary = d                                                        \
+  })
+
+#define NIL ((Object) {.type = kObjectTypeNil})
+
+#define PUT(dict, k, v)                                                       \
+  kv_push(KeyValuePair,                                                       \
+          dict,                                                               \
+          ((KeyValuePair) {.key = cstr_to_string(k), .value = v}))
+
+#define ADD(array, item)                                                      \
+  kv_push(Object, array, item)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/helpers.h.generated.h"

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -16,7 +16,7 @@
 WindowArray tabpage_get_windows(Tabpage tabpage, Error *err)
 {
   WindowArray rv = ARRAY_DICT_INIT;
-  tabpage_T *tab = find_tab(tabpage, err);
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab) {
     return rv;
@@ -53,7 +53,7 @@ WindowArray tabpage_get_windows(Tabpage tabpage, Error *err)
 /// @return The variable value
 Object tabpage_get_var(Tabpage tabpage, String name, Error *err)
 {
-  tabpage_T *tab = find_tab(tabpage, err);
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab) {
     return (Object) OBJECT_INIT;
@@ -71,7 +71,7 @@ Object tabpage_get_var(Tabpage tabpage, String name, Error *err)
 /// @return The tab page handle
 Object tabpage_set_var(Tabpage tabpage, String name, Object value, Error *err)
 {
-  tabpage_T *tab = find_tab(tabpage, err);
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab) {
     return (Object) OBJECT_INIT;
@@ -88,7 +88,7 @@ Object tabpage_set_var(Tabpage tabpage, String name, Object value, Error *err)
 Window tabpage_get_window(Tabpage tabpage, Error *err)
 {
   Window rv = 0;
-  tabpage_T *tab = find_tab(tabpage, err);
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab) {
     return rv;
@@ -117,6 +117,6 @@ Window tabpage_get_window(Tabpage tabpage, Error *err)
 Boolean tabpage_is_valid(Tabpage tabpage)
 {
   Error stub = {.set = false};
-  return find_tab(tabpage, &stub) != NULL;
+  return find_tab_by_handle(tabpage, &stub) != NULL;
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -291,7 +291,7 @@ Buffer vim_get_current_buffer(void)
 /// @param[out] err Details of an error that may have occurred
 void vim_set_current_buffer(Buffer buffer, Error *err)
 {
-  buf_T *buf = find_buffer(buffer, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return;
@@ -348,7 +348,7 @@ Window vim_get_current_window(void)
 /// @param handle The window handle
 void vim_set_current_window(Window window, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return;
@@ -407,7 +407,7 @@ Tabpage vim_get_current_tabpage(void)
 /// @param[out] err Details of an error that may have occurred
 void vim_set_current_tabpage(Tabpage tabpage, Error *err)
 {
-  tabpage_T *tp = find_tab(tabpage, err);
+  tabpage_T *tp = find_tab_by_handle(tabpage, err);
 
   if (!tp) {
     return;

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -19,7 +19,7 @@
 /// @return The buffer handle
 Buffer window_get_buffer(Window window, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return 0;
@@ -36,7 +36,7 @@ Buffer window_get_buffer(Window window, Error *err)
 Position window_get_cursor(Window window, Error *err)
 {
   Position rv = {.row = 0, .col = 0};
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (win) {
     rv.row = win->w_cursor.lnum;
@@ -53,7 +53,7 @@ Position window_get_cursor(Window window, Error *err)
 /// @param[out] err Details of an error that may have occurred
 void window_set_cursor(Window window, Position pos, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return;
@@ -89,7 +89,7 @@ void window_set_cursor(Window window, Position pos, Error *err)
 /// @return the height in rows
 Integer window_get_height(Window window, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return 0;
@@ -106,7 +106,7 @@ Integer window_get_height(Window window, Error *err)
 /// @param[out] err Details of an error that may have occurred
 void window_set_height(Window window, Integer height, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return;
@@ -132,7 +132,7 @@ void window_set_height(Window window, Integer height, Error *err)
 /// @return the width in columns
 Integer window_get_width(Window window, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return 0;
@@ -149,7 +149,7 @@ Integer window_get_width(Window window, Error *err)
 /// @param[out] err Details of an error that may have occurred
 void window_set_width(Window window, Integer width, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return;
@@ -176,7 +176,7 @@ void window_set_width(Window window, Integer width, Error *err)
 /// @return The variable value
 Object window_get_var(Window window, String name, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return (Object) OBJECT_INIT;
@@ -194,7 +194,7 @@ Object window_get_var(Window window, String name, Error *err)
 /// @return The old value
 Object window_set_var(Window window, String name, Object value, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return (Object) OBJECT_INIT;
@@ -211,7 +211,7 @@ Object window_set_var(Window window, String name, Object value, Error *err)
 /// @return The option value
 Object window_get_option(Window window, String name, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return (Object) OBJECT_INIT;
@@ -229,7 +229,7 @@ Object window_get_option(Window window, String name, Error *err)
 /// @param[out] err Details of an error that may have occurred
 void window_set_option(Window window, String name, Object value, Error *err)
 {
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (!win) {
     return;
@@ -246,7 +246,7 @@ void window_set_option(Window window, String name, Object value, Error *err)
 Position window_get_position(Window window, Error *err)
 {
   Position rv;
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (win) {
     rv.col = win->w_wincol;
@@ -264,7 +264,7 @@ Position window_get_position(Window window, Error *err)
 Tabpage window_get_tabpage(Window window, Error *err)
 {
   Tabpage rv = 0;
-  win_T *win = find_window(window, err);
+  win_T *win = find_window_by_handle(window, err);
 
   if (win) {
     rv = win_find_tabpage(win)->handle;
@@ -280,6 +280,6 @@ Tabpage window_get_tabpage(Window window, Error *err)
 Boolean window_is_valid(Window window)
 {
   Error stub = {.set = false};
-  return find_window(window, &stub) != NULL;
+  return find_window_by_handle(window, &stub) != NULL;
 }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -939,7 +939,7 @@ doESCkey:
       break;
 
     case K_EVENT:
-      event_process();
+      event_process(true);
       break;
 
     case K_HOME:        /* <Home> */

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -70,6 +70,7 @@
 #include "nvim/os/rstream_defs.h"
 #include "nvim/os/time.h"
 #include "nvim/os/channel.h"
+#include "nvim/api/private/helpers.h"
 
 #define DICT_MAXNEST 100        /* maximum nesting of lists and dicts */
 
@@ -12555,7 +12556,7 @@ static void f_send_event(typval_T *argvars, typval_T *rettv)
 
   if (!channel_send_event((uint64_t)argvars[0].vval.v_number,
                           (char *)argvars[1].vval.v_string,
-                          &argvars[2])) {
+                          vim_to_object(&argvars[2]))) {
     EMSG2(_(e_invarg2), "Channel doesn't exist");
     return;
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10471,11 +10471,12 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
   // The last item of argv must be NULL
   argv[i] = NULL;
 
-  rettv->vval.v_number = job_start(argv,
-                                   xstrdup((char *)argvars[0].vval.v_string),
-                                   on_job_stdout,
-                                   on_job_stderr,
-                                   on_job_exit);
+  job_start(argv,
+            xstrdup((char *)argvars[0].vval.v_string),
+            on_job_stdout,
+            on_job_stderr,
+            on_job_exit,
+            &rettv->vval.v_number);
 
   if (rettv->vval.v_number <= 0) {
     if (rettv->vval.v_number == 0) {
@@ -10502,19 +10503,21 @@ static void f_job_stop(typval_T *argvars, typval_T *rettv)
     return;
   }
 
-  if (!job_stop(argvars[0].vval.v_number)) {
+  Job *job = job_find(argvars[0].vval.v_number);
+
+  if (!job) {
     // Probably an invalid job id
     EMSG(_(e_invjob));
     return;
   }
 
+  job_stop(job);
   rettv->vval.v_number = 1;
 }
 
 // "jobwrite()" function
 static void f_job_write(typval_T *argvars, typval_T *rettv)
 {
-  bool res;
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
 
@@ -10529,16 +10532,16 @@ static void f_job_write(typval_T *argvars, typval_T *rettv)
     return;
   }
 
-  res = job_write(argvars[0].vval.v_number,
-                  xstrdup((char *)argvars[1].vval.v_string),
-                  strlen((char *)argvars[1].vval.v_string));
+  Job *job = job_find(argvars[0].vval.v_number);
 
-  if (!res) {
+  if (!job) {
     // Invalid job id
     EMSG(_(e_invjob));
   }
 
-  rettv->vval.v_number = 1;
+  rettv->vval.v_number = job_write(job,
+                                   xstrdup((char *)argvars[1].vval.v_string),
+                                   strlen((char *)argvars[1].vval.v_string));
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10540,9 +10540,10 @@ static void f_job_write(typval_T *argvars, typval_T *rettv)
     EMSG(_(e_invjob));
   }
 
-  rettv->vval.v_number = job_write(job,
-                                   xstrdup((char *)argvars[1].vval.v_string),
-                                   strlen((char *)argvars[1].vval.v_string));
+  WBuffer *buf = wstream_new_buffer(xstrdup((char *)argvars[1].vval.v_string),
+                                    strlen((char *)argvars[1].vval.v_string),
+                                    free);
+  rettv->vval.v_number = job_write(job, buf);
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10476,6 +10476,7 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
             on_job_stdout,
             on_job_stderr,
             on_job_exit,
+            true,
             &rettv->vval.v_number);
 
   if (rettv->vval.v_number <= 0) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -758,7 +758,7 @@ getcmdline (
      */
     switch (c) {
     case K_EVENT:
-      event_process();
+      event_process(true);
       // Force a redraw even though the command line didn't change
       shell_resized();
       goto cmdline_not_changed;
@@ -1873,8 +1873,8 @@ redraw:
       }
 
       if (IS_SPECIAL(c1)) {
-        // Process pending events
-        event_process();
+        // Process deferred events
+        event_process(true);
         // Ignore other special key codes
         continue;
       }

--- a/src/nvim/lib/kvec.h
+++ b/src/nvim/lib/kvec.h
@@ -53,39 +53,39 @@ int main() {
 
 #define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
 
-#define kvec_t(type) struct { size_t n, m; type *a; }
-#define kv_init(v) ((v).n = (v).m = 0, (v).a = 0)
-#define kv_destroy(v) free((v).a)
-#define kv_A(v, i) ((v).a[(i)])
-#define kv_pop(v) ((v).a[--(v).n])
-#define kv_size(v) ((v).n)
-#define kv_max(v) ((v).m)
+#define kvec_t(type) struct { size_t size, capacity; type *items; }
+#define kv_init(v) ((v).size = (v).capacity = 0, (v).items = 0)
+#define kv_destroy(v) free((v).items)
+#define kv_A(v, i) ((v).items[(i)])
+#define kv_pop(v) ((v).items[--(v).size])
+#define kv_size(v) ((v).size)
+#define kv_max(v) ((v).capacity)
 
-#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)xrealloc((v).a, sizeof(type) * (v).m))
+#define kv_resize(type, v, s)  ((v).capacity = (s), (v).items = (type*)xrealloc((v).items, sizeof(type) * (v).capacity))
 
 #define kv_copy(type, v1, v0) do {							\
-		if ((v1).m < (v0).n) kv_resize(type, v1, (v0).n);	\
-		(v1).n = (v0).n;									\
-		memcpy((v1).a, (v0).a, sizeof(type) * (v0).n);		\
+		if ((v1).capacity < (v0).size) kv_resize(type, v1, (v0).size);	\
+		(v1).size = (v0).size;									\
+		memcpy((v1).items, (v0).items, sizeof(type) * (v0).size);		\
 	} while (0)												\
 
 #define kv_push(type, v, x) do {									\
-		if ((v).n == (v).m) {										\
-			(v).m = (v).m? (v).m<<1 : 2;							\
-			(v).a = (type*)xrealloc((v).a, sizeof(type) * (v).m);	\
+		if ((v).size == (v).capacity) {										\
+			(v).capacity = (v).capacity? (v).capacity<<1 : 8;							\
+			(v).items = (type*)xrealloc((v).items, sizeof(type) * (v).capacity);	\
 		}															\
-		(v).a[(v).n++] = (x);										\
+		(v).items[(v).size++] = (x);										\
 	} while (0)
 
-#define kv_pushp(type, v) (((v).n == (v).m)?							\
-						   ((v).m = ((v).m? (v).m<<1 : 2),				\
-							(v).a = (type*)xrealloc((v).a, sizeof(type) * (v).m), 0)	\
-						   : 0), ((v).a + ((v).n++))
+#define kv_pushp(type, v) (((v).size == (v).capacity)?							\
+						   ((v).capacity = ((v).capacity? (v).capacity<<1 : 8),				\
+							(v).items = (type*)xrealloc((v).items, sizeof(type) * (v).capacity), 0)	\
+						   : 0), ((v).items + ((v).size++))
 
-#define kv_a(type, v, i) (((v).m <= (size_t)(i)? \
-						  ((v).m = (v).n = (i) + 1, kv_roundup32((v).m), \
-						   (v).a = (type*)xrealloc((v).a, sizeof(type) * (v).m), 0) \
-						  : (v).n <= (size_t)(i)? (v).n = (i) + 1 \
-						  : 0), (v).a[(i)])
+#define kv_a(type, v, i) (((v).capacity <= (size_t)(i)? \
+						  ((v).capacity = (v).size = (i) + 1, kv_roundup32((v).capacity), \
+						   (v).items = (type*)xrealloc((v).items, sizeof(type) * (v).capacity), 0) \
+						  : (v).size <= (size_t)(i)? (v).size = (i) + 1 \
+						  : 0), (v).items[(i)])
 
 #endif

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2064,7 +2064,7 @@ static int do_more_prompt(int typed_char)
     toscroll = 0;
     switch (c) {
     case K_EVENT:
-      event_process();
+      event_process(true);
       break;
     case BS:                    /* scroll one line back */
     case K_BS:

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7368,5 +7368,5 @@ static void nv_cursorhold(cmdarg_T *cap)
 
 static void nv_event(cmdarg_T *cap)
 {
-  event_process();
+  event_process(true);
 }

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -194,9 +194,10 @@ static void parse_msgpack(RStream *rstream, void *data, bool eof)
     // Perform the call
     msgpack_rpc_call(channel->id, &unpacked.data, &response);
     wstream_write(channel->data.streams.write,
-                  wstream_new_buffer(channel->sbuffer->data,
+                  wstream_new_buffer(xmemdup(channel->sbuffer->data,
+                                             channel->sbuffer->size),
                                      channel->sbuffer->size,
-                                     true));
+                                     free));
 
     // Clear the buffer for future calls
     msgpack_sbuffer_clear(channel->sbuffer);
@@ -218,9 +219,10 @@ static void parse_msgpack(RStream *rstream, void *data, bool eof)
                       "an object with high level of nesting",
                       &response);
     wstream_write(channel->data.streams.write,
-                  wstream_new_buffer(channel->sbuffer->data,
+                  wstream_new_buffer(xmemdup(channel->sbuffer->data,
+                                             channel->sbuffer->size),
                                      channel->sbuffer->size,
-                                     true));
+                                     free));
     // Clear the buffer for future calls
     msgpack_sbuffer_clear(channel->sbuffer);
   }
@@ -310,9 +312,10 @@ static WBuffer *serialize_event(char *type, typval_T *data)
   msgpack_packer packer;
   msgpack_packer_init(&packer, &msgpack_event_buffer, msgpack_sbuffer_write);
   msgpack_rpc_notification(event_type, event_data, &packer);
-  WBuffer *rv = wstream_new_buffer(msgpack_event_buffer.data,
+  WBuffer *rv = wstream_new_buffer(xmemdup(msgpack_event_buffer.data,
+                                           msgpack_event_buffer.size),
                                    msgpack_event_buffer.size,
-                                   true);
+                                   free);
   msgpack_rpc_free_object(event_data);
   msgpack_sbuffer_clear(&msgpack_event_buffer);
 

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -141,7 +141,7 @@ void channel_subscribe(uint64_t id, char *event)
   Channel *channel;
 
   if (!(channel = pmap_get(uint64_t)(channels, id))) {
-    return;
+    abort();
   }
 
   char *event_string = pmap_get(cstr_t)(event_strings, event);
@@ -163,7 +163,7 @@ void channel_unsubscribe(uint64_t id, char *event)
   Channel *channel;
 
   if (!(channel = pmap_get(uint64_t)(channels, id))) {
-    return;
+    abort();
   }
 
   unsubscribe(channel, event);

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -78,7 +78,8 @@ bool channel_from_job(char **argv)
                                 channel,
                                 job_out,
                                 job_err,
-                                NULL,
+                                job_exit,
+                                true,
                                 &status);
 
   if (status <= 0) {
@@ -177,6 +178,11 @@ static void job_out(RStream *rstream, void *data, bool eof)
 static void job_err(RStream *rstream, void *data, bool eof)
 {
   // TODO(tarruda): plugin error messages should be sent to the error buffer
+}
+
+static void job_exit(Job *job, void *data)
+{
+  // TODO(tarruda): what should be done here?
 }
 
 static void parse_msgpack(RStream *rstream, void *data, bool eof)

--- a/src/nvim/os/channel.h
+++ b/src/nvim/os/channel.h
@@ -2,8 +2,8 @@
 #define NVIM_OS_CHANNEL_H
 
 #include <uv.h>
-#include <msgpack.h>
 
+#include "nvim/api/private/defs.h"
 #include "nvim/vim.h"
 
 #define EVENT_MAXLEN 512

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -21,12 +21,16 @@
 #define _destroy_event(x)  // do nothing
 KLIST_INIT(Event, Event, _destroy_event)
 
+typedef struct {
+  bool timed_out;
+  int32_t ms;
+  uv_timer_t *timer;
+} TimerData;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/event.c.generated.h"
 #endif
 static klist_t(Event) *event_queue;
-static uv_timer_t timer;
-static uv_prepare_t timer_prepare;
 
 void event_init()
 {
@@ -44,9 +48,6 @@ void event_init()
   channel_init();
   // Servers
   server_init();
-  uv_timer_init(uv_default_loop(), &timer);
-  // This prepare handle that actually starts the timer
-  uv_prepare_init(uv_default_loop(), &timer_prepare);
 }
 
 void event_teardown()
@@ -59,7 +60,6 @@ void event_teardown()
 // Wait for some event
 bool event_poll(int32_t ms)
 {
-  bool timed_out;
   uv_run_mode run_mode = UV_RUN_ONCE;
 
   if (input_ready()) {
@@ -68,14 +68,20 @@ bool event_poll(int32_t ms)
   }
 
   input_start();
-  timed_out = false;
+
+  uv_timer_t timer;
+  uv_prepare_t timer_prepare;
+  TimerData timer_data = {.ms = ms, .timed_out = false, .timer = &timer};
 
   if (ms > 0) {
+    uv_timer_init(uv_default_loop(), &timer);
+    // This prepare handle that actually starts the timer
+    uv_prepare_init(uv_default_loop(), &timer_prepare);
     // Timeout passed as argument to the timer
-    timer.data = &timed_out;
+    timer.data = &timer_data;
     // We only start the timer after the loop is running, for that we
     // use a prepare handle(pass the interval as data to it)
-    timer_prepare.data = &ms;
+    timer_prepare.data = &timer_data;
     uv_prepare_start(&timer_prepare, timer_prepare_cb);
   } else if (ms == 0) {
     // For ms == 0, we need to do a non-blocking event poll by
@@ -92,13 +98,17 @@ bool event_poll(int32_t ms)
       !input_ready() &&   // we have no input
       kl_empty(event_queue) &&   // no events are waiting to be processed
       run_mode != UV_RUN_NOWAIT &&   // ms != 0
-      !timed_out);  // we didn't get a timeout
+      !timer_data.timed_out);  // we didn't get a timeout
 
   input_stop();
 
   if (ms > 0) {
-    // Stop the timer
-    uv_timer_stop(&timer);
+    // Ensure the timer-related handles are closed and run the event loop
+    // once more to let libuv perform it's cleanup
+    uv_close((uv_handle_t *)&timer, NULL);
+    uv_close((uv_handle_t *)&timer_prepare, NULL);
+    uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+    event_process(false);
   }
 
   return input_ready() || event_is_pending();
@@ -140,11 +150,14 @@ void event_process()
 // Set a flag in the `event_poll` loop for signaling of a timeout
 static void timer_cb(uv_timer_t *handle)
 {
-  *((bool *)handle->data) = true;
+  TimerData *data = handle->data;
+  data->timed_out = true;
 }
 
 static void timer_prepare_cb(uv_prepare_t *handle)
 {
-  uv_timer_start(&timer, timer_cb, *(uint32_t *)timer_prepare.data, 0);
-  uv_prepare_stop(&timer_prepare);
+  TimerData *data = handle->data;
+  assert(data->ms > 0);
+  uv_timer_start(data->timer, timer_cb, (uint32_t)data->ms, 0);
+  uv_prepare_stop(handle);
 }

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -67,7 +67,7 @@ int os_inchar(uint8_t *buf, int maxlen, int32_t ms, int tb_change_cnt)
 {
   InbufPollResult result;
 
-  if (event_is_pending()) {
+  if (event_has_deferred()) {
     // Return pending event bytes
     return push_event_key(buf, maxlen);
   }
@@ -91,8 +91,8 @@ int os_inchar(uint8_t *buf, int maxlen, int32_t ms, int tb_change_cnt)
     }
   }
 
-  // If there are pending events, return the keys directly
-  if (event_is_pending()) {
+  // If there are deferred events, return the keys directly
+  if (event_has_deferred()) {
     return push_event_key(buf, maxlen);
   }
 

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -260,13 +260,12 @@ void job_stop(Job *job)
 /// returns when the write request was sent.
 ///
 /// @param job The Job instance
-/// @param data Buffer containing the data to be written
-/// @param len Size of the data
+/// @param buffer The buffer which contains the data to be written
 /// @return true if the write request was successfully sent, false if writing
 ///         to the job stream failed (possibly because the OS buffer is full)
-bool job_write(Job *job, char *data, uint32_t len)
+bool job_write(Job *job, WBuffer *buffer)
 {
-  return wstream_write(job->in, wstream_new_buffer(data, len, free));
+  return wstream_write(job->in, buffer);
 }
 
 /// Sets the `defer` flag for a Job instance

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -258,7 +258,7 @@ bool job_write(int id, char *data, uint32_t len)
     return false;
   }
 
-  if (!wstream_write(job->in, wstream_new_buffer(data, len, false))) {
+  if (!wstream_write(job->in, wstream_new_buffer(data, len, free))) {
     job_stop(job->id);
     return false;
   }

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -390,14 +390,10 @@ static void exit_cb(uv_process_t *proc, int64_t status, int term_signal)
 
 static void emit_exit_event(Job *job)
 {
-  if (job->defer) {
-    Event event;
-    event.type = kEventJobExit;
-    event.data.job = job;
-    event_push(event);
-  } else {
-    job_exit_callback(job);
-  }
+  Event event;
+  event.type = kEventJobExit;
+  event.data.job = job;
+  event_push(event, true);
 }
 
 static void close_cb(uv_handle_t *handle)

--- a/src/nvim/os/job.h
+++ b/src/nvim/os/job.h
@@ -12,6 +12,8 @@
 
 #include "nvim/os/rstream_defs.h"
 #include "nvim/os/event_defs.h"
+#include "nvim/os/wstream.h"
+#include "nvim/os/wstream_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/job.h.generated.h"

--- a/src/nvim/os/msgpack_rpc.h
+++ b/src/nvim/os/msgpack_rpc.h
@@ -9,6 +9,12 @@
 #include "nvim/func_attr.h"
 #include "nvim/api/private/defs.h"
 
+typedef enum {
+  kUnpackResultOk,        /// Successfully parsed a document
+  kUnpackResultFail,      /// Got unexpected input
+  kUnpackResultNeedMore   /// Need more data
+} UnpackResult;
+
 /// Validates the basic structure of the msgpack-rpc call and fills `res`
 /// with the basic response structure.
 ///
@@ -39,6 +45,19 @@ void msgpack_rpc_dispatch(uint64_t id,
                           msgpack_object *req,
                           msgpack_packer *res)
   FUNC_ATTR_NONNULL_ARG(2) FUNC_ATTR_NONNULL_ARG(3);
+
+/// Try to unpack a msgpack document from the data in the unpacker buffer. This
+/// function is a replacement to msgpack.h `msgpack_unpack_next` that lets
+/// the called know if the unpacking failed due to bad input or due to missing
+/// data.
+///
+/// @param unpacker The unpacker containing the parse buffer
+/// @param result The result which will contain the parsed object
+/// @return kUnpackResultOk      : An object was parsed
+///         kUnpackResultFail    : Got bad input
+///         kUnpackResultNeedMore: Need more data
+UnpackResult msgpack_rpc_unpack(msgpack_unpacker* unpacker,
+                                msgpack_unpacked* result);
 
 /// Finishes the msgpack-rpc call with an error message.
 ///

--- a/src/nvim/os/rstream.c
+++ b/src/nvim/os/rstream.c
@@ -340,16 +340,9 @@ static void close_cb(uv_handle_t *handle)
 
 static void emit_read_event(RStream *rstream, bool eof)
 {
-  if (rstream->defer) {
-    Event event;
-
-    event.type = kEventRStreamData;
-    event.data.rstream.ptr = rstream;
-    event.data.rstream.eof = eof;
-    event_push(event);
-  } else {
-    // Invoke the callback passing in the number of bytes available and data
-    // associated with the stream
-    rstream->cb(rstream, rstream->data, eof);
-  }
+  Event event;
+  event.type = kEventRStreamData;
+  event.data.rstream.ptr = rstream;
+  event.data.rstream.eof = eof;
+  event_push(event, rstream->defer);
 }

--- a/src/nvim/os/rstream.c
+++ b/src/nvim/os/rstream.c
@@ -211,6 +211,15 @@ size_t rstream_available(RStream *rstream)
   return rstream->wpos - rstream->rpos;
 }
 
+/// Sets the `defer` flag for a a RStream instance
+///
+/// @param rstream The RStream instance
+/// @param defer The new value for the flag
+void rstream_set_defer(RStream *rstream, bool defer)
+{
+  rstream->defer = defer;
+}
+
 /// Runs the read callback associated with the rstream
 ///
 /// @param event Object containing data necessary to invoke the callback

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -159,5 +159,5 @@ static void signal_cb(uv_signal_t *handle, int signum)
       .signum = signum
     }
   };
-  event_push(event);
+  event_push(event, true);
 }

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -90,7 +90,7 @@ bool wstream_write(WStream *wstream, WBuffer *buffer)
   // This should not be called after a wstream was freed
   assert(!wstream->freed);
 
-  if (wstream->curmem + buffer->size > wstream->maxmem) {
+  if (wstream->curmem > wstream->maxmem) {
     return false;
   }
 

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -21,8 +21,9 @@ struct wstream {
 };
 
 struct wbuffer {
-  size_t refcount, size;
+  size_t size, refcount;
   char *data;
+  wbuffer_data_finalizer cb;
 };
 
 typedef struct {
@@ -116,19 +117,16 @@ bool wstream_write(WStream *wstream, WBuffer *buffer)
 ///
 /// @param data Data stored by the WBuffer
 /// @param size The size of the data array
-/// @param copy If true, the data will be copied into the WBuffer
+/// @param cb Pointer to function that will be responsible for freeing
+///        the buffer data(passing 'free' will work as expected).
 /// @return The allocated WBuffer instance
-WBuffer *wstream_new_buffer(char *data, size_t size, bool copy)
+WBuffer *wstream_new_buffer(char *data, size_t size, wbuffer_data_finalizer cb)
 {
   WBuffer *rv = xmalloc(sizeof(WBuffer));
   rv->size = size;
   rv->refcount = 0;
-
-  if (copy) {
-    rv->data = xmemdup(data, size);
-  } else {
-    rv->data = data;
-  }
+  rv->cb = cb;
+  rv->data = data;
 
   return rv;
 }
@@ -141,8 +139,7 @@ static void write_cb(uv_write_t *req, int status)
   data->wstream->curmem -= data->buffer->size;
 
   if (!--data->buffer->refcount) {
-    // Free the data written to the stream
-    free(data->buffer->data);
+    data->buffer->cb(data->buffer->data);
     free(data->buffer);
   }
 

--- a/src/nvim/os/wstream_defs.h
+++ b/src/nvim/os/wstream_defs.h
@@ -3,6 +3,7 @@
 
 typedef struct wbuffer WBuffer;
 typedef struct wstream WStream;
+typedef void (*wbuffer_data_finalizer)(void *data);
 
 #endif  // NVIM_OS_WSTREAM_DEFS_H
 


### PR DESCRIPTION
This PR does three things:
- Add code for dealing with msgpack parse failures(those are very rare but can happen as I experienced while running some manual tests)
- Enable transfering big amounts of data through WStream instances
- Use a single method of "locking" on a set of event sources, which is useful for #807  or the python ex command which will come after this.

@aktau, this should simplify the implementation of a job_sync function, it should be something like this:

``` c
job = job_start(...); // start a job
job_write(job, data); // write all data to the job
job_set_defer(job, false); // disable event deferral, we want to process job events inside `event_poll`
while (!exited) { // exited can be a flag set when the job exits
  event_poll(-1);
}
```

I have not tested the above code but it should work, let me know if you have any questions.
