### PR TITLE
[RDY] MsgPack-RPC dispatch based on function array lookup

### DIFF
--- a/src/nvim/os/msgpack_rpc.h
+++ b/src/nvim/os/msgpack_rpc.h
@@ -16,6 +16,12 @@ typedef enum {
   kUnpackResultNeedMore   /// Need more data
 } UnpackResult;
 
+/// The rpc_method_handlers table, used in msgpack_rpc_dispatch(), stores
+/// functions of this type.
+typedef Object (*rpc_method_handler_fn)(uint64_t channel_id,
+                                        msgpack_object *req,
+                                        Error *error);
+
 /// Dispatches to the actual API function after basic payload validation by
 /// `msgpack_rpc_call`. It is responsible for validating/converting arguments
 /// to C types, and converting the return value back to msgpack types.
@@ -25,12 +31,12 @@ typedef enum {
 /// @param channel_id The channel id
 /// @param method_id The method id
 /// @param req The parsed request object
-/// @param err Pointer to error structure
+/// @param error Pointer to error structure
 /// @return Some object
 Object msgpack_rpc_dispatch(uint64_t channel_id,
                             uint64_t method_id,
                             msgpack_object *req,
-                            Error *err)
+                            Error *error)
   FUNC_ATTR_NONNULL_ARG(2) FUNC_ATTR_NONNULL_ARG(3);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -38,4 +44,3 @@ Object msgpack_rpc_dispatch(uint64_t channel_id,
 #endif
 
 #endif  // NVIM_OS_MSGPACK_RPC_H
-


### PR DESCRIPTION
This simplifies the generated msgpack_rpc_dispatch() function, separates the
code for each RPC method more clearly and allows easy implementation of
alternative dispatching methods (e.g. string method id dispatch).

This is how the generated code looks like: (UPDATED) http://pastie.org/9323657 (dropped some functions as this file exceeds pastie's size limit).
