### PR TITLE
[RFC] Refactor buflist_findpat "two-iteration loop" anti-pattern

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1688,13 +1688,12 @@ static buf_T *buflist_findname_file_info(char_u *ffname, FileInfo *file_info)
  * Return fnum of the found buffer.
  * Return < 0 for error.
  */
-int 
-buflist_findpat (
+int buflist_findpat (
     char_u *pattern,
     char_u *pattern_end,       /* pointer to first char after pattern */
-    int unlisted,                   /* find unlisted buffers */
-    int diffmode,             /* find diff-mode buffers only */
-    int curtab_only                /* find buffers in current tab only */
+    int unlisted,              /* find unlisted buffers */
+    int diffmode,              /* find diff-mode buffers only */
+    int curtab_only            /* find buffers in current tab only */
 )
 {
   buf_T       *buf;


### PR DESCRIPTION
Another occurence of Issue #572. This code is much clearer but longer.
Couple of questions though:
- line 1731 - 1750: Even though the code is clearer, this still looks like something that should be replaced by a for loop?
- The infinite for loop (line 1730) could be replaced either by moving the above mentioned code into another method, or by using a goto statement (gasp). Would the first be preferable?
