### PR TITLE
[RFC] Refactor declaration generation error detection

### DIFF
--- a/scripts/gendeclarations.lua
+++ b/scripts/gendeclarations.lua
@@ -3,9 +3,8 @@
 local fname = arg[1]
 local static_fname = arg[2]
 local non_static_fname = arg[3]
-local cpp = arg[4]
+local preproc_fname = arg[4]
 
-cpp = cpp:gsub(' %-DINCLUDE_GENERATED_DECLARATIONS ', ' ')
 
 local lpeg = require('lpeg')
 
@@ -156,15 +155,14 @@ local pattern = concat(
 if fname == '--help' then
   print'Usage:'
   print()
-  print'  gendeclarations.lua definitions.c static.h non-static.h "cc -E …"'
+  print'  gendeclarations.lua definitions.c static.h non-static.h preprocessor.i'
   os.exit()
 end
 
-local pipe = io.popen(cpp .. ' -DDO_NOT_DEFINE_EMPTY_ATTRIBUTES ' .. fname, 'r')
-local text = pipe:read('*a')
-if not pipe:close() then
-  os.exit(2)
-end
+local preproc_f = io.open(preproc_fname)
+local text = preproc_f:read("*all")
+preproc_f:close()
+
 
 local header = [[
 #ifndef DEFINE_FUNC_ATTRIBUTES
@@ -181,7 +179,7 @@ local footer = [[
 local non_static = header
 local static = header
 
-local filepattern = '^# %d+ "[^"]-/?([^"/]+)"'
+local filepattern = '^#%a* %d+ "[^"]-/?([^"/]+)"'
 local curfile
 
 init = 0

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -109,13 +109,15 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 get_directory_property(gen_cdefs COMPILE_DEFINITIONS)
-foreach(gen_cdef ${gen_cdefs})
-  set(gen_cflags "${gen_cflags} -D${gen_cdef}")
+foreach(gen_cdef ${gen_cdefs} DO_NOT_DEFINE_EMPTY_ATTRIBUTES)
+  if(NOT "${gen_cdef}" MATCHES "INCLUDE_GENERATED_DECLARATIONS")
+    list(APPEND gen_cflags "-D${gen_cdef}")
+  endif()
 endforeach()
 
 get_directory_property(gen_includes INCLUDE_DIRECTORIES)
 foreach(gen_include ${gen_includes})
-  set(gen_cflags "${gen_cflags} -I${gen_include}")
+  list(APPEND gen_cflags "-I${gen_include}")
 endforeach()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type)
 set(gen_cflags "${gen_cflags} ${CMAKE_C_FLAGS_${build_type}} ${CMAKE_C_FLAGS}")
@@ -132,11 +134,12 @@ foreach(sfile ${NEOVIM_SOURCES}
   endif()
   set(gf1 "${GENERATED_DIR}/${r}.c.generated.h")
   set(gf2 "${GENERATED_INCLUDES_DIR}/${r}.h.generated.h")
+  set(gf3 "${GENERATED_DIR}/${r}.i")
+  separate_arguments(C_FLAGS_ARRAY UNIX_COMMAND ${CMAKE_C_FLAGS})
   add_custom_command(
     OUTPUT "${gf1}" "${gf2}"
-    COMMAND "${LUA_PRG}" "${HEADER_GENERATOR}"
-                             "${sfile}" "${gf1}" "${gf2}"
-                             "${CMAKE_C_COMPILER} ${gen_cflags} -E"
+    COMMAND ${CMAKE_C_COMPILER} ${sfile} -o ${gf3} ${gen_cflags} -E ${C_FLAGS_ARRAY}
+    COMMAND "${LUA_PRG}" "${HEADER_GENERATOR}" "${sfile}" "${gf1}" "${gf2}" "${gf3}"
     DEPENDS "${HEADER_GENERATOR}" "${sfile}"
     )
   list(APPEND NEOVIM_GENERATED_SOURCES "${gf1}")


### PR DESCRIPTION
The initial goal for this was to allow declaration generation to work in windows (as part of #696) however this ends up allowing us to detect cases when the generator fails.instead of failing silently. And the only _(Windows?)_ specific bit here is the different preprocessor line format.

BTW can anyone confirm in which versions of Clang preprocessor (-E) prints #line instead of just #?

Ping @ZyX-I - one case I did not cover was when the generator fails to find any declaration for a file - can we treat this as an error and fail?

In a nutshell
- Call compiler from CMake instead of lua script to generate a
  preprocessor file - allows for better/early error detection if
  the compiler fails
- Accept preprocessor lines with trailing chars after # as is
  the case in Clang/Windows
- The fourth argument to gendeclarations.lua is now the path to
  the proprocessor output file
