### PR TITLE
[RFC] fix some -Wconversion warnings

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -37,6 +37,14 @@ endforeach()
 list(REMOVE_ITEM NEOVIM_SOURCES ${to_remove})
 
 set(CONV_SRCS
+
+  api/buffer.c
+  api/private/handle.c
+  api/private/helpers.c
+  api/tabpage.c
+  api/window.c
+  api/vim.h
+  api/vim.c
   api.c
   arabic.c
   cursor.c
@@ -47,27 +55,20 @@ set(CONV_SRCS
   map.c
   memory.c
   misc2.c
-  profile.c
   os/channel.c
   os/env.c
   os/event.c
   os/job.c
   os/mem.c
+  os/msgpack_rpc.c
   os/rstream.c
   os/signal.c
   os/users.c
   os/provider.c
   os/uv_helpers.c
   os/wstream.c
-  os/msgpack_rpc.c
+  profile.c
   tempfile.c
-  api/buffer.c
-  api/private/helpers.c
-  api/private/handle.c
-  api/tabpage.c
-  api/window.c
-  api/vim.h
-  api/vim.c
   )
 
 set_source_files_properties(

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -47,8 +47,8 @@ set(CONV_SRCS
   map.c
   memory.c
   misc2.c
-  map.c
   profile.c
+  os/channel.c
   os/env.c
   os/event.c
   os/job.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CONV_SRCS
   os/channel.c
   os/env.c
   os/event.c
+  os/fs.c
   os/input.c
   os/job.c
   os/mem.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -40,6 +40,7 @@ set(CONV_SRCS
   api.c
   arabic.c
   cursor.c
+  cursor_shape.c
   garray.c
   hashtab.c
   log.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CONV_SRCS
   os/channel.c
   os/env.c
   os/event.c
+  os/input.c
   os/job.c
   os/mem.c
   os/msgpack_rpc.c

--- a/src/nvim/cursor_shape.h
+++ b/src/nvim/cursor_shape.h
@@ -37,7 +37,7 @@
 typedef struct cursor_entry {
   int shape;                    /* one of the SHAPE_ defines */
   int mshape;                   /* one of the MSHAPE defines */
-  int percentage;               /* percentage of cell for bar */
+  long percentage;              /* percentage of cell for bar */
   long blinkwait;               /* blinking, wait time before blinking starts */
   long blinkon;                 /* blinking, on time */
   long blinkoff;                /* blinking, off time */

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -588,7 +588,7 @@ EXTERN long p_ul;               /* 'undolevels' */
 EXTERN long p_ur;               /* 'undoreload' */
 EXTERN int p_unc;               /* 'unnamedclip' */
 EXTERN long p_uc;               /* 'updatecount' */
-EXTERN long p_ut;               /* 'updatetime' */
+EXTERN int32_t p_ut;            /* 'updatetime' */
 EXTERN char_u   *p_fcs;         /* 'fillchar' */
 EXTERN char_u   *p_viminfo;     /* 'viminfo' */
 EXTERN char_u   *p_vdir;        /* 'viewdir' */

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -336,7 +336,7 @@ static void parse_msgpack(RStream *rstream, void *data, bool eof)
     goto end;
   }
 
-  uint32_t count = rstream_available(rstream);
+  size_t count = rstream_available(rstream);
   DLOG("Feeding the msgpack parser with %u bytes of data from RStream(%p)",
        count,
        rstream);

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -64,7 +64,7 @@ void input_stop(void)
 }
 
 // Copies (at most `count`) of was read from `read_cmd_fd` into `buf`
-uint32_t input_read(char *buf, uint32_t count)
+size_t input_read(char *buf, size_t count)
 {
   if (embedded_mode) {
     return 0;


### PR DESCRIPTION
I just changed the `percentage` field in `cursorentry_T` to `long`. It's used only in `cursor_shape.c` so it should not be a problem.
