### PR TITLE
[RFC]coverity/68215: removed failed variable and dead code path from f_readfile

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11467,7 +11467,6 @@ static void f_range(typval_T *argvars, typval_T *rettv)
 static void f_readfile(typval_T *argvars, typval_T *rettv)
 {
   int binary = FALSE;
-  int failed = FALSE;
   char_u      *fname;
   FILE        *fd;
   char_u buf[(IOSIZE/256)*256];         /* rounded to avoid odd + 1 */
@@ -11584,7 +11583,7 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
       }
     }     /* for */
 
-    if (failed || (cnt >= maxline && maxline >= 0) || readlen <= 0)
+    if ((cnt >= maxline && maxline >= 0) || readlen <= 0)
       break;
     if (start < p) {
       /* There's part of a line in buf, store it in "prev". */
@@ -11613,17 +11612,11 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
    * For a negative line count use only the lines at the end of the file,
    * free the rest.
    */
-  if (!failed && maxline < 0)
+  if (maxline < 0)
     while (cnt > -maxline) {
       listitem_remove(rettv->vval.v_list, rettv->vval.v_list->lv_first);
       --cnt;
     }
-
-  if (failed) {
-    list_free(rettv->vval.v_list, TRUE);
-    /* readfile doc says an empty list is returned on error */
-    rettv->vval.v_list = list_alloc();
-  }
 
   free(prev);
   fclose(fd);


### PR DESCRIPTION
Should fix Coverity issue 68215. Failed was never set to true (or at all), but was being used in some conditionals. I removed the section of code that was unreachable as well. Should fix #857
