### PR TITLE
Guard Travis specific options in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
 cmake_minimum_required (VERSION 2.8.7)
 project (NEOVIM)
 
-set(CMAKE_SYSTEM_PROCESSOR i386)
-set(CMAKE_SYSTEM_LIBRARY_PATH /lib32 /usr/lib32 /usr/local/lib32)
-set(FIND_LIBRARY_USE_LIB64_PATHS OFF)
-set(CMAKE_IGNORE_PATH /lib /usr/lib /usr/local/lib)
+option(
+  TRAVIS_CI_BUILD "Travis CI build.  Extra compilation flags will be set." OFF)
+
+if(TRAVIS_CI_BUILD)
+  set(CMAKE_SYSTEM_PROCESSOR i386)
+  set(CMAKE_SYSTEM_LIBRARY_PATH /lib32 /usr/lib32 /usr/local/lib32)
+  set(FIND_LIBRARY_USE_LIB64_PATHS OFF)
+  set(CMAKE_IGNORE_PATH /lib /usr/lib /usr/local/lib)
+endif()
 
 # Point CMake at any custom modules we may ship
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
@@ -24,9 +29,6 @@ set(NEOVIM_VERSION_PATCH 0)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter -std=gnu99)
-
-option(
-  TRAVIS_CI_BUILD "Travis CI build.  Extra compilation flags will be set." OFF)
 
 if(TRAVIS_CI_BUILD)
   message(STATUS "Travis CI build enabled.")


### PR DESCRIPTION
Trying to build Neovim WITHOUT the bundled libraries failed to find libuv (and possibly other libraries). Commit [8d91bf768666157e54e462d03853f62ad7587148] sets several CMake options that prevent it from find library paths in my system. I assume these are only meant for Travis so I added a check.
