### PR TITLE
[RFC] Fix #867: cmake doesn't issue `-isystem` for versioned gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ set(NEOVIM_VERSION_PATCH 0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Work around some old, broken detection by CMake for knowing when to use the
+# isystem flag.  Apple's compilers have supported this for quite some time now.
+if(APPLE)
+  if(CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-isystem ")
+  endif()
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
+  endif()
+endif()
+
 add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter -std=gnu99)
 
 option(


### PR DESCRIPTION
CMake purposefully disables the use of the `-isystem` flag on Apple
platforms, but it's overly blunt with the detection.  Apple's compilers
have supported the flag since at least 10.4.  Let's force the switch to
be on when gcc/g++ is detected on an Apple platform to reduce the
warnings out of the msgpack-related bits.
