### PR TITLE
[RFC] win_redr_custom: pad `buf` with NUL / fix #858

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5099,7 +5099,7 @@ win_redr_custom (
   curattr = attr;
   p = buf;
   for (n = 0; hltab[n].start != NULL; n++) {
-    len = (int)(hltab[n].start - p);
+    int len = (int)(hltab[n].start - p);
     screen_puts_len(p, len, row, col, curattr);
     col += vim_strnsize(p, len);
     p = hltab[n].start;
@@ -5113,7 +5113,8 @@ win_redr_custom (
     else
       curattr = highlight_user[hltab[n].userhl - 1];
   }
-  screen_puts(p, row, col, curattr);
+  // Make sure to use an empty string instead of p, if p is beyond buf + len.
+  screen_puts(p >= buf + len ? (char_u *)"" : p, row, col, curattr);
 
   if (wp == NULL) {
     /* Fill the TabPageIdxs[] array for clicking in the tab pagesline. */


### PR DESCRIPTION
Posting this PR to see if it fixes the problem #858.

https://github.com/neovim/neovim/issues/858#issuecomment-46318842

> Quick guess: vim_strncpy fills buf with NUL to the end. STRLCPY does not "clear" buf, so 
> for windows with small maxwidth the following while loop won't set enough fillchars to "clear" buf.

I still don't see how STRLCPY causes the problem. [screen_puts_len](https://github.com/neovim/neovim/pull/866/files#diff-652ba8f711669fd3aa981ba690a56f43L5103) only displays up to `len`. So where do the remaining NUL bytes affect anything?
