### PR TITLE
[RDY] fix TCP connection (issue #870)

### DIFF
--- a/src/nvim/os/server.c
+++ b/src/nvim/os/server.c
@@ -93,9 +93,9 @@ void server_start(char *endpoint)
 
   // Trim to `ADDRESS_MAX_SIZE`
   if (xstrlcpy(addr, endpoint, sizeof(addr)) >= sizeof(addr)) {
-      // TODO(aktau): since this is not what the user wanted, perhaps we
-      // should return an error here
-      EMSG2("Address was too long, truncated to %s", addr);
+    // TODO(aktau): since this is not what the user wanted, perhaps we
+    // should return an error here
+    EMSG2("Address was too long, truncated to %s", addr);
   }
 
   // Check if the server already exists

--- a/src/nvim/os/server.c
+++ b/src/nvim/os/server.c
@@ -116,21 +116,19 @@ void server_start(char *endpoint)
 
   if (addr_len > sizeof(ip) - 1) {
     // Maximum length of an IP address buffer is 15(eg: 255.255.255.255)
-    addr_len = sizeof(ip);
+    addr_len = sizeof(ip) - 1;
   }
 
   // Extract the address part
-  xstrlcpy(ip, addr, addr_len);
+  xstrlcpy(ip, addr, addr_len + 1);
 
   int port = NEOVIM_DEFAULT_TCP_PORT;
 
   if (*ip_end == ':') {
-    char *port_end;
     // Extract the port
-    port = strtol(ip_end + 1, &port_end, 10);
-    errno = 0;
+    port = strtol(ip_end + 1, NULL, 10);
 
-    if (errno != 0 || port == 0 || port > 0xffff) {
+    if (port == 0 || port > 0xffff) {
       // Invalid port, treat as named pipe or unix socket
       server_type = kServerTypePipe;
     }


### PR DESCRIPTION
This fixes the broken TCP connection. It does not change the functions used to copy the IP address. Maybe there are some more improvements to be made here as described in issue #870.
