### PR TITLE
[RDY] coverity/62610: Remove dead code from setfname()

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2228,10 +2228,6 @@ setfname (
       close_buffer(NULL, obuf, DOBUF_WIPE, FALSE);
     }
     sfname = vim_strsave(sfname);
-    if (ffname == NULL) {
-      free(sfname);
-      return FAIL;
-    }
 #ifdef USE_FNAME_CASE
     fname_case(sfname, 0);            /* set correct case for short file name */
 #endif


### PR DESCRIPTION
From line 2204 we can see that ffname != NULL therefore ffname == NULL will always be false.
